### PR TITLE
ruby: Add size to RepeatField

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -5,3 +5,4 @@ lib/google/protobuf_java.jar
 protobuf-jruby.iml
 target/
 pkg/
+tmp/

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -4,10 +4,11 @@ Gem::Specification.new do |s|
   s.licenses    = ["BSD"]
   s.summary     = "Protocol Buffers"
   s.description = "Protocol Buffers are Google's data interchange format."
+  s.homepage    = "https://developers.google.com/protocol-buffers"
   s.authors     = ["Protobuf Authors"]
   s.email       = "protobuf@googlegroups.com"
   s.require_paths = ["lib"]
-  s.files       = ["lib/google/protobuf.rb"]
+  s.files       = `git ls-files -z`.split("\x0").find_all{|f| f =~ /lib\/.+\.rb/}
   unless RUBY_PLATFORM == "java"
     s.files     += `git ls-files "*.c" "*.h" extconf.rb Makefile`.split
     s.extensions= ["ext/google/protobuf_c/extconf.rb"]

--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -28,11 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-if RUBY_PLATFORM == "java"
-  require 'json'
-  require 'google/protobuf_java'
-else
-  require 'google/protobuf_c'
-end
+# add syntatic sugar on top of the core library
+module Google
+  module Protobuf
+    class RepeatedField
 
-require 'google/protobuf/repeated_field'
+      alias_method :size, :length
+
+    end
+  end
+end

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -377,6 +377,18 @@ module BasicTest
       end
     end
 
+    def test_rptfield_array_ducktyping
+      l = Google::Protobuf::RepeatedField.new(:int32)
+      length_methods = %w(count length size)
+      length_methods.each do |lm|
+        assert l.send(lm)  == 0
+      end
+      l.push 4
+      length_methods.each do |lm|
+        assert l.send(lm)  == 1
+      end
+    end
+
     def test_map_basic
       # allowed key types:
       # :int32, :int64, :uint32, :uint64, :bool, :string, :bytes.
@@ -827,7 +839,6 @@ module BasicTest
       assert m['a.b'] == 4
     end
 
-
     def test_int_ranges
       m = TestMessage.new
 
@@ -933,7 +944,6 @@ module BasicTest
       assert_raise RangeError do
         m.optional_uint64 = 1.5
       end
-
     end
 
     def test_stress_test


### PR DESCRIPTION
initial steps to make RepeatedField act more like a ruby Array

Let me know if this approach of aliasing and adding syntactic sugar in the ruby lib, rather than duplicating the logic in C and Java, is acceptable.