### PR TITLE
Normalize 'setup.py' to fit conventions:

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,14 @@
+prune google/protobuf/internal/import_test_package
+exclude google/protobuf/internal/*_pb2.py
+exclude google/protobuf/internal/*_test.py
+exclude google/protobuf/internal/*.proto
+exclude google/protobuf/internal/test_util.py
+
+recursive-exclude google *_test.py
+recursive-exclude google *_test.proto
+recursive-exclude google unittest*_pb2.py
+
+global-exclude *.dll
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.so

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,12 +8,12 @@ import subprocess
 # We must use setuptools, not distutils, because we need to use the
 # namespace_packages option for the "google" package.
 try:
-  from setuptools import setup, Extension
+  from setuptools import setup, Extension, find_packages
 except ImportError:
   try:
     from ez_setup import use_setuptools
     use_setuptools()
-    from setuptools import setup, Extension
+    from setuptools import setup, Extension, find_packages
   except ImportError:
     sys.stderr.write(
         "Could not import setuptools; make sure you have setuptools or "
@@ -164,37 +164,25 @@ if __name__ == '__main__':
 
   setup(name = 'protobuf',
         version = '3.0.0-pre',
-        packages = [ 'google' ],
+        description = 'Protocol Buffers',
+        long_description =
+          "Protocol Buffers are Google's data interchange format.",
+        url = 'https://developers.google.com/protocol-buffers/',
+        maintainer = maintainer_email,
+        maintainer_email = 'protobuf@googlegroups.com',
+        license = 'New BSD License',
+        classifiers=[
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.6",
+          "Programming Language :: Python :: 2.7",
+          ],
         namespace_packages = [ 'google' ],
+        packages = find_packages(
+         exclude=[
+           "import_test_package",
+           ]),
         test_suite = 'setup.MakeTestSuite',
         google_test_dir = "google/protobuf/internal",
-        # Must list modules explicitly so that we don't install tests.
-        py_modules = [
-          'google.protobuf.internal.api_implementation',
-          'google.protobuf.internal.containers',
-          'google.protobuf.internal.cpp_message',
-          'google.protobuf.internal.decoder',
-          'google.protobuf.internal.encoder',
-          'google.protobuf.internal.enum_type_wrapper',
-          'google.protobuf.internal.message_listener',
-          'google.protobuf.internal.python_message',
-          'google.protobuf.internal.type_checkers',
-          'google.protobuf.internal.wire_format',
-          'google.protobuf.descriptor',
-          'google.protobuf.descriptor_pb2',
-          'google.protobuf.compiler.plugin_pb2',
-          'google.protobuf.message',
-          'google.protobuf.descriptor_database',
-          'google.protobuf.descriptor_pool',
-          'google.protobuf.message_factory',
-          'google.protobuf.proto_builder',
-          'google.protobuf.pyext.cpp_message',
-          'google.protobuf.reflection',
-          'google.protobuf.service',
-          'google.protobuf.service_reflection',
-          'google.protobuf.symbol_database',
-          'google.protobuf.text_encoding',
-          'google.protobuf.text_format'],
         cmdclass = { 'clean': clean, 'build_py': build_py },
         install_requires = ['setuptools'],
         # TODO: Restore dependency once a Python 3 compatible google-apputils
@@ -203,11 +191,4 @@ if __name__ == '__main__':
                           if sys.version_info[0] < 3 else
                           []),
         ext_modules = ext_module_list,
-        url = 'https://developers.google.com/protocol-buffers/',
-        maintainer = maintainer_email,
-        maintainer_email = 'protobuf@googlegroups.com',
-        license = 'New BSD License',
-        description = 'Protocol Buffers',
-        long_description =
-          "Protocol Buffers are Google's data interchange format.",
         )


### PR DESCRIPTION
- Move human-centric metadata to top of 'setup()' call.

- Add Trove classifiers for supported Python versions.

- Use 'find_packages()' + MANIFEST.in to avoid errors in listing modules
  and packages.