### PR TITLE
Correct JavaDoc return value documentation for Parser#parseDelimitedFrom...

### DIFF
--- a/java/src/main/java/com/google/protobuf/Parser.java
+++ b/java/src/main/java/com/google/protobuf/Parser.java
@@ -227,8 +227,8 @@ public interface Parser<MessageType> {
    * {@link MessageLite#writeDelimitedTo(java.io.OutputStream)} to write
    * messages in this format.
    *
-   * @return True if successful, or false if the stream is at EOF when the
-   *         method starts. Any other error (including reaching EOF during
+   * @return Parsed message if successful, or null if the stream is at EOF when
+   *         the method starts. Any other error (including reaching EOF during
    *         parsing) will cause an exception to be thrown.
    */
   public MessageType parseDelimitedFrom(InputStream input)


### PR DESCRIPTION
....

In `Parser#parseDelimitedFrom`, the JavaDoc states that the return value is `true` or `false`.  This is incorrect, because the return type of the method is not `boolean`.  Otherwise, the description of the behavior with respect to EOF is accurate.  We can correct this by changing the text to mention that `null` is a possible return value.