### PR TITLE
fix problem in setup.py for python 3

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -52,8 +52,14 @@ def GetVersion():
 
   """
   with open(os.path.join('google', 'protobuf', '__init__.py')) as version_file:
-    exec(version_file.read())
-    return __version__
+    inifile = version_file.read()
+    if sys.version_info[0] >= 3:  # exec Can't reliably modify locals in python3
+        nsp = {}
+        exec(inifile, nsp, nsp)
+        return nsp['__version__']
+    else:
+        exec(inifile)
+        return __version__
 
 
 def generate_proto(source):


### PR DESCRIPTION
GetVersion failed for me under python3, because it relies on the exec operation modifying the locals of GetVersion. According to python docs, code executed by exec(str) can read the function's locals but modifications to them may not work.
The fix is to create a namespace and to read the result from the namespace (which is a good idea whenever exec is used; but here we need to avoid python2's syntax 'exec expr in ns'  in order to be python 3 compatible.

As I understand it, python 2 normally 'compiles' functions so that the locals aren't in a dictionary, eliminating name lookups;  supporting exec requires functions using exec to be compiled quite differently. I guess that was dropped in python3, and exec now fabricates a 'locals' dictionary, to support local access, but it can't propagate changes back (in particular, the exec function can't create locals which did not exist in the function at 'compile time').