### PR TITLE
Ruby generator: Use 'require_relative' instead of 'require'.

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -337,7 +337,7 @@ void GenerateFile(const google::protobuf::FileDescriptor* file,
   for (int i = 0; i < file->dependency_count(); i++) {
     const std::string& name = file->dependency(i)->name();
     printer->Print(
-      "require '$name$'\n", "name", StripDotProto(name));
+      "require_relative './$name$'\n", "name", StripDotProto(name));
   }
 
   printer->Print(


### PR DESCRIPTION
This fixes the (bad) assumption that the currently evaluated module's parent directory is in `$LOADPATH` and that `require` thus would be able to resolve dependencies.

Note that I'm not familiar enough with this project to know if `file->dependency(n)` actually always returns a relative path. If it does, this will not work, but I can amend the patch if that's necessary.