### PR TITLE
Undef GOOGLE_PROTOBUF_MISSING_HASH after it is used.

### DIFF
--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -53,6 +53,7 @@ namespace google {
 namespace protobuf {
 
 #ifdef GOOGLE_PROTOBUF_MISSING_HASH
+#undef GOOGLE_PROTOBUF_MISSING_HASH
 
 // This system doesn't have hash_map or hash_set.  Emulate them using map and
 // set.
@@ -193,7 +194,6 @@ class hash_set
   hash_set(int = 0) {}
 };
 
-#undef GOOGLE_PROTOBUF_MISSING_HASH
 #endif  // !GOOGLE_PROTOBUF_MISSING_HASH
 
 template <>


### PR DESCRIPTION
This is a follow up CL for df184fba00acc7d4aa7b9d64693c53c815a64eda
(Id937e25bbb35968ee76c92bd4a8ce6247408c443), which added
  #undef GOOGLE_PROTOBUF_MISSING_HASH
where GOOGLE_PROTOBUF_MISSING_HASH macro is never defined.

With this CL, GOOGLE_PROTOBUF_MISSING_HASH macro will be cleaned up
after it is used.