### PR TITLE
Fix unittest in i386

### DIFF
--- a/src/google/protobuf/wire_format_unittest.cc
+++ b/src/google/protobuf/wire_format_unittest.cc
@@ -767,7 +767,7 @@ TEST(WireFormatTest, RepeatedScalarsDifferentTagSizes) {
 }
 
 TEST(WireFormatTest, CompatibleTypes) {
-  const int64 data = 0x100000000;
+  const int64 data = 0x100000000LL;
   unittest::Int64Message msg1;
   msg1.set_data(data);
   string serialized;


### PR DESCRIPTION
This change fixes unittest in i386 while working in x86_64 builds. Without it "integer constant is too large for 'long' type" is reported. Tested on linux gcc 4.1.2 and gcc 4.4.6. 