### PR TITLE
Generate pbconfig.h in generate_descriptor_proto.sh

### DIFF
--- a/generate_descriptor_proto.sh
+++ b/generate_descriptor_proto.sh
@@ -27,6 +27,7 @@ __EOF__
 fi
 
 cd src
+make $@ google/protobuf/stubs/pbconfig.h
 CORE_PROTO_IS_CORRECT=0
 while [ $CORE_PROTO_IS_CORRECT -ne 1 ]
 do


### PR DESCRIPTION
pbconfig.h is needed to compile protoc in generate_descriptor_proto.sh. Previously, it was not auto-generated. Explicitly generate it now in generate_descriptor_proto.sh.