### PR TITLE
Optional write to stdout instead of file

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -591,7 +591,7 @@ CommandLineInterface::CommandLineInterface()
     source_info_in_descriptor_set_(false),
     disallow_services_(false),
     inputs_are_proto_path_relative_(false),
-		write_to_stdout(false) {}
+    write_to_stdout(false) {}
 CommandLineInterface::~CommandLineInterface() {}
 
 void CommandLineInterface::RegisterGenerator(const string& flag_name,
@@ -1107,7 +1107,7 @@ CommandLineInterface::InterpretArgument(const string& name,
     plugins_[plugin_name] = path;
 
   } else if (name == "--stdout") {
-		write_to_stdout = value == "true";
+    write_to_stdout = value == "true";
   } else if (name == "--print_free_field_numbers") {
     if (mode_ != MODE_COMPILE) {
       cerr << "Cannot use " << name << " and use --encode, --decode or print "
@@ -1324,50 +1324,50 @@ bool CommandLineInterface::GeneratePluginOutput(
 
   // Write the files.  We do this even if there was a generator error in order
   // to match the behavior of a compiled-in generator.
-	google::protobuf::scoped_ptr<io::ZeroCopyOutputStream> current_output;
-	for (int i = 0; i < response.file_size(); i++) {
-		const CodeGeneratorResponse::File& output_file = response.file(i);
-		if(!write_to_stdout) {
-			if (!output_file.insertion_point().empty()) {
-				// Open a file for insert.
-				// We reset current_output to NULL first so that the old file is closed
-				// before the new one is opened.
-				current_output.reset();
-				current_output.reset(generator_context->OpenForInsert(
-						output_file.name(), output_file.insertion_point()));
-			} else if (!output_file.name().empty()) {
-				// Starting a new file.  Open it.
-				// We reset current_output to NULL first so that the old file is closed
-				// before the new one is opened.
-				current_output.reset();
-				current_output.reset(generator_context->Open(output_file.name()));
-			} else if (current_output == NULL) {
-				*error = strings::Substitute(
-					"$0: First file chunk returned by plugin did not specify a file name.",
-					plugin_name);
-				return false;
-			}
+  google::protobuf::scoped_ptr<io::ZeroCopyOutputStream> current_output;
+  for (int i = 0; i < response.file_size(); i++) {
+    const CodeGeneratorResponse::File& output_file = response.file(i);
+    if(!write_to_stdout) {
+      if (!output_file.insertion_point().empty()) {
+        // Open a file for insert.
+        // We reset current_output to NULL first so that the old file is closed
+        // before the new one is opened.
+        current_output.reset();
+        current_output.reset(generator_context->OpenForInsert(
+            output_file.name(), output_file.insertion_point()));
+      } else if (!output_file.name().empty()) {
+        // Starting a new file.  Open it.
+        // We reset current_output to NULL first so that the old file is closed
+        // before the new one is opened.
+        current_output.reset();
+        current_output.reset(generator_context->Open(output_file.name()));
+      } else if (current_output == NULL) {
+        *error = strings::Substitute(
+          "$0: First file chunk returned by plugin did not specify a file name.",
+          plugin_name);
+        return false;
+      }
 
-			// Use CodedOutputStream for convenience; otherwise we'd need to provide
-			// our own buffer-copying loop.
-			io::CodedOutputStream writer(current_output.get());
-			writer.WriteString(output_file.content());
-		} else {
-			// Generate to stdout
-			string header = "Generating file to stdout: ";	
-			int hLineSize = header.length() + output_file.name().length();
-			string hLine = "";
-			for(int j = 0; j < hLineSize; j++){
-				hLine += "-";
-			}
+      // Use CodedOutputStream for convenience; otherwise we'd need to provide
+      // our own buffer-copying loop.
+      io::CodedOutputStream writer(current_output.get());
+      writer.WriteString(output_file.content());
+    } else {
+      // Generate to stdout
+      string header = "Generating file to stdout: ";  
+      int hLineSize = header.length() + output_file.name().length();
+      string hLine = "";
+      for(int j = 0; j < hLineSize; j++){
+        hLine += "-";
+      }
 
-			// Write header and generate file contents to stdout
-			cout << hLine << endl << hLine << endl;
-			cout << header + output_file.name() << endl;
-			cout << hLine << endl << hLine << endl;
-			cout << output_file.content() << endl;
-		}
-	}
+      // Write header and generate file contents to stdout
+      cout << hLine << endl << hLine << endl;
+      cout << header + output_file.name() << endl;
+      cout << hLine << endl << hLine << endl;
+      cout << output_file.content() << endl;
+    }
+  }
 
   // Check for errors.
   if (!response.error().empty()) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -590,7 +590,8 @@ CommandLineInterface::CommandLineInterface()
     imports_in_descriptor_set_(false),
     source_info_in_descriptor_set_(false),
     disallow_services_(false),
-    inputs_are_proto_path_relative_(false) {}
+    inputs_are_proto_path_relative_(false),
+		write_to_stdout(false) {}
 CommandLineInterface::~CommandLineInterface() {}
 
 void CommandLineInterface::RegisterGenerator(const string& flag_name,
@@ -1105,6 +1106,8 @@ CommandLineInterface::InterpretArgument(const string& name,
 
     plugins_[plugin_name] = path;
 
+  } else if (name == "--stdout") {
+		write_to_stdout = value == "true";
   } else if (name == "--print_free_field_numbers") {
     if (mode_ != MODE_COMPILE) {
       cerr << "Cannot use " << name << " and use --encode, --decode or print "
@@ -1321,35 +1324,50 @@ bool CommandLineInterface::GeneratePluginOutput(
 
   // Write the files.  We do this even if there was a generator error in order
   // to match the behavior of a compiled-in generator.
-  google::protobuf::scoped_ptr<io::ZeroCopyOutputStream> current_output;
-  for (int i = 0; i < response.file_size(); i++) {
-    const CodeGeneratorResponse::File& output_file = response.file(i);
+	google::protobuf::scoped_ptr<io::ZeroCopyOutputStream> current_output;
+	for (int i = 0; i < response.file_size(); i++) {
+		const CodeGeneratorResponse::File& output_file = response.file(i);
+		if(!write_to_stdout) {
+			if (!output_file.insertion_point().empty()) {
+				// Open a file for insert.
+				// We reset current_output to NULL first so that the old file is closed
+				// before the new one is opened.
+				current_output.reset();
+				current_output.reset(generator_context->OpenForInsert(
+						output_file.name(), output_file.insertion_point()));
+			} else if (!output_file.name().empty()) {
+				// Starting a new file.  Open it.
+				// We reset current_output to NULL first so that the old file is closed
+				// before the new one is opened.
+				current_output.reset();
+				current_output.reset(generator_context->Open(output_file.name()));
+			} else if (current_output == NULL) {
+				*error = strings::Substitute(
+					"$0: First file chunk returned by plugin did not specify a file name.",
+					plugin_name);
+				return false;
+			}
 
-    if (!output_file.insertion_point().empty()) {
-      // Open a file for insert.
-      // We reset current_output to NULL first so that the old file is closed
-      // before the new one is opened.
-      current_output.reset();
-      current_output.reset(generator_context->OpenForInsert(
-          output_file.name(), output_file.insertion_point()));
-    } else if (!output_file.name().empty()) {
-      // Starting a new file.  Open it.
-      // We reset current_output to NULL first so that the old file is closed
-      // before the new one is opened.
-      current_output.reset();
-      current_output.reset(generator_context->Open(output_file.name()));
-    } else if (current_output == NULL) {
-      *error = strings::Substitute(
-        "$0: First file chunk returned by plugin did not specify a file name.",
-        plugin_name);
-      return false;
-    }
+			// Use CodedOutputStream for convenience; otherwise we'd need to provide
+			// our own buffer-copying loop.
+			io::CodedOutputStream writer(current_output.get());
+			writer.WriteString(output_file.content());
+		} else {
+			// Generate to stdout
+			string header = "Generating file to stdout: ";	
+			int hLineSize = header.length() + output_file.name().length();
+			string hLine = "";
+			for(int j = 0; j < hLineSize; j++){
+				hLine += "-";
+			}
 
-    // Use CodedOutputStream for convenience; otherwise we'd need to provide
-    // our own buffer-copying loop.
-    io::CodedOutputStream writer(current_output.get());
-    writer.WriteString(output_file.content());
-  }
+			// Write header and generate file contents to stdout
+			cout << hLine << endl << hLine << endl;
+			cout << header + output_file.name() << endl;
+			cout << hLine << endl << hLine << endl;
+			cout << output_file.content() << endl;
+		}
+	}
 
   // Check for errors.
   if (!response.error().empty()) {

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -203,6 +203,7 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   // Return status for ParseArguments() and InterpretArgument().
   enum ParseArgumentStatus {
     PARSE_ARGUMENT_DONE_AND_CONTINUE,
+		PARSE_ARGUMENT_DONE_AND_CONTINUE_STDOUT,
     PARSE_ARGUMENT_DONE_AND_EXIT,
     PARSE_ARGUMENT_FAIL
   };
@@ -344,6 +345,9 @@ class LIBPROTOC_EXPORT CommandLineInterface {
     string output_location;
   };
   vector<OutputDirective> output_directives_;
+
+	// False by default
+	bool write_to_stdout;
 
   // When using --encode or --decode, this names the type we are encoding or
   // decoding.  (Empty string indicates --decode_raw.)

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -203,7 +203,6 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   // Return status for ParseArguments() and InterpretArgument().
   enum ParseArgumentStatus {
     PARSE_ARGUMENT_DONE_AND_CONTINUE,
-    PARSE_ARGUMENT_DONE_AND_CONTINUE_STDOUT,
     PARSE_ARGUMENT_DONE_AND_EXIT,
     PARSE_ARGUMENT_FAIL
   };

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -203,7 +203,7 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   // Return status for ParseArguments() and InterpretArgument().
   enum ParseArgumentStatus {
     PARSE_ARGUMENT_DONE_AND_CONTINUE,
-		PARSE_ARGUMENT_DONE_AND_CONTINUE_STDOUT,
+    PARSE_ARGUMENT_DONE_AND_CONTINUE_STDOUT,
     PARSE_ARGUMENT_DONE_AND_EXIT,
     PARSE_ARGUMENT_FAIL
   };
@@ -346,8 +346,8 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   };
   vector<OutputDirective> output_directives_;
 
-	// False by default
-	bool write_to_stdout;
+  // False by default
+  bool write_to_stdout;
 
   // When using --encode or --decode, this names the type we are encoding or
   // decoding.  (Empty string indicates --decode_raw.)


### PR DESCRIPTION
Here is an optional flag that allows for writing directly to stdout. Was thinking of using the stdout file descriptor, but realized the portability may be of some issues there. Unsure of it. 
So, instead, just used cout.

Also, I noticed that all arguments require a value. I am thinking of changing this, but this is a little more work.

protoc --<output>=. --stdout=true file.proto