### PR TITLE
A few fix-ups for protoc-artifacts

### DIFF
--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -63,9 +63,6 @@ deployment for all platforms. Currently the following platforms are supported:
  - MSYS with MinGW32 (x86_32 only)
 - MacOSX (x86_32 and x86_64)
 
-Remove any ``SNAPSHOT`` or ``pre`` suffix from the version string before
-deploying.
-
 Use the following command to deploy artifacts for the host platform to a
 staging repository.
 ```
@@ -118,3 +115,10 @@ stored:
   </activeProfiles>
 </settings>
 ```
+
+### Tested build environments
+We have succesfully built artifacts on the following environments:
+- Linux x86_32 and x86_64: Ubuntu 14.04.2 64-bit
+- Windows x86_32: MSYS with ``mingw32-gcc-g++ 4.8.1-4`` on Windows 7 64-bit
+- Windows x86_64: Cygwin64 with ``mingw64-x86_64-gcc-g++ 4.8.3-1`` on Windows 7 64-bit
+- Mac OS X x86_32 and x86_64: Mac OS X 10.9.5

--- a/protoc-artifacts/build-protoc.sh
+++ b/protoc-artifacts/build-protoc.sh
@@ -158,6 +158,9 @@ if [[ "$(uname)" == CYGWIN* ]]; then
 elif [[ "$(uname)" == MINGW32* ]]; then
   assertEq "$OS" windows $LINENO
   assertEq "$ARCH" x86_32 $LINENO
+elif [[ "$(uname)" == MINGW64* ]]; then
+  assertEq "$OS" windows $LINENO
+  assertEq "$ARCH" x86_64 $LINENO
 elif [[ "$(uname)" == Linux* ]]; then
   if [[ "$OS" == linux ]]; then
     if [[ "$ARCH" == x86_64 ]]; then
@@ -209,7 +212,7 @@ export CXXFLAGS LDFLAGS
 TARGET_FILE=target/protoc.exe
 
 cd "$WORKING_DIR"/.. && ./configure $CONFIGURE_ARGS &&
-  cd src && make clean && make $MAKE_TARGET &&
+  cd src && make clean && make google/protobuf/stubs/pbconfig.h $MAKE_TARGET &&
   cd "$WORKING_DIR" && mkdir -p target &&
   (cp ../src/protoc $TARGET_FILE || cp ../src/protoc.exe $TARGET_FILE) ||
   exit 1


### PR DESCRIPTION
1. make google/protobuf/stubs/pbconfig.h before making protoc, otherwise it
won't build a freshly checked-out code.
2. Document the build environments that have been tested to work.
3. Add support for MINGW64
@pherl please review