### PR TITLE
add #to_ary to RepeatedField

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -226,7 +226,8 @@ module BasicTest
       assert l.count == 0
       l = Google::Protobuf::RepeatedField.new(:int32, [1, 2, 3])
       assert l.count == 3
-      assert l == [1, 2, 3]
+      assert_equal [1, 2, 3], l
+      assert_equal l, [1, 2, 3]
       l.push 4
       assert l == [1, 2, 3, 4]
       dst_list = []


### PR DESCRIPTION
The contract of repeated field is broken, e.g.

```ruby
repeated_field.inspect
# => [1,2,3]
repeated_field == [1,2,3]
# => true
[1,2,3] == repeated_field
# => false
```

This commit add the `to_ary` method that's used to do implicit conversion to an array.