### PR TITLE
[WIP] Use `Integral` abc when checking for integer types

### DIFF
--- a/python/google/protobuf/internal/type_checkers.py
+++ b/python/google/protobuf/internal/type_checkers.py
@@ -49,6 +49,7 @@ TYPE_TO_DESERIALIZE_METHOD: A dictionary with field types and deserialization
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
+from numbers import Integral
 import sys  ##PY25
 if sys.version < '2.6': bytes = str  ##PY25
 from google.protobuf.internal import api_implementation
@@ -117,7 +118,7 @@ class IntValueChecker(object):
   """Checker used for integer fields.  Performs type-check and range check."""
 
   def CheckValue(self, proposed_value):
-    if not isinstance(proposed_value, (int, long)):
+    if not isinstance(proposed_value, Integral):
       message = ('%.1024r has type %s, but expected one of: %s' %
                  (proposed_value, type(proposed_value), (int, long)))
       raise TypeError(message)
@@ -138,7 +139,7 @@ class EnumValueChecker(object):
     self._enum_type = enum_type
 
   def CheckValue(self, proposed_value):
-    if not isinstance(proposed_value, (int, long)):
+    if not isinstance(proposed_value, Integral):
       message = ('%.1024r has type %s, but expected one of: %s' %
                  (proposed_value, type(proposed_value), (int, long)))
       raise TypeError(message)


### PR DESCRIPTION
Allows for 3rd party libraries (like numpy) to register other integer types