### PR TITLE
adding globals() to exec call for python3 compatibility

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -52,7 +52,7 @@ def GetVersion():
 
   """
   with open(os.path.join('google', 'protobuf', '__init__.py')) as version_file:
-    exec(version_file.read())
+    exec(version_file.read(),globals())
     return __version__
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -52,7 +52,7 @@ def GetVersion():
 
   """
   with open(os.path.join('google', 'protobuf', '__init__.py')) as version_file:
-    exec(version_file.read(),globals())
+    exec(version_file.read(), globals())
     return __version__
 
 


### PR DESCRIPTION
The recent change in setup.py breaks compatibility with python3. passing globals() to exec provides the same behavior across python 2 and python 3.

http://stackoverflow.com/questions/24733831/using-a-function-defined-in-an-execed-string-in-python-3