### PR TITLE
Update Ruby gem version to 3.0.0.alpha.2.0.

### DIFF
--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -7,7 +7,7 @@ end
 
 Gem::Specification.new do |s|
   s.name        = "google-protobuf"
-  s.version     = "3.0.0.alpha.2"
+  s.version     = "3.0.0.alpha.2.0"
   s.licenses    = ["BSD"]
   s.summary     = "Protocol Buffers"
   s.description = "Protocol Buffers are Google's data interchange format."


### PR DESCRIPTION
This update conforms to our two-numbers-after-alpha scheme that allows
us to bump the last number if we need to re-upload a gem. (Rubygems does
not allow re-use of a version number once a gem is uploaded.)