### PR TITLE
Ruby implementation Map#inspect should be consistent with Hash#inspect

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -683,7 +683,7 @@ VALUE Map_inspect(VALUE _self) {
       first = false;
     }
     str = rb_str_append(str, rb_funcall(key, inspect_sym, 0));
-    str = rb_str_cat2(str, " => ");
+    str = rb_str_cat2(str, "=>");
     str = rb_str_append(str, rb_funcall(value, inspect_sym, 0));
   }
 

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -391,7 +391,7 @@ module BasicTest
       # We only assert on inspect value when there is one map entry because the
       # order in which elements appear is unspecified (depends on the internal
       # hash function). We don't want a brittle test.
-      assert m.inspect == "{\"jkl;\" => 42}"
+      assert m.inspect == "{\"jkl;\"=>42}"
 
       assert m.keys == ["jkl;"]
       assert m.values == [42]


### PR DESCRIPTION
```ruby
map = Google::Protobuf::Map.new
map["foo"]  = "bar"
map == {"foo" => "bar"}
# => true
# however
map.inspect
# => "{\"foo\" => \"bar\"}"
{"foo" => "bar"}.inspect
# => "{\"foo\"=>\"bar\"}"
```

I think it's better to conserve the consistency here.