### PR TITLE
added biicode support

### DIFF
--- a/biicode.py
+++ b/biicode.py
@@ -1,0 +1,11 @@
+import os
+import shutil
+
+bii_dir = os.path.join(os.getcwd(), "tmp_bii")
+os.system("bii init tmp_bii")
+shutil.copytree(os.path.join(os.getcwd(), "src/google"), "tmp_bii/blocks/google")
+os.chdir(bii_dir)
+#os.system("bii cpp:build")
+os.system("bii publish")
+os.chdir("..")
+shutil.rmtree(bii_dir)

--- a/src/google/protobuf/CMakeLists.txt
+++ b/src/google/protobuf/CMakeLists.txt
@@ -1,0 +1,20 @@
+# The one and only required CMake script to build protoc and/or library
+
+# Basic configuration
+IF(NOT WIN32)
+	FIND_PACKAGE(Threads REQUIRED)
+	SET(HAVE_PTHREAD CMAKE_HAVE_PTHREAD_H)
+ENDIF()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+INIT_BIICODE_BLOCK()
+ADD_BIICODE_TARGETS()
+
+if(TARGET google_protobuf_compiler_main) # rename 2 protoc
+	SET_TARGET_PROPERTIES(google_protobuf_compiler_main PROPERTIES OUTPUT_NAME protoc)
+endif()
+IF(BII_LIB_SRC)
+	target_include_directories(${BII_LIB_TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ELSE()
+	target_include_directories(${BII_LIB_TARGET} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+ENDIF()

--- a/src/google/protobuf/biicode.conf
+++ b/src/google/protobuf/biicode.conf
@@ -1,0 +1,11 @@
+[requirements]
+
+[parent]
+	* google/protobuf: 1
+
+[dependencies]
+	stubs/common.h + config.h.in
+	* - *test*.cc *mock_code_generator.cc
+
+[mains]
+	!*test*


### PR DESCRIPTION
I have added a couple of files to provide support for biicode C/C++ dependency manager, which host a copy http://www.biicode.com/google/protobuf.
Usage of protobuf with biicode is simple for the 2 use cases:
- If the compiler is required, "bii open" and the full block will be retrieved and compiled, building "protoc"
- If just the library is required to link .pb.cc files, it is usually enough  to #include the headers, and just the protobuf required files (not the compiler) will be retrieved and built.

A simple example can be found in http://www.biicode.com/examples/protobuf

Tested in Win (MinGW, VS12), Ubuntu (gcc 4.8) & Mac (CLang)

The biicode.py file is just a convenient utility, just the steps required to publish protobuf to biicode. It could be automated via travis, there is already a deploy provider for biicode in TravisCI.

