### PR TITLE
Fix illegal C++ use of reinterpret_cast<> to cast between nullptr_t and a pointer

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_service.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_service.cc
@@ -301,7 +301,7 @@ void ServiceGenerator::GenerateGetPrototype(RequestOrResponse which,
   printer->Print(vars_,
     "    default:\n"
     "      GOOGLE_LOG(FATAL) << \"Bad method index; this should never happen.\";\n"
-    "      return *reinterpret_cast< ::google::protobuf::Message*>(NULL);\n"
+    "      return *static_cast< ::google::protobuf::Message*>(NULL);\n"
     "  }\n"
     "}\n"
     "\n");


### PR DESCRIPTION
The present usage of reinterpret_cast to cast a nullptr_t to a pointer generates an illegal C++ hard error in clang. This is correct, as per http://en.cppreference.com/w/cpp/language/reinterpret_cast the reinterpret_cast cast may not cast nullptr_t to any other pointer. This pull request replaces the cast with static_cast, which is the legal form of cast to use.