### PR TITLE
Add Objective C keywords to C++ keyword list

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -70,7 +70,11 @@ const char* const kKeywordList[] = {
   "return", "short", "signed", "sizeof", "static", "static_assert",
   "static_cast", "struct", "switch", "template", "this", "thread_local",
   "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned",
-  "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
+  "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq",
+  // OBJECTIVE C KEYWORDS AND MACROS
+  "__autoreleasing", "__strong", "__unsafe_unretained", "__weak", "id", "Class",
+  "_cmd", "BOOL", "BSD", "bycopy", "byref", "IMP", "In", "inout", "Nil", "nil",
+  "NO", "oneway", "out", "SEL", "self", "super", "YES"
 };
 
 hash_set<string> MakeKeywordsMap() {


### PR DESCRIPTION
Many Objective C users rely on the C++ generated code to use protobufs in objective C.

See https://www.safaribooksonline.com/library/view/learning-objective-c-20/9780133047462/app01.html for a listing of keywords.
