### PR TITLE
MSVC protoc compiler fix

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -45,15 +45,9 @@ namespace google {
 namespace protobuf {
 namespace compiler {
 namespace ruby {
-
-#if _MSC_VER >= 1400 // VS 2005 and above
-  // <stdint.h> is not part of the standard, so we need to map
-  // to MSVC's custom sized integer types instead.	
-  typedef unsigned __int32 uint32_t;
-#endif
 	
 // Forward decls.
-std::string IntToString(uint32_t value);
+std::string IntToString(uint32 value);
 std::string StripDotProto(const std::string& proto_file);
 std::string LabelForField(google::protobuf::FieldDescriptor* field);
 std::string TypeName(google::protobuf::FieldDescriptor* field);
@@ -70,7 +64,7 @@ void GenerateEnumAssignment(
     const google::protobuf::EnumDescriptor* en,
     google::protobuf::io::Printer* printer);
 
-std::string IntToString(uint32_t value) {
+std::string IntToString(uint32 value) {
   std::ostringstream os;
   os << value;
   return os.str();

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -45,7 +45,7 @@ namespace google {
 namespace protobuf {
 namespace compiler {
 namespace ruby {
-	
+
 // Forward decls.
 std::string IntToString(uint32 value);
 std::string StripDotProto(const std::string& proto_file);

--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -46,6 +46,12 @@ namespace protobuf {
 namespace compiler {
 namespace ruby {
 
+#if _MSC_VER >= 1400 // VS 2005 and above
+  // <stdint.h> is not part of the standard, so we need to map
+  // to MSVC's custom sized integer types instead.	
+  typedef unsigned __int32 uint32_t;
+#endif
+	
 // Forward decls.
 std::string IntToString(uint32_t value);
 std::string StripDotProto(const std::string& proto_file);

--- a/vsprojects/libprotoc.vcproj
+++ b/vsprojects/libprotoc.vcproj
@@ -223,6 +223,10 @@
 				RelativePath="..\src\google\protobuf\compiler\cpp\cpp_string_field.h"
 				>
 			</File>
+      <File
+				RelativePath="..\src\google\protobuf\compiler\ruby\ruby_generator.h"
+				>
+			</File>
 			<File
 				RelativePath="..\src\google\protobuf\compiler\java\java_context.h"
 				>
@@ -373,6 +377,10 @@
 			</File>
 			<File
 				RelativePath="..\src\google\protobuf\compiler\cpp\cpp_string_field.cc"
+				>
+			</File>
+      <File
+				RelativePath="..\src\google\protobuf\compiler\ruby\ruby_generator.cc"
 				>
 			</File>
 			<File


### PR DESCRIPTION
I've added the missing ruby generator files and added a workaround to deal with missing <stdint.h> types. Protoc compiles successfully in VS 2012.

This addresses Issue #87 
