### PR TITLE
Convert back to using NUnit, which is now loaded via NuGet.

### DIFF
--- a/csharp/src/ProtocolBuffers.Test/AbstractMessageTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/AbstractMessageTest.cs
@@ -39,13 +39,13 @@ using System.Collections.Generic;
 using System.IO;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class AbstractMessageTest
     {
-        [Fact]
+        [Test]
         public void Clear()
         {
             AbstractMessageWrapper message =
@@ -53,7 +53,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertClear((TestAllTypes) message.WrappedMessage);
         }
 
-        [Fact]
+        [Test]
         public void Copy()
         {
             AbstractMessageWrapper message =
@@ -61,31 +61,31 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet((TestAllTypes) message.WrappedMessage);
         }
 
-        [Fact]
+        [Test]
         public void CreateAndBuild()
         {
             TestAllTypes.CreateBuilder()
                 .Build();
         }
 
-        [Fact]
+        [Test]
         public void SerializedSize()
         {
             TestAllTypes message = TestUtil.GetAllSet();
             IMessage abstractMessage = new AbstractMessageWrapper(TestUtil.GetAllSet());
 
-            Assert.Equal(message.SerializedSize, abstractMessage.SerializedSize);
+            Assert.AreEqual(message.SerializedSize, abstractMessage.SerializedSize);
         }
 
-        [Fact]
+        [Test]
         public void Serialization()
         {
             IMessage abstractMessage = new AbstractMessageWrapper(TestUtil.GetAllSet());
             TestUtil.AssertAllFieldsSet(TestAllTypes.ParseFrom(abstractMessage.ToByteString()));
-            Assert.Equal(TestUtil.GetAllSet().ToByteString(), abstractMessage.ToByteString());
+            Assert.AreEqual(TestUtil.GetAllSet().ToByteString(), abstractMessage.ToByteString());
         }
 
-        [Fact]
+        [Test]
         public void Parsing()
         {
             IBuilder builder = new AbstractMessageWrapper.Builder(TestAllTypes.CreateBuilder());
@@ -94,15 +94,15 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet((TestAllTypes) message.WrappedMessage);
         }
 
-        [Fact]
+        [Test]
         public void PackedSerialization()
         {
             IMessage abstractMessage = new AbstractMessageWrapper(TestUtil.GetPackedSet());
             TestUtil.AssertPackedFieldsSet(TestPackedTypes.ParseFrom(abstractMessage.ToByteString()));
-            Assert.Equal(TestUtil.GetPackedSet().ToByteString(), abstractMessage.ToByteString());
+            Assert.AreEqual(TestUtil.GetPackedSet().ToByteString(), abstractMessage.ToByteString());
         }
 
-        [Fact]
+        [Test]
         public void PackedParsing()
         {
             AbstractMessageWrapper.Builder builder = new AbstractMessageWrapper.Builder(TestPackedTypes.CreateBuilder());
@@ -110,7 +110,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertPackedFieldsSet((TestPackedTypes)message.WrappedMessage);
         }
 
-        [Fact]
+        [Test]
         public void UnpackedParsingOfPackedInput()
         {
             byte[] bytes = TestUtil.GetPackedSet().ToByteArray();
@@ -118,7 +118,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertUnpackedFieldsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void PackedParsingOfUnpackedInput()
         {
             byte[] bytes = TestUnpackedTypes.ParseFrom(TestUtil.GetPackedSet().ToByteArray()).ToByteArray();
@@ -126,7 +126,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertPackedFieldsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void UnpackedParsingOfPackedInputExtensions()
         {
             byte[] bytes = TestUtil.GetPackedSet().ToByteArray();
@@ -137,7 +137,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertUnpackedExtensionsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void PackedParsingOfUnpackedInputExtensions()
         {
             byte[] bytes = TestUnpackedTypes.ParseFrom(TestUtil.GetPackedSet().ToByteArray()).ToByteArray();
@@ -147,13 +147,13 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertPackedExtensionsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void OptimizedForSize()
         {
             // We're mostly only Checking that this class was compiled successfully.
             TestOptimizedForSize message = TestOptimizedForSize.CreateBuilder().SetI(1).Build();
             message = TestOptimizedForSize.ParseFrom(message.ToByteString());
-            Assert.Equal(2, message.SerializedSize);
+            Assert.AreEqual(2, message.SerializedSize);
         }
 
         // -----------------------------------------------------------------
@@ -164,40 +164,40 @@ namespace Google.ProtocolBuffers
         private static readonly TestRequired TestRequiredInitialized =
             TestRequired.CreateBuilder().SetA(1).SetB(2).SetC(3).Build();
 
-        [Fact]
+        [Test]
         public void IsInitialized()
         {
             TestRequired.Builder builder = TestRequired.CreateBuilder();
             AbstractMessageWrapper.Builder abstractBuilder = new AbstractMessageWrapper.Builder(builder);
 
-            Assert.False(abstractBuilder.IsInitialized);
+            Assert.IsFalse(abstractBuilder.IsInitialized);
             builder.A = 1;
-            Assert.False(abstractBuilder.IsInitialized);
+            Assert.IsFalse(abstractBuilder.IsInitialized);
             builder.B = 1;
-            Assert.False(abstractBuilder.IsInitialized);
+            Assert.IsFalse(abstractBuilder.IsInitialized);
             builder.C = 1;
-            Assert.True(abstractBuilder.IsInitialized);
+            Assert.IsTrue(abstractBuilder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void ForeignIsInitialized()
         {
             TestRequiredForeign.Builder builder = TestRequiredForeign.CreateBuilder();
             AbstractMessageWrapper.Builder abstractBuilder = new AbstractMessageWrapper.Builder(builder);
 
-            Assert.True(abstractBuilder.IsInitialized);
+            Assert.IsTrue(abstractBuilder.IsInitialized);
 
             builder.SetOptionalMessage(TestRequiredUninitialized);
-            Assert.False(abstractBuilder.IsInitialized);
+            Assert.IsFalse(abstractBuilder.IsInitialized);
 
             builder.SetOptionalMessage(TestRequiredInitialized);
-            Assert.True(abstractBuilder.IsInitialized);
+            Assert.IsTrue(abstractBuilder.IsInitialized);
 
             builder.AddRepeatedMessage(TestRequiredUninitialized);
-            Assert.False(abstractBuilder.IsInitialized);
+            Assert.IsFalse(abstractBuilder.IsInitialized);
 
             builder.SetRepeatedMessage(0, TestRequiredInitialized);
-            Assert.True(abstractBuilder.IsInitialized);
+            Assert.IsTrue(abstractBuilder.IsInitialized);
         }
 
         // -----------------------------------------------------------------
@@ -226,7 +226,7 @@ namespace Google.ProtocolBuffers
                                                "repeated_string: \"qux\"\n" +
                                                "repeated_string: \"bar\"\n";
 
-        [Fact]
+        [Test]
         public void MergeFrom()
         {
             AbstractMessageWrapper result = (AbstractMessageWrapper)
@@ -234,13 +234,13 @@ namespace Google.ProtocolBuffers
                                                 .MergeFrom(MergeSource)
                                                 .Build();
 
-            Assert.Equal(MergeResultText, result.ToString());
+            Assert.AreEqual(MergeResultText, result.ToString());
         }
 
         // -----------------------------------------------------------------
         // Tests for equals and hashCode
 
-        [Fact]
+        [Test]
         public void EqualsAndHashCode()
         {
             TestAllTypes a = TestUtil.GetAllSet();
@@ -296,7 +296,7 @@ namespace Google.ProtocolBuffers
         private static void CheckEqualsIsConsistent(IMessage message)
         {
             // Object should be equal to itself.
-            Assert.Equal(message, message);
+            Assert.AreEqual(message, message);
 
             // Object should be equal to a dynamic copy of itself.
             DynamicMessage dynamic = DynamicMessage.CreateBuilder(message).Build();
@@ -310,9 +310,9 @@ namespace Google.ProtocolBuffers
         {
             // Not using Assert.AreEqual as that checks for type equality, which isn't
             // what we want bearing in mind the dynamic message checks.
-            Assert.True(message1.Equals(message2));
-            Assert.True(message2.Equals(message1));
-            Assert.Equal(message2.GetHashCode(), message1.GetHashCode());
+            Assert.IsTrue(message1.Equals(message2));
+            Assert.IsTrue(message2.Equals(message1));
+            Assert.AreEqual(message2.GetHashCode(), message1.GetHashCode());
         }
 
         /// <summary>
@@ -326,10 +326,10 @@ namespace Google.ProtocolBuffers
         private static void CheckNotEqual(IMessage m1, IMessage m2)
         {
             String equalsError = string.Format("{0} should not be equal to {1}", m1, m2);
-            Assert.False(m1.Equals(m2), equalsError);
-            Assert.False(m2.Equals(m1), equalsError);
+            Assert.IsFalse(m1.Equals(m2), equalsError);
+            Assert.IsFalse(m2.Equals(m1), equalsError);
 
-            Assert.False(m1.GetHashCode() == m2.GetHashCode(),
+            Assert.IsFalse(m1.GetHashCode() == m2.GetHashCode(),
                            string.Format("{0} should have a different hash code from {1}", m1, m2));
         }
 

--- a/csharp/src/ProtocolBuffers.Test/ByteStringTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/ByteStringTest.cs
@@ -36,112 +36,112 @@
 
 using System;
 using System.Text;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class ByteStringTest
     {
-        [Fact]
+        [Test]
         public void EmptyByteStringHasZeroSize()
         {
-            Assert.Equal(0, ByteString.Empty.Length);
+            Assert.AreEqual(0, ByteString.Empty.Length);
         }
 
-        [Fact]
+        [Test]
         public void CopyFromStringWithExplicitEncoding()
         {
             ByteString bs = ByteString.CopyFrom("AB", Encoding.Unicode);
-            Assert.Equal(4, bs.Length);
-            Assert.Equal(65, bs[0]);
-            Assert.Equal(0, bs[1]);
-            Assert.Equal(66, bs[2]);
-            Assert.Equal(0, bs[3]);
+            Assert.AreEqual(4, bs.Length);
+            Assert.AreEqual(65, bs[0]);
+            Assert.AreEqual(0, bs[1]);
+            Assert.AreEqual(66, bs[2]);
+            Assert.AreEqual(0, bs[3]);
         }
 
-        [Fact]
+        [Test]
         public void IsEmptyWhenEmpty()
         {
-            Assert.True(ByteString.CopyFromUtf8("").IsEmpty);
+            Assert.IsTrue(ByteString.CopyFromUtf8("").IsEmpty);
         }
 
-        [Fact]
+        [Test]
         public void IsEmptyWhenNotEmpty()
         {
-            Assert.False(ByteString.CopyFromUtf8("X").IsEmpty);
+            Assert.IsFalse(ByteString.CopyFromUtf8("X").IsEmpty);
         }
 
-        [Fact]
+        [Test]
         public void CopyFromByteArrayCopiesContents()
         {
             byte[] data = new byte[1];
             data[0] = 10;
             ByteString bs = ByteString.CopyFrom(data);
-            Assert.Equal(10, bs[0]);
+            Assert.AreEqual(10, bs[0]);
             data[0] = 5;
-            Assert.Equal(10, bs[0]);
+            Assert.AreEqual(10, bs[0]);
         }
 
-        [Fact]
+        [Test]
         public void ToByteArrayCopiesContents()
         {
             ByteString bs = ByteString.CopyFromUtf8("Hello");
             byte[] data = bs.ToByteArray();
-            Assert.Equal((byte)'H', data[0]);
-            Assert.Equal((byte)'H', bs[0]);
+            Assert.AreEqual((byte)'H', data[0]);
+            Assert.AreEqual((byte)'H', bs[0]);
             data[0] = 0;
-            Assert.Equal(0, data[0]);
-            Assert.Equal((byte)'H', bs[0]);
+            Assert.AreEqual(0, data[0]);
+            Assert.AreEqual((byte)'H', bs[0]);
         }
 
-        [Fact]
+        [Test]
         public void CopyFromUtf8UsesUtf8()
         {
             ByteString bs = ByteString.CopyFromUtf8("\u20ac");
-            Assert.Equal(3, bs.Length);
-            Assert.Equal(0xe2, bs[0]);
-            Assert.Equal(0x82, bs[1]);
-            Assert.Equal(0xac, bs[2]);
+            Assert.AreEqual(3, bs.Length);
+            Assert.AreEqual(0xe2, bs[0]);
+            Assert.AreEqual(0x82, bs[1]);
+            Assert.AreEqual(0xac, bs[2]);
         }
 
-        [Fact]
+        [Test]
         public void CopyFromPortion()
         {
             byte[] data = new byte[] {0, 1, 2, 3, 4, 5, 6};
             ByteString bs = ByteString.CopyFrom(data, 2, 3);
-            Assert.Equal(3, bs.Length);
-            Assert.Equal(2, bs[0]);
-            Assert.Equal(3, bs[1]);
+            Assert.AreEqual(3, bs.Length);
+            Assert.AreEqual(2, bs[0]);
+            Assert.AreEqual(3, bs[1]);
         }
 
-        [Fact]
+        [Test]
         public void ToStringUtf8()
         {
             ByteString bs = ByteString.CopyFromUtf8("\u20ac");
-            Assert.Equal("\u20ac", bs.ToStringUtf8());
+            Assert.AreEqual("\u20ac", bs.ToStringUtf8());
         }
 
-        [Fact]
+        [Test]
         public void ToStringWithExplicitEncoding()
         {
             ByteString bs = ByteString.CopyFrom("\u20ac", Encoding.Unicode);
-            Assert.Equal("\u20ac", bs.ToString(Encoding.Unicode));
+            Assert.AreEqual("\u20ac", bs.ToString(Encoding.Unicode));
         }
 
-        [Fact]
+        [Test]
         public void FromBase64_WithText()
         {
             byte[] data = new byte[] {0, 1, 2, 3, 4, 5, 6};
             string base64 = Convert.ToBase64String(data);
             ByteString bs = ByteString.FromBase64(base64);
-            Assert.Equal(data, bs.ToByteArray());
+            Assert.AreEqual(data, bs.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void FromBase64_Empty()
         {
             // Optimization which also fixes issue 61.
-            Assert.Same(ByteString.Empty, ByteString.FromBase64(""));
+            Assert.AreSame(ByteString.Empty, ByteString.FromBase64(""));
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/CodedInputStreamTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/CodedInputStreamTest.cs
@@ -39,7 +39,7 @@ using System.Collections.Generic;
 using System.IO;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -66,21 +66,21 @@ namespace Google.ProtocolBuffers
         private static void AssertReadVarint(byte[] data, ulong value)
         {
             CodedInputStream input = CodedInputStream.CreateInstance(data);
-            Assert.Equal((uint) value, input.ReadRawVarint32());
+            Assert.AreEqual((uint) value, input.ReadRawVarint32());
 
             input = CodedInputStream.CreateInstance(data);
-            Assert.Equal(value, input.ReadRawVarint64());
-            Assert.True(input.IsAtEnd);
+            Assert.AreEqual(value, input.ReadRawVarint64());
+            Assert.IsTrue(input.IsAtEnd);
 
             // Try different block sizes.
             for (int bufferSize = 1; bufferSize <= 16; bufferSize *= 2)
             {
                 input = CodedInputStream.CreateInstance(new SmallBlockInputStream(data, bufferSize));
-                Assert.Equal((uint) value, input.ReadRawVarint32());
+                Assert.AreEqual((uint) value, input.ReadRawVarint32());
 
                 input = CodedInputStream.CreateInstance(new SmallBlockInputStream(data, bufferSize));
-                Assert.Equal(value, input.ReadRawVarint64());
-                Assert.True(input.IsAtEnd);
+                Assert.AreEqual(value, input.ReadRawVarint64());
+                Assert.IsTrue(input.IsAtEnd);
             }
 
             // Try reading directly from a MemoryStream. We want to verify that it
@@ -90,8 +90,8 @@ namespace Google.ProtocolBuffers
             memoryStream.Write(data, 0, data.Length);
             memoryStream.WriteByte(0);
             memoryStream.Position = 0;
-            Assert.Equal((uint) value, CodedInputStream.ReadRawVarint32(memoryStream));
-            Assert.Equal(data.Length, memoryStream.Position);
+            Assert.AreEqual((uint) value, CodedInputStream.ReadRawVarint32(memoryStream));
+            Assert.AreEqual(data.Length, memoryStream.Position);
         }
 
         /// <summary>
@@ -103,18 +103,18 @@ namespace Google.ProtocolBuffers
         {
             CodedInputStream input = CodedInputStream.CreateInstance(data);
             var exception = Assert.Throws<InvalidProtocolBufferException>(() => input.ReadRawVarint32());
-            Assert.Equal(expected.Message, exception.Message);
+            Assert.AreEqual(expected.Message, exception.Message);
 
             input = CodedInputStream.CreateInstance(data);
             exception = Assert.Throws<InvalidProtocolBufferException>(() => input.ReadRawVarint64());
-            Assert.Equal(expected.Message, exception.Message);
+            Assert.AreEqual(expected.Message, exception.Message);
 
             // Make sure we get the same error when reading directly from a Stream.
             exception = Assert.Throws<InvalidProtocolBufferException>(() => CodedInputStream.ReadRawVarint32(new MemoryStream(data)));
-            Assert.Equal(expected.Message, exception.Message);
+            Assert.AreEqual(expected.Message, exception.Message);
         }
 
-        [Fact]
+        [Test]
         public void ReadVarint()
         {
             AssertReadVarint(Bytes(0x00), 0);
@@ -159,16 +159,16 @@ namespace Google.ProtocolBuffers
         private static void AssertReadLittleEndian32(byte[] data, uint value)
         {
             CodedInputStream input = CodedInputStream.CreateInstance(data);
-            Assert.Equal(value, input.ReadRawLittleEndian32());
-            Assert.True(input.IsAtEnd);
+            Assert.AreEqual(value, input.ReadRawLittleEndian32());
+            Assert.IsTrue(input.IsAtEnd);
 
             // Try different block sizes.
             for (int blockSize = 1; blockSize <= 16; blockSize *= 2)
             {
                 input = CodedInputStream.CreateInstance(
                     new SmallBlockInputStream(data, blockSize));
-                Assert.Equal(value, input.ReadRawLittleEndian32());
-                Assert.True(input.IsAtEnd);
+                Assert.AreEqual(value, input.ReadRawLittleEndian32());
+                Assert.IsTrue(input.IsAtEnd);
             }
         }
 
@@ -179,20 +179,20 @@ namespace Google.ProtocolBuffers
         private static void AssertReadLittleEndian64(byte[] data, ulong value)
         {
             CodedInputStream input = CodedInputStream.CreateInstance(data);
-            Assert.Equal(value, input.ReadRawLittleEndian64());
-            Assert.True(input.IsAtEnd);
+            Assert.AreEqual(value, input.ReadRawLittleEndian64());
+            Assert.IsTrue(input.IsAtEnd);
 
             // Try different block sizes.
             for (int blockSize = 1; blockSize <= 16; blockSize *= 2)
             {
                 input = CodedInputStream.CreateInstance(
                     new SmallBlockInputStream(data, blockSize));
-                Assert.Equal(value, input.ReadRawLittleEndian64());
-                Assert.True(input.IsAtEnd);
+                Assert.AreEqual(value, input.ReadRawLittleEndian64());
+                Assert.IsTrue(input.IsAtEnd);
             }
         }
 
-        [Fact]
+        [Test]
         public void ReadLittleEndian()
         {
             AssertReadLittleEndian32(Bytes(0x78, 0x56, 0x34, 0x12), 0x12345678);
@@ -204,41 +204,41 @@ namespace Google.ProtocolBuffers
                 Bytes(0x78, 0x56, 0x34, 0x12, 0xf0, 0xde, 0xbc, 0x9a), 0x9abcdef012345678UL);
         }
 
-        [Fact]
+        [Test]
         public void DecodeZigZag32()
         {
-            Assert.Equal(0, CodedInputStream.DecodeZigZag32(0));
-            Assert.Equal(-1, CodedInputStream.DecodeZigZag32(1));
-            Assert.Equal(1, CodedInputStream.DecodeZigZag32(2));
-            Assert.Equal(-2, CodedInputStream.DecodeZigZag32(3));
-            Assert.Equal(0x3FFFFFFF, CodedInputStream.DecodeZigZag32(0x7FFFFFFE));
-            Assert.Equal(unchecked((int) 0xC0000000), CodedInputStream.DecodeZigZag32(0x7FFFFFFF));
-            Assert.Equal(0x7FFFFFFF, CodedInputStream.DecodeZigZag32(0xFFFFFFFE));
-            Assert.Equal(unchecked((int) 0x80000000), CodedInputStream.DecodeZigZag32(0xFFFFFFFF));
+            Assert.AreEqual(0, CodedInputStream.DecodeZigZag32(0));
+            Assert.AreEqual(-1, CodedInputStream.DecodeZigZag32(1));
+            Assert.AreEqual(1, CodedInputStream.DecodeZigZag32(2));
+            Assert.AreEqual(-2, CodedInputStream.DecodeZigZag32(3));
+            Assert.AreEqual(0x3FFFFFFF, CodedInputStream.DecodeZigZag32(0x7FFFFFFE));
+            Assert.AreEqual(unchecked((int) 0xC0000000), CodedInputStream.DecodeZigZag32(0x7FFFFFFF));
+            Assert.AreEqual(0x7FFFFFFF, CodedInputStream.DecodeZigZag32(0xFFFFFFFE));
+            Assert.AreEqual(unchecked((int) 0x80000000), CodedInputStream.DecodeZigZag32(0xFFFFFFFF));
         }
 
-        [Fact]
+        [Test]
         public void DecodeZigZag64()
         {
-            Assert.Equal(0, CodedInputStream.DecodeZigZag64(0));
-            Assert.Equal(-1, CodedInputStream.DecodeZigZag64(1));
-            Assert.Equal(1, CodedInputStream.DecodeZigZag64(2));
-            Assert.Equal(-2, CodedInputStream.DecodeZigZag64(3));
-            Assert.Equal(0x000000003FFFFFFFL, CodedInputStream.DecodeZigZag64(0x000000007FFFFFFEL));
-            Assert.Equal(unchecked((long) 0xFFFFFFFFC0000000L), CodedInputStream.DecodeZigZag64(0x000000007FFFFFFFL));
-            Assert.Equal(0x000000007FFFFFFFL, CodedInputStream.DecodeZigZag64(0x00000000FFFFFFFEL));
-            Assert.Equal(unchecked((long) 0xFFFFFFFF80000000L), CodedInputStream.DecodeZigZag64(0x00000000FFFFFFFFL));
-            Assert.Equal(0x7FFFFFFFFFFFFFFFL, CodedInputStream.DecodeZigZag64(0xFFFFFFFFFFFFFFFEL));
-            Assert.Equal(unchecked((long) 0x8000000000000000L), CodedInputStream.DecodeZigZag64(0xFFFFFFFFFFFFFFFFL));
+            Assert.AreEqual(0, CodedInputStream.DecodeZigZag64(0));
+            Assert.AreEqual(-1, CodedInputStream.DecodeZigZag64(1));
+            Assert.AreEqual(1, CodedInputStream.DecodeZigZag64(2));
+            Assert.AreEqual(-2, CodedInputStream.DecodeZigZag64(3));
+            Assert.AreEqual(0x000000003FFFFFFFL, CodedInputStream.DecodeZigZag64(0x000000007FFFFFFEL));
+            Assert.AreEqual(unchecked((long) 0xFFFFFFFFC0000000L), CodedInputStream.DecodeZigZag64(0x000000007FFFFFFFL));
+            Assert.AreEqual(0x000000007FFFFFFFL, CodedInputStream.DecodeZigZag64(0x00000000FFFFFFFEL));
+            Assert.AreEqual(unchecked((long) 0xFFFFFFFF80000000L), CodedInputStream.DecodeZigZag64(0x00000000FFFFFFFFL));
+            Assert.AreEqual(0x7FFFFFFFFFFFFFFFL, CodedInputStream.DecodeZigZag64(0xFFFFFFFFFFFFFFFEL));
+            Assert.AreEqual(unchecked((long) 0x8000000000000000L), CodedInputStream.DecodeZigZag64(0xFFFFFFFFFFFFFFFFL));
         }
 
-        [Fact]
+        [Test]
         public void ReadWholeMessage()
         {
             TestAllTypes message = TestUtil.GetAllSet();
 
             byte[] rawBytes = message.ToByteArray();
-            Assert.Equal(rawBytes.Length, message.SerializedSize);
+            Assert.AreEqual(rawBytes.Length, message.SerializedSize);
             TestAllTypes message2 = TestAllTypes.ParseFrom(rawBytes);
             TestUtil.AssertAllFieldsSet(message2);
 
@@ -250,7 +250,7 @@ namespace Google.ProtocolBuffers
             }
         }
 
-        [Fact]
+        [Test]
         public void SkipWholeMessage()
         {
             TestAllTypes message = TestUtil.GetAllSet();
@@ -267,8 +267,8 @@ namespace Google.ProtocolBuffers
             while (input1.ReadTag(out tag, out name))
             {
                 uint tag2;
-                Assert.True(input2.ReadTag(out tag2, out name));
-                Assert.Equal(tag, tag2);
+                Assert.IsTrue(input2.ReadTag(out tag2, out name));
+                Assert.AreEqual(tag, tag2);
 
                 unknownFields.MergeFieldFrom(tag, input1);
                 input2.SkipField();
@@ -279,7 +279,7 @@ namespace Google.ProtocolBuffers
         /// Test that a bug in SkipRawBytes has been fixed: if the skip
         /// skips exactly up to a limit, this should bnot break things
         /// </summary>
-        [Fact]
+        [Test]
         public void SkipRawBytesBug()
         {
             byte[] rawBytes = new byte[] {1, 2};
@@ -288,7 +288,7 @@ namespace Google.ProtocolBuffers
             int limit = input.PushLimit(1);
             input.SkipRawBytes(1);
             input.PopLimit(limit);
-            Assert.Equal(2, input.ReadRawByte());
+            Assert.AreEqual(2, input.ReadRawByte());
         }
 
         public void ReadHugeBlob()
@@ -311,7 +311,7 @@ namespace Google.ProtocolBuffers
             // reading.
             TestAllTypes message2 = TestAllTypes.ParseFrom(message.ToByteString().CreateCodedInput());
 
-            Assert.Equal(message.OptionalBytes, message2.OptionalBytes);
+            Assert.AreEqual(message.OptionalBytes, message2.OptionalBytes);
 
             // Make sure all the other fields were parsed correctly.
             TestAllTypes message3 = TestAllTypes.CreateBuilder(message2)
@@ -320,7 +320,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(message3);
         }
 
-        [Fact]
+        [Test]
         public void ReadMaliciouslyLargeBlob()
         {
             MemoryStream ms = new MemoryStream();
@@ -336,8 +336,8 @@ namespace Google.ProtocolBuffers
             CodedInputStream input = CodedInputStream.CreateInstance(ms);
             uint testtag;
             string ignore;
-            Assert.True(input.ReadTag(out testtag, out ignore));
-            Assert.Equal(tag, testtag);
+            Assert.IsTrue(input.ReadTag(out testtag, out ignore));
+            Assert.AreEqual(tag, testtag);
 
             ByteString bytes = null;
             // TODO(jonskeet): Should this be ArgumentNullException instead?
@@ -361,17 +361,17 @@ namespace Google.ProtocolBuffers
         {
             if (depth == 0)
             {
-                Assert.False(message.HasA);
-                Assert.Equal(5, message.I);
+                Assert.IsFalse(message.HasA);
+                Assert.AreEqual(5, message.I);
             }
             else
             {
-                Assert.True(message.HasA);
+                Assert.IsTrue(message.HasA);
                 AssertMessageDepth(message.A, depth - 1);
             }
         }
 
-        [Fact]
+        [Test]
         public void MaliciousRecursion()
         {
             ByteString data64 = MakeRecursiveMessage(64).ToByteString();
@@ -386,7 +386,7 @@ namespace Google.ProtocolBuffers
             Assert.Throws<InvalidProtocolBufferException>(() => TestRecursiveMessage.ParseFrom(input));
         }
 
-        [Fact]
+        [Test]
         public void SizeLimit()
         {
             // Have to use a Stream rather than ByteString.CreateCodedInput as SizeLimit doesn't
@@ -398,7 +398,7 @@ namespace Google.ProtocolBuffers
             Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.ParseFrom(input));
         }
 
-        [Fact]
+        [Test]
         public void ResetSizeCounter()
         {
             CodedInputStream input = CodedInputStream.CreateInstance(
@@ -419,7 +419,7 @@ namespace Google.ProtocolBuffers
         /// is thrown.  Instead, the invalid bytes are replaced with the Unicode
         /// "replacement character" U+FFFD.
         /// </summary>
-        [Fact]
+        [Test]
         public void ReadInvalidUtf8()
         {
             MemoryStream ms = new MemoryStream();
@@ -437,11 +437,11 @@ namespace Google.ProtocolBuffers
             uint testtag;
             string ignored;
 
-            Assert.True(input.ReadTag(out testtag, out ignored));
-            Assert.Equal(tag, testtag);
+            Assert.IsTrue(input.ReadTag(out testtag, out ignored));
+            Assert.AreEqual(tag, testtag);
             string text = null;
             input.ReadString(ref text);
-            Assert.Equal('\ufffd', text[0]);
+            Assert.AreEqual('\ufffd', text[0]);
         }
 
         /// <summary>
@@ -467,7 +467,7 @@ namespace Google.ProtocolBuffers
 
         enum TestNegEnum { None = 0, Value = -2 }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnum()
         {
             byte[] bytes = new byte[10] { 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 };
@@ -475,12 +475,12 @@ namespace Google.ProtocolBuffers
             object unk;
             TestNegEnum val = TestNegEnum.None;
 
-            Assert.True(input.ReadEnum(ref val, out unk));
-            Assert.True(input.IsAtEnd);
-            Assert.Equal(TestNegEnum.Value, val);
+            Assert.IsTrue(input.ReadEnum(ref val, out unk));
+            Assert.IsTrue(input.IsAtEnd);
+            Assert.AreEqual(TestNegEnum.Value, val);
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumPackedArray()
         {
             int arraySize = 1 + (10 * 5);
@@ -489,26 +489,26 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WritePackedInt32Array(8, "", arraySize, new int[] { 0, -1, -2, -3, -4, -5 });
 
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
 
             CodedInputStream input = CodedInputStream.CreateInstance(bytes);
             uint tag;
             string name;
-            Assert.True(input.ReadTag(out tag, out name));
+            Assert.IsTrue(input.ReadTag(out tag, out name));
 
             List<TestNegEnum> values = new List<TestNegEnum>();
             ICollection<object> unk;
             input.ReadEnumArray(tag, name, values, out unk);
 
-            Assert.Equal(2, values.Count);
-            Assert.Equal(TestNegEnum.None, values[0]);
-            Assert.Equal(TestNegEnum.Value, values[1]);
+            Assert.AreEqual(2, values.Count);
+            Assert.AreEqual(TestNegEnum.None, values[0]);
+            Assert.AreEqual(TestNegEnum.Value, values[1]);
 
             Assert.NotNull(unk);
-            Assert.Equal(4, unk.Count);
+            Assert.AreEqual(4, unk.Count);
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumArray()
         {
             int arraySize = 1 + 1 + (11 * 5);
@@ -517,27 +517,27 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WriteInt32Array(8, "", new int[] { 0, -1, -2, -3, -4, -5 });
 
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
 
             CodedInputStream input = CodedInputStream.CreateInstance(bytes);
             uint tag;
             string name;
-            Assert.True(input.ReadTag(out tag, out name));
+            Assert.IsTrue(input.ReadTag(out tag, out name));
 
             List<TestNegEnum> values = new List<TestNegEnum>();
             ICollection<object> unk;
             input.ReadEnumArray(tag, name, values, out unk);
 
-            Assert.Equal(2, values.Count);
-            Assert.Equal(TestNegEnum.None, values[0]);
-            Assert.Equal(TestNegEnum.Value, values[1]);
+            Assert.AreEqual(2, values.Count);
+            Assert.AreEqual(TestNegEnum.None, values[0]);
+            Assert.AreEqual(TestNegEnum.Value, values[1]);
 
             Assert.NotNull(unk);
-            Assert.Equal(4, unk.Count);
+            Assert.AreEqual(4, unk.Count);
         }
 
         //Issue 71:	CodedInputStream.ReadBytes go to slow path unnecessarily
-        [Fact]
+        [Test]
         public void TestSlowPathAvoidance()
         {
             using (var ms = new MemoryStream())
@@ -554,15 +554,15 @@ namespace Google.ProtocolBuffers
                 string ignore;
                 ByteString value;
 
-                Assert.True(input.ReadTag(out tag, out ignore));
-                Assert.Equal(1, WireFormat.GetTagFieldNumber(tag));
+                Assert.IsTrue(input.ReadTag(out tag, out ignore));
+                Assert.AreEqual(1, WireFormat.GetTagFieldNumber(tag));
                 value = ByteString.Empty;
-                Assert.True(input.ReadBytes(ref value) && value.Length == 100);
+                Assert.IsTrue(input.ReadBytes(ref value) && value.Length == 100);
 
-                Assert.True(input.ReadTag(out tag, out ignore));
-                Assert.Equal(2, WireFormat.GetTagFieldNumber(tag));
+                Assert.IsTrue(input.ReadTag(out tag, out ignore));
+                Assert.AreEqual(2, WireFormat.GetTagFieldNumber(tag));
                 value = ByteString.Empty;
-                Assert.True(input.ReadBytes(ref value) && value.Length == 100);
+                Assert.IsTrue(input.ReadBytes(ref value) && value.Length == 100);
             }
         }
     }

--- a/csharp/src/ProtocolBuffers.Test/CodedOutputStreamTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/CodedOutputStreamTest.cs
@@ -38,7 +38,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -57,9 +57,9 @@ namespace Google.ProtocolBuffers
                 CodedOutputStream output = CodedOutputStream.CreateInstance(rawOutput);
                 output.WriteRawVarint32((uint) value);
                 output.Flush();
-                Assert.Equal(data, rawOutput.ToArray());
+                Assert.AreEqual(data, rawOutput.ToArray());
                 // Also try computing size.
-                Assert.Equal(data.Length, CodedOutputStream.ComputeRawVarint32Size((uint) value));
+                Assert.AreEqual(data.Length, CodedOutputStream.ComputeRawVarint32Size((uint) value));
             }
 
             {
@@ -67,10 +67,10 @@ namespace Google.ProtocolBuffers
                 CodedOutputStream output = CodedOutputStream.CreateInstance(rawOutput);
                 output.WriteRawVarint64(value);
                 output.Flush();
-                Assert.Equal(data, rawOutput.ToArray());
+                Assert.AreEqual(data, rawOutput.ToArray());
 
                 // Also try computing size.
-                Assert.Equal(data.Length, CodedOutputStream.ComputeRawVarint64Size(value));
+                Assert.AreEqual(data.Length, CodedOutputStream.ComputeRawVarint64Size(value));
             }
 
             // Try different buffer sizes.
@@ -84,7 +84,7 @@ namespace Google.ProtocolBuffers
                         CodedOutputStream.CreateInstance(rawOutput, bufferSize);
                     output.WriteRawVarint32((uint) value);
                     output.Flush();
-                    Assert.Equal(data, rawOutput.ToArray());
+                    Assert.AreEqual(data, rawOutput.ToArray());
                 }
 
                 {
@@ -92,7 +92,7 @@ namespace Google.ProtocolBuffers
                     CodedOutputStream output = CodedOutputStream.CreateInstance(rawOutput, bufferSize);
                     output.WriteRawVarint64(value);
                     output.Flush();
-                    Assert.Equal(data, rawOutput.ToArray());
+                    Assert.AreEqual(data, rawOutput.ToArray());
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace Google.ProtocolBuffers
         /// <summary>
         /// Tests WriteRawVarint32() and WriteRawVarint64()
         /// </summary>
-        [Fact]
+        [Test]
         public void WriteVarint()
         {
             AssertWriteVarint(new byte[] {0x00}, 0);
@@ -142,7 +142,7 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(rawOutput);
             output.WriteRawLittleEndian32(value);
             output.Flush();
-            Assert.Equal(data, rawOutput.ToArray());
+            Assert.AreEqual(data, rawOutput.ToArray());
 
             // Try different buffer sizes.
             for (int bufferSize = 1; bufferSize <= 16; bufferSize *= 2)
@@ -151,7 +151,7 @@ namespace Google.ProtocolBuffers
                 output = CodedOutputStream.CreateInstance(rawOutput, bufferSize);
                 output.WriteRawLittleEndian32(value);
                 output.Flush();
-                Assert.Equal(data, rawOutput.ToArray());
+                Assert.AreEqual(data, rawOutput.ToArray());
             }
         }
 
@@ -165,7 +165,7 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(rawOutput);
             output.WriteRawLittleEndian64(value);
             output.Flush();
-            Assert.Equal(data, rawOutput.ToArray());
+            Assert.AreEqual(data, rawOutput.ToArray());
 
             // Try different block sizes.
             for (int blockSize = 1; blockSize <= 16; blockSize *= 2)
@@ -174,14 +174,14 @@ namespace Google.ProtocolBuffers
                 output = CodedOutputStream.CreateInstance(rawOutput, blockSize);
                 output.WriteRawLittleEndian64(value);
                 output.Flush();
-                Assert.Equal(data, rawOutput.ToArray());
+                Assert.AreEqual(data, rawOutput.ToArray());
             }
         }
 
         /// <summary>
         /// Tests writeRawLittleEndian32() and writeRawLittleEndian64().
         /// </summary>
-        [Fact]
+        [Test]
         public void WriteLittleEndian()
         {
             AssertWriteLittleEndian32(new byte[] {0x78, 0x56, 0x34, 0x12}, 0x12345678);
@@ -195,7 +195,7 @@ namespace Google.ProtocolBuffers
                 0x9abcdef012345678UL);
         }
 
-        [Fact]
+        [Test]
         public void WriteWholeMessage()
         {
             TestAllTypes message = TestUtil.GetAllSet();
@@ -219,7 +219,7 @@ namespace Google.ProtocolBuffers
         /// Tests writing a whole message with every packed field type. Ensures the
         /// wire format of packed fields is compatible with C++.
         /// </summary>
-        [Fact]
+        [Test]
         public void WriteWholePackedFieldsMessage()
         {
             TestPackedTypes message = TestUtil.GetPackedSet();
@@ -229,97 +229,97 @@ namespace Google.ProtocolBuffers
                                       rawBytes);
         }
 
-        [Fact]
+        [Test]
         public void EncodeZigZag32()
         {
-            Assert.Equal(0u, CodedOutputStream.EncodeZigZag32(0));
-            Assert.Equal(1u, CodedOutputStream.EncodeZigZag32(-1));
-            Assert.Equal(2u, CodedOutputStream.EncodeZigZag32(1));
-            Assert.Equal(3u, CodedOutputStream.EncodeZigZag32(-2));
-            Assert.Equal(0x7FFFFFFEu, CodedOutputStream.EncodeZigZag32(0x3FFFFFFF));
-            Assert.Equal(0x7FFFFFFFu, CodedOutputStream.EncodeZigZag32(unchecked((int) 0xC0000000)));
-            Assert.Equal(0xFFFFFFFEu, CodedOutputStream.EncodeZigZag32(0x7FFFFFFF));
-            Assert.Equal(0xFFFFFFFFu, CodedOutputStream.EncodeZigZag32(unchecked((int) 0x80000000)));
+            Assert.AreEqual(0u, CodedOutputStream.EncodeZigZag32(0));
+            Assert.AreEqual(1u, CodedOutputStream.EncodeZigZag32(-1));
+            Assert.AreEqual(2u, CodedOutputStream.EncodeZigZag32(1));
+            Assert.AreEqual(3u, CodedOutputStream.EncodeZigZag32(-2));
+            Assert.AreEqual(0x7FFFFFFEu, CodedOutputStream.EncodeZigZag32(0x3FFFFFFF));
+            Assert.AreEqual(0x7FFFFFFFu, CodedOutputStream.EncodeZigZag32(unchecked((int) 0xC0000000)));
+            Assert.AreEqual(0xFFFFFFFEu, CodedOutputStream.EncodeZigZag32(0x7FFFFFFF));
+            Assert.AreEqual(0xFFFFFFFFu, CodedOutputStream.EncodeZigZag32(unchecked((int) 0x80000000)));
         }
 
-        [Fact]
+        [Test]
         public void EncodeZigZag64()
         {
-            Assert.Equal(0u, CodedOutputStream.EncodeZigZag64(0));
-            Assert.Equal(1u, CodedOutputStream.EncodeZigZag64(-1));
-            Assert.Equal(2u, CodedOutputStream.EncodeZigZag64(1));
-            Assert.Equal(3u, CodedOutputStream.EncodeZigZag64(-2));
-            Assert.Equal(0x000000007FFFFFFEuL,
+            Assert.AreEqual(0u, CodedOutputStream.EncodeZigZag64(0));
+            Assert.AreEqual(1u, CodedOutputStream.EncodeZigZag64(-1));
+            Assert.AreEqual(2u, CodedOutputStream.EncodeZigZag64(1));
+            Assert.AreEqual(3u, CodedOutputStream.EncodeZigZag64(-2));
+            Assert.AreEqual(0x000000007FFFFFFEuL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0x000000003FFFFFFFUL)));
-            Assert.Equal(0x000000007FFFFFFFuL,
+            Assert.AreEqual(0x000000007FFFFFFFuL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0xFFFFFFFFC0000000UL)));
-            Assert.Equal(0x00000000FFFFFFFEuL,
+            Assert.AreEqual(0x00000000FFFFFFFEuL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0x000000007FFFFFFFUL)));
-            Assert.Equal(0x00000000FFFFFFFFuL,
+            Assert.AreEqual(0x00000000FFFFFFFFuL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0xFFFFFFFF80000000UL)));
-            Assert.Equal(0xFFFFFFFFFFFFFFFEL,
+            Assert.AreEqual(0xFFFFFFFFFFFFFFFEL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0x7FFFFFFFFFFFFFFFUL)));
-            Assert.Equal(0xFFFFFFFFFFFFFFFFL,
+            Assert.AreEqual(0xFFFFFFFFFFFFFFFFL,
                             CodedOutputStream.EncodeZigZag64(unchecked((long) 0x8000000000000000UL)));
         }
 
-        [Fact]
+        [Test]
         public void RoundTripZigZag32()
         {
             // Some easier-to-verify round-trip tests.  The inputs (other than 0, 1, -1)
             // were chosen semi-randomly via keyboard bashing.
-            Assert.Equal(0, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(0)));
-            Assert.Equal(1, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(1)));
-            Assert.Equal(-1, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(-1)));
-            Assert.Equal(14927, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(14927)));
-            Assert.Equal(-3612, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(-3612)));
+            Assert.AreEqual(0, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(0)));
+            Assert.AreEqual(1, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(1)));
+            Assert.AreEqual(-1, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(-1)));
+            Assert.AreEqual(14927, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(14927)));
+            Assert.AreEqual(-3612, CodedInputStream.DecodeZigZag32(CodedOutputStream.EncodeZigZag32(-3612)));
         }
 
-        [Fact]
+        [Test]
         public void RoundTripZigZag64()
         {
-            Assert.Equal(0, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(0)));
-            Assert.Equal(1, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(1)));
-            Assert.Equal(-1, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(-1)));
-            Assert.Equal(14927, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(14927)));
-            Assert.Equal(-3612, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(-3612)));
+            Assert.AreEqual(0, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(0)));
+            Assert.AreEqual(1, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(1)));
+            Assert.AreEqual(-1, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(-1)));
+            Assert.AreEqual(14927, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(14927)));
+            Assert.AreEqual(-3612, CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(-3612)));
 
-            Assert.Equal(856912304801416L,
+            Assert.AreEqual(856912304801416L,
                             CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(856912304801416L)));
-            Assert.Equal(-75123905439571256L,
+            Assert.AreEqual(-75123905439571256L,
                             CodedInputStream.DecodeZigZag64(CodedOutputStream.EncodeZigZag64(-75123905439571256L)));
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumNoTag()
         {
-            Assert.Equal(10, CodedOutputStream.ComputeInt32SizeNoTag(-2));
-            Assert.Equal(10, CodedOutputStream.ComputeEnumSizeNoTag(-2));
+            Assert.AreEqual(10, CodedOutputStream.ComputeInt32SizeNoTag(-2));
+            Assert.AreEqual(10, CodedOutputStream.ComputeEnumSizeNoTag(-2));
 
             byte[] bytes = new byte[10];
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WriteEnumNoTag(-2);
 
-            Assert.Equal(0, output.SpaceLeft);
-            Assert.Equal("FE-FF-FF-FF-FF-FF-FF-FF-FF-01", BitConverter.ToString(bytes));
+            Assert.AreEqual(0, output.SpaceLeft);
+            Assert.AreEqual("FE-FF-FF-FF-FF-FF-FF-FF-FF-01", BitConverter.ToString(bytes));
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumWithTag()
         {
-            Assert.Equal(11, CodedOutputStream.ComputeInt32Size(8, -2));
-            Assert.Equal(11, CodedOutputStream.ComputeEnumSize(8, -2));
+            Assert.AreEqual(11, CodedOutputStream.ComputeInt32Size(8, -2));
+            Assert.AreEqual(11, CodedOutputStream.ComputeEnumSize(8, -2));
 
             byte[] bytes = new byte[11];
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WriteEnum(8, "", -2, -2);
 
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
             //fyi, 0x40 == 0x08 << 3 + 0, field num + wire format shift
-            Assert.Equal("40-FE-FF-FF-FF-FF-FF-FF-FF-FF-01", BitConverter.ToString(bytes));
+            Assert.AreEqual("40-FE-FF-FF-FF-FF-FF-FF-FF-FF-01", BitConverter.ToString(bytes));
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumArrayPacked()
         {
             int arraySize = 1 + (10 * 5);
@@ -328,22 +328,22 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WritePackedEnumArray(8, "", arraySize, new int[] { 0, -1, -2, -3, -4, -5 });
 
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
 
             CodedInputStream input = CodedInputStream.CreateInstance(bytes);
             uint tag;
             string name;
-            Assert.True(input.ReadTag(out tag, out name));
+            Assert.IsTrue(input.ReadTag(out tag, out name));
 
             List<int> values = new List<int>();
             input.ReadInt32Array(tag, name, values);
 
-            Assert.Equal(6, values.Count);
+            Assert.AreEqual(6, values.Count);
             for (int i = 0; i > -6; i--)
-                Assert.Equal(i, values[Math.Abs(i)]);
+                Assert.AreEqual(i, values[Math.Abs(i)]);
         }
 
-        [Fact]
+        [Test]
         public void TestNegativeEnumArray()
         {
             int arraySize = 1 + 1 + (11 * 5);
@@ -352,22 +352,22 @@ namespace Google.ProtocolBuffers
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
             output.WriteEnumArray(8, "", new int[] { 0, -1, -2, -3, -4, -5 });
 
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
 
             CodedInputStream input = CodedInputStream.CreateInstance(bytes);
             uint tag;
             string name;
-            Assert.True(input.ReadTag(out tag, out name));
+            Assert.IsTrue(input.ReadTag(out tag, out name));
 
             List<int> values = new List<int>();
             input.ReadInt32Array(tag, name, values);
 
-            Assert.Equal(6, values.Count);
+            Assert.AreEqual(6, values.Count);
             for (int i = 0; i > -6; i--)
-                Assert.Equal(i, values[Math.Abs(i)]);
+                Assert.AreEqual(i, values[Math.Abs(i)]);
         }
 
-        [Fact]
+        [Test]
         public void TestCodedInputOutputPosition()
         {
             byte[] content = new byte[110];
@@ -380,19 +380,19 @@ namespace Google.ProtocolBuffers
                 CodedOutputStream cout = CodedOutputStream.CreateInstance(ms, 20);
                 // Field 11: numeric value: 500
                 cout.WriteTag(11, WireFormat.WireType.Varint);
-                Assert.Equal(1, cout.Position);
+                Assert.AreEqual(1, cout.Position);
                 cout.WriteInt32NoTag(500);
-                Assert.Equal(3, cout.Position);
+                Assert.AreEqual(3, cout.Position);
                 //Field 12: length delimited 120 bytes
                 cout.WriteTag(12, WireFormat.WireType.LengthDelimited);
-                Assert.Equal(4, cout.Position);
+                Assert.AreEqual(4, cout.Position);
                 cout.WriteBytesNoTag(ByteString.CopyFrom(content));
-                Assert.Equal(115, cout.Position);
+                Assert.AreEqual(115, cout.Position);
                 // Field 13: fixed numeric value: 501
                 cout.WriteTag(13, WireFormat.WireType.Fixed32);
-                Assert.Equal(116, cout.Position);
+                Assert.AreEqual(116, cout.Position);
                 cout.WriteSFixed32NoTag(501);
-                Assert.Equal(120, cout.Position);
+                Assert.AreEqual(120, cout.Position);
                 cout.Flush();
             }
 
@@ -401,19 +401,19 @@ namespace Google.ProtocolBuffers
                 CodedOutputStream cout = CodedOutputStream.CreateInstance(bytes);
                 // Field 1: numeric value: 500
                 cout.WriteTag(1, WireFormat.WireType.Varint);
-                Assert.Equal(1, cout.Position);
+                Assert.AreEqual(1, cout.Position);
                 cout.WriteInt32NoTag(500);
-                Assert.Equal(3, cout.Position);
+                Assert.AreEqual(3, cout.Position);
                 //Field 2: length delimited 120 bytes
                 cout.WriteTag(2, WireFormat.WireType.LengthDelimited);
-                Assert.Equal(4, cout.Position);
+                Assert.AreEqual(4, cout.Position);
                 cout.WriteBytesNoTag(ByteString.CopyFrom(child));
-                Assert.Equal(125, cout.Position);
+                Assert.AreEqual(125, cout.Position);
                 // Field 3: fixed numeric value: 500
                 cout.WriteTag(3, WireFormat.WireType.Fixed32);
-                Assert.Equal(126, cout.Position);
+                Assert.AreEqual(126, cout.Position);
                 cout.WriteSFixed32NoTag(501);
-                Assert.Equal(130, cout.Position);
+                Assert.AreEqual(130, cout.Position);
                 cout.Flush();
             }
             //Now test Input stream:
@@ -422,49 +422,49 @@ namespace Google.ProtocolBuffers
                 uint tag;
                 int intValue = 0;
                 string ignore;
-                Assert.Equal(0, cin.Position);
+                Assert.AreEqual(0, cin.Position);
                 // Field 1:
-                Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 1);
-                Assert.Equal(1, cin.Position);
-                Assert.True(cin.ReadInt32(ref intValue) && intValue == 500);
-                Assert.Equal(3, cin.Position);
+                Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 1);
+                Assert.AreEqual(1, cin.Position);
+                Assert.IsTrue(cin.ReadInt32(ref intValue) && intValue == 500);
+                Assert.AreEqual(3, cin.Position);
                 //Field 2:
-                Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 2);
-                Assert.Equal(4, cin.Position);
+                Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 2);
+                Assert.AreEqual(4, cin.Position);
                 uint childlen = cin.ReadRawVarint32();
-                Assert.Equal(120u, childlen);
-                Assert.Equal(5, cin.Position);
+                Assert.AreEqual(120u, childlen);
+                Assert.AreEqual(5, cin.Position);
                 int oldlimit = cin.PushLimit((int)childlen);
-                Assert.Equal(5, cin.Position);
+                Assert.AreEqual(5, cin.Position);
                 // Now we are reading child message
                 {
                     // Field 11: numeric value: 500
-                    Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 11);
-                    Assert.Equal(6, cin.Position);
-                    Assert.True(cin.ReadInt32(ref intValue) && intValue == 500);
-                    Assert.Equal(8, cin.Position);
+                    Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 11);
+                    Assert.AreEqual(6, cin.Position);
+                    Assert.IsTrue(cin.ReadInt32(ref intValue) && intValue == 500);
+                    Assert.AreEqual(8, cin.Position);
                     //Field 12: length delimited 120 bytes
-                    Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 12);
-                    Assert.Equal(9, cin.Position);
+                    Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 12);
+                    Assert.AreEqual(9, cin.Position);
                     ByteString bstr = null;
-                    Assert.True(cin.ReadBytes(ref bstr) && bstr.Length == 110 && bstr.ToByteArray()[109] == 109);
-                    Assert.Equal(120, cin.Position);
+                    Assert.IsTrue(cin.ReadBytes(ref bstr) && bstr.Length == 110 && bstr.ToByteArray()[109] == 109);
+                    Assert.AreEqual(120, cin.Position);
                     // Field 13: fixed numeric value: 501
-                    Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 13);
+                    Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 13);
                     // ROK - Previously broken here, this returned 126 failing to account for bufferSizeAfterLimit
-                    Assert.Equal(121, cin.Position);
-                    Assert.True(cin.ReadSFixed32(ref intValue) && intValue == 501);
-                    Assert.Equal(125, cin.Position);
-                    Assert.True(cin.IsAtEnd);
+                    Assert.AreEqual(121, cin.Position);
+                    Assert.IsTrue(cin.ReadSFixed32(ref intValue) && intValue == 501);
+                    Assert.AreEqual(125, cin.Position);
+                    Assert.IsTrue(cin.IsAtEnd);
                 }
                 cin.PopLimit(oldlimit);
-                Assert.Equal(125, cin.Position);
+                Assert.AreEqual(125, cin.Position);
                 // Field 3: fixed numeric value: 501
-                Assert.True(cin.ReadTag(out tag, out ignore) && tag >> 3 == 3);
-                Assert.Equal(126, cin.Position);
-                Assert.True(cin.ReadSFixed32(ref intValue) && intValue == 501);
-                Assert.Equal(130, cin.Position);
-                Assert.True(cin.IsAtEnd);
+                Assert.IsTrue(cin.ReadTag(out tag, out ignore) && tag >> 3 == 3);
+                Assert.AreEqual(126, cin.Position);
+                Assert.IsTrue(cin.ReadSFixed32(ref intValue) && intValue == 501);
+                Assert.AreEqual(130, cin.Position);
+                Assert.IsTrue(cin.IsAtEnd);
             }
         }
     }

--- a/csharp/src/ProtocolBuffers.Test/Collections/PopsicleListTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/Collections/PopsicleListTest.cs
@@ -36,13 +36,13 @@
 
 using System;
 using System.Collections.Generic;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Collections
 {
     public class PopsicleListTest
     {
-        [Fact]
+        [Test]
         public void MutatingOperationsOnFrozenList()
         {
             PopsicleList<string> list = new PopsicleList<string>();
@@ -55,20 +55,20 @@ namespace Google.ProtocolBuffers.Collections
             Assert.Throws<NotSupportedException>(() => list.Add(new[] { "", "" }));
         }
 
-        [Fact]
+        [Test]
         public void NonMutatingOperationsOnFrozenList()
         {
             PopsicleList<string> list = new PopsicleList<string>();
             list.MakeReadOnly();
-            Assert.False(list.Contains(""));
-            Assert.Equal(0, list.Count);
+            Assert.IsFalse(list.Contains(""));
+            Assert.AreEqual(0, list.Count);
             list.CopyTo(new string[5], 0);
             list.GetEnumerator();
-            Assert.Equal(-1, list.IndexOf(""));
-            Assert.True(list.IsReadOnly);
+            Assert.AreEqual(-1, list.IndexOf(""));
+            Assert.IsTrue(list.IsReadOnly);
         }
 
-        [Fact]
+        [Test]
         public void MutatingOperationsOnFluidList()
         {
             PopsicleList<string> list = new PopsicleList<string>();
@@ -80,26 +80,26 @@ namespace Google.ProtocolBuffers.Collections
             list.RemoveAt(0);
         }
 
-        [Fact]
+        [Test]
         public void NonMutatingOperationsOnFluidList()
         {
             PopsicleList<string> list = new PopsicleList<string>();
-            Assert.False(list.Contains(""));
-            Assert.Equal(0, list.Count);
+            Assert.IsFalse(list.Contains(""));
+            Assert.AreEqual(0, list.Count);
             list.CopyTo(new string[5], 0);
             list.GetEnumerator();
-            Assert.Equal(-1, list.IndexOf(""));
-            Assert.False(list.IsReadOnly);
+            Assert.AreEqual(-1, list.IndexOf(""));
+            Assert.IsFalse(list.IsReadOnly);
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullEnumerable()
         {
             PopsicleList<string> list = new PopsicleList<string>();
             Assert.Throws<ArgumentNullException>(() => list.Add((IEnumerable<string>) null));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddRangeWithNull()
         {
             PopsicleList<string> list = new PopsicleList<string>();
@@ -107,14 +107,14 @@ namespace Google.ProtocolBuffers.Collections
             Assert.Throws<ArgumentNullException>(() => list.Add(new[] {"a", "b", null}));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNull()
         {
             PopsicleList<string> list = new PopsicleList<string>();
             Assert.Throws<ArgumentNullException>(() => list.Add((string) null));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotSetNull()
         {
             PopsicleList<string> list = new PopsicleList<string>();

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/CompatibilityTests.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/CompatibilityTests.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 
 namespace Google.ProtocolBuffers.Compatibility
 {
     /// <summary>
     /// This abstract base implements several tests to ensure that well-known messages can be written
-    /// and read to/from various formats without losing data.  Implementations overload the two serailization
+    /// and read to/from various formats without losing data.  Implementations override the two serialization
     /// methods to provide the tests with the means to read and write for a given format.
     /// </summary>
     public abstract class CompatibilityTests
@@ -22,10 +22,10 @@ namespace Google.ProtocolBuffers.Compatibility
 
         protected virtual void AssertOutputEquals(object lhs, object rhs)
         {
-            Assert.Equal<object>(lhs, rhs);
+            Assert.AreEqual(lhs, rhs);
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripWithEmptyChildMessageSize()
         {
             SizeMessage1 msg = SizeMessage1.CreateBuilder()
@@ -37,12 +37,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SizeMessage1 copy = DeserializeMessage<SizeMessage1, SizeMessage1.Builder>(content, SizeMessage1.CreateBuilder(), ExtensionRegistry.Empty).BuildPartial();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SizeMessage1, SizeMessage1.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(contents), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(contents), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripWithEmptyChildMessageSpeed()
         {
             SpeedMessage1 msg = SpeedMessage1.CreateBuilder()
@@ -54,12 +54,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SpeedMessage1 copy = DeserializeMessage<SpeedMessage1, SpeedMessage1.Builder>(content, SpeedMessage1.CreateBuilder(), ExtensionRegistry.Empty).BuildPartial();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SpeedMessage1, SpeedMessage1.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(contents), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(contents), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripMessage1OptimizeSize()
         {
             SizeMessage1 msg = SizeMessage1.CreateBuilder().MergeFrom(TestResources.google_message1).Build();
@@ -67,12 +67,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SizeMessage1 copy = DeserializeMessage<SizeMessage1, SizeMessage1.Builder>(content, SizeMessage1.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SizeMessage1, SizeMessage1.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(TestResources.google_message1), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(TestResources.google_message1), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripMessage2OptimizeSize()
         {
             SizeMessage2 msg = SizeMessage2.CreateBuilder().MergeFrom(TestResources.google_message2).Build();
@@ -80,12 +80,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SizeMessage2 copy = DeserializeMessage<SizeMessage2, SizeMessage2.Builder>(content, SizeMessage2.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SizeMessage2, SizeMessage2.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(TestResources.google_message2), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(TestResources.google_message2), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripMessage1OptimizeSpeed()
         {
             SpeedMessage1 msg = SpeedMessage1.CreateBuilder().MergeFrom(TestResources.google_message1).Build();
@@ -93,12 +93,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SpeedMessage1 copy = DeserializeMessage<SpeedMessage1, SpeedMessage1.Builder>(content, SpeedMessage1.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SpeedMessage1, SpeedMessage1.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(TestResources.google_message1), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(TestResources.google_message1), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public virtual void RoundTripMessage2OptimizeSpeed()
         {
             SpeedMessage2 msg = SpeedMessage2.CreateBuilder().MergeFrom(TestResources.google_message2).Build();
@@ -106,9 +106,9 @@ namespace Google.ProtocolBuffers.Compatibility
 
             SpeedMessage2 copy = DeserializeMessage<SpeedMessage2, SpeedMessage2.Builder>(content, SpeedMessage2.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<SpeedMessage2, SpeedMessage2.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(TestResources.google_message2), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(TestResources.google_message2), Convert.ToBase64String(copy.ToByteArray()));
         }
 
         #region Test message builders
@@ -185,7 +185,7 @@ namespace Google.ProtocolBuffers.Compatibility
 
         #endregion
 
-        [Fact]
+        [Test]
         public void TestRoundTripAllTypes()
         {
             TestAllTypes msg = AddAllTypes(new TestAllTypes.Builder()).Build();
@@ -193,12 +193,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             TestAllTypes copy = DeserializeMessage<TestAllTypes, TestAllTypes.Builder>(content, TestAllTypes.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<TestAllTypes, TestAllTypes.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public void TestRoundTripRepeatedTypes()
         {
             TestAllTypes msg = AddRepeatedTypes(new TestAllTypes.Builder(), 5).Build();
@@ -206,12 +206,12 @@ namespace Google.ProtocolBuffers.Compatibility
 
             TestAllTypes copy = DeserializeMessage<TestAllTypes, TestAllTypes.Builder>(content, TestAllTypes.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<TestAllTypes, TestAllTypes.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
         }
 
-        [Fact]
+        [Test]
         public void TestRoundTripPackedTypes()
         {
             TestPackedTypes msg = AddPackedTypes(new TestPackedTypes.Builder(), 5).Build();
@@ -219,9 +219,9 @@ namespace Google.ProtocolBuffers.Compatibility
 
             TestPackedTypes copy = DeserializeMessage<TestPackedTypes, TestPackedTypes.Builder>(content, TestPackedTypes.CreateBuilder(), ExtensionRegistry.Empty).Build();
 
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
             AssertOutputEquals(content, SerializeMessage<TestPackedTypes, TestPackedTypes.Builder>(copy));
-            Assert.Equal(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
+            Assert.AreEqual(Convert.ToBase64String(msg.ToByteArray()), Convert.ToBase64String(copy.ToByteArray()));
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/DictionaryCompatibilityTests.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/DictionaryCompatibilityTests.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.Serialization;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Compatibility
 {
+    [TestFixture]
     public class DictionaryCompatibilityTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)
@@ -25,7 +26,7 @@ namespace Google.ProtocolBuffers.Compatibility
             IDictionary<string, object> left = (IDictionary<string, object>)lhs;
             IDictionary<string, object> right = (IDictionary<string, object>)rhs;
 
-            Assert.Equal(
+            Assert.AreEqual(
                 String.Join(",", new List<string>(left.Keys).ToArray()),
                 String.Join(",", new List<string>(right.Keys).ToArray())
             );

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/JsonCompatibilityTests.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/JsonCompatibilityTests.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using Google.ProtocolBuffers.Serialization;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Compatibility
 {
+    [TestFixture]
     public class JsonCompatibilityTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)
@@ -20,6 +22,7 @@ namespace Google.ProtocolBuffers.Compatibility
         }
     }
 
+    [TestFixture]
     public class JsonCompatibilityFormattedTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/TestResources.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/TestResources.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Compatibility
 {
@@ -16,7 +16,7 @@ namespace Google.ProtocolBuffers.Compatibility
 
                 byte[] bytes = new byte[resource.Length];
                 int amtRead = resource.Read(bytes, 0, bytes.Length);
-                Assert.Equal(bytes.Length, amtRead);
+                Assert.AreEqual(bytes.Length, amtRead);
                 return bytes;
             }
         }
@@ -30,7 +30,7 @@ namespace Google.ProtocolBuffers.Compatibility
                 Assert.NotNull(resource);
                 byte[] bytes = new byte[resource.Length];
                 int amtRead = resource.Read(bytes, 0, bytes.Length);
-                Assert.Equal(bytes.Length, amtRead);
+                Assert.AreEqual(bytes.Length, amtRead);
                 return bytes;
             }
         }

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/TextCompatibilityTests.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/TextCompatibilityTests.cs
@@ -1,8 +1,9 @@
 using System.IO;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Compatibility
 {
+    [TestFixture]
     public class TextCompatibilityTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)
@@ -18,14 +19,14 @@ namespace Google.ProtocolBuffers.Compatibility
             return builder;
         }
         //This test can take a very long time to run.
-        [Fact]
+        [Test]
         public override void RoundTripMessage2OptimizeSize()
         {
             //base.RoundTripMessage2OptimizeSize();
         }
 
         //This test can take a very long time to run.
-        [Fact]
+        [Test]
         public override void RoundTripMessage2OptimizeSpeed()
         {
             //base.RoundTripMessage2OptimizeSpeed();

--- a/csharp/src/ProtocolBuffers.Test/Compatibility/XmlCompatibilityTests.cs
+++ b/csharp/src/ProtocolBuffers.Test/Compatibility/XmlCompatibilityTests.cs
@@ -1,9 +1,11 @@
 using System.IO;
 using System.Xml;
 using Google.ProtocolBuffers.Serialization;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers.Compatibility
 {
+    [TestFixture]
     public class XmlCompatibilityTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)
@@ -21,6 +23,7 @@ namespace Google.ProtocolBuffers.Compatibility
         }
     }
 
+    [TestFixture]
     public class XmlCompatibilityFormattedTests : CompatibilityTests
     {
         protected override object SerializeMessage<TMessage, TBuilder>(TMessage message)

--- a/csharp/src/ProtocolBuffers.Test/DeprecatedMemberTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/DeprecatedMemberTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using UnitTest.Issues.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -10,10 +10,10 @@ namespace Google.ProtocolBuffers
         private static void AssertIsDeprecated(MemberInfo member)
         {
             Assert.NotNull(member);
-            Assert.True(member.IsDefined(typeof(ObsoleteAttribute), false), "Member not obsolete: " + member);
+            Assert.IsTrue(member.IsDefined(typeof(ObsoleteAttribute), false), "Member not obsolete: " + member);
         }
 
-        [Fact]
+        [Test]
         public void TestDepreatedPrimitiveValue()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("HasPrimitiveValue"));
@@ -24,7 +24,7 @@ namespace Google.ProtocolBuffers
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("ClearPrimitiveValue"));
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("SetPrimitiveValue"));
         }
-        [Fact]
+        [Test]
         public void TestDepreatedPrimitiveArray()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("PrimitiveArrayList"));
@@ -39,7 +39,7 @@ namespace Google.ProtocolBuffers
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("AddRangePrimitiveArray"));
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("ClearPrimitiveArray"));
         }
-        [Fact]
+        [Test]
         public void TestDepreatedMessageValue()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("HasMessageValue"));
@@ -52,7 +52,7 @@ namespace Google.ProtocolBuffers
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("SetMessageValue", new[] { typeof(DeprecatedChild) }));
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("SetMessageValue", new[] { typeof(DeprecatedChild.Builder) }));
         }
-        [Fact]
+        [Test]
         public void TestDepreatedMessageArray()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("MessageArrayList"));
@@ -69,7 +69,7 @@ namespace Google.ProtocolBuffers
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("AddRangeMessageArray"));
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("ClearMessageArray"));
         }
-        [Fact]
+        [Test]
         public void TestDepreatedEnumValue()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("HasEnumValue"));
@@ -80,7 +80,7 @@ namespace Google.ProtocolBuffers
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("ClearEnumValue"));
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage.Builder).GetMethod("SetEnumValue"));
         }
-        [Fact]
+        [Test]
         public void TestDepreatedEnumArray()
         {
             AssertIsDeprecated(typeof(DeprecatedFieldsMessage).GetProperty("EnumArrayList"));

--- a/csharp/src/ProtocolBuffers.Test/DescriptorsTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/DescriptorsTest.cs
@@ -36,7 +36,7 @@
 
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -46,103 +46,103 @@ namespace Google.ProtocolBuffers
     /// </summary>
     public class DescriptorsTest
     {
-        [Fact]
+        [Test]
         public void FileDescriptor()
         {
             FileDescriptor file = Unittest.Descriptor;
 
-            Assert.Equal("google/protobuf/unittest.proto", file.Name);
-            Assert.Equal("protobuf_unittest", file.Package);
+            Assert.AreEqual("google/protobuf/unittest.proto", file.Name);
+            Assert.AreEqual("protobuf_unittest", file.Package);
 
-            Assert.Equal("UnittestProto", file.Options.JavaOuterClassname);
-            Assert.Equal("google/protobuf/unittest.proto", file.Proto.Name);
+            Assert.AreEqual("UnittestProto", file.Options.JavaOuterClassname);
+            Assert.AreEqual("google/protobuf/unittest.proto", file.Proto.Name);
 
             // unittest.proto doesn't have any public imports, but unittest_import.proto does.
-            Assert.Equal(0, file.PublicDependencies.Count);
-            Assert.Equal(1, UnittestImport.Descriptor.PublicDependencies.Count);
-            Assert.Equal(UnittestImportPublic.Descriptor, UnittestImport.Descriptor.PublicDependencies[0]);
+            Assert.AreEqual(0, file.PublicDependencies.Count);
+            Assert.AreEqual(1, UnittestImport.Descriptor.PublicDependencies.Count);
+            Assert.AreEqual(UnittestImportPublic.Descriptor, UnittestImport.Descriptor.PublicDependencies[0]);
 
-            Assert.Equal(1, file.Dependencies.Count);
-            Assert.Equal(UnittestImport.Descriptor, file.Dependencies[0]);
+            Assert.AreEqual(1, file.Dependencies.Count);
+            Assert.AreEqual(UnittestImport.Descriptor, file.Dependencies[0]);
 
             MessageDescriptor messageType = TestAllTypes.Descriptor;
-            Assert.Equal(messageType, file.MessageTypes[0]);
-            Assert.Equal(messageType, file.FindTypeByName<MessageDescriptor>("TestAllTypes"));
+            Assert.AreEqual(messageType, file.MessageTypes[0]);
+            Assert.AreEqual(messageType, file.FindTypeByName<MessageDescriptor>("TestAllTypes"));
             Assert.Null(file.FindTypeByName<MessageDescriptor>("NoSuchType"));
             Assert.Null(file.FindTypeByName<MessageDescriptor>("protobuf_unittest.TestAllTypes"));
             for (int i = 0; i < file.MessageTypes.Count; i++)
             {
-                Assert.Equal(i, file.MessageTypes[i].Index);
+                Assert.AreEqual(i, file.MessageTypes[i].Index);
             }
 
-            Assert.Equal(file.EnumTypes[0], file.FindTypeByName<EnumDescriptor>("ForeignEnum"));
+            Assert.AreEqual(file.EnumTypes[0], file.FindTypeByName<EnumDescriptor>("ForeignEnum"));
             Assert.Null(file.FindTypeByName<EnumDescriptor>("NoSuchType"));
             Assert.Null(file.FindTypeByName<EnumDescriptor>("protobuf_unittest.ForeignEnum"));
-            Assert.Equal(1, UnittestImport.Descriptor.EnumTypes.Count);
-            Assert.Equal("ImportEnum", UnittestImport.Descriptor.EnumTypes[0].Name);
+            Assert.AreEqual(1, UnittestImport.Descriptor.EnumTypes.Count);
+            Assert.AreEqual("ImportEnum", UnittestImport.Descriptor.EnumTypes[0].Name);
             for (int i = 0; i < file.EnumTypes.Count; i++)
             {
-                Assert.Equal(i, file.EnumTypes[i].Index);
+                Assert.AreEqual(i, file.EnumTypes[i].Index);
             }
 
             FieldDescriptor extension = Unittest.OptionalInt32Extension.Descriptor;
-            Assert.Equal(extension, file.Extensions[0]);
-            Assert.Equal(extension, file.FindTypeByName<FieldDescriptor>("optional_int32_extension"));
+            Assert.AreEqual(extension, file.Extensions[0]);
+            Assert.AreEqual(extension, file.FindTypeByName<FieldDescriptor>("optional_int32_extension"));
             Assert.Null(file.FindTypeByName<FieldDescriptor>("no_such_ext"));
             Assert.Null(file.FindTypeByName<FieldDescriptor>("protobuf_unittest.optional_int32_extension"));
-            Assert.Equal(0, UnittestImport.Descriptor.Extensions.Count);
+            Assert.AreEqual(0, UnittestImport.Descriptor.Extensions.Count);
             for (int i = 0; i < file.Extensions.Count; i++)
             {
-                Assert.Equal(i, file.Extensions[i].Index);
+                Assert.AreEqual(i, file.Extensions[i].Index);
             }
         }
 
-        [Fact]
+        [Test]
         public void MessageDescriptor()
         {
             MessageDescriptor messageType = TestAllTypes.Descriptor;
             MessageDescriptor nestedType = TestAllTypes.Types.NestedMessage.Descriptor;
 
-            Assert.Equal("TestAllTypes", messageType.Name);
-            Assert.Equal("protobuf_unittest.TestAllTypes", messageType.FullName);
-            Assert.Equal(Unittest.Descriptor, messageType.File);
+            Assert.AreEqual("TestAllTypes", messageType.Name);
+            Assert.AreEqual("protobuf_unittest.TestAllTypes", messageType.FullName);
+            Assert.AreEqual(Unittest.Descriptor, messageType.File);
             Assert.Null(messageType.ContainingType);
-            Assert.Equal(DescriptorProtos.MessageOptions.DefaultInstance, messageType.Options);
-            Assert.Equal("TestAllTypes", messageType.Proto.Name);
+            Assert.AreEqual(DescriptorProtos.MessageOptions.DefaultInstance, messageType.Options);
+            Assert.AreEqual("TestAllTypes", messageType.Proto.Name);
 
-            Assert.Equal("NestedMessage", nestedType.Name);
-            Assert.Equal("protobuf_unittest.TestAllTypes.NestedMessage", nestedType.FullName);
-            Assert.Equal(Unittest.Descriptor, nestedType.File);
-            Assert.Equal(messageType, nestedType.ContainingType);
+            Assert.AreEqual("NestedMessage", nestedType.Name);
+            Assert.AreEqual("protobuf_unittest.TestAllTypes.NestedMessage", nestedType.FullName);
+            Assert.AreEqual(Unittest.Descriptor, nestedType.File);
+            Assert.AreEqual(messageType, nestedType.ContainingType);
 
             FieldDescriptor field = messageType.Fields[0];
-            Assert.Equal("optional_int32", field.Name);
-            Assert.Equal(field, messageType.FindDescriptor<FieldDescriptor>("optional_int32"));
+            Assert.AreEqual("optional_int32", field.Name);
+            Assert.AreEqual(field, messageType.FindDescriptor<FieldDescriptor>("optional_int32"));
             Assert.Null(messageType.FindDescriptor<FieldDescriptor>("no_such_field"));
-            Assert.Equal(field, messageType.FindFieldByNumber(1));
+            Assert.AreEqual(field, messageType.FindFieldByNumber(1));
             Assert.Null(messageType.FindFieldByNumber(571283));
             for (int i = 0; i < messageType.Fields.Count; i++)
             {
-                Assert.Equal(i, messageType.Fields[i].Index);
+                Assert.AreEqual(i, messageType.Fields[i].Index);
             }
 
-            Assert.Equal(nestedType, messageType.NestedTypes[0]);
-            Assert.Equal(nestedType, messageType.FindDescriptor<MessageDescriptor>("NestedMessage"));
+            Assert.AreEqual(nestedType, messageType.NestedTypes[0]);
+            Assert.AreEqual(nestedType, messageType.FindDescriptor<MessageDescriptor>("NestedMessage"));
             Assert.Null(messageType.FindDescriptor<MessageDescriptor>("NoSuchType"));
             for (int i = 0; i < messageType.NestedTypes.Count; i++)
             {
-                Assert.Equal(i, messageType.NestedTypes[i].Index);
+                Assert.AreEqual(i, messageType.NestedTypes[i].Index);
             }
 
-            Assert.Equal(messageType.EnumTypes[0], messageType.FindDescriptor<EnumDescriptor>("NestedEnum"));
+            Assert.AreEqual(messageType.EnumTypes[0], messageType.FindDescriptor<EnumDescriptor>("NestedEnum"));
             Assert.Null(messageType.FindDescriptor<EnumDescriptor>("NoSuchType"));
             for (int i = 0; i < messageType.EnumTypes.Count; i++)
             {
-                Assert.Equal(i, messageType.EnumTypes[i].Index);
+                Assert.AreEqual(i, messageType.EnumTypes[i].Index);
             }
         }
 
-        [Fact]
+        [Test]
         public void FieldDescriptor()
         {
             MessageDescriptor messageType = TestAllTypes.Descriptor;
@@ -153,54 +153,54 @@ namespace Google.ProtocolBuffers
             FieldDescriptor extension = Unittest.OptionalInt32Extension.Descriptor;
             FieldDescriptor nestedExtension = TestRequired.Single.Descriptor;
 
-            Assert.Equal("optional_int32", primitiveField.Name);
-            Assert.Equal("protobuf_unittest.TestAllTypes.optional_int32",
+            Assert.AreEqual("optional_int32", primitiveField.Name);
+            Assert.AreEqual("protobuf_unittest.TestAllTypes.optional_int32",
                             primitiveField.FullName);
-            Assert.Equal(1, primitiveField.FieldNumber);
-            Assert.Equal(messageType, primitiveField.ContainingType);
-            Assert.Equal(Unittest.Descriptor, primitiveField.File);
-            Assert.Equal(FieldType.Int32, primitiveField.FieldType);
-            Assert.Equal(MappedType.Int32, primitiveField.MappedType);
-            Assert.Equal(DescriptorProtos.FieldOptions.DefaultInstance, primitiveField.Options);
-            Assert.False(primitiveField.IsExtension);
-            Assert.Equal("optional_int32", primitiveField.Proto.Name);
+            Assert.AreEqual(1, primitiveField.FieldNumber);
+            Assert.AreEqual(messageType, primitiveField.ContainingType);
+            Assert.AreEqual(Unittest.Descriptor, primitiveField.File);
+            Assert.AreEqual(FieldType.Int32, primitiveField.FieldType);
+            Assert.AreEqual(MappedType.Int32, primitiveField.MappedType);
+            Assert.AreEqual(DescriptorProtos.FieldOptions.DefaultInstance, primitiveField.Options);
+            Assert.IsFalse(primitiveField.IsExtension);
+            Assert.AreEqual("optional_int32", primitiveField.Proto.Name);
 
-            Assert.Equal("optional_nested_enum", enumField.Name);
-            Assert.Equal(FieldType.Enum, enumField.FieldType);
-            Assert.Equal(MappedType.Enum, enumField.MappedType);
-            // Assert.Equal(TestAllTypes.Types.NestedEnum.DescriptorProtoFile, enumField.EnumType);
+            Assert.AreEqual("optional_nested_enum", enumField.Name);
+            Assert.AreEqual(FieldType.Enum, enumField.FieldType);
+            Assert.AreEqual(MappedType.Enum, enumField.MappedType);
+            // Assert.AreEqual(TestAllTypes.Types.NestedEnum.DescriptorProtoFile, enumField.EnumType);
 
-            Assert.Equal("optional_foreign_message", messageField.Name);
-            Assert.Equal(FieldType.Message, messageField.FieldType);
-            Assert.Equal(MappedType.Message, messageField.MappedType);
-            Assert.Equal(ForeignMessage.Descriptor, messageField.MessageType);
+            Assert.AreEqual("optional_foreign_message", messageField.Name);
+            Assert.AreEqual(FieldType.Message, messageField.FieldType);
+            Assert.AreEqual(MappedType.Message, messageField.MappedType);
+            Assert.AreEqual(ForeignMessage.Descriptor, messageField.MessageType);
 
-            Assert.Equal("optional_cord", cordField.Name);
-            Assert.Equal(FieldType.String, cordField.FieldType);
-            Assert.Equal(MappedType.String, cordField.MappedType);
-            Assert.Equal(DescriptorProtos.FieldOptions.Types.CType.CORD, cordField.Options.Ctype);
+            Assert.AreEqual("optional_cord", cordField.Name);
+            Assert.AreEqual(FieldType.String, cordField.FieldType);
+            Assert.AreEqual(MappedType.String, cordField.MappedType);
+            Assert.AreEqual(DescriptorProtos.FieldOptions.Types.CType.CORD, cordField.Options.Ctype);
 
-            Assert.Equal("optional_int32_extension", extension.Name);
-            Assert.Equal("protobuf_unittest.optional_int32_extension", extension.FullName);
-            Assert.Equal(1, extension.FieldNumber);
-            Assert.Equal(TestAllExtensions.Descriptor, extension.ContainingType);
-            Assert.Equal(Unittest.Descriptor, extension.File);
-            Assert.Equal(FieldType.Int32, extension.FieldType);
-            Assert.Equal(MappedType.Int32, extension.MappedType);
-            Assert.Equal(DescriptorProtos.FieldOptions.DefaultInstance,
+            Assert.AreEqual("optional_int32_extension", extension.Name);
+            Assert.AreEqual("protobuf_unittest.optional_int32_extension", extension.FullName);
+            Assert.AreEqual(1, extension.FieldNumber);
+            Assert.AreEqual(TestAllExtensions.Descriptor, extension.ContainingType);
+            Assert.AreEqual(Unittest.Descriptor, extension.File);
+            Assert.AreEqual(FieldType.Int32, extension.FieldType);
+            Assert.AreEqual(MappedType.Int32, extension.MappedType);
+            Assert.AreEqual(DescriptorProtos.FieldOptions.DefaultInstance,
                             extension.Options);
-            Assert.True(extension.IsExtension);
-            Assert.Equal(null, extension.ExtensionScope);
-            Assert.Equal("optional_int32_extension", extension.Proto.Name);
+            Assert.IsTrue(extension.IsExtension);
+            Assert.AreEqual(null, extension.ExtensionScope);
+            Assert.AreEqual("optional_int32_extension", extension.Proto.Name);
 
-            Assert.Equal("single", nestedExtension.Name);
-            Assert.Equal("protobuf_unittest.TestRequired.single",
+            Assert.AreEqual("single", nestedExtension.Name);
+            Assert.AreEqual("protobuf_unittest.TestRequired.single",
                             nestedExtension.FullName);
-            Assert.Equal(TestRequired.Descriptor,
+            Assert.AreEqual(TestRequired.Descriptor,
                             nestedExtension.ExtensionScope);
         }
 
-        [Fact]
+        [Test]
         public void FieldDescriptorLabel()
         {
             FieldDescriptor requiredField =
@@ -210,76 +210,76 @@ namespace Google.ProtocolBuffers
             FieldDescriptor repeatedField =
                 TestAllTypes.Descriptor.FindDescriptor<FieldDescriptor>("repeated_int32");
 
-            Assert.True(requiredField.IsRequired);
-            Assert.False(requiredField.IsRepeated);
-            Assert.False(optionalField.IsRequired);
-            Assert.False(optionalField.IsRepeated);
-            Assert.False(repeatedField.IsRequired);
-            Assert.True(repeatedField.IsRepeated);
+            Assert.IsTrue(requiredField.IsRequired);
+            Assert.IsFalse(requiredField.IsRepeated);
+            Assert.IsFalse(optionalField.IsRequired);
+            Assert.IsFalse(optionalField.IsRepeated);
+            Assert.IsFalse(repeatedField.IsRequired);
+            Assert.IsTrue(repeatedField.IsRepeated);
         }
-        [Fact]
+        [Test]
         public void FieldDescriptorDefault()
         {
             MessageDescriptor d = TestAllTypes.Descriptor;
-            Assert.False(d.FindDescriptor<FieldDescriptor>("optional_int32").HasDefaultValue);
-            Assert.Equal<object>(0, d.FindDescriptor<FieldDescriptor>("optional_int32").DefaultValue);
-            Assert.True(d.FindDescriptor<FieldDescriptor>("default_int32").HasDefaultValue);
-            Assert.Equal<object>(41, d.FindDescriptor<FieldDescriptor>("default_int32").DefaultValue);
+            Assert.IsFalse(d.FindDescriptor<FieldDescriptor>("optional_int32").HasDefaultValue);
+            Assert.AreEqual(0, d.FindDescriptor<FieldDescriptor>("optional_int32").DefaultValue);
+            Assert.IsTrue(d.FindDescriptor<FieldDescriptor>("default_int32").HasDefaultValue);
+            Assert.AreEqual(41, d.FindDescriptor<FieldDescriptor>("default_int32").DefaultValue);
 
             d = TestExtremeDefaultValues.Descriptor;
-            Assert.Equal<object>(TestExtremeDefaultValues.DefaultInstance.EscapedBytes,
+            Assert.AreEqual(TestExtremeDefaultValues.DefaultInstance.EscapedBytes,
                 d.FindDescriptor<FieldDescriptor>("escaped_bytes").DefaultValue);
 
-            Assert.Equal<object>(uint.MaxValue, d.FindDescriptor<FieldDescriptor>("large_uint32").DefaultValue);
-            Assert.Equal<object>(ulong.MaxValue, d.FindDescriptor<FieldDescriptor>("large_uint64").DefaultValue);
+            Assert.AreEqual(uint.MaxValue, d.FindDescriptor<FieldDescriptor>("large_uint32").DefaultValue);
+            Assert.AreEqual(ulong.MaxValue, d.FindDescriptor<FieldDescriptor>("large_uint64").DefaultValue);
         }
-        [Fact]
+        [Test]
         public void EnumDescriptor()
         {
             // Note: this test is a bit different to the Java version because there's no static way of getting to the descriptor
             EnumDescriptor enumType = Unittest.Descriptor.FindTypeByName<EnumDescriptor>("ForeignEnum");
             EnumDescriptor nestedType = TestAllTypes.Descriptor.FindDescriptor<EnumDescriptor>("NestedEnum");
 
-            Assert.Equal("ForeignEnum", enumType.Name);
-            Assert.Equal("protobuf_unittest.ForeignEnum", enumType.FullName);
-            Assert.Equal(Unittest.Descriptor, enumType.File);
+            Assert.AreEqual("ForeignEnum", enumType.Name);
+            Assert.AreEqual("protobuf_unittest.ForeignEnum", enumType.FullName);
+            Assert.AreEqual(Unittest.Descriptor, enumType.File);
             Assert.Null(enumType.ContainingType);
-            Assert.Equal(DescriptorProtos.EnumOptions.DefaultInstance,
+            Assert.AreEqual(DescriptorProtos.EnumOptions.DefaultInstance,
                             enumType.Options);
 
-            Assert.Equal("NestedEnum", nestedType.Name);
-            Assert.Equal("protobuf_unittest.TestAllTypes.NestedEnum",
+            Assert.AreEqual("NestedEnum", nestedType.Name);
+            Assert.AreEqual("protobuf_unittest.TestAllTypes.NestedEnum",
                             nestedType.FullName);
-            Assert.Equal(Unittest.Descriptor, nestedType.File);
-            Assert.Equal(TestAllTypes.Descriptor, nestedType.ContainingType);
+            Assert.AreEqual(Unittest.Descriptor, nestedType.File);
+            Assert.AreEqual(TestAllTypes.Descriptor, nestedType.ContainingType);
 
             EnumValueDescriptor value = enumType.FindValueByName("FOREIGN_FOO");
-            Assert.Equal(value, enumType.Values[0]);
-            Assert.Equal("FOREIGN_FOO", value.Name);
-            Assert.Equal(4, value.Number);
-            Assert.Equal((int) ForeignEnum.FOREIGN_FOO, value.Number);
-            Assert.Equal(value, enumType.FindValueByNumber(4));
+            Assert.AreEqual(value, enumType.Values[0]);
+            Assert.AreEqual("FOREIGN_FOO", value.Name);
+            Assert.AreEqual(4, value.Number);
+            Assert.AreEqual((int) ForeignEnum.FOREIGN_FOO, value.Number);
+            Assert.AreEqual(value, enumType.FindValueByNumber(4));
             Assert.Null(enumType.FindValueByName("NO_SUCH_VALUE"));
             for (int i = 0; i < enumType.Values.Count; i++)
             {
-                Assert.Equal(i, enumType.Values[i].Index);
+                Assert.AreEqual(i, enumType.Values[i].Index);
             }
         }
         
 
-        [Fact]
+        [Test]
         public void CustomOptions()
         {
             MessageDescriptor descriptor = TestMessageWithCustomOptions.Descriptor;
-            Assert.True(descriptor.Options.HasExtension(UnittestCustomOptions.MessageOpt1));
-            Assert.Equal(-56, descriptor.Options.GetExtension(UnittestCustomOptions.MessageOpt1));
+            Assert.IsTrue(descriptor.Options.HasExtension(UnittestCustomOptions.MessageOpt1));
+            Assert.AreEqual(-56, descriptor.Options.GetExtension(UnittestCustomOptions.MessageOpt1));
 
 
             FieldDescriptor field = descriptor.FindFieldByName("field1");
             Assert.NotNull(field);
 
-            Assert.True(field.Options.HasExtension(UnittestCustomOptions.FieldOpt1));
-            Assert.Equal(8765432109uL, field.Options.GetExtension(UnittestCustomOptions.FieldOpt1));
+            Assert.IsTrue(field.Options.HasExtension(UnittestCustomOptions.FieldOpt1));
+            Assert.AreEqual(8765432109uL, field.Options.GetExtension(UnittestCustomOptions.FieldOpt1));
             
         }
     }

--- a/csharp/src/ProtocolBuffers.Test/DynamicMessageTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/DynamicMessageTest.cs
@@ -37,7 +37,7 @@
 using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -54,7 +54,7 @@ namespace Google.ProtocolBuffers
             packedReflectionTester = ReflectionTester.CreateTestPackedTypesInstance();
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageAccessors()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
@@ -63,7 +63,7 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertAllFieldsSetViaReflection(message);
         }
 
-        [Fact]
+        [Test]
         public void DoubleBuildError()
         {
             DynamicMessage.Builder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
@@ -71,14 +71,14 @@ namespace Google.ProtocolBuffers
             Assert.Throws<InvalidOperationException>(() => builder.Build());
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageSettersRejectNull()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
             reflectionTester.AssertReflectionSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageExtensionAccessors()
         {
             // We don't need to extensively test DynamicMessage's handling of
@@ -90,14 +90,14 @@ namespace Google.ProtocolBuffers
             extensionsReflectionTester.AssertAllFieldsSetViaReflection(message);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageExtensionSettersRejectNull()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllExtensions.Descriptor);
             extensionsReflectionTester.AssertReflectionSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageRepeatedSetters()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
@@ -107,21 +107,21 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertRepeatedFieldsModifiedViaReflection(message);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageRepeatedSettersRejectNull()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
             reflectionTester.AssertReflectionRepeatedSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageDefaults()
         {
             reflectionTester.AssertClearViaReflection(DynamicMessage.GetDefaultInstance(TestAllTypes.Descriptor));
             reflectionTester.AssertClearViaReflection(DynamicMessage.CreateBuilder(TestAllTypes.Descriptor).Build());
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageSerializedSize()
         {
             TestAllTypes message = TestUtil.GetAllSet();
@@ -130,10 +130,10 @@ namespace Google.ProtocolBuffers
             reflectionTester.SetAllFieldsViaReflection(dynamicBuilder);
             IMessage dynamicMessage = dynamicBuilder.WeakBuild();
 
-            Assert.Equal(message.SerializedSize, dynamicMessage.SerializedSize);
+            Assert.AreEqual(message.SerializedSize, dynamicMessage.SerializedSize);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageSerialization()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestAllTypes.Descriptor);
@@ -146,10 +146,10 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(message2);
 
             // In fact, the serialized forms should be exactly the same, byte-for-byte.
-            Assert.Equal(TestUtil.GetAllSet().ToByteString(), rawBytes);
+            Assert.AreEqual(TestUtil.GetAllSet().ToByteString(), rawBytes);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageParsing()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -162,7 +162,7 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertAllFieldsSetViaReflection(message2);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessagePackedSerialization()
         {
             IBuilder builder = DynamicMessage.CreateBuilder(TestPackedTypes.Descriptor);
@@ -175,10 +175,10 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertPackedFieldsSet(message2);
 
             // In fact, the serialized forms should be exactly the same, byte-for-byte.
-            Assert.Equal(TestUtil.GetPackedSet().ToByteString(), rawBytes);
+            Assert.AreEqual(TestUtil.GetPackedSet().ToByteString(), rawBytes);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessagePackedParsing()
         {
             TestPackedTypes.Builder builder = TestPackedTypes.CreateBuilder();
@@ -191,7 +191,7 @@ namespace Google.ProtocolBuffers
             packedReflectionTester.AssertPackedFieldsSetViaReflection(message2);
         }
 
-        [Fact]
+        [Test]
         public void DynamicMessageCopy()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -202,7 +202,7 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertAllFieldsSetViaReflection(copy);
         }
 
-        [Fact]
+        [Test]
         public void ToBuilder()
         {
             DynamicMessage.Builder builder =
@@ -220,8 +220,8 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertAllFieldsSetViaReflection(derived);
 
             IList<ulong> values = derived.UnknownFields.FieldDictionary[unknownFieldNum].VarintList;
-            Assert.Equal(1, values.Count);
-            Assert.Equal(unknownFieldVal, values[0]);
+            Assert.AreEqual(1, values.Count);
+            Assert.AreEqual(unknownFieldVal, values[0]);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/ExtendableMessageTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/ExtendableMessageTest.cs
@@ -36,13 +36,13 @@
 
 using System;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class ExtendableMessageTest
     {
-        [Fact]
+        [Test]
         public void ExtensionWriterInvalidExtension()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -50,7 +50,7 @@ namespace Google.ProtocolBuffers
                     ForeignMessage.DefaultInstance);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionWriterTest()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder()
@@ -126,75 +126,75 @@ namespace Google.ProtocolBuffers
                                                                                                 registry);
             TestAllExtensions copy = copyBuilder.Build();
 
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
 
-            Assert.Equal(true, copy.GetExtension(Unittest.DefaultBoolExtension));
-            Assert.Equal(ByteString.CopyFromUtf8("123"), copy.GetExtension(Unittest.DefaultBytesExtension));
-            Assert.Equal("123", copy.GetExtension(Unittest.DefaultCordExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultDoubleExtension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.DefaultFixed32Extension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.DefaultFixed64Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultFloatExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, copy.GetExtension(Unittest.DefaultForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.DefaultImportEnumExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultInt32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultInt64Extension));
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(true, copy.GetExtension(Unittest.DefaultBoolExtension));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"), copy.GetExtension(Unittest.DefaultBytesExtension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.DefaultCordExtension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultDoubleExtension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.DefaultFixed32Extension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.DefaultFixed64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultFloatExtension));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, copy.GetExtension(Unittest.DefaultForeignEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.DefaultImportEnumExtension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultInt32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultInt64Extension));
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             copy.GetExtension(Unittest.DefaultNestedEnumExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultSfixed32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultSfixed64Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultSint32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.DefaultSint64Extension));
-            Assert.Equal("123", copy.GetExtension(Unittest.DefaultStringExtension));
-            Assert.Equal("123", copy.GetExtension(Unittest.DefaultStringPieceExtension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.DefaultUint32Extension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.DefaultUint64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultSfixed32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultSfixed64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultSint32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.DefaultSint64Extension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.DefaultStringExtension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.DefaultStringPieceExtension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.DefaultUint32Extension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.DefaultUint64Extension));
 
-            Assert.Equal(true, copy.GetExtension(Unittest.OptionalBoolExtension));
-            Assert.Equal(ByteString.CopyFromUtf8("123"), copy.GetExtension(Unittest.OptionalBytesExtension));
-            Assert.Equal("123", copy.GetExtension(Unittest.OptionalCordExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalDoubleExtension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.OptionalFixed32Extension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.OptionalFixed64Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalFloatExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, copy.GetExtension(Unittest.OptionalForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.OptionalImportEnumExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalInt32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalInt64Extension));
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(true, copy.GetExtension(Unittest.OptionalBoolExtension));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"), copy.GetExtension(Unittest.OptionalBytesExtension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.OptionalCordExtension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalDoubleExtension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.OptionalFixed32Extension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.OptionalFixed64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalFloatExtension));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, copy.GetExtension(Unittest.OptionalForeignEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.OptionalImportEnumExtension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalInt32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalInt64Extension));
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             copy.GetExtension(Unittest.OptionalNestedEnumExtension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalSfixed32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalSfixed64Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalSint32Extension));
-            Assert.Equal(123, copy.GetExtension(Unittest.OptionalSint64Extension));
-            Assert.Equal("123", copy.GetExtension(Unittest.OptionalStringExtension));
-            Assert.Equal("123", copy.GetExtension(Unittest.OptionalStringPieceExtension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.OptionalUint32Extension));
-            Assert.Equal(123u, copy.GetExtension(Unittest.OptionalUint64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalSfixed32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalSfixed64Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalSint32Extension));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.OptionalSint64Extension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.OptionalStringExtension));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.OptionalStringPieceExtension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.OptionalUint32Extension));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.OptionalUint64Extension));
 
-            Assert.Equal(true, copy.GetExtension(Unittest.RepeatedBoolExtension, 0));
-            Assert.Equal(ByteString.CopyFromUtf8("123"),
+            Assert.AreEqual(true, copy.GetExtension(Unittest.RepeatedBoolExtension, 0));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"),
                             copy.GetExtension(Unittest.RepeatedBytesExtension, 0));
-            Assert.Equal("123", copy.GetExtension(Unittest.RepeatedCordExtension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedDoubleExtension, 0));
-            Assert.Equal(123u, copy.GetExtension(Unittest.RepeatedFixed32Extension, 0));
-            Assert.Equal(123u, copy.GetExtension(Unittest.RepeatedFixed64Extension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedFloatExtension, 0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ,
+            Assert.AreEqual("123", copy.GetExtension(Unittest.RepeatedCordExtension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedDoubleExtension, 0));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.RepeatedFixed32Extension, 0));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.RepeatedFixed64Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedFloatExtension, 0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ,
                             copy.GetExtension(Unittest.RepeatedForeignEnumExtension, 0));
-            Assert.Equal(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.RepeatedImportEnumExtension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedInt32Extension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedInt64Extension, 0));
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, copy.GetExtension(Unittest.RepeatedImportEnumExtension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedInt32Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedInt64Extension, 0));
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             copy.GetExtension(Unittest.RepeatedNestedEnumExtension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedSint32Extension, 0));
-            Assert.Equal(123, copy.GetExtension(Unittest.RepeatedSint64Extension, 0));
-            Assert.Equal("123", copy.GetExtension(Unittest.RepeatedStringExtension, 0));
-            Assert.Equal("123", copy.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
-            Assert.Equal(123u, copy.GetExtension(Unittest.RepeatedUint32Extension, 0));
-            Assert.Equal(123u, copy.GetExtension(Unittest.RepeatedUint64Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedSint32Extension, 0));
+            Assert.AreEqual(123, copy.GetExtension(Unittest.RepeatedSint64Extension, 0));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.RepeatedStringExtension, 0));
+            Assert.AreEqual("123", copy.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.RepeatedUint32Extension, 0));
+            Assert.AreEqual(123u, copy.GetExtension(Unittest.RepeatedUint64Extension, 0));
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/FieldPresenceTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/FieldPresenceTest.cs
@@ -34,7 +34,7 @@
 using System;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos.FieldPresence;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -48,7 +48,7 @@ namespace Google.ProtocolBuffers
             Assert.Null(proto3Type.GetProperty("Has" + name));
         }
 
-        [Fact]
+        [Test]
         public void TestHasMethod()
         {
             // Optional non-message fields don't have HasFoo method generated
@@ -67,11 +67,11 @@ namespace Google.ProtocolBuffers
             CheckHasMethodRemoved(proto2Type, proto3Type, "OptionalNestedEnum");
 
             // message fields still have the HasFoo method generated
-            Assert.False(TestAllTypes.CreateBuilder().Build().HasOptionalNestedMessage);
-            Assert.False(TestAllTypes.CreateBuilder().HasOptionalNestedMessage);
+            Assert.IsFalse(TestAllTypes.CreateBuilder().Build().HasOptionalNestedMessage);
+            Assert.IsFalse(TestAllTypes.CreateBuilder().HasOptionalNestedMessage);
         }
 
-        [Fact]
+        [Test]
         public void TestFieldPresence()
         {
             // Optional non-message fields set to their default value are treated the same
@@ -84,7 +84,7 @@ namespace Google.ProtocolBuffers
             builder.SetOptionalBytes(ByteString.Empty);
             builder.SetOptionalNestedEnum(TestAllTypes.Types.NestedEnum.FOO);
             TestAllTypes message = builder.Build();
-            Assert.Equal(0, message.SerializedSize);
+            Assert.AreEqual(0, message.SerializedSize);
 
             // Test merge
             TestAllTypes.Builder a = TestAllTypes.CreateBuilder();
@@ -94,19 +94,19 @@ namespace Google.ProtocolBuffers
             a.SetOptionalNestedEnum(TestAllTypes.Types.NestedEnum.BAR);
             a.MergeFrom(message);
             TestAllTypes messageA = a.Build();
-            Assert.Equal(1, messageA.OptionalInt32);
-            Assert.Equal("x", messageA.OptionalString);
-            Assert.Equal(ByteString.CopyFromUtf8("y"), messageA.OptionalBytes);
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR, messageA.OptionalNestedEnum);
+            Assert.AreEqual(1, messageA.OptionalInt32);
+            Assert.AreEqual("x", messageA.OptionalString);
+            Assert.AreEqual(ByteString.CopyFromUtf8("y"), messageA.OptionalBytes);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR, messageA.OptionalNestedEnum);
 
             // equals/hashCode should produce the same results
             TestAllTypes empty = TestAllTypes.CreateBuilder().Build();
-            Assert.True(empty.Equals(message));
-            Assert.True(message.Equals(empty));
-            Assert.Equal(empty.GetHashCode(), message.GetHashCode());
+            Assert.IsTrue(empty.Equals(message));
+            Assert.IsTrue(message.Equals(empty));
+            Assert.AreEqual(empty.GetHashCode(), message.GetHashCode());
         }
 
-        [Fact]
+        [Test]
         public void TestFieldPresenceReflection()
         {
             MessageDescriptor descriptor = TestAllTypes.Descriptor;
@@ -116,10 +116,10 @@ namespace Google.ProtocolBuffers
             FieldDescriptor optionalNestedEnumField = descriptor.FindFieldByName("optional_nested_enum");
 
             TestAllTypes message = TestAllTypes.CreateBuilder().Build();
-            Assert.False(message.HasField(optionalInt32Field));
-            Assert.False(message.HasField(optionalStringField));
-            Assert.False(message.HasField(optionalBytesField));
-            Assert.False(message.HasField(optionalNestedEnumField));
+            Assert.IsFalse(message.HasField(optionalInt32Field));
+            Assert.IsFalse(message.HasField(optionalStringField));
+            Assert.IsFalse(message.HasField(optionalBytesField));
+            Assert.IsFalse(message.HasField(optionalNestedEnumField));
 
             // Set to default value is seen as not present
             message = TestAllTypes.CreateBuilder()
@@ -128,11 +128,11 @@ namespace Google.ProtocolBuffers
                 .SetOptionalBytes(ByteString.Empty)
                 .SetOptionalNestedEnum(TestAllTypes.Types.NestedEnum.FOO)
                 .Build();
-            Assert.False(message.HasField(optionalInt32Field));
-            Assert.False(message.HasField(optionalStringField));
-            Assert.False(message.HasField(optionalBytesField));
-            Assert.False(message.HasField(optionalNestedEnumField));
-            Assert.Equal(0, message.AllFields.Count);
+            Assert.IsFalse(message.HasField(optionalInt32Field));
+            Assert.IsFalse(message.HasField(optionalStringField));
+            Assert.IsFalse(message.HasField(optionalBytesField));
+            Assert.IsFalse(message.HasField(optionalNestedEnumField));
+            Assert.AreEqual(0, message.AllFields.Count);
             
             // Set t0 non-defalut value is seen as present
             message = TestAllTypes.CreateBuilder()
@@ -141,28 +141,28 @@ namespace Google.ProtocolBuffers
                 .SetOptionalBytes(ByteString.CopyFromUtf8("y"))
                 .SetOptionalNestedEnum(TestAllTypes.Types.NestedEnum.BAR)
                 .Build();
-            Assert.True(message.HasField(optionalInt32Field));
-            Assert.True(message.HasField(optionalStringField));
-            Assert.True(message.HasField(optionalBytesField));
-            Assert.True(message.HasField(optionalNestedEnumField));
-            Assert.Equal(4, message.AllFields.Count);
+            Assert.IsTrue(message.HasField(optionalInt32Field));
+            Assert.IsTrue(message.HasField(optionalStringField));
+            Assert.IsTrue(message.HasField(optionalBytesField));
+            Assert.IsTrue(message.HasField(optionalNestedEnumField));
+            Assert.AreEqual(4, message.AllFields.Count);
         }
 
-        [Fact]
+        [Test]
         public void TestMessageField()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
-            Assert.False(builder.HasOptionalNestedMessage);
-            Assert.False(builder.Build().HasOptionalNestedMessage);
+            Assert.IsFalse(builder.HasOptionalNestedMessage);
+            Assert.IsFalse(builder.Build().HasOptionalNestedMessage);
 
             // Unlike non-message fields, if we set default value to message field, the field
             // shoule be seem as present.
             builder.SetOptionalNestedMessage(TestAllTypes.Types.NestedMessage.DefaultInstance);
-            Assert.True(builder.HasOptionalNestedMessage);
-            Assert.True(builder.Build().HasOptionalNestedMessage);
+            Assert.IsTrue(builder.HasOptionalNestedMessage);
+            Assert.IsTrue(builder.Build().HasOptionalNestedMessage);
         }
 
-        [Fact]
+        [Test]
         public void TestSerializeAndParse()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -172,12 +172,12 @@ namespace Google.ProtocolBuffers
             ByteString data = builder.Build().ToByteString();
 
             TestAllTypes message = TestAllTypes.ParseFrom(data);
-            Assert.Equal(1234, message.OptionalInt32);
-            Assert.Equal("hello", message.OptionalString);
-            Assert.Equal(ByteString.Empty, message.OptionalBytes);
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO, message.OptionalNestedEnum);
-            Assert.True(message.HasOptionalNestedMessage);
-            Assert.Equal(0, message.OptionalNestedMessage.Value);
+            Assert.AreEqual(1234, message.OptionalInt32);
+            Assert.AreEqual("hello", message.OptionalString);
+            Assert.AreEqual(ByteString.Empty, message.OptionalBytes);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO, message.OptionalNestedEnum);
+            Assert.IsTrue(message.HasOptionalNestedMessage);
+            Assert.AreEqual(0, message.OptionalNestedMessage.Value);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/GeneratedBuilderTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/GeneratedBuilderTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -17,7 +17,7 @@ namespace Google.ProtocolBuffers
             }
             public IEnumerator<T> GetEnumerator()
             {
-                Assert.False(_enumerated);
+                Assert.IsFalse(_enumerated);
                 _enumerated = true;
                 yield return _item;
             }
@@ -27,49 +27,49 @@ namespace Google.ProtocolBuffers
             }
         }
 
-        [Fact]
+        [Test]
         public void DoesNotEnumerateTwiceForMessageList()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             b.AddRangeRepeatedForeignMessage(new OneTimeEnumerator<ForeignMessage>(ForeignMessage.DefaultInstance));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotEnumerateTwiceForPrimitiveList()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             b.AddRangeRepeatedInt32(new OneTimeEnumerator<int>(1));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotEnumerateTwiceForStringList()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             b.AddRangeRepeatedString(new OneTimeEnumerator<string>("test"));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotEnumerateTwiceForEnumList()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             b.AddRangeRepeatedForeignEnum(new OneTimeEnumerator<ForeignEnum>(ForeignEnum.FOREIGN_BAR));
         }
         
-        [Fact]
+        [Test]
         public void DoesNotAddNullToMessageListByAddRange()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             Assert.Throws<ArgumentNullException>(() => b.AddRangeRepeatedForeignMessage(new ForeignMessage[] { null }));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullToMessageListByAdd()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             Assert.Throws<ArgumentNullException>(() => b.AddRepeatedForeignMessage((ForeignMessage)null));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullToMessageListBySet()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
@@ -77,21 +77,21 @@ namespace Google.ProtocolBuffers
             Assert.Throws<ArgumentNullException>(() => b.SetRepeatedForeignMessage(0, (ForeignMessage)null));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullToStringListByAddRange()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             Assert.Throws<ArgumentNullException>(() => b.AddRangeRepeatedString(new String[] { null }));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullToStringListByAdd()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();
             Assert.Throws<ArgumentNullException>(() => b.AddRepeatedString(null));
         }
 
-        [Fact]
+        [Test]
         public void DoesNotAddNullToStringListBySet()
         {
             TestAllTypes.Builder b = new TestAllTypes.Builder();

--- a/csharp/src/ProtocolBuffers.Test/GeneratedMessageTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/GeneratedMessageTest.cs
@@ -38,7 +38,7 @@ using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.Collections;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -53,14 +53,14 @@ namespace Google.ProtocolBuffers
             extensionsReflectionTester = ReflectionTester.CreateTestAllExtensionsInstance();
         }
 
-        [Fact]
+        [Test]
         public void RepeatedAddPrimitiveBeforeBuild()
         {
             TestAllTypes message = new TestAllTypes.Builder {RepeatedInt32List = {1, 2, 3}}.Build();
             TestUtil.AssertEqual(new int[] {1, 2, 3}, message.RepeatedInt32List);
         }
 
-        [Fact]
+        [Test]
         public void AddPrimitiveFailsAfterBuild()
         {
             TestAllTypes.Builder builder = new TestAllTypes.Builder();
@@ -71,7 +71,7 @@ namespace Google.ProtocolBuffers
             Assert.Throws<NotSupportedException>(() => list.Add(2));
         }
 
-        [Fact]
+        [Test]
         public void RepeatedAddMessageBeforeBuild()
         {
             TestAllTypes message = new TestAllTypes.Builder
@@ -79,11 +79,11 @@ namespace Google.ProtocolBuffers
                                            RepeatedNestedMessageList =
                                                {new TestAllTypes.Types.NestedMessage.Builder {Bb = 10}.Build()}
                                        }.Build();
-            Assert.Equal(1, message.RepeatedNestedMessageCount);
-            Assert.Equal(10, message.RepeatedNestedMessageList[0].Bb);
+            Assert.AreEqual(1, message.RepeatedNestedMessageCount);
+            Assert.AreEqual(10, message.RepeatedNestedMessageList[0].Bb);
         }
 
-        [Fact]
+        [Test]
         public void AddMessageFailsAfterBuild()
         {
             TestAllTypes.Builder builder = new TestAllTypes.Builder();
@@ -93,14 +93,14 @@ namespace Google.ProtocolBuffers
             Assert.Throws<NotSupportedException>(() => list.Add(new TestAllTypes.Types.NestedMessage.Builder { Bb = 10 }.Build()));
         }
 
-        [Fact]
+        [Test]
         public void DefaultInstance()
         {
-            Assert.Same(TestAllTypes.DefaultInstance, TestAllTypes.DefaultInstance.DefaultInstanceForType);
-            Assert.Same(TestAllTypes.DefaultInstance, TestAllTypes.CreateBuilder().DefaultInstanceForType);
+            Assert.AreSame(TestAllTypes.DefaultInstance, TestAllTypes.DefaultInstance.DefaultInstanceForType);
+            Assert.AreSame(TestAllTypes.DefaultInstance, TestAllTypes.CreateBuilder().DefaultInstanceForType);
         }
 
-        [Fact]
+        [Test]
         public void Accessors()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -109,7 +109,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void SettersRejectNull()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -127,7 +127,7 @@ namespace Google.ProtocolBuffers
                 () => builder.AddRepeatedNestedMessage((TestAllTypes.Types.NestedMessage.Builder) null));
         }
 
-        [Fact]
+        [Test]
         public void RepeatedSetters()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -137,7 +137,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertRepeatedFieldsModified(message);
         }
 
-        [Fact]
+        [Test]
         public void RepeatedAppend()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -151,11 +151,11 @@ namespace Google.ProtocolBuffers
             TestAllTypes message = builder.Build();
             TestUtil.AssertEqual(message.RepeatedInt32List, new int[] {1, 2, 3, 4});
             TestUtil.AssertEqual(message.RepeatedForeignEnumList, new ForeignEnum[] {ForeignEnum.FOREIGN_BAZ});
-            Assert.Equal(1, message.RepeatedForeignMessageCount);
-            Assert.Equal(12, message.GetRepeatedForeignMessage(0).C);
+            Assert.AreEqual(1, message.RepeatedForeignMessageCount);
+            Assert.AreEqual(12, message.GetRepeatedForeignMessage(0).C);
         }
 
-        [Fact]
+        [Test]
         public void RepeatedAppendRejectsNull()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -170,7 +170,7 @@ namespace Google.ProtocolBuffers
                 () => builder.AddRangeRepeatedBytes(new[] {TestUtil.ToBytes("one"), null}));
         }
 
-        [Fact]
+        [Test]
         public void SettingForeignMessageUsingBuilder()
         {
             TestAllTypes message = TestAllTypes.CreateBuilder()
@@ -181,10 +181,10 @@ namespace Google.ProtocolBuffers
                 // Create expected version passing foreign message instance explicitly.
                 .SetOptionalForeignMessage(ForeignMessage.CreateBuilder().SetC(123).Build())
                 .Build();
-            Assert.Equal(expectedMessage, message);
+            Assert.AreEqual(expectedMessage, message);
         }
 
-        [Fact]
+        [Test]
         public void SettingRepeatedForeignMessageUsingBuilder()
         {
             TestAllTypes message = TestAllTypes.CreateBuilder()
@@ -195,10 +195,10 @@ namespace Google.ProtocolBuffers
                 // Create expected version passing foreign message instance explicitly.
                 .AddRepeatedForeignMessage(ForeignMessage.CreateBuilder().SetC(456).Build())
                 .Build();
-            Assert.Equal(expectedMessage, message);
+            Assert.AreEqual(expectedMessage, message);
         }
 
-        [Fact]
+        [Test]
         public void SettingRepeatedValuesUsingRangeInCollectionInitializer()
         {
             int[] values = {1, 2, 3};
@@ -206,29 +206,29 @@ namespace Google.ProtocolBuffers
                                        {
                                            RepeatedSint32List = {values}
                                        }.Build();
-            Assert.True(Lists.Equals(values, message.RepeatedSint32List));
+            Assert.IsTrue(Lists.Equals(values, message.RepeatedSint32List));
         }
 
-        [Fact]
+        [Test]
         public void SettingRepeatedValuesUsingIndividualValuesInCollectionInitializer()
         {
             TestAllTypes message = new TestAllTypes.Builder
                                        {
                                            RepeatedSint32List = {6, 7}
                                        }.Build();
-            Assert.True(Lists.Equals(new int[] {6, 7}, message.RepeatedSint32List));
+            Assert.IsTrue(Lists.Equals(new int[] {6, 7}, message.RepeatedSint32List));
         }
 
-        [Fact]
+        [Test]
         public void Defaults()
         {
             TestUtil.AssertClear(TestAllTypes.DefaultInstance);
             TestUtil.AssertClear(TestAllTypes.CreateBuilder().Build());
 
-            Assert.Equal("\u1234", TestExtremeDefaultValues.DefaultInstance.Utf8String);
+            Assert.AreEqual("\u1234", TestExtremeDefaultValues.DefaultInstance.Utf8String);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionGetters()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -237,7 +237,7 @@ namespace Google.ProtocolBuffers
             reflectionTester.AssertAllFieldsSetViaReflection(message);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionSetters()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -246,7 +246,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionClear()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -256,14 +256,14 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertClear(message);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionSettersRejectNull()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             reflectionTester.AssertReflectionSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionRepeatedSetters()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -273,14 +273,14 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertRepeatedFieldsModified(message);
         }
 
-        [Fact]
+        [Test]
         public void TestReflectionRepeatedSettersRejectNull()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             reflectionTester.AssertReflectionRepeatedSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void ReflectionDefaults()
         {
             TestUtil.TestInMultipleCultures(() =>
@@ -295,7 +295,7 @@ namespace Google.ProtocolBuffers
         // =================================================================
         // Extensions.
 
-        [Fact]
+        [Test]
         public void ExtensionAccessors()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -304,7 +304,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllExtensionsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionRepeatedSetters()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -314,14 +314,14 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertRepeatedExtensionsModified(message);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionDefaults()
         {
             TestUtil.AssertExtensionsClear(TestAllExtensions.DefaultInstance);
             TestUtil.AssertExtensionsClear(TestAllExtensions.CreateBuilder().Build());
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionGetters()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -330,7 +330,7 @@ namespace Google.ProtocolBuffers
             extensionsReflectionTester.AssertAllFieldsSetViaReflection(message);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionSetters()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -339,14 +339,14 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllExtensionsSet(message);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionSettersRejectNull()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
             extensionsReflectionTester.AssertReflectionSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionRepeatedSetters()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -356,14 +356,14 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertRepeatedExtensionsModified(message);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionRepeatedSettersRejectNull()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
             extensionsReflectionTester.AssertReflectionRepeatedSettersRejectNull(builder);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionReflectionDefaults()
         {
             TestUtil.TestInMultipleCultures(() =>
@@ -375,33 +375,33 @@ namespace Google.ProtocolBuffers
                                                 });
         }
 
-        [Fact]
+        [Test]
         public void ClearExtension()
         {
             // ClearExtension() is not actually used in TestUtil, so try it manually.
-            Assert.False(TestAllExtensions.CreateBuilder()
+            Assert.IsFalse(TestAllExtensions.CreateBuilder()
                                .SetExtension(Unittest.OptionalInt32Extension, 1)
                                .ClearExtension(Unittest.OptionalInt32Extension)
                                .HasExtension(Unittest.OptionalInt32Extension));
-            Assert.Equal(0, TestAllExtensions.CreateBuilder()
+            Assert.AreEqual(0, TestAllExtensions.CreateBuilder()
                                    .AddExtension(Unittest.RepeatedInt32Extension, 1)
                                    .ClearExtension(Unittest.RepeatedInt32Extension)
                                    .GetExtensionCount(Unittest.RepeatedInt32Extension));
         }
 
-        [Fact]
+        [Test]
         public void ExtensionMergeFrom()
         {
             TestAllExtensions original = TestAllExtensions.CreateBuilder()
                 .SetExtension(Unittest.OptionalInt32Extension, 1).Build();
             TestAllExtensions merged =
                 TestAllExtensions.CreateBuilder().MergeFrom(original).Build();
-            Assert.True((merged.HasExtension(Unittest.OptionalInt32Extension)));
-            Assert.Equal(1, (int) merged.GetExtension(Unittest.OptionalInt32Extension));
+            Assert.IsTrue((merged.HasExtension(Unittest.OptionalInt32Extension)));
+            Assert.AreEqual(1, (int) merged.GetExtension(Unittest.OptionalInt32Extension));
         }
 
         /* Removed multiple files option for the moment
-    [Fact]
+    [Test]
     public void MultipleFilesOption() {
       // We mostly just want to check that things compile.
       MessageWithNoOuter message = MessageWithNoOuter.CreateBuilder()
@@ -410,63 +410,63 @@ namespace Google.ProtocolBuffers
           .SetNestedEnum(MessageWithNoOuter.Types.NestedEnum.BAZ)
           .SetForeignEnum(EnumWithNoOuter.BAR)
           .Build();
-      Assert.Equal(message, MessageWithNoOuter.ParseFrom(message.ToByteString()));
+      Assert.AreEqual(message, MessageWithNoOuter.ParseFrom(message.ToByteString()));
 
-      Assert.Equal(MultiFileProto.DescriptorProtoFile, MessageWithNoOuter.DescriptorProtoFile.File);
+      Assert.AreEqual(MultiFileProto.DescriptorProtoFile, MessageWithNoOuter.DescriptorProtoFile.File);
 
       FieldDescriptor field = MessageWithNoOuter.DescriptorProtoFile.FindDescriptor<FieldDescriptor>("foreign_enum");
-      Assert.Equal(MultiFileProto.DescriptorProtoFile.FindTypeByName<EnumDescriptor>("EnumWithNoOuter")
+      Assert.AreEqual(MultiFileProto.DescriptorProtoFile.FindTypeByName<EnumDescriptor>("EnumWithNoOuter")
         .FindValueByNumber((int)EnumWithNoOuter.BAR), message[field]);
 
-      Assert.Equal(MultiFileProto.DescriptorProtoFile, ServiceWithNoOuter.DescriptorProtoFile.File);
+      Assert.AreEqual(MultiFileProto.DescriptorProtoFile, ServiceWithNoOuter.DescriptorProtoFile.File);
 
-      Assert.False(TestAllExtensions.DefaultInstance.HasExtension(MultiFileProto.ExtensionWithOuter));
+      Assert.IsFalse(TestAllExtensions.DefaultInstance.HasExtension(MultiFileProto.ExtensionWithOuter));
     }*/
 
-        [Fact]
+        [Test]
         public void OptionalFieldWithRequiredSubfieldsOptimizedForSize()
         {
             TestOptionalOptimizedForSize message = TestOptionalOptimizedForSize.DefaultInstance;
-            Assert.True(message.IsInitialized);
+            Assert.IsTrue(message.IsInitialized);
 
             message = TestOptionalOptimizedForSize.CreateBuilder().SetO(
                 TestRequiredOptimizedForSize.CreateBuilder().BuildPartial()
                 ).BuildPartial();
-            Assert.False(message.IsInitialized);
+            Assert.IsFalse(message.IsInitialized);
 
             message = TestOptionalOptimizedForSize.CreateBuilder().SetO(
                 TestRequiredOptimizedForSize.CreateBuilder().SetX(5).BuildPartial()
                 ).BuildPartial();
-            Assert.True(message.IsInitialized);
+            Assert.IsTrue(message.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void OptimizedForSizeMergeUsesAllFieldsFromTarget()
         {
             TestOptimizedForSize withFieldSet = new TestOptimizedForSize.Builder {I = 10}.Build();
             TestOptimizedForSize.Builder builder = new TestOptimizedForSize.Builder();
             builder.MergeFrom(withFieldSet);
             TestOptimizedForSize built = builder.Build();
-            Assert.Equal(10, built.I);
+            Assert.AreEqual(10, built.I);
         }
 
-        [Fact]
+        [Test]
         public void UninitializedExtensionInOptimizedForSizeMakesMessageUninitialized()
         {
             TestOptimizedForSize.Builder builder = new TestOptimizedForSize.Builder();
             builder.SetExtension(TestOptimizedForSize.TestExtension2,
                                  new TestRequiredOptimizedForSize.Builder().BuildPartial());
-            Assert.False(builder.IsInitialized);
-            Assert.False(builder.BuildPartial().IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
+            Assert.IsFalse(builder.BuildPartial().IsInitialized);
 
             builder = new TestOptimizedForSize.Builder();
             builder.SetExtension(TestOptimizedForSize.TestExtension2,
                                  new TestRequiredOptimizedForSize.Builder {X = 10}.BuildPartial());
-            Assert.True(builder.IsInitialized);
-            Assert.True(builder.BuildPartial().IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
+            Assert.IsTrue(builder.BuildPartial().IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void ToBuilder()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -475,40 +475,40 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(message.ToBuilder().Build());
         }
 
-        [Fact]
+        [Test]
         public void FieldConstantValues()
         {
-            Assert.Equal(TestAllTypes.Types.NestedMessage.BbFieldNumber, 1);
-            Assert.Equal(TestAllTypes.OptionalInt32FieldNumber, 1);
-            Assert.Equal(TestAllTypes.OptionalGroupFieldNumber, 16);
-            Assert.Equal(TestAllTypes.OptionalNestedMessageFieldNumber, 18);
-            Assert.Equal(TestAllTypes.OptionalNestedEnumFieldNumber, 21);
-            Assert.Equal(TestAllTypes.RepeatedInt32FieldNumber, 31);
-            Assert.Equal(TestAllTypes.RepeatedGroupFieldNumber, 46);
-            Assert.Equal(TestAllTypes.RepeatedNestedMessageFieldNumber, 48);
-            Assert.Equal(TestAllTypes.RepeatedNestedEnumFieldNumber, 51);
+            Assert.AreEqual(TestAllTypes.Types.NestedMessage.BbFieldNumber, 1);
+            Assert.AreEqual(TestAllTypes.OptionalInt32FieldNumber, 1);
+            Assert.AreEqual(TestAllTypes.OptionalGroupFieldNumber, 16);
+            Assert.AreEqual(TestAllTypes.OptionalNestedMessageFieldNumber, 18);
+            Assert.AreEqual(TestAllTypes.OptionalNestedEnumFieldNumber, 21);
+            Assert.AreEqual(TestAllTypes.RepeatedInt32FieldNumber, 31);
+            Assert.AreEqual(TestAllTypes.RepeatedGroupFieldNumber, 46);
+            Assert.AreEqual(TestAllTypes.RepeatedNestedMessageFieldNumber, 48);
+            Assert.AreEqual(TestAllTypes.RepeatedNestedEnumFieldNumber, 51);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionConstantValues()
         {
-            Assert.Equal(TestRequired.SingleFieldNumber, 1000);
-            Assert.Equal(TestRequired.MultiFieldNumber, 1001);
-            Assert.Equal(Unittest.OptionalInt32ExtensionFieldNumber, 1);
-            Assert.Equal(Unittest.OptionalGroupExtensionFieldNumber, 16);
-            Assert.Equal(Unittest.OptionalNestedMessageExtensionFieldNumber, 18);
-            Assert.Equal(Unittest.OptionalNestedEnumExtensionFieldNumber, 21);
-            Assert.Equal(Unittest.RepeatedInt32ExtensionFieldNumber, 31);
-            Assert.Equal(Unittest.RepeatedGroupExtensionFieldNumber, 46);
-            Assert.Equal(Unittest.RepeatedNestedMessageExtensionFieldNumber, 48);
-            Assert.Equal(Unittest.RepeatedNestedEnumExtensionFieldNumber, 51);
+            Assert.AreEqual(TestRequired.SingleFieldNumber, 1000);
+            Assert.AreEqual(TestRequired.MultiFieldNumber, 1001);
+            Assert.AreEqual(Unittest.OptionalInt32ExtensionFieldNumber, 1);
+            Assert.AreEqual(Unittest.OptionalGroupExtensionFieldNumber, 16);
+            Assert.AreEqual(Unittest.OptionalNestedMessageExtensionFieldNumber, 18);
+            Assert.AreEqual(Unittest.OptionalNestedEnumExtensionFieldNumber, 21);
+            Assert.AreEqual(Unittest.RepeatedInt32ExtensionFieldNumber, 31);
+            Assert.AreEqual(Unittest.RepeatedGroupExtensionFieldNumber, 46);
+            Assert.AreEqual(Unittest.RepeatedNestedMessageExtensionFieldNumber, 48);
+            Assert.AreEqual(Unittest.RepeatedNestedEnumExtensionFieldNumber, 51);
         }
 
-        [Fact]
+        [Test]
         public void EmptyPackedValue()
         {
             TestPackedTypes empty = new TestPackedTypes.Builder().Build();
-            Assert.Equal(0, empty.SerializedSize);
+            Assert.AreEqual(0, empty.SerializedSize);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/IssuesTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/IssuesTest.cs
@@ -37,7 +37,7 @@
 
 using Google.ProtocolBuffers.Descriptors;
 using UnitTest.Issues.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 
 namespace Google.ProtocolBuffers
@@ -48,13 +48,13 @@ namespace Google.ProtocolBuffers
     public class IssuesTest
     {
         // Issue 45
-        [Fact]
+        [Test]
         public void FieldCalledItem()
         {
             ItemField message = new ItemField.Builder { Item = 3 }.Build();
             FieldDescriptor field = ItemField.Descriptor.FindFieldByName("item");
             Assert.NotNull(field);
-            Assert.Equal(3, (int)message[field]);
+            Assert.AreEqual(3, (int)message[field]);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/MessageStreamIteratorTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/MessageStreamIteratorTest.cs
@@ -37,27 +37,27 @@
 using System.Collections.Generic;
 using System.IO;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 using NestedMessage = Google.ProtocolBuffers.TestProtos.TestAllTypes.Types.NestedMessage;
 
 namespace Google.ProtocolBuffers
 {
     public class MessageStreamIteratorTest
     {
-        [Fact]
+        [Test]
         public void ThreeMessagesInMemory()
         {
             MemoryStream stream = new MemoryStream(MessageStreamWriterTest.ThreeMessageData);
             IEnumerable<NestedMessage> iterator = MessageStreamIterator<NestedMessage>.FromStreamProvider(() => stream);
             List<NestedMessage> messages = new List<NestedMessage>(iterator);
 
-            Assert.Equal(3, messages.Count);
-            Assert.Equal(5, messages[0].Bb);
-            Assert.Equal(1500, messages[1].Bb);
-            Assert.False(messages[2].HasBb);
+            Assert.AreEqual(3, messages.Count);
+            Assert.AreEqual(5, messages[0].Bb);
+            Assert.AreEqual(1500, messages[1].Bb);
+            Assert.IsFalse(messages[2].HasBb);
         }
 
-        [Fact]
+        [Test]
         public void ManyMessagesShouldNotTriggerSizeAlert()
         {
             int messageSize = TestUtil.GetAllSet().SerializedSize;
@@ -83,7 +83,7 @@ namespace Google.ProtocolBuffers
                     count++;
                     TestUtil.AssertAllFieldsSet(message);
                 }
-                Assert.Equal(correctCount, count);
+                Assert.AreEqual(correctCount, count);
             }
         }
     }

--- a/csharp/src/ProtocolBuffers.Test/MessageStreamWriterTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/MessageStreamWriterTest.cs
@@ -35,7 +35,7 @@
 #endregion
 
 using System.IO;
-using Xunit;
+using NUnit.Framework;
 using NestedMessage = Google.ProtocolBuffers.TestProtos.TestAllTypes.Types.NestedMessage;
 
 namespace Google.ProtocolBuffers
@@ -54,7 +54,7 @@ namespace Google.ProtocolBuffers
                                                                    (1 << 3) | 2, 0, // Field 1, no data (third message)
                                                                };
 
-        [Fact]
+        [Test]
         public void ThreeMessages()
         {
             NestedMessage message1 = new NestedMessage.Builder {Bb = 5}.Build();

--- a/csharp/src/ProtocolBuffers.Test/MessageTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/MessageTest.cs
@@ -37,7 +37,7 @@
 using System.IO;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -76,12 +76,12 @@ namespace Google.ProtocolBuffers
             "repeated_string: \"qux\"\n" +
             "repeated_string: \"bar\"\n";
 
-        [Fact]
+        [Test]
         public void MergeFrom()
         {
             TestAllTypes result = TestAllTypes.CreateBuilder(MergeDest).MergeFrom(MergeSource).Build();
 
-            Assert.Equal(MergeResultText, result.ToString());
+            Assert.AreEqual(MergeResultText, result.ToString());
         }
 
         /// <summary>
@@ -89,20 +89,20 @@ namespace Google.ProtocolBuffers
         /// As long as they have the same descriptor, this should work, but it is an
         /// entirely different code path.
         /// </summary>
-        [Fact]
+        [Test]
         public void MergeFromDynamic()
         {
             TestAllTypes result = (TestAllTypes) TestAllTypes.CreateBuilder(MergeDest)
                                                      .MergeFrom(DynamicMessage.CreateBuilder(MergeSource).Build())
                                                      .Build();
 
-            Assert.Equal(MergeResultText, result.ToString());
+            Assert.AreEqual(MergeResultText, result.ToString());
         }
 
         /// <summary>
         /// Test merging two DynamicMessages.
         /// </summary>
-        [Fact]
+        [Test]
         public void DynamicMergeFrom()
         {
             DynamicMessage result = (DynamicMessage) DynamicMessage.CreateBuilder(MergeDest)
@@ -111,7 +111,7 @@ namespace Google.ProtocolBuffers
                                                              DynamicMessage.CreateBuilder(MergeSource).Build())
                                                          .Build();
 
-            Assert.Equal(MergeResultText, result.ToString());
+            Assert.AreEqual(MergeResultText, result.ToString());
         }
 
         // =================================================================
@@ -126,121 +126,121 @@ namespace Google.ProtocolBuffers
                                                                                C = 3
                                                                            }.Build();
 
-        [Fact]
+        [Test]
         public void Initialization()
         {
             TestRequired.Builder builder = TestRequired.CreateBuilder();
 
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder.A = 1;
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder.B = 1;
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder.C = 1;
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void UninitializedBuilderToString()
         {
             TestRequired.Builder builder = TestRequired.CreateBuilder().SetA(1);
-            Assert.Equal("a: 1\n", builder.ToString());
+            Assert.AreEqual("a: 1\n", builder.ToString());
         }
 
-        [Fact]
+        [Test]
         public void RequiredForeign()
         {
             TestRequiredForeign.Builder builder = TestRequiredForeign.CreateBuilder();
 
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder.SetOptionalMessage(TestRequiredUninitialized);
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder.SetOptionalMessage(TestRequiredInitialized);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder.AddRepeatedMessage(TestRequiredUninitialized);
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder.SetRepeatedMessage(0, TestRequiredInitialized);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void RequiredExtension()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
 
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder.SetExtension(TestRequired.Single, TestRequiredUninitialized);
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder.SetExtension(TestRequired.Single, TestRequiredInitialized);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder.AddExtension(TestRequired.Multi, TestRequiredUninitialized);
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder.SetExtension(TestRequired.Multi, 0, TestRequiredInitialized);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void RequiredDynamic()
         {
             MessageDescriptor descriptor = TestRequired.Descriptor;
             DynamicMessage.Builder builder = DynamicMessage.CreateBuilder(descriptor);
 
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder[descriptor.FindDescriptor<FieldDescriptor>("a")] = 1;
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder[descriptor.FindDescriptor<FieldDescriptor>("b")] = 1;
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             builder[descriptor.FindDescriptor<FieldDescriptor>("c")] = 1;
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void RequiredDynamicForeign()
         {
             MessageDescriptor descriptor = TestRequiredForeign.Descriptor;
             DynamicMessage.Builder builder = DynamicMessage.CreateBuilder(descriptor);
 
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder[descriptor.FindDescriptor<FieldDescriptor>("optional_message")] = TestRequiredUninitialized;
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder[descriptor.FindDescriptor<FieldDescriptor>("optional_message")] = TestRequiredInitialized;
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
 
             builder.AddRepeatedField(descriptor.FindDescriptor<FieldDescriptor>("repeated_message"),
                                      TestRequiredUninitialized);
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             builder.SetRepeatedField(descriptor.FindDescriptor<FieldDescriptor>("repeated_message"), 0,
                                      TestRequiredInitialized);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void UninitializedException()
         {
             var e = Assert.Throws<UninitializedMessageException>(() => TestRequired.CreateBuilder().Build());
-            Assert.Equal("Message missing required fields: a, b, c", e.Message);
+            Assert.AreEqual("Message missing required fields: a, b, c", e.Message);
         }
 
-        [Fact]
+        [Test]
         public void BuildPartial()
         {
             // We're mostly testing that no exception is thrown.
             TestRequired message = TestRequired.CreateBuilder().BuildPartial();
-            Assert.False(message.IsInitialized);
+            Assert.IsFalse(message.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void NestedUninitializedException()
         {
             var e = Assert.Throws<UninitializedMessageException>(() => TestRequiredForeign.CreateBuilder()
@@ -248,7 +248,7 @@ namespace Google.ProtocolBuffers
                     .AddRepeatedMessage(TestRequiredUninitialized)
                     .AddRepeatedMessage(TestRequiredUninitialized)
                     .Build());
-            Assert.Equal(
+            Assert.AreEqual(
                 "Message missing required fields: " +
                 "optional_message.a, " +
                 "optional_message.b, " +
@@ -262,7 +262,7 @@ namespace Google.ProtocolBuffers
                 e.Message);
         }
 
-        [Fact]
+        [Test]
         public void BuildNestedPartial()
         {
             // We're mostly testing that no exception is thrown.
@@ -272,17 +272,17 @@ namespace Google.ProtocolBuffers
                     .AddRepeatedMessage(TestRequiredUninitialized)
                     .AddRepeatedMessage(TestRequiredUninitialized)
                     .BuildPartial();
-            Assert.False(message.IsInitialized);
+            Assert.IsFalse(message.IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void ParseUninitialized()
         {
             var e = Assert.Throws<InvalidProtocolBufferException>(() => TestRequired.ParseFrom(ByteString.Empty));
-            Assert.Equal("Message missing required fields: a, b, c", e.Message);
+            Assert.AreEqual("Message missing required fields: a, b, c", e.Message);
         }
 
-        [Fact]
+        [Test]
         public void ParseNestedUnititialized()
         {
             ByteString data =
@@ -293,7 +293,7 @@ namespace Google.ProtocolBuffers
                     .BuildPartial().ToByteString();
 
             var e = Assert.Throws<InvalidProtocolBufferException>(() => TestRequiredForeign.ParseFrom(data));
-            Assert.Equal(
+            Assert.AreEqual(
                 "Message missing required fields: " +
                 "optional_message.a, " +
                 "optional_message.b, " +
@@ -307,30 +307,30 @@ namespace Google.ProtocolBuffers
                 e.Message);
         }
 
-        [Fact]
+        [Test]
         public void DynamicUninitializedException()
         {
             var e = Assert.Throws<UninitializedMessageException>(() => DynamicMessage.CreateBuilder(TestRequired.Descriptor).Build());
-            Assert.Equal("Message missing required fields: a, b, c", e.Message);
+            Assert.AreEqual("Message missing required fields: a, b, c", e.Message);
         }
 
-        [Fact]
+        [Test]
         public void DynamicBuildPartial()
         {
             // We're mostly testing that no exception is thrown.
             DynamicMessage message = DynamicMessage.CreateBuilder(TestRequired.Descriptor).BuildPartial();
-            Assert.False(message.Initialized);
+            Assert.IsFalse(message.Initialized);
         }
 
-        [Fact]
+        [Test]
         public void DynamicParseUnititialized()
         {
             MessageDescriptor descriptor = TestRequired.Descriptor;
             var e = Assert.Throws<InvalidProtocolBufferException>(() => DynamicMessage.ParseFrom(descriptor, ByteString.Empty));
-            Assert.Equal("Message missing required fields: a, b, c", e.Message);
+            Assert.AreEqual("Message missing required fields: a, b, c", e.Message);
         }
 
-        [Fact]
+        [Test]
         public void PackedTypesWrittenDirectlyToStream()
         {
             TestPackedTypes message = new TestPackedTypes.Builder {PackedInt32List = {0, 1, 2}}.Build();
@@ -338,7 +338,7 @@ namespace Google.ProtocolBuffers
             message.WriteTo(stream);
             stream.Position = 0;
             TestPackedTypes readMessage = TestPackedTypes.ParseFrom(stream);
-            Assert.Equal(message, readMessage);
+            Assert.AreEqual(message, readMessage);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/MessageUtilTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/MessageUtilTest.cs
@@ -36,47 +36,47 @@
 
 using System;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class MessageUtilTest
     {
-        [Fact]
+        [Test]
         public void NullTypeName()
         {
             Assert.Throws<ArgumentNullException>(() => MessageUtil.GetDefaultMessage((string) null));
         }
 
-        [Fact]
+        [Test]
         public void InvalidTypeName()
         {
             Assert.Throws<ArgumentException>(() => MessageUtil.GetDefaultMessage("invalidtypename"));
         }
 
-        [Fact]
+        [Test]
         public void ValidTypeName()
         {
-            Assert.Same(TestAllTypes.DefaultInstance,
+            Assert.AreSame(TestAllTypes.DefaultInstance,
                            MessageUtil.GetDefaultMessage(typeof(TestAllTypes).AssemblyQualifiedName));
         }
 
-        [Fact]
+        [Test]
         public void NullType()
         {
             Assert.Throws<ArgumentNullException>(() => MessageUtil.GetDefaultMessage((Type)null));
         }
 
-        [Fact]
+        [Test]
         public void NonMessageType()
         {
             Assert.Throws<ArgumentException>(() => MessageUtil.GetDefaultMessage(typeof(string)));
         }
 
-        [Fact]
+        [Test]
         public void ValidType()
         {
-            Assert.Same(TestAllTypes.DefaultInstance, MessageUtil.GetDefaultMessage(typeof(TestAllTypes)));
+            Assert.AreSame(TestAllTypes.DefaultInstance, MessageUtil.GetDefaultMessage(typeof(TestAllTypes)));
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/NameHelpersTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/NameHelpersTest.cs
@@ -34,48 +34,48 @@
 
 #endregion
 
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class NameHelpersTest
     {
-        [Fact]
+        [Test]
         public void UnderscoresToPascalCase()
         {
-            Assert.Equal("FooBar", NameHelpers.UnderscoresToPascalCase("Foo_bar"));
-            Assert.Equal("FooBar", NameHelpers.UnderscoresToPascalCase("foo_bar"));
-            Assert.Equal("Foo0Bar", NameHelpers.UnderscoresToPascalCase("Foo0bar"));
-            Assert.Equal("FooBar", NameHelpers.UnderscoresToPascalCase("Foo_+_Bar"));
+            Assert.AreEqual("FooBar", NameHelpers.UnderscoresToPascalCase("Foo_bar"));
+            Assert.AreEqual("FooBar", NameHelpers.UnderscoresToPascalCase("foo_bar"));
+            Assert.AreEqual("Foo0Bar", NameHelpers.UnderscoresToPascalCase("Foo0bar"));
+            Assert.AreEqual("FooBar", NameHelpers.UnderscoresToPascalCase("Foo_+_Bar"));
 
-            Assert.Equal("Bar", NameHelpers.UnderscoresToPascalCase("__+bar"));
-            Assert.Equal("Bar", NameHelpers.UnderscoresToPascalCase("bar_"));
-            Assert.Equal("_0Bar", NameHelpers.UnderscoresToPascalCase("_0bar"));
-            Assert.Equal("_1Bar", NameHelpers.UnderscoresToPascalCase("_1_bar"));
+            Assert.AreEqual("Bar", NameHelpers.UnderscoresToPascalCase("__+bar"));
+            Assert.AreEqual("Bar", NameHelpers.UnderscoresToPascalCase("bar_"));
+            Assert.AreEqual("_0Bar", NameHelpers.UnderscoresToPascalCase("_0bar"));
+            Assert.AreEqual("_1Bar", NameHelpers.UnderscoresToPascalCase("_1_bar"));
         }
 
-        [Fact]
+        [Test]
         public void UnderscoresToCamelCase()
         {
-            Assert.Equal("fooBar", NameHelpers.UnderscoresToCamelCase("Foo_bar"));
-            Assert.Equal("fooBar", NameHelpers.UnderscoresToCamelCase("foo_bar"));
-            Assert.Equal("foo0Bar", NameHelpers.UnderscoresToCamelCase("Foo0bar"));
-            Assert.Equal("fooBar", NameHelpers.UnderscoresToCamelCase("Foo_+_Bar"));
+            Assert.AreEqual("fooBar", NameHelpers.UnderscoresToCamelCase("Foo_bar"));
+            Assert.AreEqual("fooBar", NameHelpers.UnderscoresToCamelCase("foo_bar"));
+            Assert.AreEqual("foo0Bar", NameHelpers.UnderscoresToCamelCase("Foo0bar"));
+            Assert.AreEqual("fooBar", NameHelpers.UnderscoresToCamelCase("Foo_+_Bar"));
 
-            Assert.Equal("bar", NameHelpers.UnderscoresToCamelCase("__+bar"));
-            Assert.Equal("bar", NameHelpers.UnderscoresToCamelCase("bar_"));
-            Assert.Equal("_0Bar", NameHelpers.UnderscoresToCamelCase("_0bar"));
-            Assert.Equal("_1Bar", NameHelpers.UnderscoresToCamelCase("_1_bar"));
+            Assert.AreEqual("bar", NameHelpers.UnderscoresToCamelCase("__+bar"));
+            Assert.AreEqual("bar", NameHelpers.UnderscoresToCamelCase("bar_"));
+            Assert.AreEqual("_0Bar", NameHelpers.UnderscoresToCamelCase("_0bar"));
+            Assert.AreEqual("_1Bar", NameHelpers.UnderscoresToCamelCase("_1_bar"));
         }
 
-        [Fact]
+        [Test]
         public void StripSuffix()
         {
             string text = "FooBar";
-            Assert.False(NameHelpers.StripSuffix(ref text, "Foo"));
-            Assert.Equal("FooBar", text);
-            Assert.True(NameHelpers.StripSuffix(ref text, "Bar"));
-            Assert.Equal("Foo", text);
+            Assert.IsFalse(NameHelpers.StripSuffix(ref text, "Foo"));
+            Assert.AreEqual("FooBar", text);
+            Assert.IsTrue(NameHelpers.StripSuffix(ref text, "Bar"));
+            Assert.AreEqual("Foo", text);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/ProtocolBuffers.Test.csproj
+++ b/csharp/src/ProtocolBuffers.Test/ProtocolBuffers.Test.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,7 +17,8 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
-    <NuGetPackageImportStamp>d37384c8</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,17 +49,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractMessageTest.cs" />
@@ -144,11 +154,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
 </Project>

--- a/csharp/src/ProtocolBuffers.Test/ReflectionTester.cs
+++ b/csharp/src/ProtocolBuffers.Test/ReflectionTester.cs
@@ -37,7 +37,7 @@
 using System;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 #pragma warning disable 618 // Disable warning about obsolete use miss-matched assert arguments
 
@@ -97,7 +97,7 @@ namespace Google.ProtocolBuffers
             this.extensionRegistry = extensionRegistry;
 
             this.file = baseDescriptor.File;
-            Assert.Equal(1, file.Dependencies.Count);
+            Assert.AreEqual(1, file.Dependencies.Count);
             this.importFile = file.Dependencies[0];
 
             MessageDescriptor testAllTypes;
@@ -449,199 +449,199 @@ namespace Google.ProtocolBuffers
         /// </summary>
         public void AssertAllFieldsSetViaReflection(IMessage message)
         {
-            Assert.True(message.HasField(f("optional_int32")));
-            Assert.True(message.HasField(f("optional_int64")));
-            Assert.True(message.HasField(f("optional_uint32")));
-            Assert.True(message.HasField(f("optional_uint64")));
-            Assert.True(message.HasField(f("optional_sint32")));
-            Assert.True(message.HasField(f("optional_sint64")));
-            Assert.True(message.HasField(f("optional_fixed32")));
-            Assert.True(message.HasField(f("optional_fixed64")));
-            Assert.True(message.HasField(f("optional_sfixed32")));
-            Assert.True(message.HasField(f("optional_sfixed64")));
-            Assert.True(message.HasField(f("optional_float")));
-            Assert.True(message.HasField(f("optional_double")));
-            Assert.True(message.HasField(f("optional_bool")));
-            Assert.True(message.HasField(f("optional_string")));
-            Assert.True(message.HasField(f("optional_bytes")));
+            Assert.IsTrue(message.HasField(f("optional_int32")));
+            Assert.IsTrue(message.HasField(f("optional_int64")));
+            Assert.IsTrue(message.HasField(f("optional_uint32")));
+            Assert.IsTrue(message.HasField(f("optional_uint64")));
+            Assert.IsTrue(message.HasField(f("optional_sint32")));
+            Assert.IsTrue(message.HasField(f("optional_sint64")));
+            Assert.IsTrue(message.HasField(f("optional_fixed32")));
+            Assert.IsTrue(message.HasField(f("optional_fixed64")));
+            Assert.IsTrue(message.HasField(f("optional_sfixed32")));
+            Assert.IsTrue(message.HasField(f("optional_sfixed64")));
+            Assert.IsTrue(message.HasField(f("optional_float")));
+            Assert.IsTrue(message.HasField(f("optional_double")));
+            Assert.IsTrue(message.HasField(f("optional_bool")));
+            Assert.IsTrue(message.HasField(f("optional_string")));
+            Assert.IsTrue(message.HasField(f("optional_bytes")));
 
-            Assert.True(message.HasField(f("optionalgroup")));
-            Assert.True(message.HasField(f("optional_nested_message")));
-            Assert.True(message.HasField(f("optional_foreign_message")));
-            Assert.True(message.HasField(f("optional_import_message")));
+            Assert.IsTrue(message.HasField(f("optionalgroup")));
+            Assert.IsTrue(message.HasField(f("optional_nested_message")));
+            Assert.IsTrue(message.HasField(f("optional_foreign_message")));
+            Assert.IsTrue(message.HasField(f("optional_import_message")));
 
-            Assert.True(((IMessage) message[f("optionalgroup")]).HasField(groupA));
-            Assert.True(((IMessage) message[f("optional_nested_message")]).HasField(nestedB));
-            Assert.True(((IMessage) message[f("optional_foreign_message")]).HasField(foreignC));
-            Assert.True(((IMessage) message[f("optional_import_message")]).HasField(importD));
+            Assert.IsTrue(((IMessage) message[f("optionalgroup")]).HasField(groupA));
+            Assert.IsTrue(((IMessage) message[f("optional_nested_message")]).HasField(nestedB));
+            Assert.IsTrue(((IMessage) message[f("optional_foreign_message")]).HasField(foreignC));
+            Assert.IsTrue(((IMessage) message[f("optional_import_message")]).HasField(importD));
 
-            Assert.True(message.HasField(f("optional_nested_enum")));
-            Assert.True(message.HasField(f("optional_foreign_enum")));
-            Assert.True(message.HasField(f("optional_import_enum")));
+            Assert.IsTrue(message.HasField(f("optional_nested_enum")));
+            Assert.IsTrue(message.HasField(f("optional_foreign_enum")));
+            Assert.IsTrue(message.HasField(f("optional_import_enum")));
 
-            Assert.True(message.HasField(f("optional_string_piece")));
-            Assert.True(message.HasField(f("optional_cord")));
+            Assert.IsTrue(message.HasField(f("optional_string_piece")));
+            Assert.IsTrue(message.HasField(f("optional_cord")));
 
-            Assert.Equal(101, message[f("optional_int32")]);
-            Assert.Equal(102L, message[f("optional_int64")]);
-            Assert.Equal(103u, message[f("optional_uint32")]);
-            Assert.Equal(104UL, message[f("optional_uint64")]);
-            Assert.Equal(105, message[f("optional_sint32")]);
-            Assert.Equal(106L, message[f("optional_sint64")]);
-            Assert.Equal(107U, message[f("optional_fixed32")]);
-            Assert.Equal(108UL, message[f("optional_fixed64")]);
-            Assert.Equal(109, message[f("optional_sfixed32")]);
-            Assert.Equal(110L, message[f("optional_sfixed64")]);
-            Assert.Equal(111F, message[f("optional_float")]);
-            Assert.Equal(112D, message[f("optional_double")]);
-            Assert.Equal(true, message[f("optional_bool")]);
-            Assert.Equal("115", message[f("optional_string")]);
-            Assert.Equal(TestUtil.ToBytes("116"), message[f("optional_bytes")]);
+            Assert.AreEqual(101, message[f("optional_int32")]);
+            Assert.AreEqual(102L, message[f("optional_int64")]);
+            Assert.AreEqual(103u, message[f("optional_uint32")]);
+            Assert.AreEqual(104UL, message[f("optional_uint64")]);
+            Assert.AreEqual(105, message[f("optional_sint32")]);
+            Assert.AreEqual(106L, message[f("optional_sint64")]);
+            Assert.AreEqual(107U, message[f("optional_fixed32")]);
+            Assert.AreEqual(108UL, message[f("optional_fixed64")]);
+            Assert.AreEqual(109, message[f("optional_sfixed32")]);
+            Assert.AreEqual(110L, message[f("optional_sfixed64")]);
+            Assert.AreEqual(111F, message[f("optional_float")]);
+            Assert.AreEqual(112D, message[f("optional_double")]);
+            Assert.AreEqual(true, message[f("optional_bool")]);
+            Assert.AreEqual("115", message[f("optional_string")]);
+            Assert.AreEqual(TestUtil.ToBytes("116"), message[f("optional_bytes")]);
 
-            Assert.Equal(117, ((IMessage) message[f("optionalgroup")])[groupA]);
-            Assert.Equal(118, ((IMessage) message[f("optional_nested_message")])[nestedB]);
-            Assert.Equal(119, ((IMessage) message[f("optional_foreign_message")])[foreignC]);
-            Assert.Equal(120, ((IMessage) message[f("optional_import_message")])[importD]);
+            Assert.AreEqual(117, ((IMessage) message[f("optionalgroup")])[groupA]);
+            Assert.AreEqual(118, ((IMessage) message[f("optional_nested_message")])[nestedB]);
+            Assert.AreEqual(119, ((IMessage) message[f("optional_foreign_message")])[foreignC]);
+            Assert.AreEqual(120, ((IMessage) message[f("optional_import_message")])[importD]);
 
-            Assert.Equal(nestedBaz, message[f("optional_nested_enum")]);
-            Assert.Equal(foreignBaz, message[f("optional_foreign_enum")]);
-            Assert.Equal(importBaz, message[f("optional_import_enum")]);
+            Assert.AreEqual(nestedBaz, message[f("optional_nested_enum")]);
+            Assert.AreEqual(foreignBaz, message[f("optional_foreign_enum")]);
+            Assert.AreEqual(importBaz, message[f("optional_import_enum")]);
 
-            Assert.Equal("124", message[f("optional_string_piece")]);
-            Assert.Equal("125", message[f("optional_cord")]);
-
-            // -----------------------------------------------------------------
-
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_int32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_int64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_uint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_uint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_fixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_fixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_float")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_double")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_bool")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_string")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_bytes")));
-
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeatedgroup")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_nested_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_import_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_import_enum")));
-
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_string_piece")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_cord")));
-
-            Assert.Equal(201, message[f("repeated_int32"), 0]);
-            Assert.Equal(202L, message[f("repeated_int64"), 0]);
-            Assert.Equal(203U, message[f("repeated_uint32"), 0]);
-            Assert.Equal(204UL, message[f("repeated_uint64"), 0]);
-            Assert.Equal(205, message[f("repeated_sint32"), 0]);
-            Assert.Equal(206L, message[f("repeated_sint64"), 0]);
-            Assert.Equal(207U, message[f("repeated_fixed32"), 0]);
-            Assert.Equal(208UL, message[f("repeated_fixed64"), 0]);
-            Assert.Equal(209, message[f("repeated_sfixed32"), 0]);
-            Assert.Equal(210L, message[f("repeated_sfixed64"), 0]);
-            Assert.Equal(211F, message[f("repeated_float"), 0]);
-            Assert.Equal(212D, message[f("repeated_double"), 0]);
-            Assert.Equal(true, message[f("repeated_bool"), 0]);
-            Assert.Equal("215", message[f("repeated_string"), 0]);
-            Assert.Equal(TestUtil.ToBytes("216"), message[f("repeated_bytes"), 0]);
-
-            Assert.Equal(217, ((IMessage) message[f("repeatedgroup"), 0])[repeatedGroupA]);
-            Assert.Equal(218, ((IMessage) message[f("repeated_nested_message"), 0])[nestedB]);
-            Assert.Equal(219, ((IMessage) message[f("repeated_foreign_message"), 0])[foreignC]);
-            Assert.Equal(220, ((IMessage) message[f("repeated_import_message"), 0])[importD]);
-
-            Assert.Equal(nestedBar, message[f("repeated_nested_enum"), 0]);
-            Assert.Equal(foreignBar, message[f("repeated_foreign_enum"), 0]);
-            Assert.Equal(importBar, message[f("repeated_import_enum"), 0]);
-
-            Assert.Equal("224", message[f("repeated_string_piece"), 0]);
-            Assert.Equal("225", message[f("repeated_cord"), 0]);
-
-            Assert.Equal(301, message[f("repeated_int32"), 1]);
-            Assert.Equal(302L, message[f("repeated_int64"), 1]);
-            Assert.Equal(303U, message[f("repeated_uint32"), 1]);
-            Assert.Equal(304UL, message[f("repeated_uint64"), 1]);
-            Assert.Equal(305, message[f("repeated_sint32"), 1]);
-            Assert.Equal(306L, message[f("repeated_sint64"), 1]);
-            Assert.Equal(307U, message[f("repeated_fixed32"), 1]);
-            Assert.Equal(308UL, message[f("repeated_fixed64"), 1]);
-            Assert.Equal(309, message[f("repeated_sfixed32"), 1]);
-            Assert.Equal(310L, message[f("repeated_sfixed64"), 1]);
-            Assert.Equal(311F, message[f("repeated_float"), 1]);
-            Assert.Equal(312D, message[f("repeated_double"), 1]);
-            Assert.Equal(false, message[f("repeated_bool"), 1]);
-            Assert.Equal("315", message[f("repeated_string"), 1]);
-            Assert.Equal(TestUtil.ToBytes("316"), message[f("repeated_bytes"), 1]);
-
-            Assert.Equal(317, ((IMessage) message[f("repeatedgroup"), 1])[repeatedGroupA]);
-            Assert.Equal(318, ((IMessage) message[f("repeated_nested_message"), 1])[nestedB]);
-            Assert.Equal(319, ((IMessage) message[f("repeated_foreign_message"), 1])[foreignC]);
-            Assert.Equal(320, ((IMessage) message[f("repeated_import_message"), 1])[importD]);
-
-            Assert.Equal(nestedBaz, message[f("repeated_nested_enum"), 1]);
-            Assert.Equal(foreignBaz, message[f("repeated_foreign_enum"), 1]);
-            Assert.Equal(importBaz, message[f("repeated_import_enum"), 1]);
-
-            Assert.Equal("324", message[f("repeated_string_piece"), 1]);
-            Assert.Equal("325", message[f("repeated_cord"), 1]);
+            Assert.AreEqual("124", message[f("optional_string_piece")]);
+            Assert.AreEqual("125", message[f("optional_cord")]);
 
             // -----------------------------------------------------------------
 
-            Assert.True(message.HasField(f("default_int32")));
-            Assert.True(message.HasField(f("default_int64")));
-            Assert.True(message.HasField(f("default_uint32")));
-            Assert.True(message.HasField(f("default_uint64")));
-            Assert.True(message.HasField(f("default_sint32")));
-            Assert.True(message.HasField(f("default_sint64")));
-            Assert.True(message.HasField(f("default_fixed32")));
-            Assert.True(message.HasField(f("default_fixed64")));
-            Assert.True(message.HasField(f("default_sfixed32")));
-            Assert.True(message.HasField(f("default_sfixed64")));
-            Assert.True(message.HasField(f("default_float")));
-            Assert.True(message.HasField(f("default_double")));
-            Assert.True(message.HasField(f("default_bool")));
-            Assert.True(message.HasField(f("default_string")));
-            Assert.True(message.HasField(f("default_bytes")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_int32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_int64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_uint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_uint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_fixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_fixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_float")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_double")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_bool")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_string")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_bytes")));
 
-            Assert.True(message.HasField(f("default_nested_enum")));
-            Assert.True(message.HasField(f("default_foreign_enum")));
-            Assert.True(message.HasField(f("default_import_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeatedgroup")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_nested_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_import_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_import_enum")));
 
-            Assert.True(message.HasField(f("default_string_piece")));
-            Assert.True(message.HasField(f("default_cord")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_string_piece")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_cord")));
 
-            Assert.Equal(401, message[f("default_int32")]);
-            Assert.Equal(402L, message[f("default_int64")]);
-            Assert.Equal(403U, message[f("default_uint32")]);
-            Assert.Equal(404UL, message[f("default_uint64")]);
-            Assert.Equal(405, message[f("default_sint32")]);
-            Assert.Equal(406L, message[f("default_sint64")]);
-            Assert.Equal(407U, message[f("default_fixed32")]);
-            Assert.Equal(408UL, message[f("default_fixed64")]);
-            Assert.Equal(409, message[f("default_sfixed32")]);
-            Assert.Equal(410L, message[f("default_sfixed64")]);
-            Assert.Equal(411F, message[f("default_float")]);
-            Assert.Equal(412D, message[f("default_double")]);
-            Assert.Equal(false, message[f("default_bool")]);
-            Assert.Equal("415", message[f("default_string")]);
-            Assert.Equal(TestUtil.ToBytes("416"), message[f("default_bytes")]);
+            Assert.AreEqual(201, message[f("repeated_int32"), 0]);
+            Assert.AreEqual(202L, message[f("repeated_int64"), 0]);
+            Assert.AreEqual(203U, message[f("repeated_uint32"), 0]);
+            Assert.AreEqual(204UL, message[f("repeated_uint64"), 0]);
+            Assert.AreEqual(205, message[f("repeated_sint32"), 0]);
+            Assert.AreEqual(206L, message[f("repeated_sint64"), 0]);
+            Assert.AreEqual(207U, message[f("repeated_fixed32"), 0]);
+            Assert.AreEqual(208UL, message[f("repeated_fixed64"), 0]);
+            Assert.AreEqual(209, message[f("repeated_sfixed32"), 0]);
+            Assert.AreEqual(210L, message[f("repeated_sfixed64"), 0]);
+            Assert.AreEqual(211F, message[f("repeated_float"), 0]);
+            Assert.AreEqual(212D, message[f("repeated_double"), 0]);
+            Assert.AreEqual(true, message[f("repeated_bool"), 0]);
+            Assert.AreEqual("215", message[f("repeated_string"), 0]);
+            Assert.AreEqual(TestUtil.ToBytes("216"), message[f("repeated_bytes"), 0]);
 
-            Assert.Equal(nestedFoo, message[f("default_nested_enum")]);
-            Assert.Equal(foreignFoo, message[f("default_foreign_enum")]);
-            Assert.Equal(importFoo, message[f("default_import_enum")]);
+            Assert.AreEqual(217, ((IMessage) message[f("repeatedgroup"), 0])[repeatedGroupA]);
+            Assert.AreEqual(218, ((IMessage) message[f("repeated_nested_message"), 0])[nestedB]);
+            Assert.AreEqual(219, ((IMessage) message[f("repeated_foreign_message"), 0])[foreignC]);
+            Assert.AreEqual(220, ((IMessage) message[f("repeated_import_message"), 0])[importD]);
 
-            Assert.Equal("424", message[f("default_string_piece")]);
-            Assert.Equal("425", message[f("default_cord")]);
+            Assert.AreEqual(nestedBar, message[f("repeated_nested_enum"), 0]);
+            Assert.AreEqual(foreignBar, message[f("repeated_foreign_enum"), 0]);
+            Assert.AreEqual(importBar, message[f("repeated_import_enum"), 0]);
+
+            Assert.AreEqual("224", message[f("repeated_string_piece"), 0]);
+            Assert.AreEqual("225", message[f("repeated_cord"), 0]);
+
+            Assert.AreEqual(301, message[f("repeated_int32"), 1]);
+            Assert.AreEqual(302L, message[f("repeated_int64"), 1]);
+            Assert.AreEqual(303U, message[f("repeated_uint32"), 1]);
+            Assert.AreEqual(304UL, message[f("repeated_uint64"), 1]);
+            Assert.AreEqual(305, message[f("repeated_sint32"), 1]);
+            Assert.AreEqual(306L, message[f("repeated_sint64"), 1]);
+            Assert.AreEqual(307U, message[f("repeated_fixed32"), 1]);
+            Assert.AreEqual(308UL, message[f("repeated_fixed64"), 1]);
+            Assert.AreEqual(309, message[f("repeated_sfixed32"), 1]);
+            Assert.AreEqual(310L, message[f("repeated_sfixed64"), 1]);
+            Assert.AreEqual(311F, message[f("repeated_float"), 1]);
+            Assert.AreEqual(312D, message[f("repeated_double"), 1]);
+            Assert.AreEqual(false, message[f("repeated_bool"), 1]);
+            Assert.AreEqual("315", message[f("repeated_string"), 1]);
+            Assert.AreEqual(TestUtil.ToBytes("316"), message[f("repeated_bytes"), 1]);
+
+            Assert.AreEqual(317, ((IMessage) message[f("repeatedgroup"), 1])[repeatedGroupA]);
+            Assert.AreEqual(318, ((IMessage) message[f("repeated_nested_message"), 1])[nestedB]);
+            Assert.AreEqual(319, ((IMessage) message[f("repeated_foreign_message"), 1])[foreignC]);
+            Assert.AreEqual(320, ((IMessage) message[f("repeated_import_message"), 1])[importD]);
+
+            Assert.AreEqual(nestedBaz, message[f("repeated_nested_enum"), 1]);
+            Assert.AreEqual(foreignBaz, message[f("repeated_foreign_enum"), 1]);
+            Assert.AreEqual(importBaz, message[f("repeated_import_enum"), 1]);
+
+            Assert.AreEqual("324", message[f("repeated_string_piece"), 1]);
+            Assert.AreEqual("325", message[f("repeated_cord"), 1]);
+
+            // -----------------------------------------------------------------
+
+            Assert.IsTrue(message.HasField(f("default_int32")));
+            Assert.IsTrue(message.HasField(f("default_int64")));
+            Assert.IsTrue(message.HasField(f("default_uint32")));
+            Assert.IsTrue(message.HasField(f("default_uint64")));
+            Assert.IsTrue(message.HasField(f("default_sint32")));
+            Assert.IsTrue(message.HasField(f("default_sint64")));
+            Assert.IsTrue(message.HasField(f("default_fixed32")));
+            Assert.IsTrue(message.HasField(f("default_fixed64")));
+            Assert.IsTrue(message.HasField(f("default_sfixed32")));
+            Assert.IsTrue(message.HasField(f("default_sfixed64")));
+            Assert.IsTrue(message.HasField(f("default_float")));
+            Assert.IsTrue(message.HasField(f("default_double")));
+            Assert.IsTrue(message.HasField(f("default_bool")));
+            Assert.IsTrue(message.HasField(f("default_string")));
+            Assert.IsTrue(message.HasField(f("default_bytes")));
+
+            Assert.IsTrue(message.HasField(f("default_nested_enum")));
+            Assert.IsTrue(message.HasField(f("default_foreign_enum")));
+            Assert.IsTrue(message.HasField(f("default_import_enum")));
+
+            Assert.IsTrue(message.HasField(f("default_string_piece")));
+            Assert.IsTrue(message.HasField(f("default_cord")));
+
+            Assert.AreEqual(401, message[f("default_int32")]);
+            Assert.AreEqual(402L, message[f("default_int64")]);
+            Assert.AreEqual(403U, message[f("default_uint32")]);
+            Assert.AreEqual(404UL, message[f("default_uint64")]);
+            Assert.AreEqual(405, message[f("default_sint32")]);
+            Assert.AreEqual(406L, message[f("default_sint64")]);
+            Assert.AreEqual(407U, message[f("default_fixed32")]);
+            Assert.AreEqual(408UL, message[f("default_fixed64")]);
+            Assert.AreEqual(409, message[f("default_sfixed32")]);
+            Assert.AreEqual(410L, message[f("default_sfixed64")]);
+            Assert.AreEqual(411F, message[f("default_float")]);
+            Assert.AreEqual(412D, message[f("default_double")]);
+            Assert.AreEqual(false, message[f("default_bool")]);
+            Assert.AreEqual("415", message[f("default_string")]);
+            Assert.AreEqual(TestUtil.ToBytes("416"), message[f("default_bytes")]);
+
+            Assert.AreEqual(nestedFoo, message[f("default_nested_enum")]);
+            Assert.AreEqual(foreignFoo, message[f("default_foreign_enum")]);
+            Assert.AreEqual(importFoo, message[f("default_import_enum")]);
+
+            Assert.AreEqual("424", message[f("default_string_piece")]);
+            Assert.AreEqual("425", message[f("default_cord")]);
         }
 
         /// <summary>
@@ -651,148 +651,148 @@ namespace Google.ProtocolBuffers
         public void AssertClearViaReflection(IMessage message)
         {
             // has_blah() should initially be false for all optional fields.
-            Assert.False(message.HasField(f("optional_int32")));
-            Assert.False(message.HasField(f("optional_int64")));
-            Assert.False(message.HasField(f("optional_uint32")));
-            Assert.False(message.HasField(f("optional_uint64")));
-            Assert.False(message.HasField(f("optional_sint32")));
-            Assert.False(message.HasField(f("optional_sint64")));
-            Assert.False(message.HasField(f("optional_fixed32")));
-            Assert.False(message.HasField(f("optional_fixed64")));
-            Assert.False(message.HasField(f("optional_sfixed32")));
-            Assert.False(message.HasField(f("optional_sfixed64")));
-            Assert.False(message.HasField(f("optional_float")));
-            Assert.False(message.HasField(f("optional_double")));
-            Assert.False(message.HasField(f("optional_bool")));
-            Assert.False(message.HasField(f("optional_string")));
-            Assert.False(message.HasField(f("optional_bytes")));
+            Assert.IsFalse(message.HasField(f("optional_int32")));
+            Assert.IsFalse(message.HasField(f("optional_int64")));
+            Assert.IsFalse(message.HasField(f("optional_uint32")));
+            Assert.IsFalse(message.HasField(f("optional_uint64")));
+            Assert.IsFalse(message.HasField(f("optional_sint32")));
+            Assert.IsFalse(message.HasField(f("optional_sint64")));
+            Assert.IsFalse(message.HasField(f("optional_fixed32")));
+            Assert.IsFalse(message.HasField(f("optional_fixed64")));
+            Assert.IsFalse(message.HasField(f("optional_sfixed32")));
+            Assert.IsFalse(message.HasField(f("optional_sfixed64")));
+            Assert.IsFalse(message.HasField(f("optional_float")));
+            Assert.IsFalse(message.HasField(f("optional_double")));
+            Assert.IsFalse(message.HasField(f("optional_bool")));
+            Assert.IsFalse(message.HasField(f("optional_string")));
+            Assert.IsFalse(message.HasField(f("optional_bytes")));
 
-            Assert.False(message.HasField(f("optionalgroup")));
-            Assert.False(message.HasField(f("optional_nested_message")));
-            Assert.False(message.HasField(f("optional_foreign_message")));
-            Assert.False(message.HasField(f("optional_import_message")));
+            Assert.IsFalse(message.HasField(f("optionalgroup")));
+            Assert.IsFalse(message.HasField(f("optional_nested_message")));
+            Assert.IsFalse(message.HasField(f("optional_foreign_message")));
+            Assert.IsFalse(message.HasField(f("optional_import_message")));
 
-            Assert.False(message.HasField(f("optional_nested_enum")));
-            Assert.False(message.HasField(f("optional_foreign_enum")));
-            Assert.False(message.HasField(f("optional_import_enum")));
+            Assert.IsFalse(message.HasField(f("optional_nested_enum")));
+            Assert.IsFalse(message.HasField(f("optional_foreign_enum")));
+            Assert.IsFalse(message.HasField(f("optional_import_enum")));
 
-            Assert.False(message.HasField(f("optional_string_piece")));
-            Assert.False(message.HasField(f("optional_cord")));
+            Assert.IsFalse(message.HasField(f("optional_string_piece")));
+            Assert.IsFalse(message.HasField(f("optional_cord")));
 
             // Optional fields without defaults are set to zero or something like it.
-            Assert.Equal(0, message[f("optional_int32")]);
-            Assert.Equal(0L, message[f("optional_int64")]);
-            Assert.Equal(0U, message[f("optional_uint32")]);
-            Assert.Equal(0UL, message[f("optional_uint64")]);
-            Assert.Equal(0, message[f("optional_sint32")]);
-            Assert.Equal(0L, message[f("optional_sint64")]);
-            Assert.Equal(0U, message[f("optional_fixed32")]);
-            Assert.Equal(0UL, message[f("optional_fixed64")]);
-            Assert.Equal(0, message[f("optional_sfixed32")]);
-            Assert.Equal(0L, message[f("optional_sfixed64")]);
-            Assert.Equal(0F, message[f("optional_float")]);
-            Assert.Equal(0D, message[f("optional_double")]);
-            Assert.Equal(false, message[f("optional_bool")]);
-            Assert.Equal("", message[f("optional_string")]);
-            Assert.Equal(ByteString.Empty, message[f("optional_bytes")]);
+            Assert.AreEqual(0, message[f("optional_int32")]);
+            Assert.AreEqual(0L, message[f("optional_int64")]);
+            Assert.AreEqual(0U, message[f("optional_uint32")]);
+            Assert.AreEqual(0UL, message[f("optional_uint64")]);
+            Assert.AreEqual(0, message[f("optional_sint32")]);
+            Assert.AreEqual(0L, message[f("optional_sint64")]);
+            Assert.AreEqual(0U, message[f("optional_fixed32")]);
+            Assert.AreEqual(0UL, message[f("optional_fixed64")]);
+            Assert.AreEqual(0, message[f("optional_sfixed32")]);
+            Assert.AreEqual(0L, message[f("optional_sfixed64")]);
+            Assert.AreEqual(0F, message[f("optional_float")]);
+            Assert.AreEqual(0D, message[f("optional_double")]);
+            Assert.AreEqual(false, message[f("optional_bool")]);
+            Assert.AreEqual("", message[f("optional_string")]);
+            Assert.AreEqual(ByteString.Empty, message[f("optional_bytes")]);
 
             // Embedded messages should also be clear.
-            Assert.False(((IMessage) message[f("optionalgroup")]).HasField(groupA));
-            Assert.False(((IMessage) message[f("optional_nested_message")])
+            Assert.IsFalse(((IMessage) message[f("optionalgroup")]).HasField(groupA));
+            Assert.IsFalse(((IMessage) message[f("optional_nested_message")])
                                .HasField(nestedB));
-            Assert.False(((IMessage) message[f("optional_foreign_message")])
+            Assert.IsFalse(((IMessage) message[f("optional_foreign_message")])
                                .HasField(foreignC));
-            Assert.False(((IMessage) message[f("optional_import_message")])
+            Assert.IsFalse(((IMessage) message[f("optional_import_message")])
                                .HasField(importD));
 
-            Assert.Equal(0, ((IMessage) message[f("optionalgroup")])[groupA]);
-            Assert.Equal(0, ((IMessage) message[f("optional_nested_message")])[nestedB]);
-            Assert.Equal(0, ((IMessage) message[f("optional_foreign_message")])[foreignC]);
-            Assert.Equal(0, ((IMessage) message[f("optional_import_message")])[importD]);
+            Assert.AreEqual(0, ((IMessage) message[f("optionalgroup")])[groupA]);
+            Assert.AreEqual(0, ((IMessage) message[f("optional_nested_message")])[nestedB]);
+            Assert.AreEqual(0, ((IMessage) message[f("optional_foreign_message")])[foreignC]);
+            Assert.AreEqual(0, ((IMessage) message[f("optional_import_message")])[importD]);
 
             // Enums without defaults are set to the first value in the enum.
-            Assert.Equal(nestedFoo, message[f("optional_nested_enum")]);
-            Assert.Equal(foreignFoo, message[f("optional_foreign_enum")]);
-            Assert.Equal(importFoo, message[f("optional_import_enum")]);
+            Assert.AreEqual(nestedFoo, message[f("optional_nested_enum")]);
+            Assert.AreEqual(foreignFoo, message[f("optional_foreign_enum")]);
+            Assert.AreEqual(importFoo, message[f("optional_import_enum")]);
 
-            Assert.Equal("", message[f("optional_string_piece")]);
-            Assert.Equal("", message[f("optional_cord")]);
+            Assert.AreEqual("", message[f("optional_string_piece")]);
+            Assert.AreEqual("", message[f("optional_cord")]);
 
             // Repeated fields are empty.
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_int32")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_int64")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_uint32")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_uint64")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_sint32")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_sint64")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_fixed32")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_fixed64")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_float")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_double")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_bool")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_string")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_bytes")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_int32")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_int64")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_uint32")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_uint64")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_sint32")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_sint64")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_fixed32")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_fixed64")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_float")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_double")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_bool")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_string")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_bytes")));
 
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeatedgroup")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_nested_message")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_import_message")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_import_enum")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeatedgroup")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_nested_message")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_import_message")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_import_enum")));
 
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_string_piece")));
-            Assert.Equal(0, message.GetRepeatedFieldCount(f("repeated_cord")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_string_piece")));
+            Assert.AreEqual(0, message.GetRepeatedFieldCount(f("repeated_cord")));
 
             // has_blah() should also be false for all default fields.
-            Assert.False(message.HasField(f("default_int32")));
-            Assert.False(message.HasField(f("default_int64")));
-            Assert.False(message.HasField(f("default_uint32")));
-            Assert.False(message.HasField(f("default_uint64")));
-            Assert.False(message.HasField(f("default_sint32")));
-            Assert.False(message.HasField(f("default_sint64")));
-            Assert.False(message.HasField(f("default_fixed32")));
-            Assert.False(message.HasField(f("default_fixed64")));
-            Assert.False(message.HasField(f("default_sfixed32")));
-            Assert.False(message.HasField(f("default_sfixed64")));
-            Assert.False(message.HasField(f("default_float")));
-            Assert.False(message.HasField(f("default_double")));
-            Assert.False(message.HasField(f("default_bool")));
-            Assert.False(message.HasField(f("default_string")));
-            Assert.False(message.HasField(f("default_bytes")));
+            Assert.IsFalse(message.HasField(f("default_int32")));
+            Assert.IsFalse(message.HasField(f("default_int64")));
+            Assert.IsFalse(message.HasField(f("default_uint32")));
+            Assert.IsFalse(message.HasField(f("default_uint64")));
+            Assert.IsFalse(message.HasField(f("default_sint32")));
+            Assert.IsFalse(message.HasField(f("default_sint64")));
+            Assert.IsFalse(message.HasField(f("default_fixed32")));
+            Assert.IsFalse(message.HasField(f("default_fixed64")));
+            Assert.IsFalse(message.HasField(f("default_sfixed32")));
+            Assert.IsFalse(message.HasField(f("default_sfixed64")));
+            Assert.IsFalse(message.HasField(f("default_float")));
+            Assert.IsFalse(message.HasField(f("default_double")));
+            Assert.IsFalse(message.HasField(f("default_bool")));
+            Assert.IsFalse(message.HasField(f("default_string")));
+            Assert.IsFalse(message.HasField(f("default_bytes")));
 
-            Assert.False(message.HasField(f("default_nested_enum")));
-            Assert.False(message.HasField(f("default_foreign_enum")));
-            Assert.False(message.HasField(f("default_import_enum")));
+            Assert.IsFalse(message.HasField(f("default_nested_enum")));
+            Assert.IsFalse(message.HasField(f("default_foreign_enum")));
+            Assert.IsFalse(message.HasField(f("default_import_enum")));
 
-            Assert.False(message.HasField(f("default_string_piece")));
-            Assert.False(message.HasField(f("default_cord")));
+            Assert.IsFalse(message.HasField(f("default_string_piece")));
+            Assert.IsFalse(message.HasField(f("default_cord")));
 
             // Fields with defaults have their default values (duh).
-            Assert.Equal(41, message[f("default_int32")]);
-            Assert.Equal(42L, message[f("default_int64")]);
-            Assert.Equal(43U, message[f("default_uint32")]);
-            Assert.Equal(44UL, message[f("default_uint64")]);
-            Assert.Equal(-45, message[f("default_sint32")]);
-            Assert.Equal(46L, message[f("default_sint64")]);
-            Assert.Equal(47U, message[f("default_fixed32")]);
-            Assert.Equal(48UL, message[f("default_fixed64")]);
-            Assert.Equal(49, message[f("default_sfixed32")]);
-            Assert.Equal(-50L, message[f("default_sfixed64")]);
-            Assert.Equal(51.5F, message[f("default_float")]);
-            Assert.Equal(52e3D, message[f("default_double")]);
-            Assert.Equal(true, message[f("default_bool")]);
-            Assert.Equal("hello", message[f("default_string")]);
-            Assert.Equal(TestUtil.ToBytes("world"), message[f("default_bytes")]);
+            Assert.AreEqual(41, message[f("default_int32")]);
+            Assert.AreEqual(42L, message[f("default_int64")]);
+            Assert.AreEqual(43U, message[f("default_uint32")]);
+            Assert.AreEqual(44UL, message[f("default_uint64")]);
+            Assert.AreEqual(-45, message[f("default_sint32")]);
+            Assert.AreEqual(46L, message[f("default_sint64")]);
+            Assert.AreEqual(47U, message[f("default_fixed32")]);
+            Assert.AreEqual(48UL, message[f("default_fixed64")]);
+            Assert.AreEqual(49, message[f("default_sfixed32")]);
+            Assert.AreEqual(-50L, message[f("default_sfixed64")]);
+            Assert.AreEqual(51.5F, message[f("default_float")]);
+            Assert.AreEqual(52e3D, message[f("default_double")]);
+            Assert.AreEqual(true, message[f("default_bool")]);
+            Assert.AreEqual("hello", message[f("default_string")]);
+            Assert.AreEqual(TestUtil.ToBytes("world"), message[f("default_bytes")]);
 
-            Assert.Equal(nestedBar, message[f("default_nested_enum")]);
-            Assert.Equal(foreignBar, message[f("default_foreign_enum")]);
-            Assert.Equal(importBar, message[f("default_import_enum")]);
+            Assert.AreEqual(nestedBar, message[f("default_nested_enum")]);
+            Assert.AreEqual(foreignBar, message[f("default_foreign_enum")]);
+            Assert.AreEqual(importBar, message[f("default_import_enum")]);
 
-            Assert.Equal("abc", message[f("default_string_piece")]);
-            Assert.Equal("123", message[f("default_cord")]);
+            Assert.AreEqual("abc", message[f("default_string_piece")]);
+            Assert.AreEqual("123", message[f("default_cord")]);
         }
 
         // ---------------------------------------------------------------
@@ -802,88 +802,88 @@ namespace Google.ProtocolBuffers
             // ModifyRepeatedFields only sets the second repeated element of each
             // field.  In addition to verifying this, we also verify that the first
             // element and size were *not* modified.
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_int32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_int64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_uint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_uint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_fixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_fixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_float")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_double")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_bool")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_string")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_bytes")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_int32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_int64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_uint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_uint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_fixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_fixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sfixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_sfixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_float")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_double")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_bool")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_string")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_bytes")));
 
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeatedgroup")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_nested_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_import_message")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_import_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeatedgroup")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_nested_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_foreign_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_import_message")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_nested_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_foreign_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_import_enum")));
 
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_string_piece")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("repeated_cord")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_string_piece")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("repeated_cord")));
 
-            Assert.Equal(201, message[f("repeated_int32"), 0]);
-            Assert.Equal(202L, message[f("repeated_int64"), 0]);
-            Assert.Equal(203U, message[f("repeated_uint32"), 0]);
-            Assert.Equal(204UL, message[f("repeated_uint64"), 0]);
-            Assert.Equal(205, message[f("repeated_sint32"), 0]);
-            Assert.Equal(206L, message[f("repeated_sint64"), 0]);
-            Assert.Equal(207U, message[f("repeated_fixed32"), 0]);
-            Assert.Equal(208UL, message[f("repeated_fixed64"), 0]);
-            Assert.Equal(209, message[f("repeated_sfixed32"), 0]);
-            Assert.Equal(210L, message[f("repeated_sfixed64"), 0]);
-            Assert.Equal(211F, message[f("repeated_float"), 0]);
-            Assert.Equal(212D, message[f("repeated_double"), 0]);
-            Assert.Equal(true, message[f("repeated_bool"), 0]);
-            Assert.Equal("215", message[f("repeated_string"), 0]);
-            Assert.Equal(TestUtil.ToBytes("216"), message[f("repeated_bytes"), 0]);
+            Assert.AreEqual(201, message[f("repeated_int32"), 0]);
+            Assert.AreEqual(202L, message[f("repeated_int64"), 0]);
+            Assert.AreEqual(203U, message[f("repeated_uint32"), 0]);
+            Assert.AreEqual(204UL, message[f("repeated_uint64"), 0]);
+            Assert.AreEqual(205, message[f("repeated_sint32"), 0]);
+            Assert.AreEqual(206L, message[f("repeated_sint64"), 0]);
+            Assert.AreEqual(207U, message[f("repeated_fixed32"), 0]);
+            Assert.AreEqual(208UL, message[f("repeated_fixed64"), 0]);
+            Assert.AreEqual(209, message[f("repeated_sfixed32"), 0]);
+            Assert.AreEqual(210L, message[f("repeated_sfixed64"), 0]);
+            Assert.AreEqual(211F, message[f("repeated_float"), 0]);
+            Assert.AreEqual(212D, message[f("repeated_double"), 0]);
+            Assert.AreEqual(true, message[f("repeated_bool"), 0]);
+            Assert.AreEqual("215", message[f("repeated_string"), 0]);
+            Assert.AreEqual(TestUtil.ToBytes("216"), message[f("repeated_bytes"), 0]);
 
-            Assert.Equal(217, ((IMessage) message[f("repeatedgroup"), 0])[repeatedGroupA]);
-            Assert.Equal(218, ((IMessage) message[f("repeated_nested_message"), 0])[nestedB]);
-            Assert.Equal(219, ((IMessage) message[f("repeated_foreign_message"), 0])[foreignC]);
-            Assert.Equal(220, ((IMessage) message[f("repeated_import_message"), 0])[importD]);
+            Assert.AreEqual(217, ((IMessage) message[f("repeatedgroup"), 0])[repeatedGroupA]);
+            Assert.AreEqual(218, ((IMessage) message[f("repeated_nested_message"), 0])[nestedB]);
+            Assert.AreEqual(219, ((IMessage) message[f("repeated_foreign_message"), 0])[foreignC]);
+            Assert.AreEqual(220, ((IMessage) message[f("repeated_import_message"), 0])[importD]);
 
-            Assert.Equal(nestedBar, message[f("repeated_nested_enum"), 0]);
-            Assert.Equal(foreignBar, message[f("repeated_foreign_enum"), 0]);
-            Assert.Equal(importBar, message[f("repeated_import_enum"), 0]);
+            Assert.AreEqual(nestedBar, message[f("repeated_nested_enum"), 0]);
+            Assert.AreEqual(foreignBar, message[f("repeated_foreign_enum"), 0]);
+            Assert.AreEqual(importBar, message[f("repeated_import_enum"), 0]);
 
-            Assert.Equal("224", message[f("repeated_string_piece"), 0]);
-            Assert.Equal("225", message[f("repeated_cord"), 0]);
+            Assert.AreEqual("224", message[f("repeated_string_piece"), 0]);
+            Assert.AreEqual("225", message[f("repeated_cord"), 0]);
 
-            Assert.Equal(501, message[f("repeated_int32"), 1]);
-            Assert.Equal(502L, message[f("repeated_int64"), 1]);
-            Assert.Equal(503U, message[f("repeated_uint32"), 1]);
-            Assert.Equal(504UL, message[f("repeated_uint64"), 1]);
-            Assert.Equal(505, message[f("repeated_sint32"), 1]);
-            Assert.Equal(506L, message[f("repeated_sint64"), 1]);
-            Assert.Equal(507U, message[f("repeated_fixed32"), 1]);
-            Assert.Equal(508UL, message[f("repeated_fixed64"), 1]);
-            Assert.Equal(509, message[f("repeated_sfixed32"), 1]);
-            Assert.Equal(510L, message[f("repeated_sfixed64"), 1]);
-            Assert.Equal(511F, message[f("repeated_float"), 1]);
-            Assert.Equal(512D, message[f("repeated_double"), 1]);
-            Assert.Equal(true, message[f("repeated_bool"), 1]);
-            Assert.Equal("515", message[f("repeated_string"), 1]);
-            Assert.Equal(TestUtil.ToBytes("516"), message[f("repeated_bytes"), 1]);
+            Assert.AreEqual(501, message[f("repeated_int32"), 1]);
+            Assert.AreEqual(502L, message[f("repeated_int64"), 1]);
+            Assert.AreEqual(503U, message[f("repeated_uint32"), 1]);
+            Assert.AreEqual(504UL, message[f("repeated_uint64"), 1]);
+            Assert.AreEqual(505, message[f("repeated_sint32"), 1]);
+            Assert.AreEqual(506L, message[f("repeated_sint64"), 1]);
+            Assert.AreEqual(507U, message[f("repeated_fixed32"), 1]);
+            Assert.AreEqual(508UL, message[f("repeated_fixed64"), 1]);
+            Assert.AreEqual(509, message[f("repeated_sfixed32"), 1]);
+            Assert.AreEqual(510L, message[f("repeated_sfixed64"), 1]);
+            Assert.AreEqual(511F, message[f("repeated_float"), 1]);
+            Assert.AreEqual(512D, message[f("repeated_double"), 1]);
+            Assert.AreEqual(true, message[f("repeated_bool"), 1]);
+            Assert.AreEqual("515", message[f("repeated_string"), 1]);
+            Assert.AreEqual(TestUtil.ToBytes("516"), message[f("repeated_bytes"), 1]);
 
-            Assert.Equal(517, ((IMessage) message[f("repeatedgroup"), 1])[repeatedGroupA]);
-            Assert.Equal(518, ((IMessage) message[f("repeated_nested_message"), 1])[nestedB]);
-            Assert.Equal(519, ((IMessage) message[f("repeated_foreign_message"), 1])[foreignC]);
-            Assert.Equal(520, ((IMessage) message[f("repeated_import_message"), 1])[importD]);
+            Assert.AreEqual(517, ((IMessage) message[f("repeatedgroup"), 1])[repeatedGroupA]);
+            Assert.AreEqual(518, ((IMessage) message[f("repeated_nested_message"), 1])[nestedB]);
+            Assert.AreEqual(519, ((IMessage) message[f("repeated_foreign_message"), 1])[foreignC]);
+            Assert.AreEqual(520, ((IMessage) message[f("repeated_import_message"), 1])[importD]);
 
-            Assert.Equal(nestedFoo, message[f("repeated_nested_enum"), 1]);
-            Assert.Equal(foreignFoo, message[f("repeated_foreign_enum"), 1]);
-            Assert.Equal(importFoo, message[f("repeated_import_enum"), 1]);
+            Assert.AreEqual(nestedFoo, message[f("repeated_nested_enum"), 1]);
+            Assert.AreEqual(foreignFoo, message[f("repeated_foreign_enum"), 1]);
+            Assert.AreEqual(importFoo, message[f("repeated_import_enum"), 1]);
 
-            Assert.Equal("524", message[f("repeated_string_piece"), 1]);
-            Assert.Equal("525", message[f("repeated_cord"), 1]);
+            Assert.AreEqual("524", message[f("repeated_string_piece"), 1]);
+            Assert.AreEqual("525", message[f("repeated_cord"), 1]);
         }
 
         /// <summary>
@@ -955,50 +955,50 @@ namespace Google.ProtocolBuffers
 
         public void AssertPackedFieldsSetViaReflection(IMessage message)
         {
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_int32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_int64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_uint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_uint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_sint32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_sint64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_fixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_fixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_sfixed32")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_sfixed64")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_float")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_double")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_bool")));
-            Assert.Equal(2, message.GetRepeatedFieldCount(f("packed_enum")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_int32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_int64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_uint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_uint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_sint32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_sint64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_fixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_fixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_sfixed32")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_sfixed64")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_float")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_double")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_bool")));
+            Assert.AreEqual(2, message.GetRepeatedFieldCount(f("packed_enum")));
 
-            Assert.Equal(601, message[f("packed_int32"), 0]);
-            Assert.Equal(602L, message[f("packed_int64"), 0]);
-            Assert.Equal(603u, message[f("packed_uint32"), 0]);
-            Assert.Equal(604uL, message[f("packed_uint64"), 0]);
-            Assert.Equal(605, message[f("packed_sint32"), 0]);
-            Assert.Equal(606L, message[f("packed_sint64"), 0]);
-            Assert.Equal(607u, message[f("packed_fixed32"), 0]);
-            Assert.Equal(608uL, message[f("packed_fixed64"), 0]);
-            Assert.Equal(609, message[f("packed_sfixed32"), 0]);
-            Assert.Equal(610L, message[f("packed_sfixed64"), 0]);
-            Assert.Equal(611F, message[f("packed_float"), 0]);
-            Assert.Equal(612D, message[f("packed_double"), 0]);
-            Assert.Equal(true, message[f("packed_bool"), 0]);
-            Assert.Equal(foreignBar, message[f("packed_enum"), 0]);
+            Assert.AreEqual(601, message[f("packed_int32"), 0]);
+            Assert.AreEqual(602L, message[f("packed_int64"), 0]);
+            Assert.AreEqual(603u, message[f("packed_uint32"), 0]);
+            Assert.AreEqual(604uL, message[f("packed_uint64"), 0]);
+            Assert.AreEqual(605, message[f("packed_sint32"), 0]);
+            Assert.AreEqual(606L, message[f("packed_sint64"), 0]);
+            Assert.AreEqual(607u, message[f("packed_fixed32"), 0]);
+            Assert.AreEqual(608uL, message[f("packed_fixed64"), 0]);
+            Assert.AreEqual(609, message[f("packed_sfixed32"), 0]);
+            Assert.AreEqual(610L, message[f("packed_sfixed64"), 0]);
+            Assert.AreEqual(611F, message[f("packed_float"), 0]);
+            Assert.AreEqual(612D, message[f("packed_double"), 0]);
+            Assert.AreEqual(true, message[f("packed_bool"), 0]);
+            Assert.AreEqual(foreignBar, message[f("packed_enum"), 0]);
 
-            Assert.Equal(701, message[f("packed_int32"), 1]);
-            Assert.Equal(702L, message[f("packed_int64"), 1]);
-            Assert.Equal(703u, message[f("packed_uint32"), 1]);
-            Assert.Equal(704uL, message[f("packed_uint64"), 1]);
-            Assert.Equal(705, message[f("packed_sint32"), 1]);
-            Assert.Equal(706L, message[f("packed_sint64"), 1]);
-            Assert.Equal(707u, message[f("packed_fixed32"), 1]);
-            Assert.Equal(708uL, message[f("packed_fixed64"), 1]);
-            Assert.Equal(709, message[f("packed_sfixed32"), 1]);
-            Assert.Equal(710L, message[f("packed_sfixed64"), 1]);
-            Assert.Equal(711F, message[f("packed_float"), 1]);
-            Assert.Equal(712D, message[f("packed_double"), 1]);
-            Assert.Equal(false, message[f("packed_bool"), 1]);
-            Assert.Equal(foreignBaz, message[f("packed_enum"), 1]);
+            Assert.AreEqual(701, message[f("packed_int32"), 1]);
+            Assert.AreEqual(702L, message[f("packed_int64"), 1]);
+            Assert.AreEqual(703u, message[f("packed_uint32"), 1]);
+            Assert.AreEqual(704uL, message[f("packed_uint64"), 1]);
+            Assert.AreEqual(705, message[f("packed_sint32"), 1]);
+            Assert.AreEqual(706L, message[f("packed_sint64"), 1]);
+            Assert.AreEqual(707u, message[f("packed_fixed32"), 1]);
+            Assert.AreEqual(708uL, message[f("packed_fixed64"), 1]);
+            Assert.AreEqual(709, message[f("packed_sfixed32"), 1]);
+            Assert.AreEqual(710L, message[f("packed_sfixed64"), 1]);
+            Assert.AreEqual(711F, message[f("packed_float"), 1]);
+            Assert.AreEqual(712D, message[f("packed_double"), 1]);
+            Assert.AreEqual(false, message[f("packed_bool"), 1]);
+            Assert.AreEqual(foreignBaz, message[f("packed_enum"), 1]);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/ReusableBuilderTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/ReusableBuilderTest.cs
@@ -2,14 +2,14 @@
 using Google.ProtocolBuffers.Collections;
 using Google.ProtocolBuffers.TestProtos;
 using UnitTest.Issues.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class ReusableBuilderTest
     {
         //Issue 28: Circular message dependencies result in null defaults for DefaultInstance
-        [Fact]
+        [Test]
         public void EnsureStaticCicularReference()
         {
             MyMessageAReferenceB ab = MyMessageAReferenceB.DefaultInstance;
@@ -20,24 +20,24 @@ namespace Google.ProtocolBuffers
             Assert.NotNull(ba.Value);
         }
 
-        [Fact]
+        [Test]
         public void TestModifyDefaultInstance()
         {
             //verify that the default instance has correctly been marked as read-only
-            Assert.Equal(typeof(PopsicleList<bool>), TestAllTypes.DefaultInstance.RepeatedBoolList.GetType());
+            Assert.AreEqual(typeof(PopsicleList<bool>), TestAllTypes.DefaultInstance.RepeatedBoolList.GetType());
             PopsicleList<bool> list = (PopsicleList<bool>)TestAllTypes.DefaultInstance.RepeatedBoolList;
-            Assert.True(list.IsReadOnly);
+            Assert.IsTrue(list.IsReadOnly);
         }
 
-        [Fact]
+        [Test]
         public void TestUnmodifiedDefaultInstance()
         {
             //Simply calling ToBuilder().Build() no longer creates a copy of the message
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void BuildMultipleWithoutChange()
         {
             //Calling Build() or BuildPartial() does not require a copy of the message
@@ -46,31 +46,31 @@ namespace Google.ProtocolBuffers
 
             TestAllTypes first = builder.BuildPartial();
             //Still the same instance?
-            Assert.True(ReferenceEquals(first, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(first, builder.Build()));
             //Still the same instance?
-            Assert.True(ReferenceEquals(first, builder.BuildPartial().ToBuilder().Build()));
+            Assert.IsTrue(ReferenceEquals(first, builder.BuildPartial().ToBuilder().Build()));
         }
 
-        [Fact]
+        [Test]
         public void MergeFromDefaultInstance()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.MergeFrom(TestAllTypes.DefaultInstance);
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void BuildNewBuilderIsDefaultInstance()
         {
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, new TestAllTypes.Builder().Build()));
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, TestAllTypes.CreateBuilder().Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, new TestAllTypes.Builder().Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, TestAllTypes.CreateBuilder().Build()));
             //last test, if you clear a builder it reverts to default instance
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance,
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance,
                 TestAllTypes.CreateBuilder().SetOptionalBool(true).Build().ToBuilder().Clear().Build()));
         }
 
-        [Fact]
+        [Test]
         public void BuildModifyAndRebuild()
         {
             TestAllTypes.Builder b1 = new TestAllTypes.Builder();
@@ -86,80 +86,80 @@ namespace Google.ProtocolBuffers
 
             TestAllTypes m2 = b1.Build();
             
-            Assert.Equal("{\"optional_foreign_message\":{},\"repeated_int32\":[2],\"default_int32\":1}", Extensions.ToJson(m1));
-            Assert.Equal("{\"optional_foreign_message\":{\"c\":7},\"repeated_int32\":[2,6],\"default_int32\":5}", Extensions.ToJson(m2));
+            Assert.AreEqual("{\"optional_foreign_message\":{},\"repeated_int32\":[2],\"default_int32\":1}", Extensions.ToJson(m1));
+            Assert.AreEqual("{\"optional_foreign_message\":{\"c\":7},\"repeated_int32\":[2,6],\"default_int32\":5}", Extensions.ToJson(m2));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnChangePrimitive()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.SetDefaultBool(true);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnAddRepeatedBool()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.AddRepeatedBool(true);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnGetRepeatedBoolList()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             GC.KeepAlive(builder.RepeatedBoolList);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnChangeMessage()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.SetOptionalForeignMessage(new ForeignMessage.Builder());
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnClearMessage()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.ClearOptionalForeignMessage();
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnGetRepeatedForeignMessageList()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             GC.KeepAlive(builder.RepeatedForeignMessageList);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnChangeEnumValue()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             builder.SetOptionalForeignEnum(ForeignEnum.FOREIGN_BAR);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
-        [Fact]
+        [Test]
         public void CloneOnGetRepeatedForeignEnumList()
         {
             TestAllTypes.Builder builder = TestAllTypes.DefaultInstance.ToBuilder();
-            Assert.True(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsTrue(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
             GC.KeepAlive(builder.RepeatedForeignEnumList);
-            Assert.False(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
+            Assert.IsFalse(ReferenceEquals(TestAllTypes.DefaultInstance, builder.Build()));
         }
 
     }

--- a/csharp/src/ProtocolBuffers.Test/TestCornerCases.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestCornerCases.cs
@@ -1,11 +1,11 @@
 ﻿using UnitTest.Issues.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class TestCornerCases
     {
-        [Fact]
+        [Test]
         public void TestRoundTripNegativeEnums()
         {
             NegativeEnumMessage msg = NegativeEnumMessage.CreateBuilder()
@@ -19,16 +19,16 @@ namespace Google.ProtocolBuffers
                 .AddPackedValues(NegativeEnum.FiveBelow) //10
                 .Build();
 
-            Assert.Equal(58, msg.SerializedSize);
+            Assert.AreEqual(58, msg.SerializedSize);
 
             byte[] bytes = new byte[58];
             CodedOutputStream output = CodedOutputStream.CreateInstance(bytes);
 
             msg.WriteTo(output);
-            Assert.Equal(0, output.SpaceLeft);
+            Assert.AreEqual(0, output.SpaceLeft);
 
             NegativeEnumMessage copy = NegativeEnumMessage.ParseFrom(bytes);
-            Assert.Equal(msg, copy);
+            Assert.AreEqual(msg, copy);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/TestMimeMessageFormats.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestMimeMessageFormats.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Google.ProtocolBuffers.Serialization;
 using Google.ProtocolBuffers.Serialization.Http;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -16,91 +16,91 @@ namespace Google.ProtocolBuffers
         readonly IEnumerable<string> XmlTypes = new string[] { "text/xml", "application/xml" };
         readonly IEnumerable<string> ProtobufTypes = new string[] { "application/binary", "application/x-protobuf", "application/vnd.google.protobuf" };
 
-        [Fact]
+        [Test]
         public void TestReadJsonMimeTypes()
         {
             foreach (string type in JsonTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateInputStream(new MessageFormatOptions(), type, Stream.Null)
                     is JsonFormatReader);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateInputStream(new MessageFormatOptions() { DefaultContentType = "application/json" }, null, Stream.Null)
                 is JsonFormatReader);
         }
 
-        [Fact]
+        [Test]
         public void TestWriteJsonMimeTypes()
         {
             foreach (string type in JsonTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateOutputStream(new MessageFormatOptions(), type, Stream.Null)
                     is JsonFormatWriter);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateOutputStream(new MessageFormatOptions() { DefaultContentType = "application/json" }, null, Stream.Null)
                 is JsonFormatWriter);
         }
 
-        [Fact]
+        [Test]
         public void TestReadXmlMimeTypes()
         {
             foreach (string type in XmlTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateInputStream(new MessageFormatOptions(), type, Stream.Null)
                     is XmlFormatReader);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateInputStream(new MessageFormatOptions() { DefaultContentType = "application/xml" }, null, Stream.Null)
                 is XmlFormatReader);
         }
 
-        [Fact]
+        [Test]
         public void TestWriteXmlMimeTypes()
         {
             foreach (string type in XmlTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateOutputStream(new MessageFormatOptions(), type, Stream.Null)
                     is XmlFormatWriter);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateOutputStream(new MessageFormatOptions() { DefaultContentType = "application/xml" }, null, Stream.Null)
                 is XmlFormatWriter);
         }
 
-        [Fact]
+        [Test]
         public void TestReadProtoMimeTypes()
         {
             foreach (string type in ProtobufTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateInputStream(new MessageFormatOptions(), type, Stream.Null)
                     is CodedInputStream);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateInputStream(new MessageFormatOptions() { DefaultContentType = "application/vnd.google.protobuf" }, null, Stream.Null)
                 is CodedInputStream);
         }
 
-        [Fact]
+        [Test]
         public void TestWriteProtoMimeTypes()
         {
             foreach (string type in ProtobufTypes)
             {
-                Assert.True(
+                Assert.IsTrue(
                     MessageFormatFactory.CreateOutputStream(new MessageFormatOptions(), type, Stream.Null)
                     is CodedOutputStream);
             }
-            Assert.True(
+            Assert.IsTrue(
                 MessageFormatFactory.CreateOutputStream(new MessageFormatOptions() { DefaultContentType = "application/vnd.google.protobuf" }, null, Stream.Null)
                 is CodedOutputStream);
         }
 
-        [Fact]
+        [Test]
         public void TestMergeFromJsonType()
         {
             TestXmlMessage msg = Extensions.MergeFrom(new TestXmlMessage.Builder(),
@@ -108,11 +108,11 @@ namespace Google.ProtocolBuffers
                     Extensions.ToJson(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build())
                     )))
                 .Build();
-            Assert.Equal("a", msg.Text);
-            Assert.Equal(1, msg.Number);
+            Assert.AreEqual("a", msg.Text);
+            Assert.AreEqual(1, msg.Number);
         }
 
-        [Fact]
+        [Test]
         public void TestMergeFromXmlType()
         {
             TestXmlMessage msg = Extensions.MergeFrom(new TestXmlMessage.Builder(),
@@ -120,10 +120,10 @@ namespace Google.ProtocolBuffers
                     Extensions.ToXml(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build())
                     )))
                 .Build();
-            Assert.Equal("a", msg.Text);
-            Assert.Equal(1, msg.Number);
+            Assert.AreEqual("a", msg.Text);
+            Assert.AreEqual(1, msg.Number);
         }
-        [Fact]
+        [Test]
         public void TestMergeFromProtoType()
         {
             TestXmlMessage msg = Extensions.MergeFrom(new TestXmlMessage.Builder(),
@@ -131,30 +131,30 @@ namespace Google.ProtocolBuffers
                     TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build().ToByteArray()
                     ))
                 .Build();
-            Assert.Equal("a", msg.Text);
-            Assert.Equal(1, msg.Number);
+            Assert.AreEqual("a", msg.Text);
+            Assert.AreEqual(1, msg.Number);
         }
 
-        [Fact]
+        [Test]
         public void TestWriteToJsonType()
         {
             MemoryStream ms = new MemoryStream();
             Extensions.WriteTo(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build(),
                 new MessageFormatOptions(), "application/json", ms);
 
-            Assert.Equal(@"{""text"":""a"",""number"":1}", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
+            Assert.AreEqual(@"{""text"":""a"",""number"":1}", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
         }
 
-        [Fact]
+        [Test]
         public void TestWriteToXmlType()
         {
             MemoryStream ms = new MemoryStream();
             Extensions.WriteTo(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build(),
                 new MessageFormatOptions(), "application/xml", ms);
 
-            Assert.Equal("<root><text>a</text><number>1</number></root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
+            Assert.AreEqual("<root><text>a</text><number>1</number></root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
         }
-        [Fact]
+        [Test]
         public void TestWriteToProtoType()
         {
             MemoryStream ms = new MemoryStream();
@@ -162,10 +162,10 @@ namespace Google.ProtocolBuffers
                 new MessageFormatOptions(), "application/vnd.google.protobuf", ms);
 
             byte[] bytes = TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build().ToByteArray();
-            Assert.Equal(bytes, ms.ToArray());
+            Assert.AreEqual(bytes, ms.ToArray());
         }
 
-        [Fact]
+        [Test]
         public void TestXmlReaderOptions()
         {
             MemoryStream ms = new MemoryStream();
@@ -184,13 +184,13 @@ namespace Google.ProtocolBuffers
                 options, "application/xml", ms)
                 .Build();
 
-            Assert.Equal("a", msg.Text);
-            Assert.Equal(1, msg.NumbersList[0]);
-            Assert.Equal(2, msg.NumbersList[1]);
+            Assert.AreEqual("a", msg.Text);
+            Assert.AreEqual(1, msg.NumbersList[0]);
+            Assert.AreEqual(2, msg.NumbersList[1]);
 
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWriterOptions()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder().SetText("a").AddNumbers(1).AddNumbers(2).Build();
@@ -209,32 +209,32 @@ namespace Google.ProtocolBuffers
                 .SetOptions(XmlReaderOptions.ReadNestedArrays)
                 .Merge("root-node", builder);
 
-            Assert.Equal("a", builder.Text);
-            Assert.Equal(1, builder.NumbersList[0]);
-            Assert.Equal(2, builder.NumbersList[1]);
+            Assert.AreEqual("a", builder.Text);
+            Assert.AreEqual(1, builder.NumbersList[0]);
+            Assert.AreEqual(2, builder.NumbersList[1]);
         }
 
-        [Fact]
+        [Test]
         public void TestJsonFormatted()
         {
             MemoryStream ms = new MemoryStream();
             Extensions.WriteTo(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build(),
                 new MessageFormatOptions() { FormattedOutput = true }, "application/json", ms);
 
-            Assert.Equal("{\r\n    \"text\": \"a\",\r\n    \"number\": 1\r\n}", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
+            Assert.AreEqual("{\r\n    \"text\": \"a\",\r\n    \"number\": 1\r\n}", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
         }
 
-        [Fact]
+        [Test]
         public void TestXmlFormatted()
         {
             MemoryStream ms = new MemoryStream();
             Extensions.WriteTo(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build(),
                 new MessageFormatOptions() { FormattedOutput = true }, "application/xml", ms);
 
-            Assert.Equal("<root>\r\n    <text>a</text>\r\n    <number>1</number>\r\n</root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
+            Assert.AreEqual("<root>\r\n    <text>a</text>\r\n    <number>1</number>\r\n</root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
         }
 
-        [Fact]
+        [Test]
         public void TestReadCustomMimeTypes()
         {
             var options = new MessageFormatOptions();
@@ -242,7 +242,7 @@ namespace Google.ProtocolBuffers
             options.MimeInputTypes.Clear();
             //Add our own
             options.MimeInputTypes.Add("-custom-XML-mime-type-", XmlFormatReader.CreateInstance);
-            Assert.Equal(1, options.MimeInputTypes.Count);
+            Assert.AreEqual(1, options.MimeInputTypes.Count);
 
             Stream xmlStream = new MemoryStream(Encoding.UTF8.GetBytes(
                 Extensions.ToXml(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build())
@@ -251,11 +251,11 @@ namespace Google.ProtocolBuffers
             TestXmlMessage msg = Extensions.MergeFrom(new TestXmlMessage.Builder(),
                 options, "-custom-XML-mime-type-", xmlStream)
                 .Build();
-            Assert.Equal("a", msg.Text);
-            Assert.Equal(1, msg.Number);
+            Assert.AreEqual("a", msg.Text);
+            Assert.AreEqual(1, msg.Number);
         }
 
-        [Fact]
+        [Test]
         public void TestWriteToCustomType()
         {
             var options = new MessageFormatOptions();
@@ -264,13 +264,13 @@ namespace Google.ProtocolBuffers
             //Add our own
             options.MimeOutputTypes.Add("-custom-XML-mime-type-", XmlFormatWriter.CreateInstance);
             
-            Assert.Equal(1, options.MimeOutputTypes.Count);
+            Assert.AreEqual(1, options.MimeOutputTypes.Count);
 
             MemoryStream ms = new MemoryStream();
             Extensions.WriteTo(TestXmlMessage.CreateBuilder().SetText("a").SetNumber(1).Build(),
                 options, "-custom-XML-mime-type-", ms);
 
-            Assert.Equal("<root><text>a</text><number>1</number></root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
+            Assert.AreEqual("<root><text>a</text><number>1</number></root>", Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Length));
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/TestReaderForUrlEncoded.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestReaderForUrlEncoded.cs
@@ -3,13 +3,13 @@ using System.IO;
 using System.Text;
 using Google.ProtocolBuffers.TestProtos;
 using Google.ProtocolBuffers.Serialization.Http;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class TestReaderForUrlEncoded
     {
-        [Fact]
+        [Test]
         public void Example_FromQueryString()
         {
             Uri sampleUri = new Uri("http://sample.com/Path/File.ext?text=two+three%20four&valid=true&numbers=1&numbers=2", UriKind.Absolute);
@@ -20,14 +20,14 @@ namespace Google.ProtocolBuffers
             builder.MergeFrom(input);
             
             TestXmlMessage message = builder.Build();
-            Assert.Equal(true, message.Valid);
-            Assert.Equal("two three four", message.Text);
-            Assert.Equal(2, message.NumbersCount);
-            Assert.Equal(1, message.NumbersList[0]);
-            Assert.Equal(2, message.NumbersList[1]);
+            Assert.AreEqual(true, message.Valid);
+            Assert.AreEqual("two three four", message.Text);
+            Assert.AreEqual(2, message.NumbersCount);
+            Assert.AreEqual(1, message.NumbersList[0]);
+            Assert.AreEqual(2, message.NumbersList[1]);
         }
 
-        [Fact]
+        [Test]
         public void Example_FromFormData()
         {
             Stream rawPost = new MemoryStream(Encoding.UTF8.GetBytes("text=two+three%20four&valid=true&numbers=1&numbers=2"), false);
@@ -38,42 +38,42 @@ namespace Google.ProtocolBuffers
             builder.MergeFrom(input);
 
             TestXmlMessage message = builder.Build();
-            Assert.Equal(true, message.Valid);
-            Assert.Equal("two three four", message.Text);
-            Assert.Equal(2, message.NumbersCount);
-            Assert.Equal(1, message.NumbersList[0]);
-            Assert.Equal(2, message.NumbersList[1]);
+            Assert.AreEqual(true, message.Valid);
+            Assert.AreEqual("two three four", message.Text);
+            Assert.AreEqual(2, message.NumbersCount);
+            Assert.AreEqual(1, message.NumbersList[0]);
+            Assert.AreEqual(2, message.NumbersList[1]);
         }
 
-        [Fact]
+        [Test]
         public void TestEmptyValues()
         {
             ICodedInputStream input = FormUrlEncodedReader.CreateInstance("valid=true&text=&numbers=1");
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
             builder.MergeFrom(input);
 
-            Assert.True(builder.Valid);
-            Assert.True(builder.HasText);
-            Assert.Equal("", builder.Text);
-            Assert.Equal(1, builder.NumbersCount);
-            Assert.Equal(1, builder.NumbersList[0]);
+            Assert.IsTrue(builder.Valid);
+            Assert.IsTrue(builder.HasText);
+            Assert.AreEqual("", builder.Text);
+            Assert.AreEqual(1, builder.NumbersCount);
+            Assert.AreEqual(1, builder.NumbersList[0]);
         }
 
-        [Fact]
+        [Test]
         public void TestNoValue()
         {
             ICodedInputStream input = FormUrlEncodedReader.CreateInstance("valid=true&text&numbers=1");
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
             builder.MergeFrom(input);
 
-            Assert.True(builder.Valid);
-            Assert.True(builder.HasText);
-            Assert.Equal("", builder.Text);
-            Assert.Equal(1, builder.NumbersCount);
-            Assert.Equal(1, builder.NumbersList[0]);
+            Assert.IsTrue(builder.Valid);
+            Assert.IsTrue(builder.HasText);
+            Assert.AreEqual("", builder.Text);
+            Assert.AreEqual(1, builder.NumbersCount);
+            Assert.AreEqual(1, builder.NumbersList[0]);
         }
 
-        [Fact]
+        [Test]
         public void FormUrlEncodedReaderDoesNotSupportChildren()
         {
             ICodedInputStream input = FormUrlEncodedReader.CreateInstance("child=uh0");

--- a/csharp/src/ProtocolBuffers.Test/TestUtil.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestUtil.cs
@@ -41,7 +41,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -324,343 +324,343 @@ namespace Google.ProtocolBuffers
         /// </summary>
         internal static void AssertAllFieldsSet(TestAllTypes message)
         {
-            Assert.True(message.HasOptionalInt32);
-            Assert.True(message.HasOptionalInt64);
-            Assert.True(message.HasOptionalUint32);
-            Assert.True(message.HasOptionalUint64);
-            Assert.True(message.HasOptionalSint32);
-            Assert.True(message.HasOptionalSint64);
-            Assert.True(message.HasOptionalFixed32);
-            Assert.True(message.HasOptionalFixed64);
-            Assert.True(message.HasOptionalSfixed32);
-            Assert.True(message.HasOptionalSfixed64);
-            Assert.True(message.HasOptionalFloat);
-            Assert.True(message.HasOptionalDouble);
-            Assert.True(message.HasOptionalBool);
-            Assert.True(message.HasOptionalString);
-            Assert.True(message.HasOptionalBytes);
+            Assert.IsTrue(message.HasOptionalInt32);
+            Assert.IsTrue(message.HasOptionalInt64);
+            Assert.IsTrue(message.HasOptionalUint32);
+            Assert.IsTrue(message.HasOptionalUint64);
+            Assert.IsTrue(message.HasOptionalSint32);
+            Assert.IsTrue(message.HasOptionalSint64);
+            Assert.IsTrue(message.HasOptionalFixed32);
+            Assert.IsTrue(message.HasOptionalFixed64);
+            Assert.IsTrue(message.HasOptionalSfixed32);
+            Assert.IsTrue(message.HasOptionalSfixed64);
+            Assert.IsTrue(message.HasOptionalFloat);
+            Assert.IsTrue(message.HasOptionalDouble);
+            Assert.IsTrue(message.HasOptionalBool);
+            Assert.IsTrue(message.HasOptionalString);
+            Assert.IsTrue(message.HasOptionalBytes);
 
-            Assert.True(message.HasOptionalGroup);
-            Assert.True(message.HasOptionalNestedMessage);
-            Assert.True(message.HasOptionalForeignMessage);
-            Assert.True(message.HasOptionalImportMessage);
+            Assert.IsTrue(message.HasOptionalGroup);
+            Assert.IsTrue(message.HasOptionalNestedMessage);
+            Assert.IsTrue(message.HasOptionalForeignMessage);
+            Assert.IsTrue(message.HasOptionalImportMessage);
 
-            Assert.True(message.OptionalGroup.HasA);
-            Assert.True(message.OptionalNestedMessage.HasBb);
-            Assert.True(message.OptionalForeignMessage.HasC);
-            Assert.True(message.OptionalImportMessage.HasD);
+            Assert.IsTrue(message.OptionalGroup.HasA);
+            Assert.IsTrue(message.OptionalNestedMessage.HasBb);
+            Assert.IsTrue(message.OptionalForeignMessage.HasC);
+            Assert.IsTrue(message.OptionalImportMessage.HasD);
 
-            Assert.True(message.HasOptionalNestedEnum);
-            Assert.True(message.HasOptionalForeignEnum);
-            Assert.True(message.HasOptionalImportEnum);
+            Assert.IsTrue(message.HasOptionalNestedEnum);
+            Assert.IsTrue(message.HasOptionalForeignEnum);
+            Assert.IsTrue(message.HasOptionalImportEnum);
 
-            Assert.True(message.HasOptionalStringPiece);
-            Assert.True(message.HasOptionalCord);
+            Assert.IsTrue(message.HasOptionalStringPiece);
+            Assert.IsTrue(message.HasOptionalCord);
 
-            Assert.Equal(101, message.OptionalInt32);
-            Assert.Equal(102, message.OptionalInt64);
-            Assert.Equal(103u, message.OptionalUint32);
-            Assert.Equal(104u, message.OptionalUint64);
-            Assert.Equal(105, message.OptionalSint32);
-            Assert.Equal(106, message.OptionalSint64);
-            Assert.Equal(107u, message.OptionalFixed32);
-            Assert.Equal(108u, message.OptionalFixed64);
-            Assert.Equal(109, message.OptionalSfixed32);
-            Assert.Equal(110, message.OptionalSfixed64);
-            Assert.Equal(111, message.OptionalFloat);
-            Assert.Equal(112, message.OptionalDouble);
-            Assert.Equal(true, message.OptionalBool);
-            Assert.Equal("115", message.OptionalString);
-            Assert.Equal(ToBytes("116"), message.OptionalBytes);
+            Assert.AreEqual(101, message.OptionalInt32);
+            Assert.AreEqual(102, message.OptionalInt64);
+            Assert.AreEqual(103u, message.OptionalUint32);
+            Assert.AreEqual(104u, message.OptionalUint64);
+            Assert.AreEqual(105, message.OptionalSint32);
+            Assert.AreEqual(106, message.OptionalSint64);
+            Assert.AreEqual(107u, message.OptionalFixed32);
+            Assert.AreEqual(108u, message.OptionalFixed64);
+            Assert.AreEqual(109, message.OptionalSfixed32);
+            Assert.AreEqual(110, message.OptionalSfixed64);
+            Assert.AreEqual(111, message.OptionalFloat);
+            Assert.AreEqual(112, message.OptionalDouble);
+            Assert.AreEqual(true, message.OptionalBool);
+            Assert.AreEqual("115", message.OptionalString);
+            Assert.AreEqual(ToBytes("116"), message.OptionalBytes);
 
-            Assert.Equal(117, message.OptionalGroup.A);
-            Assert.Equal(118, message.OptionalNestedMessage.Bb);
-            Assert.Equal(119, message.OptionalForeignMessage.C);
-            Assert.Equal(120, message.OptionalImportMessage.D);
+            Assert.AreEqual(117, message.OptionalGroup.A);
+            Assert.AreEqual(118, message.OptionalNestedMessage.Bb);
+            Assert.AreEqual(119, message.OptionalForeignMessage.C);
+            Assert.AreEqual(120, message.OptionalImportMessage.D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAZ, message.OptionalNestedEnum);
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.OptionalForeignEnum);
-            Assert.Equal(ImportEnum.IMPORT_BAZ, message.OptionalImportEnum);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAZ, message.OptionalNestedEnum);
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.OptionalForeignEnum);
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, message.OptionalImportEnum);
 
-            Assert.Equal("124", message.OptionalStringPiece);
-            Assert.Equal("125", message.OptionalCord);
-
-            // -----------------------------------------------------------------
-
-            Assert.Equal(2, message.RepeatedInt32Count);
-            Assert.Equal(2, message.RepeatedInt64Count);
-            Assert.Equal(2, message.RepeatedUint32Count);
-            Assert.Equal(2, message.RepeatedUint64Count);
-            Assert.Equal(2, message.RepeatedSint32Count);
-            Assert.Equal(2, message.RepeatedSint64Count);
-            Assert.Equal(2, message.RepeatedFixed32Count);
-            Assert.Equal(2, message.RepeatedFixed64Count);
-            Assert.Equal(2, message.RepeatedSfixed32Count);
-            Assert.Equal(2, message.RepeatedSfixed64Count);
-            Assert.Equal(2, message.RepeatedFloatCount);
-            Assert.Equal(2, message.RepeatedDoubleCount);
-            Assert.Equal(2, message.RepeatedBoolCount);
-            Assert.Equal(2, message.RepeatedStringCount);
-            Assert.Equal(2, message.RepeatedBytesCount);
-
-            Assert.Equal(2, message.RepeatedGroupCount);
-            Assert.Equal(2, message.RepeatedNestedMessageCount);
-            Assert.Equal(2, message.RepeatedForeignMessageCount);
-            Assert.Equal(2, message.RepeatedImportMessageCount);
-            Assert.Equal(2, message.RepeatedNestedEnumCount);
-            Assert.Equal(2, message.RepeatedForeignEnumCount);
-            Assert.Equal(2, message.RepeatedImportEnumCount);
-
-            Assert.Equal(2, message.RepeatedStringPieceCount);
-            Assert.Equal(2, message.RepeatedCordCount);
-
-            Assert.Equal(201, message.GetRepeatedInt32(0));
-            Assert.Equal(202, message.GetRepeatedInt64(0));
-            Assert.Equal(203u, message.GetRepeatedUint32(0));
-            Assert.Equal(204u, message.GetRepeatedUint64(0));
-            Assert.Equal(205, message.GetRepeatedSint32(0));
-            Assert.Equal(206, message.GetRepeatedSint64(0));
-            Assert.Equal(207u, message.GetRepeatedFixed32(0));
-            Assert.Equal(208u, message.GetRepeatedFixed64(0));
-            Assert.Equal(209, message.GetRepeatedSfixed32(0));
-            Assert.Equal(210, message.GetRepeatedSfixed64(0));
-            Assert.Equal(211, message.GetRepeatedFloat(0));
-            Assert.Equal(212, message.GetRepeatedDouble(0));
-            Assert.Equal(true, message.GetRepeatedBool(0));
-            Assert.Equal("215", message.GetRepeatedString(0));
-            Assert.Equal(ToBytes("216"), message.GetRepeatedBytes(0));
-
-            Assert.Equal(217, message.GetRepeatedGroup(0).A);
-            Assert.Equal(218, message.GetRepeatedNestedMessage(0).Bb);
-            Assert.Equal(219, message.GetRepeatedForeignMessage(0).C);
-            Assert.Equal(220, message.GetRepeatedImportMessage(0).D);
-
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR, message.GetRepeatedNestedEnum(0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetRepeatedForeignEnum(0));
-            Assert.Equal(ImportEnum.IMPORT_BAR, message.GetRepeatedImportEnum(0));
-
-            Assert.Equal("224", message.GetRepeatedStringPiece(0));
-            Assert.Equal("225", message.GetRepeatedCord(0));
-
-            Assert.Equal(301, message.GetRepeatedInt32(1));
-            Assert.Equal(302, message.GetRepeatedInt64(1));
-            Assert.Equal(303u, message.GetRepeatedUint32(1));
-            Assert.Equal(304u, message.GetRepeatedUint64(1));
-            Assert.Equal(305, message.GetRepeatedSint32(1));
-            Assert.Equal(306, message.GetRepeatedSint64(1));
-            Assert.Equal(307u, message.GetRepeatedFixed32(1));
-            Assert.Equal(308u, message.GetRepeatedFixed64(1));
-            Assert.Equal(309, message.GetRepeatedSfixed32(1));
-            Assert.Equal(310, message.GetRepeatedSfixed64(1));
-            Assert.Equal(311f, message.GetRepeatedFloat(1));
-            Assert.Equal(312d, message.GetRepeatedDouble(1));
-            Assert.Equal(false, message.GetRepeatedBool(1));
-            Assert.Equal("315", message.GetRepeatedString(1));
-            Assert.Equal(ToBytes("316"), message.GetRepeatedBytes(1));
-
-            Assert.Equal(317, message.GetRepeatedGroup(1).A);
-            Assert.Equal(318, message.GetRepeatedNestedMessage(1).Bb);
-            Assert.Equal(319, message.GetRepeatedForeignMessage(1).C);
-            Assert.Equal(320, message.GetRepeatedImportMessage(1).D);
-
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAZ, message.GetRepeatedNestedEnum(1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.GetRepeatedForeignEnum(1));
-            Assert.Equal(ImportEnum.IMPORT_BAZ, message.GetRepeatedImportEnum(1));
-
-            Assert.Equal("324", message.GetRepeatedStringPiece(1));
-            Assert.Equal("325", message.GetRepeatedCord(1));
+            Assert.AreEqual("124", message.OptionalStringPiece);
+            Assert.AreEqual("125", message.OptionalCord);
 
             // -----------------------------------------------------------------
 
-            Assert.True(message.HasDefaultInt32);
-            Assert.True(message.HasDefaultInt64);
-            Assert.True(message.HasDefaultUint32);
-            Assert.True(message.HasDefaultUint64);
-            Assert.True(message.HasDefaultSint32);
-            Assert.True(message.HasDefaultSint64);
-            Assert.True(message.HasDefaultFixed32);
-            Assert.True(message.HasDefaultFixed64);
-            Assert.True(message.HasDefaultSfixed32);
-            Assert.True(message.HasDefaultSfixed64);
-            Assert.True(message.HasDefaultFloat);
-            Assert.True(message.HasDefaultDouble);
-            Assert.True(message.HasDefaultBool);
-            Assert.True(message.HasDefaultString);
-            Assert.True(message.HasDefaultBytes);
+            Assert.AreEqual(2, message.RepeatedInt32Count);
+            Assert.AreEqual(2, message.RepeatedInt64Count);
+            Assert.AreEqual(2, message.RepeatedUint32Count);
+            Assert.AreEqual(2, message.RepeatedUint64Count);
+            Assert.AreEqual(2, message.RepeatedSint32Count);
+            Assert.AreEqual(2, message.RepeatedSint64Count);
+            Assert.AreEqual(2, message.RepeatedFixed32Count);
+            Assert.AreEqual(2, message.RepeatedFixed64Count);
+            Assert.AreEqual(2, message.RepeatedSfixed32Count);
+            Assert.AreEqual(2, message.RepeatedSfixed64Count);
+            Assert.AreEqual(2, message.RepeatedFloatCount);
+            Assert.AreEqual(2, message.RepeatedDoubleCount);
+            Assert.AreEqual(2, message.RepeatedBoolCount);
+            Assert.AreEqual(2, message.RepeatedStringCount);
+            Assert.AreEqual(2, message.RepeatedBytesCount);
 
-            Assert.True(message.HasDefaultNestedEnum);
-            Assert.True(message.HasDefaultForeignEnum);
-            Assert.True(message.HasDefaultImportEnum);
+            Assert.AreEqual(2, message.RepeatedGroupCount);
+            Assert.AreEqual(2, message.RepeatedNestedMessageCount);
+            Assert.AreEqual(2, message.RepeatedForeignMessageCount);
+            Assert.AreEqual(2, message.RepeatedImportMessageCount);
+            Assert.AreEqual(2, message.RepeatedNestedEnumCount);
+            Assert.AreEqual(2, message.RepeatedForeignEnumCount);
+            Assert.AreEqual(2, message.RepeatedImportEnumCount);
 
-            Assert.True(message.HasDefaultStringPiece);
-            Assert.True(message.HasDefaultCord);
+            Assert.AreEqual(2, message.RepeatedStringPieceCount);
+            Assert.AreEqual(2, message.RepeatedCordCount);
 
-            Assert.Equal(401, message.DefaultInt32);
-            Assert.Equal(402, message.DefaultInt64);
-            Assert.Equal(403u, message.DefaultUint32);
-            Assert.Equal(404u, message.DefaultUint64);
-            Assert.Equal(405, message.DefaultSint32);
-            Assert.Equal(406, message.DefaultSint64);
-            Assert.Equal(407u, message.DefaultFixed32);
-            Assert.Equal(408u, message.DefaultFixed64);
-            Assert.Equal(409, message.DefaultSfixed32);
-            Assert.Equal(410, message.DefaultSfixed64);
-            Assert.Equal(411, message.DefaultFloat);
-            Assert.Equal(412, message.DefaultDouble);
-            Assert.Equal(false, message.DefaultBool);
-            Assert.Equal("415", message.DefaultString);
-            Assert.Equal(ToBytes("416"), message.DefaultBytes);
+            Assert.AreEqual(201, message.GetRepeatedInt32(0));
+            Assert.AreEqual(202, message.GetRepeatedInt64(0));
+            Assert.AreEqual(203u, message.GetRepeatedUint32(0));
+            Assert.AreEqual(204u, message.GetRepeatedUint64(0));
+            Assert.AreEqual(205, message.GetRepeatedSint32(0));
+            Assert.AreEqual(206, message.GetRepeatedSint64(0));
+            Assert.AreEqual(207u, message.GetRepeatedFixed32(0));
+            Assert.AreEqual(208u, message.GetRepeatedFixed64(0));
+            Assert.AreEqual(209, message.GetRepeatedSfixed32(0));
+            Assert.AreEqual(210, message.GetRepeatedSfixed64(0));
+            Assert.AreEqual(211, message.GetRepeatedFloat(0));
+            Assert.AreEqual(212, message.GetRepeatedDouble(0));
+            Assert.AreEqual(true, message.GetRepeatedBool(0));
+            Assert.AreEqual("215", message.GetRepeatedString(0));
+            Assert.AreEqual(ToBytes("216"), message.GetRepeatedBytes(0));
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO, message.DefaultNestedEnum);
-            Assert.Equal(ForeignEnum.FOREIGN_FOO, message.DefaultForeignEnum);
-            Assert.Equal(ImportEnum.IMPORT_FOO, message.DefaultImportEnum);
+            Assert.AreEqual(217, message.GetRepeatedGroup(0).A);
+            Assert.AreEqual(218, message.GetRepeatedNestedMessage(0).Bb);
+            Assert.AreEqual(219, message.GetRepeatedForeignMessage(0).C);
+            Assert.AreEqual(220, message.GetRepeatedImportMessage(0).D);
 
-            Assert.Equal("424", message.DefaultStringPiece);
-            Assert.Equal("425", message.DefaultCord);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR, message.GetRepeatedNestedEnum(0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetRepeatedForeignEnum(0));
+            Assert.AreEqual(ImportEnum.IMPORT_BAR, message.GetRepeatedImportEnum(0));
+
+            Assert.AreEqual("224", message.GetRepeatedStringPiece(0));
+            Assert.AreEqual("225", message.GetRepeatedCord(0));
+
+            Assert.AreEqual(301, message.GetRepeatedInt32(1));
+            Assert.AreEqual(302, message.GetRepeatedInt64(1));
+            Assert.AreEqual(303u, message.GetRepeatedUint32(1));
+            Assert.AreEqual(304u, message.GetRepeatedUint64(1));
+            Assert.AreEqual(305, message.GetRepeatedSint32(1));
+            Assert.AreEqual(306, message.GetRepeatedSint64(1));
+            Assert.AreEqual(307u, message.GetRepeatedFixed32(1));
+            Assert.AreEqual(308u, message.GetRepeatedFixed64(1));
+            Assert.AreEqual(309, message.GetRepeatedSfixed32(1));
+            Assert.AreEqual(310, message.GetRepeatedSfixed64(1));
+            Assert.AreEqual(311f, message.GetRepeatedFloat(1));
+            Assert.AreEqual(312d, message.GetRepeatedDouble(1));
+            Assert.AreEqual(false, message.GetRepeatedBool(1));
+            Assert.AreEqual("315", message.GetRepeatedString(1));
+            Assert.AreEqual(ToBytes("316"), message.GetRepeatedBytes(1));
+
+            Assert.AreEqual(317, message.GetRepeatedGroup(1).A);
+            Assert.AreEqual(318, message.GetRepeatedNestedMessage(1).Bb);
+            Assert.AreEqual(319, message.GetRepeatedForeignMessage(1).C);
+            Assert.AreEqual(320, message.GetRepeatedImportMessage(1).D);
+
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAZ, message.GetRepeatedNestedEnum(1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.GetRepeatedForeignEnum(1));
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, message.GetRepeatedImportEnum(1));
+
+            Assert.AreEqual("324", message.GetRepeatedStringPiece(1));
+            Assert.AreEqual("325", message.GetRepeatedCord(1));
+
+            // -----------------------------------------------------------------
+
+            Assert.IsTrue(message.HasDefaultInt32);
+            Assert.IsTrue(message.HasDefaultInt64);
+            Assert.IsTrue(message.HasDefaultUint32);
+            Assert.IsTrue(message.HasDefaultUint64);
+            Assert.IsTrue(message.HasDefaultSint32);
+            Assert.IsTrue(message.HasDefaultSint64);
+            Assert.IsTrue(message.HasDefaultFixed32);
+            Assert.IsTrue(message.HasDefaultFixed64);
+            Assert.IsTrue(message.HasDefaultSfixed32);
+            Assert.IsTrue(message.HasDefaultSfixed64);
+            Assert.IsTrue(message.HasDefaultFloat);
+            Assert.IsTrue(message.HasDefaultDouble);
+            Assert.IsTrue(message.HasDefaultBool);
+            Assert.IsTrue(message.HasDefaultString);
+            Assert.IsTrue(message.HasDefaultBytes);
+
+            Assert.IsTrue(message.HasDefaultNestedEnum);
+            Assert.IsTrue(message.HasDefaultForeignEnum);
+            Assert.IsTrue(message.HasDefaultImportEnum);
+
+            Assert.IsTrue(message.HasDefaultStringPiece);
+            Assert.IsTrue(message.HasDefaultCord);
+
+            Assert.AreEqual(401, message.DefaultInt32);
+            Assert.AreEqual(402, message.DefaultInt64);
+            Assert.AreEqual(403u, message.DefaultUint32);
+            Assert.AreEqual(404u, message.DefaultUint64);
+            Assert.AreEqual(405, message.DefaultSint32);
+            Assert.AreEqual(406, message.DefaultSint64);
+            Assert.AreEqual(407u, message.DefaultFixed32);
+            Assert.AreEqual(408u, message.DefaultFixed64);
+            Assert.AreEqual(409, message.DefaultSfixed32);
+            Assert.AreEqual(410, message.DefaultSfixed64);
+            Assert.AreEqual(411, message.DefaultFloat);
+            Assert.AreEqual(412, message.DefaultDouble);
+            Assert.AreEqual(false, message.DefaultBool);
+            Assert.AreEqual("415", message.DefaultString);
+            Assert.AreEqual(ToBytes("416"), message.DefaultBytes);
+
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO, message.DefaultNestedEnum);
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO, message.DefaultForeignEnum);
+            Assert.AreEqual(ImportEnum.IMPORT_FOO, message.DefaultImportEnum);
+
+            Assert.AreEqual("424", message.DefaultStringPiece);
+            Assert.AreEqual("425", message.DefaultCord);
         }
 
         internal static void AssertClear(TestAllTypes message)
         {
             // HasBlah() should initially be false for all optional fields.
-            Assert.False(message.HasOptionalInt32);
-            Assert.False(message.HasOptionalInt64);
-            Assert.False(message.HasOptionalUint32);
-            Assert.False(message.HasOptionalUint64);
-            Assert.False(message.HasOptionalSint32);
-            Assert.False(message.HasOptionalSint64);
-            Assert.False(message.HasOptionalFixed32);
-            Assert.False(message.HasOptionalFixed64);
-            Assert.False(message.HasOptionalSfixed32);
-            Assert.False(message.HasOptionalSfixed64);
-            Assert.False(message.HasOptionalFloat);
-            Assert.False(message.HasOptionalDouble);
-            Assert.False(message.HasOptionalBool);
-            Assert.False(message.HasOptionalString);
-            Assert.False(message.HasOptionalBytes);
+            Assert.IsFalse(message.HasOptionalInt32);
+            Assert.IsFalse(message.HasOptionalInt64);
+            Assert.IsFalse(message.HasOptionalUint32);
+            Assert.IsFalse(message.HasOptionalUint64);
+            Assert.IsFalse(message.HasOptionalSint32);
+            Assert.IsFalse(message.HasOptionalSint64);
+            Assert.IsFalse(message.HasOptionalFixed32);
+            Assert.IsFalse(message.HasOptionalFixed64);
+            Assert.IsFalse(message.HasOptionalSfixed32);
+            Assert.IsFalse(message.HasOptionalSfixed64);
+            Assert.IsFalse(message.HasOptionalFloat);
+            Assert.IsFalse(message.HasOptionalDouble);
+            Assert.IsFalse(message.HasOptionalBool);
+            Assert.IsFalse(message.HasOptionalString);
+            Assert.IsFalse(message.HasOptionalBytes);
 
-            Assert.False(message.HasOptionalGroup);
-            Assert.False(message.HasOptionalNestedMessage);
-            Assert.False(message.HasOptionalForeignMessage);
-            Assert.False(message.HasOptionalImportMessage);
+            Assert.IsFalse(message.HasOptionalGroup);
+            Assert.IsFalse(message.HasOptionalNestedMessage);
+            Assert.IsFalse(message.HasOptionalForeignMessage);
+            Assert.IsFalse(message.HasOptionalImportMessage);
 
-            Assert.False(message.HasOptionalNestedEnum);
-            Assert.False(message.HasOptionalForeignEnum);
-            Assert.False(message.HasOptionalImportEnum);
+            Assert.IsFalse(message.HasOptionalNestedEnum);
+            Assert.IsFalse(message.HasOptionalForeignEnum);
+            Assert.IsFalse(message.HasOptionalImportEnum);
 
-            Assert.False(message.HasOptionalStringPiece);
-            Assert.False(message.HasOptionalCord);
+            Assert.IsFalse(message.HasOptionalStringPiece);
+            Assert.IsFalse(message.HasOptionalCord);
 
             // Optional fields without defaults are set to zero or something like it.
-            Assert.Equal(0, message.OptionalInt32);
-            Assert.Equal(0, message.OptionalInt64);
-            Assert.Equal(0u, message.OptionalUint32);
-            Assert.Equal(0u, message.OptionalUint64);
-            Assert.Equal(0, message.OptionalSint32);
-            Assert.Equal(0, message.OptionalSint64);
-            Assert.Equal(0u, message.OptionalFixed32);
-            Assert.Equal(0u, message.OptionalFixed64);
-            Assert.Equal(0, message.OptionalSfixed32);
-            Assert.Equal(0, message.OptionalSfixed64);
-            Assert.Equal(0, message.OptionalFloat);
-            Assert.Equal(0, message.OptionalDouble);
-            Assert.Equal(false, message.OptionalBool);
-            Assert.Equal("", message.OptionalString);
-            Assert.Equal(ByteString.Empty, message.OptionalBytes);
+            Assert.AreEqual(0, message.OptionalInt32);
+            Assert.AreEqual(0, message.OptionalInt64);
+            Assert.AreEqual(0u, message.OptionalUint32);
+            Assert.AreEqual(0u, message.OptionalUint64);
+            Assert.AreEqual(0, message.OptionalSint32);
+            Assert.AreEqual(0, message.OptionalSint64);
+            Assert.AreEqual(0u, message.OptionalFixed32);
+            Assert.AreEqual(0u, message.OptionalFixed64);
+            Assert.AreEqual(0, message.OptionalSfixed32);
+            Assert.AreEqual(0, message.OptionalSfixed64);
+            Assert.AreEqual(0, message.OptionalFloat);
+            Assert.AreEqual(0, message.OptionalDouble);
+            Assert.AreEqual(false, message.OptionalBool);
+            Assert.AreEqual("", message.OptionalString);
+            Assert.AreEqual(ByteString.Empty, message.OptionalBytes);
 
             // Embedded messages should also be clear.
-            Assert.False(message.OptionalGroup.HasA);
-            Assert.False(message.OptionalNestedMessage.HasBb);
-            Assert.False(message.OptionalForeignMessage.HasC);
-            Assert.False(message.OptionalImportMessage.HasD);
+            Assert.IsFalse(message.OptionalGroup.HasA);
+            Assert.IsFalse(message.OptionalNestedMessage.HasBb);
+            Assert.IsFalse(message.OptionalForeignMessage.HasC);
+            Assert.IsFalse(message.OptionalImportMessage.HasD);
 
-            Assert.Equal(0, message.OptionalGroup.A);
-            Assert.Equal(0, message.OptionalNestedMessage.Bb);
-            Assert.Equal(0, message.OptionalForeignMessage.C);
-            Assert.Equal(0, message.OptionalImportMessage.D);
+            Assert.AreEqual(0, message.OptionalGroup.A);
+            Assert.AreEqual(0, message.OptionalNestedMessage.Bb);
+            Assert.AreEqual(0, message.OptionalForeignMessage.C);
+            Assert.AreEqual(0, message.OptionalImportMessage.D);
 
             // Enums without defaults are set to the first value in the enum.
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO, message.OptionalNestedEnum);
-            Assert.Equal(ForeignEnum.FOREIGN_FOO, message.OptionalForeignEnum);
-            Assert.Equal(ImportEnum.IMPORT_FOO, message.OptionalImportEnum);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO, message.OptionalNestedEnum);
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO, message.OptionalForeignEnum);
+            Assert.AreEqual(ImportEnum.IMPORT_FOO, message.OptionalImportEnum);
 
-            Assert.Equal("", message.OptionalStringPiece);
-            Assert.Equal("", message.OptionalCord);
+            Assert.AreEqual("", message.OptionalStringPiece);
+            Assert.AreEqual("", message.OptionalCord);
 
             // Repeated fields are empty.
-            Assert.Equal(0, message.RepeatedInt32Count);
-            Assert.Equal(0, message.RepeatedInt64Count);
-            Assert.Equal(0, message.RepeatedUint32Count);
-            Assert.Equal(0, message.RepeatedUint64Count);
-            Assert.Equal(0, message.RepeatedSint32Count);
-            Assert.Equal(0, message.RepeatedSint64Count);
-            Assert.Equal(0, message.RepeatedFixed32Count);
-            Assert.Equal(0, message.RepeatedFixed64Count);
-            Assert.Equal(0, message.RepeatedSfixed32Count);
-            Assert.Equal(0, message.RepeatedSfixed64Count);
-            Assert.Equal(0, message.RepeatedFloatCount);
-            Assert.Equal(0, message.RepeatedDoubleCount);
-            Assert.Equal(0, message.RepeatedBoolCount);
-            Assert.Equal(0, message.RepeatedStringCount);
-            Assert.Equal(0, message.RepeatedBytesCount);
+            Assert.AreEqual(0, message.RepeatedInt32Count);
+            Assert.AreEqual(0, message.RepeatedInt64Count);
+            Assert.AreEqual(0, message.RepeatedUint32Count);
+            Assert.AreEqual(0, message.RepeatedUint64Count);
+            Assert.AreEqual(0, message.RepeatedSint32Count);
+            Assert.AreEqual(0, message.RepeatedSint64Count);
+            Assert.AreEqual(0, message.RepeatedFixed32Count);
+            Assert.AreEqual(0, message.RepeatedFixed64Count);
+            Assert.AreEqual(0, message.RepeatedSfixed32Count);
+            Assert.AreEqual(0, message.RepeatedSfixed64Count);
+            Assert.AreEqual(0, message.RepeatedFloatCount);
+            Assert.AreEqual(0, message.RepeatedDoubleCount);
+            Assert.AreEqual(0, message.RepeatedBoolCount);
+            Assert.AreEqual(0, message.RepeatedStringCount);
+            Assert.AreEqual(0, message.RepeatedBytesCount);
 
-            Assert.Equal(0, message.RepeatedGroupCount);
-            Assert.Equal(0, message.RepeatedNestedMessageCount);
-            Assert.Equal(0, message.RepeatedForeignMessageCount);
-            Assert.Equal(0, message.RepeatedImportMessageCount);
-            Assert.Equal(0, message.RepeatedNestedEnumCount);
-            Assert.Equal(0, message.RepeatedForeignEnumCount);
-            Assert.Equal(0, message.RepeatedImportEnumCount);
+            Assert.AreEqual(0, message.RepeatedGroupCount);
+            Assert.AreEqual(0, message.RepeatedNestedMessageCount);
+            Assert.AreEqual(0, message.RepeatedForeignMessageCount);
+            Assert.AreEqual(0, message.RepeatedImportMessageCount);
+            Assert.AreEqual(0, message.RepeatedNestedEnumCount);
+            Assert.AreEqual(0, message.RepeatedForeignEnumCount);
+            Assert.AreEqual(0, message.RepeatedImportEnumCount);
 
-            Assert.Equal(0, message.RepeatedStringPieceCount);
-            Assert.Equal(0, message.RepeatedCordCount);
+            Assert.AreEqual(0, message.RepeatedStringPieceCount);
+            Assert.AreEqual(0, message.RepeatedCordCount);
 
             // HasBlah() should also be false for all default fields.
-            Assert.False(message.HasDefaultInt32);
-            Assert.False(message.HasDefaultInt64);
-            Assert.False(message.HasDefaultUint32);
-            Assert.False(message.HasDefaultUint64);
-            Assert.False(message.HasDefaultSint32);
-            Assert.False(message.HasDefaultSint64);
-            Assert.False(message.HasDefaultFixed32);
-            Assert.False(message.HasDefaultFixed64);
-            Assert.False(message.HasDefaultSfixed32);
-            Assert.False(message.HasDefaultSfixed64);
-            Assert.False(message.HasDefaultFloat);
-            Assert.False(message.HasDefaultDouble);
-            Assert.False(message.HasDefaultBool);
-            Assert.False(message.HasDefaultString);
-            Assert.False(message.HasDefaultBytes);
+            Assert.IsFalse(message.HasDefaultInt32);
+            Assert.IsFalse(message.HasDefaultInt64);
+            Assert.IsFalse(message.HasDefaultUint32);
+            Assert.IsFalse(message.HasDefaultUint64);
+            Assert.IsFalse(message.HasDefaultSint32);
+            Assert.IsFalse(message.HasDefaultSint64);
+            Assert.IsFalse(message.HasDefaultFixed32);
+            Assert.IsFalse(message.HasDefaultFixed64);
+            Assert.IsFalse(message.HasDefaultSfixed32);
+            Assert.IsFalse(message.HasDefaultSfixed64);
+            Assert.IsFalse(message.HasDefaultFloat);
+            Assert.IsFalse(message.HasDefaultDouble);
+            Assert.IsFalse(message.HasDefaultBool);
+            Assert.IsFalse(message.HasDefaultString);
+            Assert.IsFalse(message.HasDefaultBytes);
 
-            Assert.False(message.HasDefaultNestedEnum);
-            Assert.False(message.HasDefaultForeignEnum);
-            Assert.False(message.HasDefaultImportEnum);
+            Assert.IsFalse(message.HasDefaultNestedEnum);
+            Assert.IsFalse(message.HasDefaultForeignEnum);
+            Assert.IsFalse(message.HasDefaultImportEnum);
 
-            Assert.False(message.HasDefaultStringPiece);
-            Assert.False(message.HasDefaultCord);
+            Assert.IsFalse(message.HasDefaultStringPiece);
+            Assert.IsFalse(message.HasDefaultCord);
 
             // Fields with defaults have their default values (duh).
-            Assert.Equal(41, message.DefaultInt32);
-            Assert.Equal(42, message.DefaultInt64);
-            Assert.Equal(43u, message.DefaultUint32);
-            Assert.Equal(44u, message.DefaultUint64);
-            Assert.Equal(-45, message.DefaultSint32);
-            Assert.Equal(46, message.DefaultSint64);
-            Assert.Equal(47u, message.DefaultFixed32);
-            Assert.Equal(48u, message.DefaultFixed64);
-            Assert.Equal(49, message.DefaultSfixed32);
-            Assert.Equal(-50, message.DefaultSfixed64);
-            Assert.Equal(51.5f, message.DefaultFloat);
-            Assert.Equal(52e3d, message.DefaultDouble);
-            Assert.Equal(true, message.DefaultBool);
-            Assert.Equal("hello", message.DefaultString);
-            Assert.Equal(ToBytes("world"), message.DefaultBytes);
+            Assert.AreEqual(41, message.DefaultInt32);
+            Assert.AreEqual(42, message.DefaultInt64);
+            Assert.AreEqual(43u, message.DefaultUint32);
+            Assert.AreEqual(44u, message.DefaultUint64);
+            Assert.AreEqual(-45, message.DefaultSint32);
+            Assert.AreEqual(46, message.DefaultSint64);
+            Assert.AreEqual(47u, message.DefaultFixed32);
+            Assert.AreEqual(48u, message.DefaultFixed64);
+            Assert.AreEqual(49, message.DefaultSfixed32);
+            Assert.AreEqual(-50, message.DefaultSfixed64);
+            Assert.AreEqual(51.5f, message.DefaultFloat);
+            Assert.AreEqual(52e3d, message.DefaultDouble);
+            Assert.AreEqual(true, message.DefaultBool);
+            Assert.AreEqual("hello", message.DefaultString);
+            Assert.AreEqual(ToBytes("world"), message.DefaultBytes);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR, message.DefaultNestedEnum);
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.DefaultForeignEnum);
-            Assert.Equal(ImportEnum.IMPORT_BAR, message.DefaultImportEnum);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR, message.DefaultNestedEnum);
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.DefaultForeignEnum);
+            Assert.AreEqual(ImportEnum.IMPORT_BAR, message.DefaultImportEnum);
 
-            Assert.Equal("abc", message.DefaultStringPiece);
-            Assert.Equal("123", message.DefaultCord);
+            Assert.AreEqual("abc", message.DefaultStringPiece);
+            Assert.AreEqual("123", message.DefaultCord);
         }
 
         /// <summary>
@@ -855,89 +855,89 @@ namespace Google.ProtocolBuffers
             // ModifyRepeatedFields only sets the second repeated element of each
             // field.  In addition to verifying this, we also verify that the first
             // element and size were *not* modified.
-            Assert.Equal(2, message.RepeatedInt32Count);
-            Assert.Equal(2, message.RepeatedInt64Count);
-            Assert.Equal(2, message.RepeatedUint32Count);
-            Assert.Equal(2, message.RepeatedUint64Count);
-            Assert.Equal(2, message.RepeatedSint32Count);
-            Assert.Equal(2, message.RepeatedSint64Count);
-            Assert.Equal(2, message.RepeatedFixed32Count);
-            Assert.Equal(2, message.RepeatedFixed64Count);
-            Assert.Equal(2, message.RepeatedSfixed32Count);
-            Assert.Equal(2, message.RepeatedSfixed64Count);
-            Assert.Equal(2, message.RepeatedFloatCount);
-            Assert.Equal(2, message.RepeatedDoubleCount);
-            Assert.Equal(2, message.RepeatedBoolCount);
-            Assert.Equal(2, message.RepeatedStringCount);
-            Assert.Equal(2, message.RepeatedBytesCount);
+            Assert.AreEqual(2, message.RepeatedInt32Count);
+            Assert.AreEqual(2, message.RepeatedInt64Count);
+            Assert.AreEqual(2, message.RepeatedUint32Count);
+            Assert.AreEqual(2, message.RepeatedUint64Count);
+            Assert.AreEqual(2, message.RepeatedSint32Count);
+            Assert.AreEqual(2, message.RepeatedSint64Count);
+            Assert.AreEqual(2, message.RepeatedFixed32Count);
+            Assert.AreEqual(2, message.RepeatedFixed64Count);
+            Assert.AreEqual(2, message.RepeatedSfixed32Count);
+            Assert.AreEqual(2, message.RepeatedSfixed64Count);
+            Assert.AreEqual(2, message.RepeatedFloatCount);
+            Assert.AreEqual(2, message.RepeatedDoubleCount);
+            Assert.AreEqual(2, message.RepeatedBoolCount);
+            Assert.AreEqual(2, message.RepeatedStringCount);
+            Assert.AreEqual(2, message.RepeatedBytesCount);
 
-            Assert.Equal(2, message.RepeatedGroupCount);
-            Assert.Equal(2, message.RepeatedNestedMessageCount);
-            Assert.Equal(2, message.RepeatedForeignMessageCount);
-            Assert.Equal(2, message.RepeatedImportMessageCount);
-            Assert.Equal(2, message.RepeatedNestedEnumCount);
-            Assert.Equal(2, message.RepeatedForeignEnumCount);
-            Assert.Equal(2, message.RepeatedImportEnumCount);
+            Assert.AreEqual(2, message.RepeatedGroupCount);
+            Assert.AreEqual(2, message.RepeatedNestedMessageCount);
+            Assert.AreEqual(2, message.RepeatedForeignMessageCount);
+            Assert.AreEqual(2, message.RepeatedImportMessageCount);
+            Assert.AreEqual(2, message.RepeatedNestedEnumCount);
+            Assert.AreEqual(2, message.RepeatedForeignEnumCount);
+            Assert.AreEqual(2, message.RepeatedImportEnumCount);
 
-            Assert.Equal(2, message.RepeatedStringPieceCount);
-            Assert.Equal(2, message.RepeatedCordCount);
+            Assert.AreEqual(2, message.RepeatedStringPieceCount);
+            Assert.AreEqual(2, message.RepeatedCordCount);
 
-            Assert.Equal(201, message.GetRepeatedInt32(0));
-            Assert.Equal(202L, message.GetRepeatedInt64(0));
-            Assert.Equal(203U, message.GetRepeatedUint32(0));
-            Assert.Equal(204UL, message.GetRepeatedUint64(0));
-            Assert.Equal(205, message.GetRepeatedSint32(0));
-            Assert.Equal(206L, message.GetRepeatedSint64(0));
-            Assert.Equal(207U, message.GetRepeatedFixed32(0));
-            Assert.Equal(208UL, message.GetRepeatedFixed64(0));
-            Assert.Equal(209, message.GetRepeatedSfixed32(0));
-            Assert.Equal(210L, message.GetRepeatedSfixed64(0));
-            Assert.Equal(211F, message.GetRepeatedFloat(0));
-            Assert.Equal(212D, message.GetRepeatedDouble(0));
-            Assert.Equal(true, message.GetRepeatedBool(0));
-            Assert.Equal("215", message.GetRepeatedString(0));
-            Assert.Equal(ToBytes("216"), message.GetRepeatedBytes(0));
+            Assert.AreEqual(201, message.GetRepeatedInt32(0));
+            Assert.AreEqual(202L, message.GetRepeatedInt64(0));
+            Assert.AreEqual(203U, message.GetRepeatedUint32(0));
+            Assert.AreEqual(204UL, message.GetRepeatedUint64(0));
+            Assert.AreEqual(205, message.GetRepeatedSint32(0));
+            Assert.AreEqual(206L, message.GetRepeatedSint64(0));
+            Assert.AreEqual(207U, message.GetRepeatedFixed32(0));
+            Assert.AreEqual(208UL, message.GetRepeatedFixed64(0));
+            Assert.AreEqual(209, message.GetRepeatedSfixed32(0));
+            Assert.AreEqual(210L, message.GetRepeatedSfixed64(0));
+            Assert.AreEqual(211F, message.GetRepeatedFloat(0));
+            Assert.AreEqual(212D, message.GetRepeatedDouble(0));
+            Assert.AreEqual(true, message.GetRepeatedBool(0));
+            Assert.AreEqual("215", message.GetRepeatedString(0));
+            Assert.AreEqual(ToBytes("216"), message.GetRepeatedBytes(0));
 
-            Assert.Equal(217, message.GetRepeatedGroup(0).A);
-            Assert.Equal(218, message.GetRepeatedNestedMessage(0).Bb);
-            Assert.Equal(219, message.GetRepeatedForeignMessage(0).C);
-            Assert.Equal(220, message.GetRepeatedImportMessage(0).D);
+            Assert.AreEqual(217, message.GetRepeatedGroup(0).A);
+            Assert.AreEqual(218, message.GetRepeatedNestedMessage(0).Bb);
+            Assert.AreEqual(219, message.GetRepeatedForeignMessage(0).C);
+            Assert.AreEqual(220, message.GetRepeatedImportMessage(0).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR, message.GetRepeatedNestedEnum(0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetRepeatedForeignEnum(0));
-            Assert.Equal(ImportEnum.IMPORT_BAR, message.GetRepeatedImportEnum(0));
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR, message.GetRepeatedNestedEnum(0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetRepeatedForeignEnum(0));
+            Assert.AreEqual(ImportEnum.IMPORT_BAR, message.GetRepeatedImportEnum(0));
 
-            Assert.Equal("224", message.GetRepeatedStringPiece(0));
-            Assert.Equal("225", message.GetRepeatedCord(0));
+            Assert.AreEqual("224", message.GetRepeatedStringPiece(0));
+            Assert.AreEqual("225", message.GetRepeatedCord(0));
 
             // Actually verify the second (modified) elements now.
-            Assert.Equal(501, message.GetRepeatedInt32(1));
-            Assert.Equal(502L, message.GetRepeatedInt64(1));
-            Assert.Equal(503U, message.GetRepeatedUint32(1));
-            Assert.Equal(504UL, message.GetRepeatedUint64(1));
-            Assert.Equal(505, message.GetRepeatedSint32(1));
-            Assert.Equal(506L, message.GetRepeatedSint64(1));
-            Assert.Equal(507U, message.GetRepeatedFixed32(1));
-            Assert.Equal(508UL, message.GetRepeatedFixed64(1));
-            Assert.Equal(509, message.GetRepeatedSfixed32(1));
-            Assert.Equal(510L, message.GetRepeatedSfixed64(1));
-            Assert.Equal(511F, message.GetRepeatedFloat(1));
-            Assert.Equal(512D, message.GetRepeatedDouble(1));
-            Assert.Equal(true, message.GetRepeatedBool(1));
-            Assert.Equal("515", message.GetRepeatedString(1));
-            Assert.Equal(ToBytes("516"), message.GetRepeatedBytes(1));
+            Assert.AreEqual(501, message.GetRepeatedInt32(1));
+            Assert.AreEqual(502L, message.GetRepeatedInt64(1));
+            Assert.AreEqual(503U, message.GetRepeatedUint32(1));
+            Assert.AreEqual(504UL, message.GetRepeatedUint64(1));
+            Assert.AreEqual(505, message.GetRepeatedSint32(1));
+            Assert.AreEqual(506L, message.GetRepeatedSint64(1));
+            Assert.AreEqual(507U, message.GetRepeatedFixed32(1));
+            Assert.AreEqual(508UL, message.GetRepeatedFixed64(1));
+            Assert.AreEqual(509, message.GetRepeatedSfixed32(1));
+            Assert.AreEqual(510L, message.GetRepeatedSfixed64(1));
+            Assert.AreEqual(511F, message.GetRepeatedFloat(1));
+            Assert.AreEqual(512D, message.GetRepeatedDouble(1));
+            Assert.AreEqual(true, message.GetRepeatedBool(1));
+            Assert.AreEqual("515", message.GetRepeatedString(1));
+            Assert.AreEqual(ToBytes("516"), message.GetRepeatedBytes(1));
 
-            Assert.Equal(517, message.GetRepeatedGroup(1).A);
-            Assert.Equal(518, message.GetRepeatedNestedMessage(1).Bb);
-            Assert.Equal(519, message.GetRepeatedForeignMessage(1).C);
-            Assert.Equal(520, message.GetRepeatedImportMessage(1).D);
+            Assert.AreEqual(517, message.GetRepeatedGroup(1).A);
+            Assert.AreEqual(518, message.GetRepeatedNestedMessage(1).Bb);
+            Assert.AreEqual(519, message.GetRepeatedForeignMessage(1).C);
+            Assert.AreEqual(520, message.GetRepeatedImportMessage(1).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO, message.GetRepeatedNestedEnum(1));
-            Assert.Equal(ForeignEnum.FOREIGN_FOO, message.GetRepeatedForeignEnum(1));
-            Assert.Equal(ImportEnum.IMPORT_FOO, message.GetRepeatedImportEnum(1));
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO, message.GetRepeatedNestedEnum(1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO, message.GetRepeatedForeignEnum(1));
+            Assert.AreEqual(ImportEnum.IMPORT_FOO, message.GetRepeatedImportEnum(1));
 
-            Assert.Equal("524", message.GetRepeatedStringPiece(1));
-            Assert.Equal("525", message.GetRepeatedCord(1));
+            Assert.AreEqual("524", message.GetRepeatedStringPiece(1));
+            Assert.AreEqual("525", message.GetRepeatedCord(1));
         }
 
         /// <summary>
@@ -949,222 +949,222 @@ namespace Google.ProtocolBuffers
             {
                 foreach (T secondElement in second)
                 {
-                    Assert.True(firstEnumerator.MoveNext(), "First enumerator ran out of elements too early.");
-                    Assert.Equal(firstEnumerator.Current, secondElement);
+                    Assert.IsTrue(firstEnumerator.MoveNext(), "First enumerator ran out of elements too early.");
+                    Assert.AreEqual(firstEnumerator.Current, secondElement);
                 }
-                Assert.False(firstEnumerator.MoveNext(), "Second enumerator ran out of elements too early.");
+                Assert.IsFalse(firstEnumerator.MoveNext(), "Second enumerator ran out of elements too early.");
             }
         }
 
         internal static void AssertEqualBytes(byte[] expected, byte[] actual)
         {
-            Assert.Equal(ByteString.CopyFrom(expected), ByteString.CopyFrom(actual));
+            Assert.AreEqual(ByteString.CopyFrom(expected), ByteString.CopyFrom(actual));
         }
 
         internal static void AssertAllExtensionsSet(TestAllExtensions message)
         {
-            Assert.True(message.HasExtension(Unittest.OptionalInt32Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalInt64Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalUint32Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalUint64Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalSint32Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalSint64Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalFixed32Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalFixed64Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalSfixed32Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalSfixed64Extension));
-            Assert.True(message.HasExtension(Unittest.OptionalFloatExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalDoubleExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalBoolExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalStringExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalBytesExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalInt32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalInt64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalUint32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalUint64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalSint32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalSint64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalFixed32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalFixed64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalSfixed32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalSfixed64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalFloatExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalDoubleExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalBoolExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalStringExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalBytesExtension));
 
-            Assert.True(message.HasExtension(Unittest.OptionalGroupExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalNestedMessageExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalForeignMessageExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalImportMessageExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalGroupExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalNestedMessageExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalForeignMessageExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalImportMessageExtension));
 
-            Assert.True(message.GetExtension(Unittest.OptionalGroupExtension).HasA);
-            Assert.True(message.GetExtension(Unittest.OptionalNestedMessageExtension).HasBb);
-            Assert.True(message.GetExtension(Unittest.OptionalForeignMessageExtension).HasC);
-            Assert.True(message.GetExtension(Unittest.OptionalImportMessageExtension).HasD);
+            Assert.IsTrue(message.GetExtension(Unittest.OptionalGroupExtension).HasA);
+            Assert.IsTrue(message.GetExtension(Unittest.OptionalNestedMessageExtension).HasBb);
+            Assert.IsTrue(message.GetExtension(Unittest.OptionalForeignMessageExtension).HasC);
+            Assert.IsTrue(message.GetExtension(Unittest.OptionalImportMessageExtension).HasD);
 
-            Assert.True(message.HasExtension(Unittest.OptionalNestedEnumExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalForeignEnumExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalImportEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalNestedEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalForeignEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalImportEnumExtension));
 
-            Assert.True(message.HasExtension(Unittest.OptionalStringPieceExtension));
-            Assert.True(message.HasExtension(Unittest.OptionalCordExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalStringPieceExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.OptionalCordExtension));
 
-            Assert.Equal(101, message.GetExtension(Unittest.OptionalInt32Extension));
-            Assert.Equal(102L, message.GetExtension(Unittest.OptionalInt64Extension));
-            Assert.Equal(103U, message.GetExtension(Unittest.OptionalUint32Extension));
-            Assert.Equal(104UL, message.GetExtension(Unittest.OptionalUint64Extension));
-            Assert.Equal(105, message.GetExtension(Unittest.OptionalSint32Extension));
-            Assert.Equal(106L, message.GetExtension(Unittest.OptionalSint64Extension));
-            Assert.Equal(107U, message.GetExtension(Unittest.OptionalFixed32Extension));
-            Assert.Equal(108UL, message.GetExtension(Unittest.OptionalFixed64Extension));
-            Assert.Equal(109, message.GetExtension(Unittest.OptionalSfixed32Extension));
-            Assert.Equal(110L, message.GetExtension(Unittest.OptionalSfixed64Extension));
-            Assert.Equal(111F, message.GetExtension(Unittest.OptionalFloatExtension));
-            Assert.Equal(112D, message.GetExtension(Unittest.OptionalDoubleExtension));
-            Assert.Equal(true, message.GetExtension(Unittest.OptionalBoolExtension));
-            Assert.Equal("115", message.GetExtension(Unittest.OptionalStringExtension));
-            Assert.Equal(ToBytes("116"), message.GetExtension(Unittest.OptionalBytesExtension));
+            Assert.AreEqual(101, message.GetExtension(Unittest.OptionalInt32Extension));
+            Assert.AreEqual(102L, message.GetExtension(Unittest.OptionalInt64Extension));
+            Assert.AreEqual(103U, message.GetExtension(Unittest.OptionalUint32Extension));
+            Assert.AreEqual(104UL, message.GetExtension(Unittest.OptionalUint64Extension));
+            Assert.AreEqual(105, message.GetExtension(Unittest.OptionalSint32Extension));
+            Assert.AreEqual(106L, message.GetExtension(Unittest.OptionalSint64Extension));
+            Assert.AreEqual(107U, message.GetExtension(Unittest.OptionalFixed32Extension));
+            Assert.AreEqual(108UL, message.GetExtension(Unittest.OptionalFixed64Extension));
+            Assert.AreEqual(109, message.GetExtension(Unittest.OptionalSfixed32Extension));
+            Assert.AreEqual(110L, message.GetExtension(Unittest.OptionalSfixed64Extension));
+            Assert.AreEqual(111F, message.GetExtension(Unittest.OptionalFloatExtension));
+            Assert.AreEqual(112D, message.GetExtension(Unittest.OptionalDoubleExtension));
+            Assert.AreEqual(true, message.GetExtension(Unittest.OptionalBoolExtension));
+            Assert.AreEqual("115", message.GetExtension(Unittest.OptionalStringExtension));
+            Assert.AreEqual(ToBytes("116"), message.GetExtension(Unittest.OptionalBytesExtension));
 
-            Assert.Equal(117, message.GetExtension(Unittest.OptionalGroupExtension).A);
-            Assert.Equal(118, message.GetExtension(Unittest.OptionalNestedMessageExtension).Bb);
-            Assert.Equal(119, message.GetExtension(Unittest.OptionalForeignMessageExtension).C);
-            Assert.Equal(120, message.GetExtension(Unittest.OptionalImportMessageExtension).D);
+            Assert.AreEqual(117, message.GetExtension(Unittest.OptionalGroupExtension).A);
+            Assert.AreEqual(118, message.GetExtension(Unittest.OptionalNestedMessageExtension).Bb);
+            Assert.AreEqual(119, message.GetExtension(Unittest.OptionalForeignMessageExtension).C);
+            Assert.AreEqual(120, message.GetExtension(Unittest.OptionalImportMessageExtension).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAZ,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAZ,
                             message.GetExtension(Unittest.OptionalNestedEnumExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ,
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ,
                             message.GetExtension(Unittest.OptionalForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_BAZ, message.GetExtension(Unittest.OptionalImportEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ, message.GetExtension(Unittest.OptionalImportEnumExtension));
 
-            Assert.Equal("124", message.GetExtension(Unittest.OptionalStringPieceExtension));
-            Assert.Equal("125", message.GetExtension(Unittest.OptionalCordExtension));
+            Assert.AreEqual("124", message.GetExtension(Unittest.OptionalStringPieceExtension));
+            Assert.AreEqual("125", message.GetExtension(Unittest.OptionalCordExtension));
 
             // -----------------------------------------------------------------
 
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedStringExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedStringExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
 
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
 
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedCordExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedCordExtension));
 
-            Assert.Equal(201, message.GetExtension(Unittest.RepeatedInt32Extension, 0));
-            Assert.Equal(202L, message.GetExtension(Unittest.RepeatedInt64Extension, 0));
-            Assert.Equal(203U, message.GetExtension(Unittest.RepeatedUint32Extension, 0));
-            Assert.Equal(204UL, message.GetExtension(Unittest.RepeatedUint64Extension, 0));
-            Assert.Equal(205, message.GetExtension(Unittest.RepeatedSint32Extension, 0));
-            Assert.Equal(206L, message.GetExtension(Unittest.RepeatedSint64Extension, 0));
-            Assert.Equal(207U, message.GetExtension(Unittest.RepeatedFixed32Extension, 0));
-            Assert.Equal(208UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 0));
-            Assert.Equal(209, message.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
-            Assert.Equal(210L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
-            Assert.Equal(211F, message.GetExtension(Unittest.RepeatedFloatExtension, 0));
-            Assert.Equal(212D, message.GetExtension(Unittest.RepeatedDoubleExtension, 0));
-            Assert.Equal(true, message.GetExtension(Unittest.RepeatedBoolExtension, 0));
-            Assert.Equal("215", message.GetExtension(Unittest.RepeatedStringExtension, 0));
-            Assert.Equal(ToBytes("216"), message.GetExtension(Unittest.RepeatedBytesExtension, 0));
+            Assert.AreEqual(201, message.GetExtension(Unittest.RepeatedInt32Extension, 0));
+            Assert.AreEqual(202L, message.GetExtension(Unittest.RepeatedInt64Extension, 0));
+            Assert.AreEqual(203U, message.GetExtension(Unittest.RepeatedUint32Extension, 0));
+            Assert.AreEqual(204UL, message.GetExtension(Unittest.RepeatedUint64Extension, 0));
+            Assert.AreEqual(205, message.GetExtension(Unittest.RepeatedSint32Extension, 0));
+            Assert.AreEqual(206L, message.GetExtension(Unittest.RepeatedSint64Extension, 0));
+            Assert.AreEqual(207U, message.GetExtension(Unittest.RepeatedFixed32Extension, 0));
+            Assert.AreEqual(208UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 0));
+            Assert.AreEqual(209, message.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
+            Assert.AreEqual(210L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
+            Assert.AreEqual(211F, message.GetExtension(Unittest.RepeatedFloatExtension, 0));
+            Assert.AreEqual(212D, message.GetExtension(Unittest.RepeatedDoubleExtension, 0));
+            Assert.AreEqual(true, message.GetExtension(Unittest.RepeatedBoolExtension, 0));
+            Assert.AreEqual("215", message.GetExtension(Unittest.RepeatedStringExtension, 0));
+            Assert.AreEqual(ToBytes("216"), message.GetExtension(Unittest.RepeatedBytesExtension, 0));
 
-            Assert.Equal(217, message.GetExtension(Unittest.RepeatedGroupExtension, 0).A);
-            Assert.Equal(218, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 0).Bb);
-            Assert.Equal(219, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 0).C);
-            Assert.Equal(220, message.GetExtension(Unittest.RepeatedImportMessageExtension, 0).D);
+            Assert.AreEqual(217, message.GetExtension(Unittest.RepeatedGroupExtension, 0).A);
+            Assert.AreEqual(218, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 0).Bb);
+            Assert.AreEqual(219, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 0).C);
+            Assert.AreEqual(220, message.GetExtension(Unittest.RepeatedImportMessageExtension, 0).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR,
                             message.GetExtension(Unittest.RepeatedNestedEnumExtension, 0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR,
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR,
                             message.GetExtension(Unittest.RepeatedForeignEnumExtension, 0));
-            Assert.Equal(ImportEnum.IMPORT_BAR,
+            Assert.AreEqual(ImportEnum.IMPORT_BAR,
                             message.GetExtension(Unittest.RepeatedImportEnumExtension, 0));
 
-            Assert.Equal("224", message.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
-            Assert.Equal("225", message.GetExtension(Unittest.RepeatedCordExtension, 0));
+            Assert.AreEqual("224", message.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
+            Assert.AreEqual("225", message.GetExtension(Unittest.RepeatedCordExtension, 0));
 
-            Assert.Equal(301, message.GetExtension(Unittest.RepeatedInt32Extension, 1));
-            Assert.Equal(302L, message.GetExtension(Unittest.RepeatedInt64Extension, 1));
-            Assert.Equal(303U, message.GetExtension(Unittest.RepeatedUint32Extension, 1));
-            Assert.Equal(304UL, message.GetExtension(Unittest.RepeatedUint64Extension, 1));
-            Assert.Equal(305, message.GetExtension(Unittest.RepeatedSint32Extension, 1));
-            Assert.Equal(306L, message.GetExtension(Unittest.RepeatedSint64Extension, 1));
-            Assert.Equal(307U, message.GetExtension(Unittest.RepeatedFixed32Extension, 1));
-            Assert.Equal(308UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 1));
-            Assert.Equal(309, message.GetExtension(Unittest.RepeatedSfixed32Extension, 1));
-            Assert.Equal(310L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 1));
-            Assert.Equal(311F, message.GetExtension(Unittest.RepeatedFloatExtension, 1));
-            Assert.Equal(312D, message.GetExtension(Unittest.RepeatedDoubleExtension, 1));
-            Assert.Equal(false, message.GetExtension(Unittest.RepeatedBoolExtension, 1));
-            Assert.Equal("315", message.GetExtension(Unittest.RepeatedStringExtension, 1));
-            Assert.Equal(ToBytes("316"), message.GetExtension(Unittest.RepeatedBytesExtension, 1));
+            Assert.AreEqual(301, message.GetExtension(Unittest.RepeatedInt32Extension, 1));
+            Assert.AreEqual(302L, message.GetExtension(Unittest.RepeatedInt64Extension, 1));
+            Assert.AreEqual(303U, message.GetExtension(Unittest.RepeatedUint32Extension, 1));
+            Assert.AreEqual(304UL, message.GetExtension(Unittest.RepeatedUint64Extension, 1));
+            Assert.AreEqual(305, message.GetExtension(Unittest.RepeatedSint32Extension, 1));
+            Assert.AreEqual(306L, message.GetExtension(Unittest.RepeatedSint64Extension, 1));
+            Assert.AreEqual(307U, message.GetExtension(Unittest.RepeatedFixed32Extension, 1));
+            Assert.AreEqual(308UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 1));
+            Assert.AreEqual(309, message.GetExtension(Unittest.RepeatedSfixed32Extension, 1));
+            Assert.AreEqual(310L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 1));
+            Assert.AreEqual(311F, message.GetExtension(Unittest.RepeatedFloatExtension, 1));
+            Assert.AreEqual(312D, message.GetExtension(Unittest.RepeatedDoubleExtension, 1));
+            Assert.AreEqual(false, message.GetExtension(Unittest.RepeatedBoolExtension, 1));
+            Assert.AreEqual("315", message.GetExtension(Unittest.RepeatedStringExtension, 1));
+            Assert.AreEqual(ToBytes("316"), message.GetExtension(Unittest.RepeatedBytesExtension, 1));
 
-            Assert.Equal(317, message.GetExtension(Unittest.RepeatedGroupExtension, 1).A);
-            Assert.Equal(318, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 1).Bb);
-            Assert.Equal(319, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 1).C);
-            Assert.Equal(320, message.GetExtension(Unittest.RepeatedImportMessageExtension, 1).D);
+            Assert.AreEqual(317, message.GetExtension(Unittest.RepeatedGroupExtension, 1).A);
+            Assert.AreEqual(318, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 1).Bb);
+            Assert.AreEqual(319, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 1).C);
+            Assert.AreEqual(320, message.GetExtension(Unittest.RepeatedImportMessageExtension, 1).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAZ,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAZ,
                             message.GetExtension(Unittest.RepeatedNestedEnumExtension, 1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ,
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ,
                             message.GetExtension(Unittest.RepeatedForeignEnumExtension, 1));
-            Assert.Equal(ImportEnum.IMPORT_BAZ,
+            Assert.AreEqual(ImportEnum.IMPORT_BAZ,
                             message.GetExtension(Unittest.RepeatedImportEnumExtension, 1));
 
-            Assert.Equal("324", message.GetExtension(Unittest.RepeatedStringPieceExtension, 1));
-            Assert.Equal("325", message.GetExtension(Unittest.RepeatedCordExtension, 1));
+            Assert.AreEqual("324", message.GetExtension(Unittest.RepeatedStringPieceExtension, 1));
+            Assert.AreEqual("325", message.GetExtension(Unittest.RepeatedCordExtension, 1));
 
             // -----------------------------------------------------------------
 
-            Assert.True(message.HasExtension(Unittest.DefaultInt32Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultInt64Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultUint32Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultUint64Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultSint32Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultSint64Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultFixed32Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultFixed64Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultSfixed32Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultSfixed64Extension));
-            Assert.True(message.HasExtension(Unittest.DefaultFloatExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultDoubleExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultBoolExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultStringExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultBytesExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultInt32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultInt64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultUint32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultUint64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultSint32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultSint64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultFixed32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultFixed64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultSfixed32Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultSfixed64Extension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultFloatExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultDoubleExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultBoolExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultStringExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultBytesExtension));
 
-            Assert.True(message.HasExtension(Unittest.DefaultNestedEnumExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultForeignEnumExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultImportEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultNestedEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultForeignEnumExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultImportEnumExtension));
 
-            Assert.True(message.HasExtension(Unittest.DefaultStringPieceExtension));
-            Assert.True(message.HasExtension(Unittest.DefaultCordExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultStringPieceExtension));
+            Assert.IsTrue(message.HasExtension(Unittest.DefaultCordExtension));
 
-            Assert.Equal(401, message.GetExtension(Unittest.DefaultInt32Extension));
-            Assert.Equal(402L, message.GetExtension(Unittest.DefaultInt64Extension));
-            Assert.Equal(403U, message.GetExtension(Unittest.DefaultUint32Extension));
-            Assert.Equal(404UL, message.GetExtension(Unittest.DefaultUint64Extension));
-            Assert.Equal(405, message.GetExtension(Unittest.DefaultSint32Extension));
-            Assert.Equal(406L, message.GetExtension(Unittest.DefaultSint64Extension));
-            Assert.Equal(407U, message.GetExtension(Unittest.DefaultFixed32Extension));
-            Assert.Equal(408UL, message.GetExtension(Unittest.DefaultFixed64Extension));
-            Assert.Equal(409, message.GetExtension(Unittest.DefaultSfixed32Extension));
-            Assert.Equal(410L, message.GetExtension(Unittest.DefaultSfixed64Extension));
-            Assert.Equal(411F, message.GetExtension(Unittest.DefaultFloatExtension));
-            Assert.Equal(412D, message.GetExtension(Unittest.DefaultDoubleExtension));
-            Assert.Equal(false, message.GetExtension(Unittest.DefaultBoolExtension));
-            Assert.Equal("415", message.GetExtension(Unittest.DefaultStringExtension));
-            Assert.Equal(ToBytes("416"), message.GetExtension(Unittest.DefaultBytesExtension));
+            Assert.AreEqual(401, message.GetExtension(Unittest.DefaultInt32Extension));
+            Assert.AreEqual(402L, message.GetExtension(Unittest.DefaultInt64Extension));
+            Assert.AreEqual(403U, message.GetExtension(Unittest.DefaultUint32Extension));
+            Assert.AreEqual(404UL, message.GetExtension(Unittest.DefaultUint64Extension));
+            Assert.AreEqual(405, message.GetExtension(Unittest.DefaultSint32Extension));
+            Assert.AreEqual(406L, message.GetExtension(Unittest.DefaultSint64Extension));
+            Assert.AreEqual(407U, message.GetExtension(Unittest.DefaultFixed32Extension));
+            Assert.AreEqual(408UL, message.GetExtension(Unittest.DefaultFixed64Extension));
+            Assert.AreEqual(409, message.GetExtension(Unittest.DefaultSfixed32Extension));
+            Assert.AreEqual(410L, message.GetExtension(Unittest.DefaultSfixed64Extension));
+            Assert.AreEqual(411F, message.GetExtension(Unittest.DefaultFloatExtension));
+            Assert.AreEqual(412D, message.GetExtension(Unittest.DefaultDoubleExtension));
+            Assert.AreEqual(false, message.GetExtension(Unittest.DefaultBoolExtension));
+            Assert.AreEqual("415", message.GetExtension(Unittest.DefaultStringExtension));
+            Assert.AreEqual(ToBytes("416"), message.GetExtension(Unittest.DefaultBytesExtension));
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             message.GetExtension(Unittest.DefaultNestedEnumExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_FOO, message.GetExtension(Unittest.DefaultForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_FOO, message.GetExtension(Unittest.DefaultImportEnumExtension));
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO, message.GetExtension(Unittest.DefaultForeignEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_FOO, message.GetExtension(Unittest.DefaultImportEnumExtension));
 
-            Assert.Equal("424", message.GetExtension(Unittest.DefaultStringPieceExtension));
-            Assert.Equal("425", message.GetExtension(Unittest.DefaultCordExtension));
+            Assert.AreEqual("424", message.GetExtension(Unittest.DefaultStringPieceExtension));
+            Assert.AreEqual("425", message.GetExtension(Unittest.DefaultCordExtension));
         }
 
         /// <summary>
@@ -1215,242 +1215,242 @@ namespace Google.ProtocolBuffers
             // ModifyRepeatedFields only sets the second repeated element of each
             // field.  In addition to verifying this, we also verify that the first
             // element and size were *not* modified.
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedStringExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedStringExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
 
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
 
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.RepeatedCordExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.RepeatedCordExtension));
 
-            Assert.Equal(201, message.GetExtension(Unittest.RepeatedInt32Extension, 0));
-            Assert.Equal(202L, message.GetExtension(Unittest.RepeatedInt64Extension, 0));
-            Assert.Equal(203U, message.GetExtension(Unittest.RepeatedUint32Extension, 0));
-            Assert.Equal(204UL, message.GetExtension(Unittest.RepeatedUint64Extension, 0));
-            Assert.Equal(205, message.GetExtension(Unittest.RepeatedSint32Extension, 0));
-            Assert.Equal(206L, message.GetExtension(Unittest.RepeatedSint64Extension, 0));
-            Assert.Equal(207U, message.GetExtension(Unittest.RepeatedFixed32Extension, 0));
-            Assert.Equal(208UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 0));
-            Assert.Equal(209, message.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
-            Assert.Equal(210L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
-            Assert.Equal(211F, message.GetExtension(Unittest.RepeatedFloatExtension, 0));
-            Assert.Equal(212D, message.GetExtension(Unittest.RepeatedDoubleExtension, 0));
-            Assert.Equal(true, message.GetExtension(Unittest.RepeatedBoolExtension, 0));
-            Assert.Equal("215", message.GetExtension(Unittest.RepeatedStringExtension, 0));
-            Assert.Equal(ToBytes("216"), message.GetExtension(Unittest.RepeatedBytesExtension, 0));
+            Assert.AreEqual(201, message.GetExtension(Unittest.RepeatedInt32Extension, 0));
+            Assert.AreEqual(202L, message.GetExtension(Unittest.RepeatedInt64Extension, 0));
+            Assert.AreEqual(203U, message.GetExtension(Unittest.RepeatedUint32Extension, 0));
+            Assert.AreEqual(204UL, message.GetExtension(Unittest.RepeatedUint64Extension, 0));
+            Assert.AreEqual(205, message.GetExtension(Unittest.RepeatedSint32Extension, 0));
+            Assert.AreEqual(206L, message.GetExtension(Unittest.RepeatedSint64Extension, 0));
+            Assert.AreEqual(207U, message.GetExtension(Unittest.RepeatedFixed32Extension, 0));
+            Assert.AreEqual(208UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 0));
+            Assert.AreEqual(209, message.GetExtension(Unittest.RepeatedSfixed32Extension, 0));
+            Assert.AreEqual(210L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 0));
+            Assert.AreEqual(211F, message.GetExtension(Unittest.RepeatedFloatExtension, 0));
+            Assert.AreEqual(212D, message.GetExtension(Unittest.RepeatedDoubleExtension, 0));
+            Assert.AreEqual(true, message.GetExtension(Unittest.RepeatedBoolExtension, 0));
+            Assert.AreEqual("215", message.GetExtension(Unittest.RepeatedStringExtension, 0));
+            Assert.AreEqual(ToBytes("216"), message.GetExtension(Unittest.RepeatedBytesExtension, 0));
 
-            Assert.Equal(217, message.GetExtension(Unittest.RepeatedGroupExtension, 0).A);
-            Assert.Equal(218, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 0).Bb);
-            Assert.Equal(219, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 0).C);
-            Assert.Equal(220, message.GetExtension(Unittest.RepeatedImportMessageExtension, 0).D);
+            Assert.AreEqual(217, message.GetExtension(Unittest.RepeatedGroupExtension, 0).A);
+            Assert.AreEqual(218, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 0).Bb);
+            Assert.AreEqual(219, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 0).C);
+            Assert.AreEqual(220, message.GetExtension(Unittest.RepeatedImportMessageExtension, 0).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR,
                             message.GetExtension(Unittest.RepeatedNestedEnumExtension, 0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR,
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR,
                             message.GetExtension(Unittest.RepeatedForeignEnumExtension, 0));
-            Assert.Equal(ImportEnum.IMPORT_BAR,
+            Assert.AreEqual(ImportEnum.IMPORT_BAR,
                             message.GetExtension(Unittest.RepeatedImportEnumExtension, 0));
 
-            Assert.Equal("224", message.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
-            Assert.Equal("225", message.GetExtension(Unittest.RepeatedCordExtension, 0));
+            Assert.AreEqual("224", message.GetExtension(Unittest.RepeatedStringPieceExtension, 0));
+            Assert.AreEqual("225", message.GetExtension(Unittest.RepeatedCordExtension, 0));
 
             // Actually verify the second (modified) elements now.
-            Assert.Equal(501, message.GetExtension(Unittest.RepeatedInt32Extension, 1));
-            Assert.Equal(502L, message.GetExtension(Unittest.RepeatedInt64Extension, 1));
-            Assert.Equal(503U, message.GetExtension(Unittest.RepeatedUint32Extension, 1));
-            Assert.Equal(504UL, message.GetExtension(Unittest.RepeatedUint64Extension, 1));
-            Assert.Equal(505, message.GetExtension(Unittest.RepeatedSint32Extension, 1));
-            Assert.Equal(506L, message.GetExtension(Unittest.RepeatedSint64Extension, 1));
-            Assert.Equal(507U, message.GetExtension(Unittest.RepeatedFixed32Extension, 1));
-            Assert.Equal(508UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 1));
-            Assert.Equal(509, message.GetExtension(Unittest.RepeatedSfixed32Extension, 1));
-            Assert.Equal(510L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 1));
-            Assert.Equal(511F, message.GetExtension(Unittest.RepeatedFloatExtension, 1));
-            Assert.Equal(512D, message.GetExtension(Unittest.RepeatedDoubleExtension, 1));
-            Assert.Equal(true, message.GetExtension(Unittest.RepeatedBoolExtension, 1));
-            Assert.Equal("515", message.GetExtension(Unittest.RepeatedStringExtension, 1));
-            Assert.Equal(ToBytes("516"), message.GetExtension(Unittest.RepeatedBytesExtension, 1));
+            Assert.AreEqual(501, message.GetExtension(Unittest.RepeatedInt32Extension, 1));
+            Assert.AreEqual(502L, message.GetExtension(Unittest.RepeatedInt64Extension, 1));
+            Assert.AreEqual(503U, message.GetExtension(Unittest.RepeatedUint32Extension, 1));
+            Assert.AreEqual(504UL, message.GetExtension(Unittest.RepeatedUint64Extension, 1));
+            Assert.AreEqual(505, message.GetExtension(Unittest.RepeatedSint32Extension, 1));
+            Assert.AreEqual(506L, message.GetExtension(Unittest.RepeatedSint64Extension, 1));
+            Assert.AreEqual(507U, message.GetExtension(Unittest.RepeatedFixed32Extension, 1));
+            Assert.AreEqual(508UL, message.GetExtension(Unittest.RepeatedFixed64Extension, 1));
+            Assert.AreEqual(509, message.GetExtension(Unittest.RepeatedSfixed32Extension, 1));
+            Assert.AreEqual(510L, message.GetExtension(Unittest.RepeatedSfixed64Extension, 1));
+            Assert.AreEqual(511F, message.GetExtension(Unittest.RepeatedFloatExtension, 1));
+            Assert.AreEqual(512D, message.GetExtension(Unittest.RepeatedDoubleExtension, 1));
+            Assert.AreEqual(true, message.GetExtension(Unittest.RepeatedBoolExtension, 1));
+            Assert.AreEqual("515", message.GetExtension(Unittest.RepeatedStringExtension, 1));
+            Assert.AreEqual(ToBytes("516"), message.GetExtension(Unittest.RepeatedBytesExtension, 1));
 
-            Assert.Equal(517, message.GetExtension(Unittest.RepeatedGroupExtension, 1).A);
-            Assert.Equal(518, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 1).Bb);
-            Assert.Equal(519, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 1).C);
-            Assert.Equal(520, message.GetExtension(Unittest.RepeatedImportMessageExtension, 1).D);
+            Assert.AreEqual(517, message.GetExtension(Unittest.RepeatedGroupExtension, 1).A);
+            Assert.AreEqual(518, message.GetExtension(Unittest.RepeatedNestedMessageExtension, 1).Bb);
+            Assert.AreEqual(519, message.GetExtension(Unittest.RepeatedForeignMessageExtension, 1).C);
+            Assert.AreEqual(520, message.GetExtension(Unittest.RepeatedImportMessageExtension, 1).D);
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             message.GetExtension(Unittest.RepeatedNestedEnumExtension, 1));
-            Assert.Equal(ForeignEnum.FOREIGN_FOO,
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO,
                             message.GetExtension(Unittest.RepeatedForeignEnumExtension, 1));
-            Assert.Equal(ImportEnum.IMPORT_FOO,
+            Assert.AreEqual(ImportEnum.IMPORT_FOO,
                             message.GetExtension(Unittest.RepeatedImportEnumExtension, 1));
 
-            Assert.Equal("524", message.GetExtension(Unittest.RepeatedStringPieceExtension, 1));
-            Assert.Equal("525", message.GetExtension(Unittest.RepeatedCordExtension, 1));
+            Assert.AreEqual("524", message.GetExtension(Unittest.RepeatedStringPieceExtension, 1));
+            Assert.AreEqual("525", message.GetExtension(Unittest.RepeatedCordExtension, 1));
         }
 
         internal static void AssertExtensionsClear(TestAllExtensions message)
         {
             // HasBlah() should initially be false for all optional fields.
-            Assert.False(message.HasExtension(Unittest.OptionalInt32Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalInt64Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalUint32Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalUint64Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalSint32Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalSint64Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalFixed32Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalFixed64Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalSfixed32Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalSfixed64Extension));
-            Assert.False(message.HasExtension(Unittest.OptionalFloatExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalDoubleExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalBoolExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalStringExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalBytesExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalInt32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalInt64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalUint32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalUint64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalSint32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalSint64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalFixed32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalFixed64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalSfixed32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalSfixed64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalFloatExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalDoubleExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalBoolExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalStringExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalBytesExtension));
 
-            Assert.False(message.HasExtension(Unittest.OptionalGroupExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalNestedMessageExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalForeignMessageExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalImportMessageExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalGroupExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalNestedMessageExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalForeignMessageExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalImportMessageExtension));
 
-            Assert.False(message.HasExtension(Unittest.OptionalNestedEnumExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalForeignEnumExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalImportEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalNestedEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalForeignEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalImportEnumExtension));
 
-            Assert.False(message.HasExtension(Unittest.OptionalStringPieceExtension));
-            Assert.False(message.HasExtension(Unittest.OptionalCordExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalStringPieceExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.OptionalCordExtension));
 
             // Optional fields without defaults are set to zero or something like it.
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalInt32Extension));
-            Assert.Equal(0L, message.GetExtension(Unittest.OptionalInt64Extension));
-            Assert.Equal(0U, message.GetExtension(Unittest.OptionalUint32Extension));
-            Assert.Equal(0UL, message.GetExtension(Unittest.OptionalUint64Extension));
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalSint32Extension));
-            Assert.Equal(0L, message.GetExtension(Unittest.OptionalSint64Extension));
-            Assert.Equal(0U, message.GetExtension(Unittest.OptionalFixed32Extension));
-            Assert.Equal(0UL, message.GetExtension(Unittest.OptionalFixed64Extension));
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalSfixed32Extension));
-            Assert.Equal(0L, message.GetExtension(Unittest.OptionalSfixed64Extension));
-            Assert.Equal(0F, message.GetExtension(Unittest.OptionalFloatExtension));
-            Assert.Equal(0D, message.GetExtension(Unittest.OptionalDoubleExtension));
-            Assert.Equal(false, message.GetExtension(Unittest.OptionalBoolExtension));
-            Assert.Equal("", message.GetExtension(Unittest.OptionalStringExtension));
-            Assert.Equal(ByteString.Empty, message.GetExtension(Unittest.OptionalBytesExtension));
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalInt32Extension));
+            Assert.AreEqual(0L, message.GetExtension(Unittest.OptionalInt64Extension));
+            Assert.AreEqual(0U, message.GetExtension(Unittest.OptionalUint32Extension));
+            Assert.AreEqual(0UL, message.GetExtension(Unittest.OptionalUint64Extension));
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalSint32Extension));
+            Assert.AreEqual(0L, message.GetExtension(Unittest.OptionalSint64Extension));
+            Assert.AreEqual(0U, message.GetExtension(Unittest.OptionalFixed32Extension));
+            Assert.AreEqual(0UL, message.GetExtension(Unittest.OptionalFixed64Extension));
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalSfixed32Extension));
+            Assert.AreEqual(0L, message.GetExtension(Unittest.OptionalSfixed64Extension));
+            Assert.AreEqual(0F, message.GetExtension(Unittest.OptionalFloatExtension));
+            Assert.AreEqual(0D, message.GetExtension(Unittest.OptionalDoubleExtension));
+            Assert.AreEqual(false, message.GetExtension(Unittest.OptionalBoolExtension));
+            Assert.AreEqual("", message.GetExtension(Unittest.OptionalStringExtension));
+            Assert.AreEqual(ByteString.Empty, message.GetExtension(Unittest.OptionalBytesExtension));
 
             // Embedded messages should also be clear.
-            Assert.False(message.GetExtension(Unittest.OptionalGroupExtension).HasA);
-            Assert.False(message.GetExtension(Unittest.OptionalNestedMessageExtension).HasBb);
-            Assert.False(message.GetExtension(Unittest.OptionalForeignMessageExtension).HasC);
-            Assert.False(message.GetExtension(Unittest.OptionalImportMessageExtension).HasD);
+            Assert.IsFalse(message.GetExtension(Unittest.OptionalGroupExtension).HasA);
+            Assert.IsFalse(message.GetExtension(Unittest.OptionalNestedMessageExtension).HasBb);
+            Assert.IsFalse(message.GetExtension(Unittest.OptionalForeignMessageExtension).HasC);
+            Assert.IsFalse(message.GetExtension(Unittest.OptionalImportMessageExtension).HasD);
 
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalGroupExtension).A);
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalNestedMessageExtension).Bb);
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalForeignMessageExtension).C);
-            Assert.Equal(0, message.GetExtension(Unittest.OptionalImportMessageExtension).D);
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalGroupExtension).A);
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalNestedMessageExtension).Bb);
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalForeignMessageExtension).C);
+            Assert.AreEqual(0, message.GetExtension(Unittest.OptionalImportMessageExtension).D);
 
             // Enums without defaults are set to the first value in the enum.
-            Assert.Equal(TestAllTypes.Types.NestedEnum.FOO,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.FOO,
                             message.GetExtension(Unittest.OptionalNestedEnumExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_FOO,
+            Assert.AreEqual(ForeignEnum.FOREIGN_FOO,
                             message.GetExtension(Unittest.OptionalForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_FOO, message.GetExtension(Unittest.OptionalImportEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_FOO, message.GetExtension(Unittest.OptionalImportEnumExtension));
 
-            Assert.Equal("", message.GetExtension(Unittest.OptionalStringPieceExtension));
-            Assert.Equal("", message.GetExtension(Unittest.OptionalCordExtension));
+            Assert.AreEqual("", message.GetExtension(Unittest.OptionalStringPieceExtension));
+            Assert.AreEqual("", message.GetExtension(Unittest.OptionalCordExtension));
 
             // Repeated fields are empty.
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedStringExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedInt32Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedInt64Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedUint32Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedUint64Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedSint32Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedSint64Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedFixed32Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedFixed64Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedSfixed32Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedSfixed64Extension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedFloatExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedDoubleExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedBoolExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedStringExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedBytesExtension));
 
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedGroupExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedNestedMessageExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedForeignMessageExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedImportMessageExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedNestedEnumExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedForeignEnumExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedImportEnumExtension));
 
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
-            Assert.Equal(0, message.GetExtensionCount(Unittest.RepeatedCordExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedStringPieceExtension));
+            Assert.AreEqual(0, message.GetExtensionCount(Unittest.RepeatedCordExtension));
 
             // HasBlah() should also be false for all default fields.
-            Assert.False(message.HasExtension(Unittest.DefaultInt32Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultInt64Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultUint32Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultUint64Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultSint32Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultSint64Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultFixed32Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultFixed64Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultSfixed32Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultSfixed64Extension));
-            Assert.False(message.HasExtension(Unittest.DefaultFloatExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultDoubleExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultBoolExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultStringExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultBytesExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultInt32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultInt64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultUint32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultUint64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultSint32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultSint64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultFixed32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultFixed64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultSfixed32Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultSfixed64Extension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultFloatExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultDoubleExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultBoolExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultStringExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultBytesExtension));
 
-            Assert.False(message.HasExtension(Unittest.DefaultNestedEnumExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultForeignEnumExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultImportEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultNestedEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultForeignEnumExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultImportEnumExtension));
 
-            Assert.False(message.HasExtension(Unittest.DefaultStringPieceExtension));
-            Assert.False(message.HasExtension(Unittest.DefaultCordExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultStringPieceExtension));
+            Assert.IsFalse(message.HasExtension(Unittest.DefaultCordExtension));
 
             // Fields with defaults have their default values (duh).
-            Assert.Equal(41, message.GetExtension(Unittest.DefaultInt32Extension));
-            Assert.Equal(42L, message.GetExtension(Unittest.DefaultInt64Extension));
-            Assert.Equal(43U, message.GetExtension(Unittest.DefaultUint32Extension));
-            Assert.Equal(44UL, message.GetExtension(Unittest.DefaultUint64Extension));
-            Assert.Equal(-45, message.GetExtension(Unittest.DefaultSint32Extension));
-            Assert.Equal(46L, message.GetExtension(Unittest.DefaultSint64Extension));
-            Assert.Equal(47U, message.GetExtension(Unittest.DefaultFixed32Extension));
-            Assert.Equal(48UL, message.GetExtension(Unittest.DefaultFixed64Extension));
-            Assert.Equal(49, message.GetExtension(Unittest.DefaultSfixed32Extension));
-            Assert.Equal(-50L, message.GetExtension(Unittest.DefaultSfixed64Extension));
-            Assert.Equal(51.5F, message.GetExtension(Unittest.DefaultFloatExtension));
-            Assert.Equal(52e3D, message.GetExtension(Unittest.DefaultDoubleExtension));
-            Assert.Equal(true, message.GetExtension(Unittest.DefaultBoolExtension));
-            Assert.Equal("hello", message.GetExtension(Unittest.DefaultStringExtension));
-            Assert.Equal(ToBytes("world"), message.GetExtension(Unittest.DefaultBytesExtension));
+            Assert.AreEqual(41, message.GetExtension(Unittest.DefaultInt32Extension));
+            Assert.AreEqual(42L, message.GetExtension(Unittest.DefaultInt64Extension));
+            Assert.AreEqual(43U, message.GetExtension(Unittest.DefaultUint32Extension));
+            Assert.AreEqual(44UL, message.GetExtension(Unittest.DefaultUint64Extension));
+            Assert.AreEqual(-45, message.GetExtension(Unittest.DefaultSint32Extension));
+            Assert.AreEqual(46L, message.GetExtension(Unittest.DefaultSint64Extension));
+            Assert.AreEqual(47U, message.GetExtension(Unittest.DefaultFixed32Extension));
+            Assert.AreEqual(48UL, message.GetExtension(Unittest.DefaultFixed64Extension));
+            Assert.AreEqual(49, message.GetExtension(Unittest.DefaultSfixed32Extension));
+            Assert.AreEqual(-50L, message.GetExtension(Unittest.DefaultSfixed64Extension));
+            Assert.AreEqual(51.5F, message.GetExtension(Unittest.DefaultFloatExtension));
+            Assert.AreEqual(52e3D, message.GetExtension(Unittest.DefaultDoubleExtension));
+            Assert.AreEqual(true, message.GetExtension(Unittest.DefaultBoolExtension));
+            Assert.AreEqual("hello", message.GetExtension(Unittest.DefaultStringExtension));
+            Assert.AreEqual(ToBytes("world"), message.GetExtension(Unittest.DefaultBytesExtension));
 
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR,
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR,
                             message.GetExtension(Unittest.DefaultNestedEnumExtension));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetExtension(Unittest.DefaultForeignEnumExtension));
-            Assert.Equal(ImportEnum.IMPORT_BAR, message.GetExtension(Unittest.DefaultImportEnumExtension));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetExtension(Unittest.DefaultForeignEnumExtension));
+            Assert.AreEqual(ImportEnum.IMPORT_BAR, message.GetExtension(Unittest.DefaultImportEnumExtension));
 
-            Assert.Equal("abc", message.GetExtension(Unittest.DefaultStringPieceExtension));
-            Assert.Equal("123", message.GetExtension(Unittest.DefaultCordExtension));
+            Assert.AreEqual("abc", message.GetExtension(Unittest.DefaultStringPieceExtension));
+            Assert.AreEqual("123", message.GetExtension(Unittest.DefaultCordExtension));
         }
 
         /// <summary>
@@ -1495,48 +1495,48 @@ namespace Google.ProtocolBuffers
         /// </summary>
         public static void AssertPackedFieldsSet(TestPackedTypes message)
         {
-            Assert.Equal(2, message.PackedInt32Count);
-            Assert.Equal(2, message.PackedInt64Count);
-            Assert.Equal(2, message.PackedUint32Count);
-            Assert.Equal(2, message.PackedUint64Count);
-            Assert.Equal(2, message.PackedSint32Count);
-            Assert.Equal(2, message.PackedSint64Count);
-            Assert.Equal(2, message.PackedFixed32Count);
-            Assert.Equal(2, message.PackedFixed64Count);
-            Assert.Equal(2, message.PackedSfixed32Count);
-            Assert.Equal(2, message.PackedSfixed64Count);
-            Assert.Equal(2, message.PackedFloatCount);
-            Assert.Equal(2, message.PackedDoubleCount);
-            Assert.Equal(2, message.PackedBoolCount);
-            Assert.Equal(2, message.PackedEnumCount);
-            Assert.Equal(601, message.GetPackedInt32(0));
-            Assert.Equal(602, message.GetPackedInt64(0));
-            Assert.Equal(603u, message.GetPackedUint32(0));
-            Assert.Equal(604u, message.GetPackedUint64(0));
-            Assert.Equal(605, message.GetPackedSint32(0));
-            Assert.Equal(606, message.GetPackedSint64(0));
-            Assert.Equal(607u, message.GetPackedFixed32(0));
-            Assert.Equal(608u, message.GetPackedFixed64(0));
-            Assert.Equal(609, message.GetPackedSfixed32(0));
-            Assert.Equal(610, message.GetPackedSfixed64(0));
-            Assert.Equal(611f, message.GetPackedFloat(0));
-            Assert.Equal(612d, message.GetPackedDouble(0));
-            Assert.Equal(true, message.GetPackedBool(0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetPackedEnum(0));
-            Assert.Equal(701, message.GetPackedInt32(1));
-            Assert.Equal(702, message.GetPackedInt64(1));
-            Assert.Equal(703u, message.GetPackedUint32(1));
-            Assert.Equal(704u, message.GetPackedUint64(1));
-            Assert.Equal(705, message.GetPackedSint32(1));
-            Assert.Equal(706, message.GetPackedSint64(1));
-            Assert.Equal(707u, message.GetPackedFixed32(1));
-            Assert.Equal(708u, message.GetPackedFixed64(1));
-            Assert.Equal(709, message.GetPackedSfixed32(1));
-            Assert.Equal(710, message.GetPackedSfixed64(1));
-            Assert.Equal(711f, message.GetPackedFloat(1));
-            Assert.Equal(712d, message.GetPackedDouble(1));
-            Assert.Equal(false, message.GetPackedBool(1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.GetPackedEnum(1));
+            Assert.AreEqual(2, message.PackedInt32Count);
+            Assert.AreEqual(2, message.PackedInt64Count);
+            Assert.AreEqual(2, message.PackedUint32Count);
+            Assert.AreEqual(2, message.PackedUint64Count);
+            Assert.AreEqual(2, message.PackedSint32Count);
+            Assert.AreEqual(2, message.PackedSint64Count);
+            Assert.AreEqual(2, message.PackedFixed32Count);
+            Assert.AreEqual(2, message.PackedFixed64Count);
+            Assert.AreEqual(2, message.PackedSfixed32Count);
+            Assert.AreEqual(2, message.PackedSfixed64Count);
+            Assert.AreEqual(2, message.PackedFloatCount);
+            Assert.AreEqual(2, message.PackedDoubleCount);
+            Assert.AreEqual(2, message.PackedBoolCount);
+            Assert.AreEqual(2, message.PackedEnumCount);
+            Assert.AreEqual(601, message.GetPackedInt32(0));
+            Assert.AreEqual(602, message.GetPackedInt64(0));
+            Assert.AreEqual(603u, message.GetPackedUint32(0));
+            Assert.AreEqual(604u, message.GetPackedUint64(0));
+            Assert.AreEqual(605, message.GetPackedSint32(0));
+            Assert.AreEqual(606, message.GetPackedSint64(0));
+            Assert.AreEqual(607u, message.GetPackedFixed32(0));
+            Assert.AreEqual(608u, message.GetPackedFixed64(0));
+            Assert.AreEqual(609, message.GetPackedSfixed32(0));
+            Assert.AreEqual(610, message.GetPackedSfixed64(0));
+            Assert.AreEqual(611f, message.GetPackedFloat(0));
+            Assert.AreEqual(612d, message.GetPackedDouble(0));
+            Assert.AreEqual(true, message.GetPackedBool(0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetPackedEnum(0));
+            Assert.AreEqual(701, message.GetPackedInt32(1));
+            Assert.AreEqual(702, message.GetPackedInt64(1));
+            Assert.AreEqual(703u, message.GetPackedUint32(1));
+            Assert.AreEqual(704u, message.GetPackedUint64(1));
+            Assert.AreEqual(705, message.GetPackedSint32(1));
+            Assert.AreEqual(706, message.GetPackedSint64(1));
+            Assert.AreEqual(707u, message.GetPackedFixed32(1));
+            Assert.AreEqual(708u, message.GetPackedFixed64(1));
+            Assert.AreEqual(709, message.GetPackedSfixed32(1));
+            Assert.AreEqual(710, message.GetPackedSfixed64(1));
+            Assert.AreEqual(711f, message.GetPackedFloat(1));
+            Assert.AreEqual(712d, message.GetPackedDouble(1));
+            Assert.AreEqual(false, message.GetPackedBool(1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.GetPackedEnum(1));
         }
         /// <summary>
         /// Asserts that all the fields of the specified message are set to the values assigned
@@ -1544,48 +1544,48 @@ namespace Google.ProtocolBuffers
         /// </summary>
         public static void AssertUnpackedFieldsSet(TestUnpackedTypes message)
         {
-            Assert.Equal(2, message.UnpackedInt32Count);
-            Assert.Equal(2, message.UnpackedInt64Count);
-            Assert.Equal(2, message.UnpackedUint32Count);
-            Assert.Equal(2, message.UnpackedUint64Count);
-            Assert.Equal(2, message.UnpackedSint32Count);
-            Assert.Equal(2, message.UnpackedSint64Count);
-            Assert.Equal(2, message.UnpackedFixed32Count);
-            Assert.Equal(2, message.UnpackedFixed64Count);
-            Assert.Equal(2, message.UnpackedSfixed32Count);
-            Assert.Equal(2, message.UnpackedSfixed64Count);
-            Assert.Equal(2, message.UnpackedFloatCount);
-            Assert.Equal(2, message.UnpackedDoubleCount);
-            Assert.Equal(2, message.UnpackedBoolCount);
-            Assert.Equal(2, message.UnpackedEnumCount);
-            Assert.Equal(601, message.GetUnpackedInt32(0));
-            Assert.Equal(602, message.GetUnpackedInt64(0));
-            Assert.Equal(603u, message.GetUnpackedUint32(0));
-            Assert.Equal(604u, message.GetUnpackedUint64(0));
-            Assert.Equal(605, message.GetUnpackedSint32(0));
-            Assert.Equal(606, message.GetUnpackedSint64(0));
-            Assert.Equal(607u, message.GetUnpackedFixed32(0));
-            Assert.Equal(608u, message.GetUnpackedFixed64(0));
-            Assert.Equal(609, message.GetUnpackedSfixed32(0));
-            Assert.Equal(610, message.GetUnpackedSfixed64(0));
-            Assert.Equal(611f, message.GetUnpackedFloat(0));
-            Assert.Equal(612d, message.GetUnpackedDouble(0));
-            Assert.Equal(true, message.GetUnpackedBool(0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetUnpackedEnum(0));
-            Assert.Equal(701, message.GetUnpackedInt32(1));
-            Assert.Equal(702, message.GetUnpackedInt64(1));
-            Assert.Equal(703u, message.GetUnpackedUint32(1));
-            Assert.Equal(704u, message.GetUnpackedUint64(1));
-            Assert.Equal(705, message.GetUnpackedSint32(1));
-            Assert.Equal(706, message.GetUnpackedSint64(1));
-            Assert.Equal(707u, message.GetUnpackedFixed32(1));
-            Assert.Equal(708u, message.GetUnpackedFixed64(1));
-            Assert.Equal(709, message.GetUnpackedSfixed32(1));
-            Assert.Equal(710, message.GetUnpackedSfixed64(1));
-            Assert.Equal(711f, message.GetUnpackedFloat(1));
-            Assert.Equal(712d, message.GetUnpackedDouble(1));
-            Assert.Equal(false, message.GetUnpackedBool(1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.GetUnpackedEnum(1));
+            Assert.AreEqual(2, message.UnpackedInt32Count);
+            Assert.AreEqual(2, message.UnpackedInt64Count);
+            Assert.AreEqual(2, message.UnpackedUint32Count);
+            Assert.AreEqual(2, message.UnpackedUint64Count);
+            Assert.AreEqual(2, message.UnpackedSint32Count);
+            Assert.AreEqual(2, message.UnpackedSint64Count);
+            Assert.AreEqual(2, message.UnpackedFixed32Count);
+            Assert.AreEqual(2, message.UnpackedFixed64Count);
+            Assert.AreEqual(2, message.UnpackedSfixed32Count);
+            Assert.AreEqual(2, message.UnpackedSfixed64Count);
+            Assert.AreEqual(2, message.UnpackedFloatCount);
+            Assert.AreEqual(2, message.UnpackedDoubleCount);
+            Assert.AreEqual(2, message.UnpackedBoolCount);
+            Assert.AreEqual(2, message.UnpackedEnumCount);
+            Assert.AreEqual(601, message.GetUnpackedInt32(0));
+            Assert.AreEqual(602, message.GetUnpackedInt64(0));
+            Assert.AreEqual(603u, message.GetUnpackedUint32(0));
+            Assert.AreEqual(604u, message.GetUnpackedUint64(0));
+            Assert.AreEqual(605, message.GetUnpackedSint32(0));
+            Assert.AreEqual(606, message.GetUnpackedSint64(0));
+            Assert.AreEqual(607u, message.GetUnpackedFixed32(0));
+            Assert.AreEqual(608u, message.GetUnpackedFixed64(0));
+            Assert.AreEqual(609, message.GetUnpackedSfixed32(0));
+            Assert.AreEqual(610, message.GetUnpackedSfixed64(0));
+            Assert.AreEqual(611f, message.GetUnpackedFloat(0));
+            Assert.AreEqual(612d, message.GetUnpackedDouble(0));
+            Assert.AreEqual(true, message.GetUnpackedBool(0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetUnpackedEnum(0));
+            Assert.AreEqual(701, message.GetUnpackedInt32(1));
+            Assert.AreEqual(702, message.GetUnpackedInt64(1));
+            Assert.AreEqual(703u, message.GetUnpackedUint32(1));
+            Assert.AreEqual(704u, message.GetUnpackedUint64(1));
+            Assert.AreEqual(705, message.GetUnpackedSint32(1));
+            Assert.AreEqual(706, message.GetUnpackedSint64(1));
+            Assert.AreEqual(707u, message.GetUnpackedFixed32(1));
+            Assert.AreEqual(708u, message.GetUnpackedFixed64(1));
+            Assert.AreEqual(709, message.GetUnpackedSfixed32(1));
+            Assert.AreEqual(710, message.GetUnpackedSfixed64(1));
+            Assert.AreEqual(711f, message.GetUnpackedFloat(1));
+            Assert.AreEqual(712d, message.GetUnpackedDouble(1));
+            Assert.AreEqual(false, message.GetUnpackedBool(1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.GetUnpackedEnum(1));
         }
 
         public static void SetPackedExtensions(TestPackedExtensions.Builder message)
@@ -1623,95 +1623,95 @@ namespace Google.ProtocolBuffers
 
         public static void AssertPackedExtensionsSet(TestPackedExtensions message)
         {
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedInt32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedInt64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedUint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedUint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedSint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedSint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedFixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedFixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedSfixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedSfixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedFloatExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedDoubleExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedBoolExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.PackedEnumExtension));
-            Assert.Equal(601, message.GetExtension(Unittest.PackedInt32Extension, 0));
-            Assert.Equal(602L, message.GetExtension(Unittest.PackedInt64Extension, 0));
-            Assert.Equal(603u, message.GetExtension(Unittest.PackedUint32Extension, 0));
-            Assert.Equal(604uL, message.GetExtension(Unittest.PackedUint64Extension, 0));
-            Assert.Equal(605, message.GetExtension(Unittest.PackedSint32Extension, 0));
-            Assert.Equal(606L, message.GetExtension(Unittest.PackedSint64Extension, 0));
-            Assert.Equal(607u, message.GetExtension(Unittest.PackedFixed32Extension, 0));
-            Assert.Equal(608uL, message.GetExtension(Unittest.PackedFixed64Extension, 0));
-            Assert.Equal(609, message.GetExtension(Unittest.PackedSfixed32Extension, 0));
-            Assert.Equal(610L, message.GetExtension(Unittest.PackedSfixed64Extension, 0));
-            Assert.Equal(611F, message.GetExtension(Unittest.PackedFloatExtension, 0));
-            Assert.Equal(612D, message.GetExtension(Unittest.PackedDoubleExtension, 0));
-            Assert.Equal(true, message.GetExtension(Unittest.PackedBoolExtension, 0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR,
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedInt32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedInt64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedUint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedUint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedSint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedSint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedFixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedFixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedSfixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedSfixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedFloatExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedDoubleExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedBoolExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.PackedEnumExtension));
+            Assert.AreEqual(601, message.GetExtension(Unittest.PackedInt32Extension, 0));
+            Assert.AreEqual(602L, message.GetExtension(Unittest.PackedInt64Extension, 0));
+            Assert.AreEqual(603u, message.GetExtension(Unittest.PackedUint32Extension, 0));
+            Assert.AreEqual(604uL, message.GetExtension(Unittest.PackedUint64Extension, 0));
+            Assert.AreEqual(605, message.GetExtension(Unittest.PackedSint32Extension, 0));
+            Assert.AreEqual(606L, message.GetExtension(Unittest.PackedSint64Extension, 0));
+            Assert.AreEqual(607u, message.GetExtension(Unittest.PackedFixed32Extension, 0));
+            Assert.AreEqual(608uL, message.GetExtension(Unittest.PackedFixed64Extension, 0));
+            Assert.AreEqual(609, message.GetExtension(Unittest.PackedSfixed32Extension, 0));
+            Assert.AreEqual(610L, message.GetExtension(Unittest.PackedSfixed64Extension, 0));
+            Assert.AreEqual(611F, message.GetExtension(Unittest.PackedFloatExtension, 0));
+            Assert.AreEqual(612D, message.GetExtension(Unittest.PackedDoubleExtension, 0));
+            Assert.AreEqual(true, message.GetExtension(Unittest.PackedBoolExtension, 0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR,
                             message.GetExtension(Unittest.PackedEnumExtension, 0));
-            Assert.Equal(701, message.GetExtension(Unittest.PackedInt32Extension, 1));
-            Assert.Equal(702L, message.GetExtension(Unittest.PackedInt64Extension, 1));
-            Assert.Equal(703u, message.GetExtension(Unittest.PackedUint32Extension, 1));
-            Assert.Equal(704uL, message.GetExtension(Unittest.PackedUint64Extension, 1));
-            Assert.Equal(705, message.GetExtension(Unittest.PackedSint32Extension, 1));
-            Assert.Equal(706L, message.GetExtension(Unittest.PackedSint64Extension, 1));
-            Assert.Equal(707u, message.GetExtension(Unittest.PackedFixed32Extension, 1));
-            Assert.Equal(708uL, message.GetExtension(Unittest.PackedFixed64Extension, 1));
-            Assert.Equal(709, message.GetExtension(Unittest.PackedSfixed32Extension, 1));
-            Assert.Equal(710L, message.GetExtension(Unittest.PackedSfixed64Extension, 1));
-            Assert.Equal(711F, message.GetExtension(Unittest.PackedFloatExtension, 1));
-            Assert.Equal(712D, message.GetExtension(Unittest.PackedDoubleExtension, 1));
-            Assert.Equal(false, message.GetExtension(Unittest.PackedBoolExtension, 1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.GetExtension(Unittest.PackedEnumExtension, 1));
+            Assert.AreEqual(701, message.GetExtension(Unittest.PackedInt32Extension, 1));
+            Assert.AreEqual(702L, message.GetExtension(Unittest.PackedInt64Extension, 1));
+            Assert.AreEqual(703u, message.GetExtension(Unittest.PackedUint32Extension, 1));
+            Assert.AreEqual(704uL, message.GetExtension(Unittest.PackedUint64Extension, 1));
+            Assert.AreEqual(705, message.GetExtension(Unittest.PackedSint32Extension, 1));
+            Assert.AreEqual(706L, message.GetExtension(Unittest.PackedSint64Extension, 1));
+            Assert.AreEqual(707u, message.GetExtension(Unittest.PackedFixed32Extension, 1));
+            Assert.AreEqual(708uL, message.GetExtension(Unittest.PackedFixed64Extension, 1));
+            Assert.AreEqual(709, message.GetExtension(Unittest.PackedSfixed32Extension, 1));
+            Assert.AreEqual(710L, message.GetExtension(Unittest.PackedSfixed64Extension, 1));
+            Assert.AreEqual(711F, message.GetExtension(Unittest.PackedFloatExtension, 1));
+            Assert.AreEqual(712D, message.GetExtension(Unittest.PackedDoubleExtension, 1));
+            Assert.AreEqual(false, message.GetExtension(Unittest.PackedBoolExtension, 1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.GetExtension(Unittest.PackedEnumExtension, 1));
         }
 
         public static void AssertUnpackedExtensionsSet(TestUnpackedExtensions message)
         {
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedInt32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedInt64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedUint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedUint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedSint32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedSint64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedFixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedFixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedSfixed32Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedSfixed64Extension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedFloatExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedDoubleExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedBoolExtension));
-            Assert.Equal(2, message.GetExtensionCount(Unittest.UnpackedEnumExtension));
-            Assert.Equal(601, message.GetExtension(Unittest.UnpackedInt32Extension, 0));
-            Assert.Equal(602L, message.GetExtension(Unittest.UnpackedInt64Extension, 0));
-            Assert.Equal(603u, message.GetExtension(Unittest.UnpackedUint32Extension, 0));
-            Assert.Equal(604uL, message.GetExtension(Unittest.UnpackedUint64Extension, 0));
-            Assert.Equal(605, message.GetExtension(Unittest.UnpackedSint32Extension, 0));
-            Assert.Equal(606L, message.GetExtension(Unittest.UnpackedSint64Extension, 0));
-            Assert.Equal(607u, message.GetExtension(Unittest.UnpackedFixed32Extension, 0));
-            Assert.Equal(608uL, message.GetExtension(Unittest.UnpackedFixed64Extension, 0));
-            Assert.Equal(609, message.GetExtension(Unittest.UnpackedSfixed32Extension, 0));
-            Assert.Equal(610L, message.GetExtension(Unittest.UnpackedSfixed64Extension, 0));
-            Assert.Equal(611F, message.GetExtension(Unittest.UnpackedFloatExtension, 0));
-            Assert.Equal(612D, message.GetExtension(Unittest.UnpackedDoubleExtension, 0));
-            Assert.Equal(true, message.GetExtension(Unittest.UnpackedBoolExtension, 0));
-            Assert.Equal(ForeignEnum.FOREIGN_BAR, message.GetExtension(Unittest.UnpackedEnumExtension, 0));
-            Assert.Equal(701, message.GetExtension(Unittest.UnpackedInt32Extension, 1));
-            Assert.Equal(702L, message.GetExtension(Unittest.UnpackedInt64Extension, 1));
-            Assert.Equal(703u, message.GetExtension(Unittest.UnpackedUint32Extension, 1));
-            Assert.Equal(704uL, message.GetExtension(Unittest.UnpackedUint64Extension, 1));
-            Assert.Equal(705, message.GetExtension(Unittest.UnpackedSint32Extension, 1));
-            Assert.Equal(706L, message.GetExtension(Unittest.UnpackedSint64Extension, 1));
-            Assert.Equal(707u, message.GetExtension(Unittest.UnpackedFixed32Extension, 1));
-            Assert.Equal(708uL, message.GetExtension(Unittest.UnpackedFixed64Extension, 1));
-            Assert.Equal(709, message.GetExtension(Unittest.UnpackedSfixed32Extension, 1));
-            Assert.Equal(710L, message.GetExtension(Unittest.UnpackedSfixed64Extension, 1));
-            Assert.Equal(711F, message.GetExtension(Unittest.UnpackedFloatExtension, 1));
-            Assert.Equal(712D, message.GetExtension(Unittest.UnpackedDoubleExtension, 1));
-            Assert.Equal(false, message.GetExtension(Unittest.UnpackedBoolExtension, 1));
-            Assert.Equal(ForeignEnum.FOREIGN_BAZ, message.GetExtension(Unittest.UnpackedEnumExtension, 1));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedInt32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedInt64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedUint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedUint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedSint32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedSint64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedFixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedFixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedSfixed32Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedSfixed64Extension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedFloatExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedDoubleExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedBoolExtension));
+            Assert.AreEqual(2, message.GetExtensionCount(Unittest.UnpackedEnumExtension));
+            Assert.AreEqual(601, message.GetExtension(Unittest.UnpackedInt32Extension, 0));
+            Assert.AreEqual(602L, message.GetExtension(Unittest.UnpackedInt64Extension, 0));
+            Assert.AreEqual(603u, message.GetExtension(Unittest.UnpackedUint32Extension, 0));
+            Assert.AreEqual(604uL, message.GetExtension(Unittest.UnpackedUint64Extension, 0));
+            Assert.AreEqual(605, message.GetExtension(Unittest.UnpackedSint32Extension, 0));
+            Assert.AreEqual(606L, message.GetExtension(Unittest.UnpackedSint64Extension, 0));
+            Assert.AreEqual(607u, message.GetExtension(Unittest.UnpackedFixed32Extension, 0));
+            Assert.AreEqual(608uL, message.GetExtension(Unittest.UnpackedFixed64Extension, 0));
+            Assert.AreEqual(609, message.GetExtension(Unittest.UnpackedSfixed32Extension, 0));
+            Assert.AreEqual(610L, message.GetExtension(Unittest.UnpackedSfixed64Extension, 0));
+            Assert.AreEqual(611F, message.GetExtension(Unittest.UnpackedFloatExtension, 0));
+            Assert.AreEqual(612D, message.GetExtension(Unittest.UnpackedDoubleExtension, 0));
+            Assert.AreEqual(true, message.GetExtension(Unittest.UnpackedBoolExtension, 0));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAR, message.GetExtension(Unittest.UnpackedEnumExtension, 0));
+            Assert.AreEqual(701, message.GetExtension(Unittest.UnpackedInt32Extension, 1));
+            Assert.AreEqual(702L, message.GetExtension(Unittest.UnpackedInt64Extension, 1));
+            Assert.AreEqual(703u, message.GetExtension(Unittest.UnpackedUint32Extension, 1));
+            Assert.AreEqual(704uL, message.GetExtension(Unittest.UnpackedUint64Extension, 1));
+            Assert.AreEqual(705, message.GetExtension(Unittest.UnpackedSint32Extension, 1));
+            Assert.AreEqual(706L, message.GetExtension(Unittest.UnpackedSint64Extension, 1));
+            Assert.AreEqual(707u, message.GetExtension(Unittest.UnpackedFixed32Extension, 1));
+            Assert.AreEqual(708uL, message.GetExtension(Unittest.UnpackedFixed64Extension, 1));
+            Assert.AreEqual(709, message.GetExtension(Unittest.UnpackedSfixed32Extension, 1));
+            Assert.AreEqual(710L, message.GetExtension(Unittest.UnpackedSfixed64Extension, 1));
+            Assert.AreEqual(711F, message.GetExtension(Unittest.UnpackedFloatExtension, 1));
+            Assert.AreEqual(712D, message.GetExtension(Unittest.UnpackedDoubleExtension, 1));
+            Assert.AreEqual(false, message.GetExtension(Unittest.UnpackedBoolExtension, 1));
+            Assert.AreEqual(ForeignEnum.FOREIGN_BAZ, message.GetExtension(Unittest.UnpackedEnumExtension, 1));
         }
 
         private static readonly string[] TestCultures = {"en-US", "en-GB", "fr-FR", "de-DE"};

--- a/csharp/src/ProtocolBuffers.Test/TestWriterFormatJson.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestWriterFormatJson.cs
@@ -6,13 +6,13 @@ using EnumOptions = Google.ProtocolBuffers.TestProtos.EnumOptions;
 using Google.ProtocolBuffers.DescriptorProtos;
 using Google.ProtocolBuffers.Serialization;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class TestWriterFormatJson
     {
-        [Fact]
+        [Test]
         public void Example_FromJson()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -21,10 +21,10 @@ namespace Google.ProtocolBuffers
             Extensions.MergeFromJson(builder, @"{""valid"":true}");
             
             TestXmlMessage message = builder.Build();
-            Assert.Equal(true, message.Valid);
+            Assert.AreEqual(true, message.Valid);
         }
 
-        [Fact]
+        [Test]
         public void Example_ToJson()
         {
             TestXmlMessage message = 
@@ -35,10 +35,10 @@ namespace Google.ProtocolBuffers
             //3.5: string json = message.ToJson();
             string json = Extensions.ToJson(message);
 
-            Assert.Equal(@"{""valid"":true}", json);
+            Assert.AreEqual(@"{""valid"":true}", json);
         }
 
-        [Fact]
+        [Test]
         public void Example_WriteJsonUsingICodedOutputStream()
         {
             TestXmlMessage message =
@@ -52,20 +52,20 @@ namespace Google.ProtocolBuffers
                 writer.WriteMessageStart();      //manually begin the message, output is '{'
                 
                 writer.Flush();
-                Assert.Equal("{", output.ToString());
+                Assert.AreEqual("{", output.ToString());
 
                 ICodedOutputStream stream = writer;
                 message.WriteTo(stream);    //write the message normally
 
                 writer.Flush();
-                Assert.Equal(@"{""valid"":true", output.ToString());
+                Assert.AreEqual(@"{""valid"":true", output.ToString());
 
                 writer.WriteMessageEnd();        //manually write the end message '}'
-                Assert.Equal(@"{""valid"":true}", output.ToString());
+                Assert.AreEqual(@"{""valid"":true}", output.ToString());
             }
         }
 
-        [Fact]
+        [Test]
         public void Example_ReadJsonUsingICodedInputStream()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -94,37 +94,37 @@ namespace Google.ProtocolBuffers
                 JsonFormatReader.CreateInstance(Content)
                 .Merge(message.WeakCreateBuilderForType(), registry).WeakBuild();
 
-            Assert.Equal(typeof(TMessage), copy.GetType());
-            Assert.Equal(message, copy);
+            Assert.AreEqual(typeof(TMessage), copy.GetType());
+            Assert.AreEqual(message, copy);
             foreach (string expect in expecting)
             {
-                Assert.True(Content.IndexOf(expect) >= 0);
+                Assert.IsTrue(Content.IndexOf(expect) >= 0);
             }
         }
 
-        [Fact]
+        [Test]
         public void TestToJsonParseFromJson()
         {
             TestAllTypes msg = new TestAllTypes.Builder().SetDefaultBool(true).Build();
             string json = Extensions.ToJson(msg);
-            Assert.Equal("{\"default_bool\":true}", json);
+            Assert.AreEqual("{\"default_bool\":true}", json);
             TestAllTypes copy = Extensions.MergeFromJson(new TestAllTypes.Builder(), json).Build();
-            Assert.True(copy.HasDefaultBool && copy.DefaultBool);
-            Assert.Equal(msg, copy);
+            Assert.IsTrue(copy.HasDefaultBool && copy.DefaultBool);
+            Assert.AreEqual(msg, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestToJsonParseFromJsonReader()
         {
             TestAllTypes msg = new TestAllTypes.Builder().SetDefaultBool(true).Build();
             string json = Extensions.ToJson(msg);
-            Assert.Equal("{\"default_bool\":true}", json);
+            Assert.AreEqual("{\"default_bool\":true}", json);
             TestAllTypes copy = Extensions.MergeFromJson(new TestAllTypes.Builder(), new StringReader(json)).Build();
-            Assert.True(copy.HasDefaultBool && copy.DefaultBool);
-            Assert.Equal(msg, copy);
+            Assert.IsTrue(copy.HasDefaultBool && copy.DefaultBool);
+            Assert.AreEqual(msg, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestJsonFormatted()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -144,10 +144,10 @@ namespace Google.ProtocolBuffers
 
             TestXmlMessage copy = JsonFormatReader.CreateInstance(json)
                 .Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestEmptyMessage()
         {
             FormatterAssert(
@@ -157,7 +157,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestRepeatedField()
         {
             FormatterAssert(
@@ -169,7 +169,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestNestedEmptyMessage()
         {
             FormatterAssert(
@@ -180,7 +180,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestNestedMessage()
         {
             FormatterAssert(
@@ -191,7 +191,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestBooleanTypes()
         {
             FormatterAssert(
@@ -202,7 +202,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestFullMessage()
         {
             FormatterAssert(
@@ -232,7 +232,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestMessageWithXmlText()
         {
             FormatterAssert(
@@ -243,7 +243,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestWithEscapeChars()
         {
             FormatterAssert(
@@ -254,7 +254,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestWithExtensionText()
         {
             FormatterAssert(
@@ -266,7 +266,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestWithExtensionNumber()
         {
             FormatterAssert(
@@ -278,7 +278,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestWithExtensionArray()
         {
             FormatterAssert(
@@ -291,7 +291,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestWithExtensionEnum()
         {
             FormatterAssert(
@@ -302,7 +302,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestMessageWithExtensions()
         {
             FormatterAssert(
@@ -325,7 +325,7 @@ namespace Google.ProtocolBuffers
                 );
         }
         
-        [Fact]
+        [Test]
         public void TestMessageMissingExtensions()
         {
             TestXmlMessage original = TestXmlMessage.CreateBuilder()
@@ -353,23 +353,23 @@ namespace Google.ProtocolBuffers
             IMessageLite copy = JsonFormatReader.CreateInstance(Content)
                 .Merge(message.CreateBuilderForType()).Build();
 
-            Assert.NotEqual(original, message);
-            Assert.NotEqual(original, copy);
-            Assert.Equal(message, copy);
+            Assert.AreNotEqual(original, message);
+            Assert.AreNotEqual(original, copy);
+            Assert.AreEqual(message, copy);
         }
         
-        [Fact]
+        [Test]
         public void TestMergeFields()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
             builder.MergeFrom(JsonFormatReader.CreateInstance("\"valid\": true"));
             builder.MergeFrom(JsonFormatReader.CreateInstance("\"text\": \"text\", \"number\": \"411\""));
-            Assert.Equal(true, builder.Valid);
-            Assert.Equal("text", builder.Text);
-            Assert.Equal(411, builder.Number);
+            Assert.AreEqual(true, builder.Valid);
+            Assert.AreEqual("text", builder.Text);
+            Assert.AreEqual(411, builder.Number);
         }
         
-        [Fact]
+        [Test]
         public void TestMessageArray()
         {
             JsonFormatWriter writer = JsonFormatWriter.CreateInstance().Formatted();
@@ -388,13 +388,13 @@ namespace Google.ProtocolBuffers
             foreach (JsonFormatReader r in reader.EnumerateArray())
             {
                 r.Merge(builder);
-                Assert.Equal(++ordinal, builder.Number);
+                Assert.AreEqual(++ordinal, builder.Number);
             }
-            Assert.Equal(3, ordinal);
-            Assert.Equal(3, builder.TextlinesCount);
+            Assert.AreEqual(3, ordinal);
+            Assert.AreEqual(3, builder.TextlinesCount);
         }
         
-        [Fact]
+        [Test]
         public void TestNestedMessageArray()
         {
             JsonFormatWriter writer = JsonFormatWriter.CreateInstance();
@@ -418,13 +418,13 @@ namespace Google.ProtocolBuffers
                 foreach (JsonFormatReader r2 in r.EnumerateArray())
                 {
                     r2.Merge(builder);
-                    Assert.Equal(++ordinal, builder.Number);
+                    Assert.AreEqual(++ordinal, builder.Number);
                 }
-            Assert.Equal(3, ordinal);
-            Assert.Equal(3, builder.TextlinesCount);
+            Assert.AreEqual(3, ordinal);
+            Assert.AreEqual(3, builder.TextlinesCount);
         }
         
-        [Fact]
+        [Test]
         public void TestReadWriteJsonWithoutRoot()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -439,15 +439,15 @@ namespace Google.ProtocolBuffers
                 output.Flush();
                 Json = sw.ToString();
             }
-            Assert.Equal(@"""text"":""abc"",""number"":123", Json);
+            Assert.AreEqual(@"""text"":""abc"",""number"":123", Json);
 
             ICodedInputStream input = JsonFormatReader.CreateInstance(Json);
             TestXmlMessage copy = TestXmlMessage.CreateBuilder().MergeFrom(input).Build();
 
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
         
-        [Fact]
+        [Test]
         public void TestRecursiveLimit()
         {
             StringBuilder sb = new StringBuilder(8192);
@@ -458,32 +458,32 @@ namespace Google.ProtocolBuffers
             Assert.Throws<RecursionLimitExceededException>(() => Extensions.MergeFromJson(new TestXmlRescursive.Builder(), sb.ToString()).Build());
         }
 
-        [Fact]
+        [Test]
         public void FailWithEmptyText()
         {
             Assert.Throws<FormatException>(() => JsonFormatReader.CreateInstance("").Merge(TestXmlMessage.CreateBuilder()));
         }
         
-        [Fact]
+        [Test]
         public void FailWithUnexpectedValue()
         {
             Assert.Throws<FormatException>(() => JsonFormatReader.CreateInstance("{{}}").Merge(TestXmlMessage.CreateBuilder()));
         }
         
-        [Fact]
+        [Test]
         public void FailWithUnQuotedName()
         {
             Assert.Throws<FormatException>(() => JsonFormatReader.CreateInstance("{name:{}}").Merge(TestXmlMessage.CreateBuilder()));
         }
         
-        [Fact]
+        [Test]
         public void FailWithUnexpectedType()
         {
             Assert.Throws<FormatException>(() => JsonFormatReader.CreateInstance("{\"valid\":{}}").Merge(TestXmlMessage.CreateBuilder()));
         }
 
         // See issue 64 for background.
-        [Fact]
+        [Test]
         public void ToJsonRequiringBufferExpansion()
         {
             string s = new string('.', 4086);

--- a/csharp/src/ProtocolBuffers.Test/TestWriterFormatXml.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestWriterFormatXml.cs
@@ -4,13 +4,13 @@ using System.Text;
 using System.Xml;
 using Google.ProtocolBuffers.Serialization;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class TestWriterFormatXml
     {
-        [Fact]
+        [Test]
         public void Example_FromXml()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -20,10 +20,10 @@ namespace Google.ProtocolBuffers
             Extensions.MergeFromXml(builder, rdr);
 
             TestXmlMessage message = builder.Build();
-            Assert.Equal(true, message.Valid);
+            Assert.AreEqual(true, message.Valid);
         }
 
-        [Fact]
+        [Test]
         public void Example_ToXml()
         {
             TestXmlMessage message =
@@ -34,10 +34,10 @@ namespace Google.ProtocolBuffers
             //3.5: string Xml = message.ToXml();
             string Xml = Extensions.ToXml(message);
 
-            Assert.Equal(@"<root><valid>true</valid></root>", Xml);
+            Assert.AreEqual(@"<root><valid>true</valid></root>", Xml);
         }
 
-        [Fact]
+        [Test]
         public void Example_WriteXmlUsingICodedOutputStream()
         {
             TestXmlMessage message =
@@ -54,11 +54,11 @@ namespace Google.ProtocolBuffers
                 message.WriteTo(stream);         //write the message normally
 
                 writer.WriteMessageEnd();        //manually write the end message '}'
-                Assert.Equal(@"<root><valid>true</valid></root>", output.ToString());
+                Assert.AreEqual(@"<root><valid>true</valid></root>", output.ToString());
             }
         }
 
-        [Fact]
+        [Test]
         public void Example_ReadXmlUsingICodedInputStream()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -71,29 +71,29 @@ namespace Google.ProtocolBuffers
             reader.ReadMessageEnd();    //manually read the end message '}'
         }
 
-        [Fact]
+        [Test]
         public void TestToXmlParseFromXml()
         {
             TestAllTypes msg = new TestAllTypes.Builder().SetDefaultBool(true).Build();
             string xml = Extensions.ToXml(msg);
-            Assert.Equal("<root><default_bool>true</default_bool></root>", xml);
+            Assert.AreEqual("<root><default_bool>true</default_bool></root>", xml);
             TestAllTypes copy = Extensions.MergeFromXml(new TestAllTypes.Builder(), XmlReader.Create(new StringReader(xml))).Build();
-            Assert.True(copy.HasDefaultBool && copy.DefaultBool);
-            Assert.Equal(msg, copy);
+            Assert.IsTrue(copy.HasDefaultBool && copy.DefaultBool);
+            Assert.AreEqual(msg, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestToXmlParseFromXmlWithRootName()
         {
             TestAllTypes msg = new TestAllTypes.Builder().SetDefaultBool(true).Build();
             string xml = Extensions.ToXml(msg, "message");
-            Assert.Equal("<message><default_bool>true</default_bool></message>", xml);
+            Assert.AreEqual("<message><default_bool>true</default_bool></message>", xml);
             TestAllTypes copy = Extensions.MergeFromXml(new TestAllTypes.Builder(), "message", XmlReader.Create(new StringReader(xml))).Build();
-            Assert.True(copy.HasDefaultBool && copy.DefaultBool);
-            Assert.Equal(msg, copy);
+            Assert.IsTrue(copy.HasDefaultBool && copy.DefaultBool);
+            Assert.AreEqual(msg, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestEmptyMessage()
         {
             TestXmlChild message = TestXmlChild.CreateBuilder()
@@ -111,9 +111,9 @@ namespace Google.ProtocolBuffers
             string xml = sw.ToString();
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlChild copy = rdr.Merge(TestXmlChild.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
-        [Fact]
+        [Test]
         public void TestRepeatedField()
         {
             TestXmlChild message = TestXmlChild.CreateBuilder()
@@ -128,10 +128,10 @@ namespace Google.ProtocolBuffers
             string xml = sw.ToString();
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlChild copy = rdr.Merge(TestXmlChild.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestNestedEmptyMessage()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -144,10 +144,10 @@ namespace Google.ProtocolBuffers
             string xml = sw.ToString();
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestNestedMessage()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -160,10 +160,10 @@ namespace Google.ProtocolBuffers
             string xml = sw.ToString();
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestBooleanTypes()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -176,10 +176,10 @@ namespace Google.ProtocolBuffers
             string xml = sw.ToString();
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestFullMessage()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -206,10 +206,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestFullMessageWithRichTypes()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -239,10 +239,10 @@ namespace Google.ProtocolBuffers
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             rdr.Options = XmlReaderOptions.ReadNestedArrays;
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestFullMessageWithUnknownFields()
         {
             TestXmlMessage origial = TestXmlMessage.CreateBuilder()
@@ -261,7 +261,7 @@ namespace Google.ProtocolBuffers
                 .Build();
             TestXmlNoFields message = TestXmlNoFields.CreateBuilder().MergeFrom(origial.ToByteArray()).Build();
 
-            Assert.Equal(0, message.AllFields.Count);
+            Assert.AreEqual(0, message.AllFields.Count);
 
             StringWriter sw = new StringWriter();
             XmlFormatWriter.CreateInstance(sw)
@@ -273,9 +273,9 @@ namespace Google.ProtocolBuffers
             using (XmlReader x = XmlReader.Create(new StringReader(xml)))
             {
                 x.MoveToContent();
-                Assert.Equal(XmlNodeType.Element, x.NodeType);
+                Assert.AreEqual(XmlNodeType.Element, x.NodeType);
                 //should always be empty
-                Assert.True(x.IsEmptyElement ||
+                Assert.IsTrue(x.IsEmptyElement ||
                     (x.Read() && x.NodeType == XmlNodeType.EndElement)
                     );
             }
@@ -283,10 +283,10 @@ namespace Google.ProtocolBuffers
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             rdr.Options = XmlReaderOptions.ReadNestedArrays;
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(TestXmlMessage.DefaultInstance, copy);
+            Assert.AreEqual(TestXmlMessage.DefaultInstance, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestMessageWithXmlText()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -299,10 +299,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWithWhitespace()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -315,10 +315,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder()).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWithExtensionText()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -335,10 +335,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder(), registry).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWithExtensionMessage()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -355,10 +355,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder(), registry).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWithExtensionArray()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -377,10 +377,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder(), registry).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlWithExtensionEnum()
         {
             TestXmlMessage message = TestXmlMessage.CreateBuilder()
@@ -397,10 +397,10 @@ namespace Google.ProtocolBuffers
 
             XmlFormatReader rdr = XmlFormatReader.CreateInstance(xml);
             TestXmlMessage copy = rdr.Merge(TestXmlMessage.CreateBuilder(), registry).Build();
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlReadEmptyRoot()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -413,7 +413,7 @@ namespace Google.ProtocolBuffers
             reader.ReadMessageEnd();    //manually read the end message '}'
         }
 
-        [Fact]
+        [Test]
         public void TestXmlReadEmptyChild()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -422,11 +422,11 @@ namespace Google.ProtocolBuffers
             reader.ReadMessageStart();  //manually read the begin the message '{'
 
             builder.MergeFrom(reader);  //write the message normally
-            Assert.True(builder.HasText);
-            Assert.Equal(String.Empty, builder.Text);
+            Assert.IsTrue(builder.HasText);
+            Assert.AreEqual(String.Empty, builder.Text);
         }
 
-        [Fact]
+        [Test]
         public void TestXmlReadWriteWithoutRoot()
         {
             TestXmlMessage.Builder builder = TestXmlMessage.CreateBuilder();
@@ -442,7 +442,7 @@ namespace Google.ProtocolBuffers
                 output.Flush();
                 xml = sw.ToString();
             }
-            Assert.Equal("<text>abc</text><number>123</number>", xml);
+            Assert.AreEqual("<text>abc</text><number>123</number>", xml);
 
             TestXmlMessage copy;
             using (XmlReader xr = XmlReader.Create(new StringReader(xml), new XmlReaderSettings() { ConformanceLevel = ConformanceLevel.Fragment }))
@@ -451,10 +451,10 @@ namespace Google.ProtocolBuffers
                 copy = TestXmlMessage.CreateBuilder().MergeFrom(input).Build();
             }
 
-            Assert.Equal(message, copy);
+            Assert.AreEqual(message, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestRecursiveLimit()
         {
             StringBuilder sb = new StringBuilder(8192);

--- a/csharp/src/ProtocolBuffers.Test/TextFormatTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/TextFormatTest.cs
@@ -37,7 +37,7 @@
 using System;
 using System.IO;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -84,13 +84,13 @@ namespace Google.ProtocolBuffers
         /// <summary>
         /// Print TestAllTypes and compare with golden file. 
         /// </summary>
-        [Fact]
+        [Test]
         public void PrintMessage()
         {
             TestUtil.TestInMultipleCultures(() =>
             {
                 string text = TextFormat.PrintToString(TestUtil.GetAllSet());
-                Assert.Equal(AllFieldsSetText.Replace("\r\n", "\n").Trim(),
+                Assert.AreEqual(AllFieldsSetText.Replace("\r\n", "\n").Trim(),
                                 text.Replace("\r\n", "\n").Trim());
             });
         }
@@ -98,32 +98,32 @@ namespace Google.ProtocolBuffers
         /// <summary>
         /// Tests that a builder prints the same way as a message.
         /// </summary>
-        [Fact]
+        [Test]
         public void PrintBuilder()
         {
             TestUtil.TestInMultipleCultures(() =>
             {
                 string messageText = TextFormat.PrintToString(TestUtil.GetAllSet());
                 string builderText = TextFormat.PrintToString(TestUtil.GetAllSet().ToBuilder());
-                Assert.Equal(messageText, builderText);
+                Assert.AreEqual(messageText, builderText);
             });
         }
 
         /// <summary>
         /// Print TestAllExtensions and compare with golden file.
         /// </summary>
-        [Fact]
+        [Test]
         public void PrintExtensions()
         {
             string text = TextFormat.PrintToString(TestUtil.GetAllExtensionsSet());
 
-            Assert.Equal(AllExtensionsSetText.Replace("\r\n", "\n").Trim(), text.Replace("\r\n", "\n").Trim());
+            Assert.AreEqual(AllExtensionsSetText.Replace("\r\n", "\n").Trim(), text.Replace("\r\n", "\n").Trim());
         }
 
         /// <summary>
         /// Test printing of unknown fields in a message.
         /// </summary>
-        [Fact]
+        [Test]
         public void PrintUnknownFields()
         {
             TestEmptyMessage message =
@@ -159,7 +159,7 @@ namespace Google.ProtocolBuffers
                             .Build())
                     .Build();
 
-            Assert.Equal(
+            Assert.AreEqual(
                 "5: 1\n" +
                 "5: 0x00000002\n" +
                 "5: 0x0000000000000003\n" +
@@ -189,7 +189,7 @@ namespace Google.ProtocolBuffers
             return ByteString.CopyFrom(bytes);
         }
 
-        [Fact]
+        [Test]
         public void PrintExotic()
         {
             IMessage message = TestAllTypes.CreateBuilder()
@@ -220,10 +220,10 @@ namespace Google.ProtocolBuffers
                 .AddRepeatedBytes(Bytes("\0\u0001\u0007\b\f\n\r\t\v\\\'\"\u00fe"))
                 .Build();
 
-            Assert.Equal(ExoticText, message.ToString());
+            Assert.AreEqual(ExoticText, message.ToString());
         }
 
-        [Fact]
+        [Test]
         public void PrintMessageSet()
         {
             TestMessageSet messageSet =
@@ -236,12 +236,12 @@ namespace Google.ProtocolBuffers
                         TestMessageSetExtension2.CreateBuilder().SetStr("foo").Build())
                     .Build();
 
-            Assert.Equal(MessageSetText, messageSet.ToString());
+            Assert.AreEqual(MessageSetText, messageSet.ToString());
         }
 
         // =================================================================
 
-        [Fact]
+        [Test]
         public void Parse()
         {
             TestUtil.TestInMultipleCultures(() =>
@@ -252,7 +252,7 @@ namespace Google.ProtocolBuffers
                                                 });
         }
 
-        [Fact]
+        [Test]
         public void ParseReader()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -260,7 +260,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllFieldsSet(builder.Build());
         }
 
-        [Fact]
+        [Test]
         public void ParseExtensions()
         {
             TestAllExtensions.Builder builder = TestAllExtensions.CreateBuilder();
@@ -270,7 +270,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllExtensionsSet(builder.Build());
         }
 
-        [Fact]
+        [Test]
         public void ParseCompatibility()
         {
             string original = "repeated_float: inf\n" +
@@ -299,10 +299,10 @@ namespace Google.ProtocolBuffers
                                "repeated_double: NaN\n";
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             TextFormat.Merge(original, builder);
-            Assert.Equal(canonical, builder.Build().ToString());
+            Assert.AreEqual(canonical, builder.Build().ToString());
         }
 
-        [Fact]
+        [Test]
         public void ParseExotic()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -310,10 +310,10 @@ namespace Google.ProtocolBuffers
 
             // Too lazy to check things individually.  Don't try to debug this
             // if testPrintExotic() is Assert.Failing.
-            Assert.Equal(ExoticText, builder.Build().ToString());
+            Assert.AreEqual(ExoticText, builder.Build().ToString());
         }
 
-        [Fact]
+        [Test]
         public void ParseMessageSet()
         {
             ExtensionRegistry extensionRegistry = ExtensionRegistry.CreateInstance();
@@ -324,30 +324,30 @@ namespace Google.ProtocolBuffers
             TextFormat.Merge(MessageSetText, extensionRegistry, builder);
             TestMessageSet messageSet = builder.Build();
 
-            Assert.True(messageSet.HasExtension(TestMessageSetExtension1.MessageSetExtension));
-            Assert.Equal(123, messageSet.GetExtension(TestMessageSetExtension1.MessageSetExtension).I);
-            Assert.True(messageSet.HasExtension(TestMessageSetExtension2.MessageSetExtension));
-            Assert.Equal("foo", messageSet.GetExtension(TestMessageSetExtension2.MessageSetExtension).Str);
+            Assert.IsTrue(messageSet.HasExtension(TestMessageSetExtension1.MessageSetExtension));
+            Assert.AreEqual(123, messageSet.GetExtension(TestMessageSetExtension1.MessageSetExtension).I);
+            Assert.IsTrue(messageSet.HasExtension(TestMessageSetExtension2.MessageSetExtension));
+            Assert.AreEqual("foo", messageSet.GetExtension(TestMessageSetExtension2.MessageSetExtension).Str);
         }
 
-        [Fact]
+        [Test]
         public void ParseNumericEnum()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             TextFormat.Merge("optional_nested_enum: 2", builder);
-            Assert.Equal(TestAllTypes.Types.NestedEnum.BAR, builder.OptionalNestedEnum);
+            Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR, builder.OptionalNestedEnum);
         }
 
-        [Fact]
+        [Test]
         public void ParseAngleBrackets()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             TextFormat.Merge("OptionalGroup: < a: 1 >", builder);
-            Assert.True(builder.HasOptionalGroup);
-            Assert.Equal(1, builder.OptionalGroup.A);
+            Assert.IsTrue(builder.HasOptionalGroup);
+            Assert.AreEqual(1, builder.OptionalGroup.A);
         }
 
-        [Fact]
+        [Test]
         public void ParseComment()
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
@@ -356,8 +356,8 @@ namespace Google.ProtocolBuffers
                 "optional_int32: 1  # another comment\n" +
                 "optional_int64: 2\n" +
                 "# EOF comment", builder);
-            Assert.Equal(1, builder.OptionalInt32);
-            Assert.Equal(2, builder.OptionalInt64);
+            Assert.AreEqual(1, builder.OptionalInt32);
+            Assert.AreEqual(2, builder.OptionalInt64);
         }
 
 
@@ -365,10 +365,10 @@ namespace Google.ProtocolBuffers
         {
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             Exception exception = Assert.Throws<FormatException>(() => TextFormat.Merge(text, TestUtil.CreateExtensionRegistry(), builder));
-            Assert.Equal(error, exception.Message);
+            Assert.AreEqual(error, exception.Message);
         }
 
-        [Fact]
+        [Test]
         public void ParseErrors()
         {
             AssertParseError(
@@ -443,26 +443,26 @@ namespace Google.ProtocolBuffers
             return ByteString.CopyFrom(bytes);
         }
 
-        [Fact]
+        [Test]
         public void Escape()
         {
             // Escape sequences.
-            Assert.Equal("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"",
+            Assert.AreEqual("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"",
                             TextFormat.EscapeBytes(Bytes("\0\u0001\u0007\b\f\n\r\t\v\\\'\"")));
-            Assert.Equal("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"",
+            Assert.AreEqual("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\"",
                             TextFormat.EscapeText("\0\u0001\u0007\b\f\n\r\t\v\\\'\""));
-            Assert.Equal(Bytes("\0\u0001\u0007\b\f\n\r\t\v\\\'\""),
+            Assert.AreEqual(Bytes("\0\u0001\u0007\b\f\n\r\t\v\\\'\""),
                             TextFormat.UnescapeBytes("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\""));
-            Assert.Equal("\0\u0001\u0007\b\f\n\r\t\v\\\'\"",
+            Assert.AreEqual("\0\u0001\u0007\b\f\n\r\t\v\\\'\"",
                             TextFormat.UnescapeText("\\000\\001\\a\\b\\f\\n\\r\\t\\v\\\\\\'\\\""));
 
             // Unicode handling.
-            Assert.Equal("\\341\\210\\264", TextFormat.EscapeText("\u1234"));
-            Assert.Equal("\\341\\210\\264", TextFormat.EscapeBytes(Bytes(0xe1, 0x88, 0xb4)));
-            Assert.Equal("\u1234", TextFormat.UnescapeText("\\341\\210\\264"));
-            Assert.Equal(Bytes(0xe1, 0x88, 0xb4), TextFormat.UnescapeBytes("\\341\\210\\264"));
-            Assert.Equal("\u1234", TextFormat.UnescapeText("\\xe1\\x88\\xb4"));
-            Assert.Equal(Bytes(0xe1, 0x88, 0xb4), TextFormat.UnescapeBytes("\\xe1\\x88\\xb4"));
+            Assert.AreEqual("\\341\\210\\264", TextFormat.EscapeText("\u1234"));
+            Assert.AreEqual("\\341\\210\\264", TextFormat.EscapeBytes(Bytes(0xe1, 0x88, 0xb4)));
+            Assert.AreEqual("\u1234", TextFormat.UnescapeText("\\341\\210\\264"));
+            Assert.AreEqual(Bytes(0xe1, 0x88, 0xb4), TextFormat.UnescapeBytes("\\341\\210\\264"));
+            Assert.AreEqual("\u1234", TextFormat.UnescapeText("\\xe1\\x88\\xb4"));
+            Assert.AreEqual(Bytes(0xe1, 0x88, 0xb4), TextFormat.UnescapeBytes("\\xe1\\x88\\xb4"));
 
             // Errors.
             Assert.Throws<FormatException>(() => TextFormat.UnescapeText("\\x"));
@@ -470,55 +470,55 @@ namespace Google.ProtocolBuffers
             Assert.Throws<FormatException>(() => TextFormat.UnescapeText("\\"));
         }
 
-        [Fact]
+        [Test]
         public void ParseInteger()
         {
-            Assert.Equal(0, TextFormat.ParseInt32("0"));
-            Assert.Equal(1, TextFormat.ParseInt32("1"));
-            Assert.Equal(-1, TextFormat.ParseInt32("-1"));
-            Assert.Equal(12345, TextFormat.ParseInt32("12345"));
-            Assert.Equal(-12345, TextFormat.ParseInt32("-12345"));
-            Assert.Equal(2147483647, TextFormat.ParseInt32("2147483647"));
-            Assert.Equal(-2147483648, TextFormat.ParseInt32("-2147483648"));
+            Assert.AreEqual(0, TextFormat.ParseInt32("0"));
+            Assert.AreEqual(1, TextFormat.ParseInt32("1"));
+            Assert.AreEqual(-1, TextFormat.ParseInt32("-1"));
+            Assert.AreEqual(12345, TextFormat.ParseInt32("12345"));
+            Assert.AreEqual(-12345, TextFormat.ParseInt32("-12345"));
+            Assert.AreEqual(2147483647, TextFormat.ParseInt32("2147483647"));
+            Assert.AreEqual(-2147483648, TextFormat.ParseInt32("-2147483648"));
 
-            Assert.Equal(0u, TextFormat.ParseUInt32("0"));
-            Assert.Equal(1u, TextFormat.ParseUInt32("1"));
-            Assert.Equal(12345u, TextFormat.ParseUInt32("12345"));
-            Assert.Equal(2147483647u, TextFormat.ParseUInt32("2147483647"));
-            Assert.Equal(2147483648U, TextFormat.ParseUInt32("2147483648"));
-            Assert.Equal(4294967295U, TextFormat.ParseUInt32("4294967295"));
+            Assert.AreEqual(0u, TextFormat.ParseUInt32("0"));
+            Assert.AreEqual(1u, TextFormat.ParseUInt32("1"));
+            Assert.AreEqual(12345u, TextFormat.ParseUInt32("12345"));
+            Assert.AreEqual(2147483647u, TextFormat.ParseUInt32("2147483647"));
+            Assert.AreEqual(2147483648U, TextFormat.ParseUInt32("2147483648"));
+            Assert.AreEqual(4294967295U, TextFormat.ParseUInt32("4294967295"));
 
-            Assert.Equal(0L, TextFormat.ParseInt64("0"));
-            Assert.Equal(1L, TextFormat.ParseInt64("1"));
-            Assert.Equal(-1L, TextFormat.ParseInt64("-1"));
-            Assert.Equal(12345L, TextFormat.ParseInt64("12345"));
-            Assert.Equal(-12345L, TextFormat.ParseInt64("-12345"));
-            Assert.Equal(2147483647L, TextFormat.ParseInt64("2147483647"));
-            Assert.Equal(-2147483648L, TextFormat.ParseInt64("-2147483648"));
-            Assert.Equal(4294967295L, TextFormat.ParseInt64("4294967295"));
-            Assert.Equal(4294967296L, TextFormat.ParseInt64("4294967296"));
-            Assert.Equal(9223372036854775807L, TextFormat.ParseInt64("9223372036854775807"));
-            Assert.Equal(-9223372036854775808L, TextFormat.ParseInt64("-9223372036854775808"));
+            Assert.AreEqual(0L, TextFormat.ParseInt64("0"));
+            Assert.AreEqual(1L, TextFormat.ParseInt64("1"));
+            Assert.AreEqual(-1L, TextFormat.ParseInt64("-1"));
+            Assert.AreEqual(12345L, TextFormat.ParseInt64("12345"));
+            Assert.AreEqual(-12345L, TextFormat.ParseInt64("-12345"));
+            Assert.AreEqual(2147483647L, TextFormat.ParseInt64("2147483647"));
+            Assert.AreEqual(-2147483648L, TextFormat.ParseInt64("-2147483648"));
+            Assert.AreEqual(4294967295L, TextFormat.ParseInt64("4294967295"));
+            Assert.AreEqual(4294967296L, TextFormat.ParseInt64("4294967296"));
+            Assert.AreEqual(9223372036854775807L, TextFormat.ParseInt64("9223372036854775807"));
+            Assert.AreEqual(-9223372036854775808L, TextFormat.ParseInt64("-9223372036854775808"));
 
-            Assert.Equal(0uL, TextFormat.ParseUInt64("0"));
-            Assert.Equal(1uL, TextFormat.ParseUInt64("1"));
-            Assert.Equal(12345uL, TextFormat.ParseUInt64("12345"));
-            Assert.Equal(2147483647uL, TextFormat.ParseUInt64("2147483647"));
-            Assert.Equal(4294967295uL, TextFormat.ParseUInt64("4294967295"));
-            Assert.Equal(4294967296uL, TextFormat.ParseUInt64("4294967296"));
-            Assert.Equal(9223372036854775807UL, TextFormat.ParseUInt64("9223372036854775807"));
-            Assert.Equal(9223372036854775808UL, TextFormat.ParseUInt64("9223372036854775808"));
-            Assert.Equal(18446744073709551615UL, TextFormat.ParseUInt64("18446744073709551615"));
+            Assert.AreEqual(0uL, TextFormat.ParseUInt64("0"));
+            Assert.AreEqual(1uL, TextFormat.ParseUInt64("1"));
+            Assert.AreEqual(12345uL, TextFormat.ParseUInt64("12345"));
+            Assert.AreEqual(2147483647uL, TextFormat.ParseUInt64("2147483647"));
+            Assert.AreEqual(4294967295uL, TextFormat.ParseUInt64("4294967295"));
+            Assert.AreEqual(4294967296uL, TextFormat.ParseUInt64("4294967296"));
+            Assert.AreEqual(9223372036854775807UL, TextFormat.ParseUInt64("9223372036854775807"));
+            Assert.AreEqual(9223372036854775808UL, TextFormat.ParseUInt64("9223372036854775808"));
+            Assert.AreEqual(18446744073709551615UL, TextFormat.ParseUInt64("18446744073709551615"));
 
             // Hex
-            Assert.Equal(0x1234abcd, TextFormat.ParseInt32("0x1234abcd"));
-            Assert.Equal(-0x1234abcd, TextFormat.ParseInt32("-0x1234abcd"));
-            Assert.Equal(0xffffffffffffffffUL, TextFormat.ParseUInt64("0xffffffffffffffff"));
-            Assert.Equal(0x7fffffffffffffffL,
+            Assert.AreEqual(0x1234abcd, TextFormat.ParseInt32("0x1234abcd"));
+            Assert.AreEqual(-0x1234abcd, TextFormat.ParseInt32("-0x1234abcd"));
+            Assert.AreEqual(0xffffffffffffffffUL, TextFormat.ParseUInt64("0xffffffffffffffff"));
+            Assert.AreEqual(0x7fffffffffffffffL,
                             TextFormat.ParseInt64("0x7fffffffffffffff"));
 
             // Octal
-            Assert.Equal(342391, TextFormat.ParseInt32("01234567"));
+            Assert.AreEqual(342391, TextFormat.ParseInt32("01234567"));
 
             // Out-of-range
             Assert.Throws<FormatException>(() => TextFormat.ParseInt32("2147483648"));
@@ -532,7 +532,7 @@ namespace Google.ProtocolBuffers
             Assert.Throws<FormatException>(() => TextFormat.ParseInt32("abcd"));
         }
 
-        [Fact]
+        [Test]
         public void ParseLongString()
         {
             string longText =
@@ -554,7 +554,7 @@ namespace Google.ProtocolBuffers
                 "123456789012345678901234567890123456789012345678901234567890";
             TestAllTypes.Builder builder = TestAllTypes.CreateBuilder();
             TextFormat.Merge("optional_string: \"" + longText + "\"", builder);
-            Assert.Equal(longText, builder.OptionalString);
+            Assert.AreEqual(longText, builder.OptionalString);
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/UnknownFieldSetTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/UnknownFieldSetTest.cs
@@ -38,7 +38,7 @@ using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -103,39 +103,39 @@ namespace Google.ProtocolBuffers
 
         // =================================================================
 
-        [Fact]
+        [Test]
         public void Varint()
         {
             UnknownField field = GetField("optional_int32");
-            Assert.Equal(1, field.VarintList.Count);
-            Assert.Equal(allFields.OptionalInt32, (long) field.VarintList[0]);
+            Assert.AreEqual(1, field.VarintList.Count);
+            Assert.AreEqual(allFields.OptionalInt32, (long) field.VarintList[0]);
         }
 
-        [Fact]
+        [Test]
         public void Fixed32()
         {
             UnknownField field = GetField("optional_fixed32");
-            Assert.Equal(1, field.Fixed32List.Count);
-            Assert.Equal<long>(allFields.OptionalFixed32, (int) field.Fixed32List[0]);
+            Assert.AreEqual(1, field.Fixed32List.Count);
+            Assert.AreEqual(allFields.OptionalFixed32, (int) field.Fixed32List[0]);
         }
 
-        [Fact]
+        [Test]
         public void Fixed64()
         {
             UnknownField field = GetField("optional_fixed64");
-            Assert.Equal(1, field.Fixed64List.Count);
-            Assert.Equal((long)allFields.OptionalFixed64, (long)field.Fixed64List[0]);
+            Assert.AreEqual(1, field.Fixed64List.Count);
+            Assert.AreEqual((long)allFields.OptionalFixed64, (long)field.Fixed64List[0]);
         }
 
-        [Fact]
+        [Test]
         public void LengthDelimited()
         {
             UnknownField field = GetField("optional_bytes");
-            Assert.Equal(1, field.LengthDelimitedList.Count);
-            Assert.Equal(allFields.OptionalBytes, field.LengthDelimitedList[0]);
+            Assert.AreEqual(1, field.LengthDelimitedList.Count);
+            Assert.AreEqual(allFields.OptionalBytes, field.LengthDelimitedList[0]);
         }
 
-        [Fact]
+        [Test]
         public void Group()
         {
             FieldDescriptor nestedFieldDescriptor =
@@ -143,35 +143,35 @@ namespace Google.ProtocolBuffers
             Assert.NotNull(nestedFieldDescriptor);
 
             UnknownField field = GetField("optionalgroup");
-            Assert.Equal(1, field.GroupList.Count);
+            Assert.AreEqual(1, field.GroupList.Count);
 
             UnknownFieldSet group = field.GroupList[0];
-            Assert.Equal(1, group.FieldDictionary.Count);
-            Assert.True(group.HasField(nestedFieldDescriptor.FieldNumber));
+            Assert.AreEqual(1, group.FieldDictionary.Count);
+            Assert.IsTrue(group.HasField(nestedFieldDescriptor.FieldNumber));
 
             UnknownField nestedField = group[nestedFieldDescriptor.FieldNumber];
-            Assert.Equal(1, nestedField.VarintList.Count);
-            Assert.Equal(allFields.OptionalGroup.A, (long) nestedField.VarintList[0]);
+            Assert.AreEqual(1, nestedField.VarintList.Count);
+            Assert.AreEqual(allFields.OptionalGroup.A, (long) nestedField.VarintList[0]);
         }
 
-        [Fact]
+        [Test]
         public void Serialize()
         {
             // Check that serializing the UnknownFieldSet produces the original data again.
             ByteString data = emptyMessage.ToByteString();
-            Assert.Equal(allFieldsData, data);
+            Assert.AreEqual(allFieldsData, data);
         }
 
-        [Fact]
+        [Test]
         public void CopyFrom()
         {
             TestEmptyMessage message =
                 TestEmptyMessage.CreateBuilder().MergeFrom(emptyMessage).Build();
 
-            Assert.Equal(emptyMessage.ToString(), message.ToString());
+            Assert.AreEqual(emptyMessage.ToString(), message.ToString());
         }
 
-        [Fact]
+        [Test]
         public void MergeFrom()
         {
             TestEmptyMessage source =
@@ -200,7 +200,7 @@ namespace Google.ProtocolBuffers
                     .MergeFrom(source)
                     .Build();
 
-            Assert.Equal(
+            Assert.AreEqual(
                 "1: 1\n" +
                 "2: 2\n" +
                 "3: 3\n" +
@@ -208,23 +208,23 @@ namespace Google.ProtocolBuffers
                 destination.ToString());
         }
 
-        [Fact]
+        [Test]
         public void Clear()
         {
             UnknownFieldSet fields =
                 UnknownFieldSet.CreateBuilder().MergeFrom(unknownFields).Clear().Build();
-            Assert.Equal(0, fields.FieldDictionary.Count);
+            Assert.AreEqual(0, fields.FieldDictionary.Count);
         }
 
-        [Fact]
+        [Test]
         public void ClearMessage()
         {
             TestEmptyMessage message =
                 TestEmptyMessage.CreateBuilder().MergeFrom(emptyMessage).Clear().Build();
-            Assert.Equal(0, message.SerializedSize);
+            Assert.AreEqual(0, message.SerializedSize);
         }
 
-        [Fact]
+        [Test]
         public void ParseKnownAndUnknown()
         {
             // Test mixing known and unknown fields when parsing.
@@ -239,14 +239,14 @@ namespace Google.ProtocolBuffers
             TestAllTypes destination = TestAllTypes.ParseFrom(data);
 
             TestUtil.AssertAllFieldsSet(destination);
-            Assert.Equal(1, destination.UnknownFields.FieldDictionary.Count);
+            Assert.AreEqual(1, destination.UnknownFields.FieldDictionary.Count);
 
             UnknownField field = destination.UnknownFields[123456];
-            Assert.Equal(1, field.VarintList.Count);
-            Assert.Equal(654321, (long) field.VarintList[0]);
+            Assert.AreEqual(1, field.VarintList.Count);
+            Assert.AreEqual(654321, (long) field.VarintList[0]);
         }
 
-        [Fact]
+        [Test]
         public void WrongTypeTreatedAsUnknown()
         {
             // Test that fields of the wrong wire type are treated like unknown fields
@@ -258,10 +258,10 @@ namespace Google.ProtocolBuffers
 
             // All fields should have been interpreted as unknown, so the debug strings
             // should be the same.
-            Assert.Equal(emptyMessage.ToString(), allTypesMessage.ToString());
+            Assert.AreEqual(emptyMessage.ToString(), allTypesMessage.ToString());
         }
 
-        [Fact]
+        [Test]
         public void UnknownExtensions()
         {
             // Make sure fields are properly parsed to the UnknownFieldSet even when
@@ -270,12 +270,12 @@ namespace Google.ProtocolBuffers
             TestEmptyMessageWithExtensions message =
                 TestEmptyMessageWithExtensions.ParseFrom(allFieldsData);
 
-            Assert.Equal(unknownFields.FieldDictionary.Count,
+            Assert.AreEqual(unknownFields.FieldDictionary.Count,
                             message.UnknownFields.FieldDictionary.Count);
-            Assert.Equal(allFieldsData, message.ToByteString());
+            Assert.AreEqual(allFieldsData, message.ToByteString());
         }
 
-        [Fact]
+        [Test]
         public void WrongExtensionTypeTreatedAsUnknown()
         {
             // Test that fields of the wrong wire type are treated like unknown fields
@@ -287,11 +287,11 @@ namespace Google.ProtocolBuffers
 
             // All fields should have been interpreted as unknown, so the debug strings
             // should be the same.
-            Assert.Equal(emptyMessage.ToString(),
+            Assert.AreEqual(emptyMessage.ToString(),
                             allExtensionsMessage.ToString());
         }
 
-        [Fact]
+        [Test]
         public void ParseUnknownEnumValue()
         {
             FieldDescriptor singularField =
@@ -320,7 +320,7 @@ namespace Google.ProtocolBuffers
 
             {
                 TestAllTypes message = TestAllTypes.ParseFrom(data);
-                Assert.Equal(TestAllTypes.Types.NestedEnum.BAR,
+                Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR,
                                 message.OptionalNestedEnum);
                 TestUtil.AssertEqual(new[] {TestAllTypes.Types.NestedEnum.FOO, TestAllTypes.Types.NestedEnum.BAZ},
                                      message.RepeatedNestedEnumList);
@@ -331,7 +331,7 @@ namespace Google.ProtocolBuffers
             {
                 TestAllExtensions message =
                     TestAllExtensions.ParseFrom(data, TestUtil.CreateExtensionRegistry());
-                Assert.Equal(TestAllTypes.Types.NestedEnum.BAR,
+                Assert.AreEqual(TestAllTypes.Types.NestedEnum.BAR,
                                 message.GetExtension(Unittest.OptionalNestedEnumExtension));
                 TestUtil.AssertEqual(new[] {TestAllTypes.Types.NestedEnum.FOO, TestAllTypes.Types.NestedEnum.BAZ},
                                      message.GetExtension(Unittest.RepeatedNestedEnumExtension));
@@ -340,7 +340,7 @@ namespace Google.ProtocolBuffers
             }
         }
 
-        [Fact]
+        [Test]
         public void LargeVarint()
         {
             ByteString data =
@@ -353,11 +353,11 @@ namespace Google.ProtocolBuffers
                     .ToByteString();
             UnknownFieldSet parsed = UnknownFieldSet.ParseFrom(data);
             UnknownField field = parsed[1];
-            Assert.Equal(1, field.VarintList.Count);
-            Assert.Equal(0x7FFFFFFFFFFFFFFFUL, field.VarintList[0]);
+            Assert.AreEqual(1, field.VarintList.Count);
+            Assert.AreEqual(0x7FFFFFFFFFFFFFFFUL, field.VarintList[0]);
         }
 
-        [Fact]
+        [Test]
         public void EqualsAndHashCode()
         {
             UnknownField fixed32Field = UnknownField.CreateBuilder().AddFixed32(1).Build();
@@ -405,10 +405,10 @@ namespace Google.ProtocolBuffers
         private static void CheckNotEqual(UnknownFieldSet s1, UnknownFieldSet s2)
         {
             String equalsError = string.Format("{0} should not be equal to {1}", s1, s2);
-            Assert.False(s1.Equals(s2), equalsError);
-            Assert.False(s2.Equals(s1), equalsError);
+            Assert.IsFalse(s1.Equals(s2), equalsError);
+            Assert.IsFalse(s2.Equals(s1), equalsError);
 
-            Assert.False(s1.GetHashCode() == s2.GetHashCode(),
+            Assert.IsFalse(s1.GetHashCode() == s2.GetHashCode(),
                            string.Format("{0} should have a different hash code from {1}", s1, s2));
         }
 
@@ -419,13 +419,13 @@ namespace Google.ProtocolBuffers
         private static void CheckEqualsIsConsistent(UnknownFieldSet set)
         {
             // Object should be equal to itself.
-            Assert.Equal(set, set);
+            Assert.AreEqual(set, set);
 
             // Object should be equal to a copy of itself.
             UnknownFieldSet copy = UnknownFieldSet.CreateBuilder(set).Build();
-            Assert.Equal(set, copy);
-            Assert.Equal(copy, set);
-            Assert.Equal(set.GetHashCode(), copy.GetHashCode());
+            Assert.AreEqual(set, copy);
+            Assert.AreEqual(copy, set);
+            Assert.AreEqual(set.GetHashCode(), copy.GetHashCode());
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/WireFormatTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/WireFormatTest.cs
@@ -38,7 +38,7 @@ using System.IO;
 using System.Reflection;
 using Google.ProtocolBuffers.Descriptors;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -47,7 +47,7 @@ namespace Google.ProtocolBuffers
         /// <summary>
         /// Keeps the attributes on FieldType and the switch statement in WireFormat in sync.
         /// </summary>
-        [Fact]
+        [Test]
         public void FieldTypeToWireTypeMapping()
         {
             foreach (FieldInfo field in typeof(FieldType).GetFields(BindingFlags.Static | BindingFlags.Public))
@@ -55,34 +55,34 @@ namespace Google.ProtocolBuffers
                 FieldType fieldType = (FieldType) field.GetValue(null);
                 FieldMappingAttribute mapping =
                     (FieldMappingAttribute) field.GetCustomAttributes(typeof(FieldMappingAttribute), false)[0];
-                Assert.Equal(mapping.WireType, WireFormat.GetWireType(fieldType));
+                Assert.AreEqual(mapping.WireType, WireFormat.GetWireType(fieldType));
             }
         }
 
-        [Fact]
+        [Test]
         public void Serialization()
         {
             TestAllTypes message = TestUtil.GetAllSet();
 
             ByteString rawBytes = message.ToByteString();
-            Assert.Equal(rawBytes.Length, message.SerializedSize);
+            Assert.AreEqual(rawBytes.Length, message.SerializedSize);
 
             TestAllTypes message2 = TestAllTypes.ParseFrom(rawBytes);
 
             TestUtil.AssertAllFieldsSet(message2);
         }
 
-        [Fact]
+        [Test]
         public void SerializationPacked()
         {
             TestPackedTypes message = TestUtil.GetPackedSet();
             ByteString rawBytes = message.ToByteString();
-            Assert.Equal(rawBytes.Length, message.SerializedSize);
+            Assert.AreEqual(rawBytes.Length, message.SerializedSize);
             TestPackedTypes message2 = TestPackedTypes.ParseFrom(rawBytes);
             TestUtil.AssertPackedFieldsSet(message2);
         }
 
-        [Fact]
+        [Test]
         public void SerializeExtensions()
         {
             // TestAllTypes and TestAllExtensions should have compatible wire formats,
@@ -90,14 +90,14 @@ namespace Google.ProtocolBuffers
             // it should work.
             TestAllExtensions message = TestUtil.GetAllExtensionsSet();
             ByteString rawBytes = message.ToByteString();
-            Assert.Equal(rawBytes.Length, message.SerializedSize);
+            Assert.AreEqual(rawBytes.Length, message.SerializedSize);
 
             TestAllTypes message2 = TestAllTypes.ParseFrom(rawBytes);
 
             TestUtil.AssertAllFieldsSet(message2);
         }
 
-        [Fact]
+        [Test]
         public void SerializePackedExtensions()
         {
             // TestPackedTypes and TestPackedExtensions should have compatible wire
@@ -108,10 +108,10 @@ namespace Google.ProtocolBuffers
             TestPackedTypes message2 = TestUtil.GetPackedSet();
             ByteString rawBytes2 = message2.ToByteString();
 
-            Assert.Equal(rawBytes, rawBytes2);
+            Assert.AreEqual(rawBytes, rawBytes2);
         }
 
-        [Fact]
+        [Test]
         public void SerializeDelimited()
         {
             MemoryStream stream = new MemoryStream();
@@ -123,13 +123,13 @@ namespace Google.ProtocolBuffers
             stream.Position = 0;
 
             TestUtil.AssertAllFieldsSet(TestAllTypes.ParseDelimitedFrom(stream));
-            Assert.Equal(12, stream.ReadByte());
+            Assert.AreEqual(12, stream.ReadByte());
             TestUtil.AssertPackedFieldsSet(TestPackedTypes.ParseDelimitedFrom(stream));
-            Assert.Equal(34, stream.ReadByte());
-            Assert.Equal(-1, stream.ReadByte());
+            Assert.AreEqual(34, stream.ReadByte());
+            Assert.AreEqual(-1, stream.ReadByte());
         }
 
-        [Fact]
+        [Test]
         public void ParseExtensions()
         {
             // TestAllTypes and TestAllExtensions should have compatible wire formats,
@@ -148,7 +148,7 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertAllExtensionsSet(message2);
         }
 
-        [Fact]
+        [Test]
         public void ParsePackedExtensions()
         {
             // Ensure that packed extensions can be properly parsed.
@@ -161,10 +161,10 @@ namespace Google.ProtocolBuffers
             TestUtil.AssertPackedExtensionsSet(message2);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionsSerializedSize()
         {
-            Assert.Equal(TestUtil.GetAllSet().SerializedSize, TestUtil.GetAllExtensionsSet().SerializedSize);
+            Assert.AreEqual(TestUtil.GetAllSet().SerializedSize, TestUtil.GetAllExtensionsSet().SerializedSize);
         }
 
         private static void AssertFieldsInOrder(ByteString data)
@@ -176,13 +176,13 @@ namespace Google.ProtocolBuffers
             string name;
             while (input.ReadTag(out tag, out name))
             {
-                Assert.True(tag > previousTag);
+                Assert.IsTrue(tag > previousTag);
                 previousTag = tag;
                 input.SkipField();
             }
         }
 
-        [Fact]
+        [Test]
         public void InterleavedFieldsAndExtensions()
         {
             // Tests that fields are written in order even when extension ranges
@@ -213,7 +213,7 @@ namespace Google.ProtocolBuffers
         private static readonly int TypeId1 = TestMessageSetExtension1.Descriptor.Extensions[0].FieldNumber;
         private static readonly int TypeId2 = TestMessageSetExtension2.Descriptor.Extensions[0].FieldNumber;
 
-        [Fact]
+        [Test]
         public void SerializeMessageSet()
         {
             // Set up a TestMessageSet with two known messages and an unknown one.
@@ -239,23 +239,23 @@ namespace Google.ProtocolBuffers
             // Parse back using RawMessageSet and check the contents.
             RawMessageSet raw = RawMessageSet.ParseFrom(data);
 
-            Assert.Equal(0, raw.UnknownFields.FieldDictionary.Count);
+            Assert.AreEqual(0, raw.UnknownFields.FieldDictionary.Count);
 
-            Assert.Equal(3, raw.ItemCount);
-            Assert.Equal(TypeId1, raw.ItemList[0].TypeId);
-            Assert.Equal(TypeId2, raw.ItemList[1].TypeId);
-            Assert.Equal(UnknownTypeId, raw.ItemList[2].TypeId);
+            Assert.AreEqual(3, raw.ItemCount);
+            Assert.AreEqual(TypeId1, raw.ItemList[0].TypeId);
+            Assert.AreEqual(TypeId2, raw.ItemList[1].TypeId);
+            Assert.AreEqual(UnknownTypeId, raw.ItemList[2].TypeId);
 
             TestMessageSetExtension1 message1 = TestMessageSetExtension1.ParseFrom(raw.GetItem(0).Message.ToByteArray());
-            Assert.Equal(123, message1.I);
+            Assert.AreEqual(123, message1.I);
 
             TestMessageSetExtension2 message2 = TestMessageSetExtension2.ParseFrom(raw.GetItem(1).Message.ToByteArray());
-            Assert.Equal("foo", message2.Str);
+            Assert.AreEqual("foo", message2.Str);
 
-            Assert.Equal("bar", raw.GetItem(2).Message.ToStringUtf8());
+            Assert.AreEqual("bar", raw.GetItem(2).Message.ToStringUtf8());
         }
 
-        [Fact]
+        [Test]
         public void ParseMessageSet()
         {
             ExtensionRegistry extensionRegistry = ExtensionRegistry.CreateInstance();
@@ -294,18 +294,18 @@ namespace Google.ProtocolBuffers
             TestMessageSet messageSet =
                 TestMessageSet.ParseFrom(data, extensionRegistry);
 
-            Assert.Equal(123, messageSet.GetExtension(TestMessageSetExtension1.MessageSetExtension).I);
-            Assert.Equal("foo", messageSet.GetExtension(TestMessageSetExtension2.MessageSetExtension).Str);
+            Assert.AreEqual(123, messageSet.GetExtension(TestMessageSetExtension1.MessageSetExtension).I);
+            Assert.AreEqual("foo", messageSet.GetExtension(TestMessageSetExtension2.MessageSetExtension).Str);
 
             // Check for unknown field with type LENGTH_DELIMITED,
             //   number UNKNOWN_TYPE_ID, and contents "bar".
             UnknownFieldSet unknownFields = messageSet.UnknownFields;
-            Assert.Equal(1, unknownFields.FieldDictionary.Count);
-            Assert.True(unknownFields.HasField(UnknownTypeId));
+            Assert.AreEqual(1, unknownFields.FieldDictionary.Count);
+            Assert.IsTrue(unknownFields.HasField(UnknownTypeId));
 
             UnknownField field = unknownFields[UnknownTypeId];
-            Assert.Equal(1, field.LengthDelimitedList.Count);
-            Assert.Equal("bar", field.LengthDelimitedList[0].ToStringUtf8());
+            Assert.AreEqual(1, field.LengthDelimitedList.Count);
+            Assert.AreEqual("bar", field.LengthDelimitedList[0].ToStringUtf8());
         }
     }
 }

--- a/csharp/src/ProtocolBuffers.Test/packages.config
+++ b/csharp/src/ProtocolBuffers.Test/packages.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" userInstalled="true" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/csharp/src/ProtocolBuffersLite.Test/AbstractBuilderLiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/AbstractBuilderLiteTest.cs
@@ -36,13 +36,13 @@
 
 using System.IO;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class AbstractBuilderLiteTest
     {
-        [Fact]
+        [Test]
         public void TestMergeFromCodedInputStream()
         {
             TestAllTypesLite copy,
@@ -50,7 +50,7 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalUint32(uint.MaxValue).Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             using (MemoryStream ms = new MemoryStream(msg.ToByteArray()))
             {
@@ -58,22 +58,22 @@ namespace Google.ProtocolBuffers
                 copy = copy.ToBuilder().MergeFrom(ci).Build();
             }
 
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakClear()
         {
             TestAllTypesLite copy, msg = TestAllTypesLite.DefaultInstance;
 
             copy = msg.ToBuilder().SetOptionalString("Should be removed.").Build();
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             copy = (TestAllTypesLite) ((IBuilderLite) copy.ToBuilder()).WeakClear().WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestBuilderLiteMergeFromCodedInputStream()
         {
             TestAllTypesLite copy,
@@ -81,14 +81,14 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalString("Should be merged.").Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             copy =
                 copy.ToBuilder().MergeFrom(CodedInputStream.CreateInstance(new MemoryStream(msg.ToByteArray()))).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestBuilderLiteMergeDelimitedFrom()
         {
             TestAllTypesLite copy,
@@ -96,15 +96,15 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalString("Should be merged.").Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
             Stream s = new MemoryStream();
             msg.WriteDelimitedTo(s);
             s.Position = 0;
             copy = copy.ToBuilder().MergeDelimitedFrom(s).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestBuilderLiteMergeDelimitedFromExtensions()
         {
             TestAllExtensionsLite copy,
@@ -113,7 +113,7 @@ namespace Google.ProtocolBuffers
                                                     "Should be merged.").Build();
 
             copy = TestAllExtensionsLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             Stream s = new MemoryStream();
             msg.WriteDelimitedTo(s);
@@ -123,11 +123,11 @@ namespace Google.ProtocolBuffers
             UnittestLite.RegisterAllExtensions(registry);
 
             copy = copy.ToBuilder().MergeDelimitedFrom(s, registry).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
-            Assert.Equal("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestBuilderLiteMergeFromStream()
         {
             TestAllTypesLite copy,
@@ -135,15 +135,15 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalString("Should be merged.").Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
             Stream s = new MemoryStream();
             msg.WriteTo(s);
             s.Position = 0;
             copy = copy.ToBuilder().MergeFrom(s).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestBuilderLiteMergeFromStreamExtensions()
         {
             TestAllExtensionsLite copy,
@@ -152,7 +152,7 @@ namespace Google.ProtocolBuffers
                                                     "Should be merged.").Build();
 
             copy = TestAllExtensionsLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             Stream s = new MemoryStream();
             msg.WriteTo(s);
@@ -162,11 +162,11 @@ namespace Google.ProtocolBuffers
             UnittestLite.RegisterAllExtensions(registry);
 
             copy = copy.ToBuilder().MergeFrom(s, registry).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
-            Assert.Equal("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakMergeFromIMessageLite()
         {
             TestAllTypesLite copy,
@@ -174,13 +174,13 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalString("Should be merged.").Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             copy = (TestAllTypesLite) ((IBuilderLite) copy.ToBuilder()).WeakMergeFrom((IMessageLite) msg).WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakMergeFromByteString()
         {
             TestAllTypesLite copy,
@@ -188,13 +188,13 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalString("Should be merged.").Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             copy = (TestAllTypesLite) ((IBuilderLite) copy.ToBuilder()).WeakMergeFrom(msg.ToByteString()).WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakMergeFromByteStringExtensions()
         {
             TestAllExtensionsLite copy,
@@ -203,12 +203,12 @@ namespace Google.ProtocolBuffers
                                                     "Should be merged.").Build();
 
             copy = TestAllExtensionsLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             copy =
                 (TestAllExtensionsLite)
                 ((IBuilderLite) copy.ToBuilder()).WeakMergeFrom(msg.ToByteString(), ExtensionRegistry.Empty).WeakBuild();
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             ExtensionRegistry registry = ExtensionRegistry.CreateInstance();
             UnittestLite.RegisterAllExtensions(registry);
@@ -216,11 +216,11 @@ namespace Google.ProtocolBuffers
             copy =
                 (TestAllExtensionsLite)
                 ((IBuilderLite) copy.ToBuilder()).WeakMergeFrom(msg.ToByteString(), registry).WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
-            Assert.Equal("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual("Should be merged.", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakMergeFromCodedInputStream()
         {
             TestAllTypesLite copy,
@@ -228,7 +228,7 @@ namespace Google.ProtocolBuffers
                                  .SetOptionalUint32(uint.MaxValue).Build();
 
             copy = TestAllTypesLite.DefaultInstance;
-            Assert.NotEqual(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreNotEqual(msg.ToByteArray(), copy.ToByteArray());
 
             using (MemoryStream ms = new MemoryStream(msg.ToByteArray()))
             {
@@ -236,58 +236,58 @@ namespace Google.ProtocolBuffers
                 copy = (TestAllTypesLite) ((IBuilderLite) copy.ToBuilder()).WeakMergeFrom(ci).WeakBuild();
             }
 
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakBuildPartial()
         {
             IBuilderLite builder = TestRequiredLite.CreateBuilder();
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
 
             IMessageLite msg = builder.WeakBuildPartial();
-            Assert.False(msg.IsInitialized);
+            Assert.IsFalse(msg.IsInitialized);
 
-            Assert.Equal(msg.ToByteArray(), TestRequiredLite.DefaultInstance.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), TestRequiredLite.DefaultInstance.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakBuildUninitialized()
         {
             IBuilderLite builder = TestRequiredLite.CreateBuilder();
-            Assert.False(builder.IsInitialized);
+            Assert.IsFalse(builder.IsInitialized);
             Assert.Throws<UninitializedMessageException>(() => builder.WeakBuild());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakBuild()
         {
             IBuilderLite builder = TestRequiredLite.CreateBuilder()
                 .SetD(0)
                 .SetEn(ExtraEnum.EXLITE_BAZ);
-            Assert.True(builder.IsInitialized);
+            Assert.IsTrue(builder.IsInitialized);
             builder.WeakBuild();
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakClone()
         {
             TestRequiredLite msg = TestRequiredLite.CreateBuilder()
                 .SetD(1).SetEn(ExtraEnum.EXLITE_BAR).Build();
-            Assert.True(msg.IsInitialized);
+            Assert.IsTrue(msg.IsInitialized);
 
             IMessageLite copy = ((IBuilderLite) msg.ToBuilder()).WeakClone().WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestIBuilderLiteWeakDefaultInstance()
         {
-            Assert.True(ReferenceEquals(TestRequiredLite.DefaultInstance,
+            Assert.IsTrue(ReferenceEquals(TestRequiredLite.DefaultInstance,
                                           ((IBuilderLite) TestRequiredLite.CreateBuilder()).WeakDefaultInstanceForType));
         }
 
-        [Fact]
+        [Test]
         public void TestGeneratedBuilderLiteAddRange()
         {
             TestAllTypesLite copy,
@@ -299,11 +299,11 @@ namespace Google.ProtocolBuffers
                                  .Build();
 
             copy = msg.DefaultInstanceForType.ToBuilder().MergeFrom(msg).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
         // ROK 5/7/2013 Issue #54: should retire all bytes in buffer (bufferSize)
-        [Fact]
+        [Test]
         public void TestBufferRefillIssue()
         {
             var ms = new MemoryStream();
@@ -322,15 +322,15 @@ namespace Google.ProtocolBuffers
             var input = CodedInputStream.CreateInstance(ms);
             var builder = BucketOfBytes.CreateBuilder();
             input.ReadMessage(builder, ExtensionRegistry.Empty);
-            Assert.Equal(3005L, input.Position);
-            Assert.Equal(3000, builder.Value.Length);
+            Assert.AreEqual(3005L, input.Position);
+            Assert.AreEqual(3000, builder.Value.Length);
             input.ReadMessage(builder, ExtensionRegistry.Empty);
-            Assert.Equal(5114, input.Position);
-            Assert.Equal(1000, builder.Value.Length);
+            Assert.AreEqual(5114, input.Position);
+            Assert.AreEqual(1000, builder.Value.Length);
             input.ReadMessage(builder, ExtensionRegistry.Empty);
-            Assert.Equal(5217L, input.Position);
-            Assert.Equal(input.Position, ms.Length);
-            Assert.Equal(100, builder.Value.Length);
+            Assert.AreEqual(5217L, input.Position);
+            Assert.AreEqual(input.Position, ms.Length);
+            Assert.AreEqual(100, builder.Value.Length);
         }
     }
 }

--- a/csharp/src/ProtocolBuffersLite.Test/AbstractMessageLiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/AbstractMessageLiteTest.cs
@@ -37,13 +37,13 @@
 using System;
 using System.IO;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class AbstractMessageLiteTest
     {
-        [Fact]
+        [Test]
         public void TestMessageLiteToByteString()
         {
             TestRequiredLite msg = TestRequiredLite.CreateBuilder()
@@ -52,14 +52,14 @@ namespace Google.ProtocolBuffers
                 .Build();
 
             ByteString b = msg.ToByteString();
-            Assert.Equal(4, b.Length);
-            Assert.Equal(TestRequiredLite.DFieldNumber << 3, b[0]);
-            Assert.Equal(42, b[1]);
-            Assert.Equal(TestRequiredLite.EnFieldNumber << 3, b[2]);
-            Assert.Equal((int) ExtraEnum.EXLITE_BAZ, b[3]);
+            Assert.AreEqual(4, b.Length);
+            Assert.AreEqual(TestRequiredLite.DFieldNumber << 3, b[0]);
+            Assert.AreEqual(42, b[1]);
+            Assert.AreEqual(TestRequiredLite.EnFieldNumber << 3, b[2]);
+            Assert.AreEqual((int) ExtraEnum.EXLITE_BAZ, b[3]);
         }
 
-        [Fact]
+        [Test]
         public void TestMessageLiteToByteArray()
         {
             TestRequiredLite msg = TestRequiredLite.CreateBuilder()
@@ -69,10 +69,10 @@ namespace Google.ProtocolBuffers
 
             ByteString b = msg.ToByteString();
             ByteString copy = ByteString.CopyFrom(msg.ToByteArray());
-            Assert.Equal(b, copy);
+            Assert.AreEqual(b, copy);
         }
 
-        [Fact]
+        [Test]
         public void TestMessageLiteWriteTo()
         {
             TestRequiredLite msg = TestRequiredLite.CreateBuilder()
@@ -82,10 +82,10 @@ namespace Google.ProtocolBuffers
 
             MemoryStream ms = new MemoryStream();
             msg.WriteTo(ms);
-            Assert.Equal(msg.ToByteArray(), ms.ToArray());
+            Assert.AreEqual(msg.ToByteArray(), ms.ToArray());
         }
 
-        [Fact]
+        [Test]
         public void TestMessageLiteWriteDelimitedTo()
         {
             TestRequiredLite msg = TestRequiredLite.CreateBuilder()
@@ -97,21 +97,21 @@ namespace Google.ProtocolBuffers
             msg.WriteDelimitedTo(ms);
             byte[] buffer = ms.ToArray();
 
-            Assert.Equal(5, buffer.Length);
-            Assert.Equal(4, buffer[0]);
+            Assert.AreEqual(5, buffer.Length);
+            Assert.AreEqual(4, buffer[0]);
             byte[] msgBytes = new byte[4];
             Array.Copy(buffer, 1, msgBytes, 0, 4);
-            Assert.Equal(msg.ToByteArray(), msgBytes);
+            Assert.AreEqual(msg.ToByteArray(), msgBytes);
         }
 
-        [Fact]
+        [Test]
         public void TestIMessageLiteWeakCreateBuilderForType()
         {
             IMessageLite msg = TestRequiredLite.DefaultInstance;
-            Assert.Equal(typeof(TestRequiredLite.Builder), msg.WeakCreateBuilderForType().GetType());
+            Assert.AreEqual(typeof(TestRequiredLite.Builder), msg.WeakCreateBuilderForType().GetType());
         }
 
-        [Fact]
+        [Test]
         public void TestMessageLiteWeakToBuilder()
         {
             IMessageLite msg = TestRequiredLite.CreateBuilder()
@@ -120,14 +120,14 @@ namespace Google.ProtocolBuffers
                 .Build();
 
             IMessageLite copy = msg.WeakToBuilder().WeakBuild();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestMessageLiteWeakDefaultInstanceForType()
         {
             IMessageLite msg = TestRequiredLite.DefaultInstance;
-            Assert.True(Object.ReferenceEquals(TestRequiredLite.DefaultInstance, msg.WeakDefaultInstanceForType));
+            Assert.IsTrue(Object.ReferenceEquals(TestRequiredLite.DefaultInstance, msg.WeakDefaultInstanceForType));
         }
     }
 }

--- a/csharp/src/ProtocolBuffersLite.Test/ExtendableBuilderLiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/ExtendableBuilderLiteTest.cs
@@ -37,29 +37,29 @@
 using System;
 using System.Collections.Generic;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class ExtendableBuilderLiteTest
     {
-        [Fact]
+        [Test]
         public void TestHasExtensionT()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .SetExtension(UnittestLite.OptionalInt32ExtensionLite, 123);
 
-            Assert.True(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsTrue(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestHasExtensionTMissing()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
-            Assert.False(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsFalse(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionCountT()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
@@ -67,17 +67,17 @@ namespace Google.ProtocolBuffers
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 2)
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 3);
 
-            Assert.Equal(3, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(3, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionCountTEmpty()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
-            Assert.Equal(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTNull()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
@@ -85,23 +85,23 @@ namespace Google.ProtocolBuffers
             Assert.Null(value);
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTValue()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .SetExtension(UnittestLite.OptionalInt32ExtensionLite, 3);
 
-            Assert.Equal(3, builder.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.AreEqual(3, builder.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTEmpty()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
-            Assert.Equal(0, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite).Count);
+            Assert.AreEqual(0, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite).Count);
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTList()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
@@ -110,10 +110,10 @@ namespace Google.ProtocolBuffers
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 3);
 
             IList<int> values = builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite);
-            Assert.Equal(3, values.Count);
+            Assert.AreEqual(3, values.Count);
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTIndex()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
@@ -122,17 +122,17 @@ namespace Google.ProtocolBuffers
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 2);
 
             for (int i = 0; i < 3; i++)
-                Assert.Equal(i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
+                Assert.AreEqual(i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
         }
 
-        [Fact]
+        [Test]
         public void TestGetExtensionTIndexOutOfRange()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
             Assert.Throws<ArgumentOutOfRangeException>(() => builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0));
         }
 
-        [Fact]
+        [Test]
         public void TestSetExtensionTIndex()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
@@ -141,107 +141,107 @@ namespace Google.ProtocolBuffers
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 2);
 
             for (int i = 0; i < 3; i++)
-                Assert.Equal(i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
+                Assert.AreEqual(i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
 
             builder.SetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0, 5);
             builder.SetExtension(UnittestLite.RepeatedInt32ExtensionLite, 1, 6);
             builder.SetExtension(UnittestLite.RepeatedInt32ExtensionLite, 2, 7);
 
             for (int i = 0; i < 3; i++)
-                Assert.Equal(5 + i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
+                Assert.AreEqual(5 + i, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, i));
         }
 
-        [Fact]
+        [Test]
         public void TestSetExtensionTIndexOutOfRange()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
             Assert.Throws<ArgumentOutOfRangeException>(() => builder.SetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0, -1));
         }
 
-        [Fact]
+        [Test]
         public void TestClearExtensionTList()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 0);
-            Assert.Equal(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
 
             builder.ClearExtension(UnittestLite.RepeatedInt32ExtensionLite);
-            Assert.Equal(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestClearExtensionTValue()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .SetExtension(UnittestLite.OptionalInt32ExtensionLite, 0);
-            Assert.True(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsTrue(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
 
             builder.ClearExtension(UnittestLite.OptionalInt32ExtensionLite);
-            Assert.False(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsFalse(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestIndexedByDescriptor()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
-            Assert.False(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsFalse(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
 
             builder[UnittestLite.OptionalInt32ExtensionLite.Descriptor] = 123;
 
-            Assert.True(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
-            Assert.Equal(123, builder.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.IsTrue(builder.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.AreEqual(123, builder.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestIndexedByDescriptorAndOrdinal()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 0);
-            Assert.Equal(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
 
             IFieldDescriptorLite f = UnittestLite.RepeatedInt32ExtensionLite.Descriptor;
             builder[f, 0] = 123;
 
-            Assert.Equal(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
-            Assert.Equal(123, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0));
+            Assert.AreEqual(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(123, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0));
         }
 
-        [Fact]
+        [Test]
         public void TestIndexedByDescriptorAndOrdinalOutOfRange()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder();
-            Assert.Equal(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
 
             IFieldDescriptorLite f = UnittestLite.RepeatedInt32ExtensionLite.Descriptor;
             Assert.Throws<ArgumentOutOfRangeException>(() => builder[f, 0] = 123);
         }
 
-        [Fact]
+        [Test]
         public void TestClearFieldByDescriptor()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 0);
-            Assert.Equal(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
 
             IFieldDescriptorLite f = UnittestLite.RepeatedInt32ExtensionLite.Descriptor;
             builder.ClearField(f);
-            Assert.Equal(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(0, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
         }
 
-        [Fact]
+        [Test]
         public void TestAddRepeatedFieldByDescriptor()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
                 .AddExtension(UnittestLite.RepeatedInt32ExtensionLite, 0);
-            Assert.Equal(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(1, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
 
             IFieldDescriptorLite f = UnittestLite.RepeatedInt32ExtensionLite.Descriptor;
             builder.AddRepeatedField(f, 123);
-            Assert.Equal(2, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
-            Assert.Equal(123, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 1));
+            Assert.AreEqual(2, builder.GetExtensionCount(UnittestLite.RepeatedInt32ExtensionLite));
+            Assert.AreEqual(123, builder.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 1));
         }
 
-        [Fact]
+        [Test]
         public void TestMissingExtensionsLite()
         {
             const int optionalInt32 = 12345678;
@@ -252,21 +252,21 @@ namespace Google.ProtocolBuffers
             builder.AddExtension(UnittestLite.RepeatedDoubleExtensionLite, 1.3);
             TestAllExtensionsLite msg = builder.Build();
 
-            Assert.True(msg.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
-            Assert.Equal(3, msg.GetExtensionCount(UnittestLite.RepeatedDoubleExtensionLite));
+            Assert.IsTrue(msg.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.AreEqual(3, msg.GetExtensionCount(UnittestLite.RepeatedDoubleExtensionLite));
 
             byte[] bits = msg.ToByteArray();
             TestAllExtensionsLite copy = TestAllExtensionsLite.ParseFrom(bits);
-            Assert.False(copy.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
-            Assert.Equal(0, copy.GetExtensionCount(UnittestLite.RepeatedDoubleExtensionLite));
-            Assert.NotEqual(msg, copy);
+            Assert.IsFalse(copy.HasExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.AreEqual(0, copy.GetExtensionCount(UnittestLite.RepeatedDoubleExtensionLite));
+            Assert.AreNotEqual(msg, copy);
 
             //The lite runtime removes all unknown fields and extensions
             byte[] copybits = copy.ToByteArray();
-            Assert.Equal(0, copybits.Length);
+            Assert.AreEqual(0, copybits.Length);
         }
 
-        [Fact]
+        [Test]
         public void TestMissingFieldsLite()
         {
             TestAllTypesLite msg = TestAllTypesLite.CreateBuilder()
@@ -276,13 +276,11 @@ namespace Google.ProtocolBuffers
 
             byte[] bits = msg.ToByteArray();
             IMessageLite copy = TestAllExtensionsLite.ParseFrom(bits);
-            // Use explicit call to Equals to avoid xUnit checking for type equality.
-            Assert.False(msg.Equals(copy));
-            Assert.False(copy.Equals(msg));
+            Assert.AreNotEqual(msg, copy);
 
             //The lite runtime removes all unknown fields and extensions
             byte[] copybits = copy.ToByteArray();
-            Assert.Equal(0, copybits.Length);
+            Assert.AreEqual(0, copybits.Length);
         }
     }
 }

--- a/csharp/src/ProtocolBuffersLite.Test/ExtendableMessageLiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/ExtendableMessageLiteTest.cs
@@ -39,7 +39,7 @@ using System.Collections.Generic;
 using System.Text;
 using Google.ProtocolBuffers;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -54,7 +54,7 @@ namespace Google.ProtocolBuffers
         //        ForeignMessageLite.DefaultInstance;
         //}
 
-        [Fact]
+        [Test]
         public void ExtensionWriterTestMessages()
         {
             TestAllExtensionsLite.Builder b = TestAllExtensionsLite.CreateBuilder().SetExtension(
@@ -66,20 +66,20 @@ namespace Google.ProtocolBuffers
             UnittestLite.RegisterAllExtensions(registry);
 
             copy = TestAllExtensionsLite.ParseFrom(msg.ToByteArray(), registry);
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void ExtensionWriterIsInitialized()
         {
-            Assert.True(ForeignMessageLite.DefaultInstance.IsInitialized);
-            Assert.True(TestPackedExtensionsLite.CreateBuilder().IsInitialized);
-            Assert.True(TestAllExtensionsLite.CreateBuilder().SetExtension(
+            Assert.IsTrue(ForeignMessageLite.DefaultInstance.IsInitialized);
+            Assert.IsTrue(TestPackedExtensionsLite.CreateBuilder().IsInitialized);
+            Assert.IsTrue(TestAllExtensionsLite.CreateBuilder().SetExtension(
                 UnittestLite.OptionalForeignMessageExtensionLite, ForeignMessageLite.DefaultInstance)
                               .IsInitialized);
         }
 
-        [Fact]
+        [Test]
         public void ExtensionWriterTestSetExtensionLists()
         {
             TestAllExtensionsLite msg, copy;
@@ -95,13 +95,13 @@ namespace Google.ProtocolBuffers
             UnittestLite.RegisterAllExtensions(registry);
 
             copy = TestAllExtensionsLite.ParseFrom(msg.ToByteArray(), registry);
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
 
-            Assert.Equal(ForeignEnumLite.FOREIGN_LITE_FOO,
+            Assert.AreEqual(ForeignEnumLite.FOREIGN_LITE_FOO,
                             copy.GetExtension(UnittestLite.RepeatedForeignEnumExtensionLite, 1));
         }
 
-        [Fact]
+        [Test]
         public void ExtensionWriterTest()
         {
             TestAllExtensionsLite.Builder builder = TestAllExtensionsLite.CreateBuilder()
@@ -180,82 +180,82 @@ namespace Google.ProtocolBuffers
                 TestAllExtensionsLite.CreateBuilder().MergeFrom(msg.ToByteArray(), registry);
             TestAllExtensionsLite copy = copyBuilder.Build();
 
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
 
-            Assert.Equal(true, copy.GetExtension(UnittestLite.DefaultBoolExtensionLite));
-            Assert.Equal(ByteString.CopyFromUtf8("123"),
+            Assert.AreEqual(true, copy.GetExtension(UnittestLite.DefaultBoolExtensionLite));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"),
                             copy.GetExtension(UnittestLite.DefaultBytesExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.DefaultCordExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultDoubleExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.DefaultFixed32ExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.DefaultFixed64ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultFloatExtensionLite));
-            Assert.Equal(ForeignEnumLite.FOREIGN_LITE_BAZ,
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.DefaultCordExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultDoubleExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.DefaultFixed32ExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.DefaultFixed64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultFloatExtensionLite));
+            Assert.AreEqual(ForeignEnumLite.FOREIGN_LITE_BAZ,
                             copy.GetExtension(UnittestLite.DefaultForeignEnumExtensionLite));
-            Assert.Equal(ImportEnumLite.IMPORT_LITE_BAZ,
+            Assert.AreEqual(ImportEnumLite.IMPORT_LITE_BAZ,
                             copy.GetExtension(UnittestLite.DefaultImportEnumExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultInt32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultInt64ExtensionLite));
-            Assert.Equal(TestAllTypesLite.Types.NestedEnum.FOO,
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultInt32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultInt64ExtensionLite));
+            Assert.AreEqual(TestAllTypesLite.Types.NestedEnum.FOO,
                             copy.GetExtension(UnittestLite.DefaultNestedEnumExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultSfixed32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultSfixed64ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultSint32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.DefaultSint64ExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.DefaultStringExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.DefaultStringPieceExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.DefaultUint32ExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.DefaultUint64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultSfixed32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultSfixed64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultSint32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.DefaultSint64ExtensionLite));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.DefaultStringExtensionLite));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.DefaultStringPieceExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.DefaultUint32ExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.DefaultUint64ExtensionLite));
 
-            Assert.Equal(true, copy.GetExtension(UnittestLite.OptionalBoolExtensionLite));
-            Assert.Equal(ByteString.CopyFromUtf8("123"),
+            Assert.AreEqual(true, copy.GetExtension(UnittestLite.OptionalBoolExtensionLite));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"),
                             copy.GetExtension(UnittestLite.OptionalBytesExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.OptionalCordExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalDoubleExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.OptionalFixed32ExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.OptionalFixed64ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalFloatExtensionLite));
-            Assert.Equal(ForeignEnumLite.FOREIGN_LITE_BAZ,
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.OptionalCordExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalDoubleExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.OptionalFixed32ExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.OptionalFixed64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalFloatExtensionLite));
+            Assert.AreEqual(ForeignEnumLite.FOREIGN_LITE_BAZ,
                             copy.GetExtension(UnittestLite.OptionalForeignEnumExtensionLite));
-            Assert.Equal(ImportEnumLite.IMPORT_LITE_BAZ,
+            Assert.AreEqual(ImportEnumLite.IMPORT_LITE_BAZ,
                             copy.GetExtension(UnittestLite.OptionalImportEnumExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalInt64ExtensionLite));
-            Assert.Equal(TestAllTypesLite.Types.NestedEnum.FOO,
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalInt32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalInt64ExtensionLite));
+            Assert.AreEqual(TestAllTypesLite.Types.NestedEnum.FOO,
                             copy.GetExtension(UnittestLite.OptionalNestedEnumExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalSfixed32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalSfixed64ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalSint32ExtensionLite));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.OptionalSint64ExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.OptionalStringPieceExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.OptionalUint32ExtensionLite));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.OptionalUint64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalSfixed32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalSfixed64ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalSint32ExtensionLite));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.OptionalSint64ExtensionLite));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.OptionalStringExtensionLite));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.OptionalStringPieceExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.OptionalUint32ExtensionLite));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.OptionalUint64ExtensionLite));
 
-            Assert.Equal(true, copy.GetExtension(UnittestLite.RepeatedBoolExtensionLite, 0));
-            Assert.Equal(ByteString.CopyFromUtf8("123"),
+            Assert.AreEqual(true, copy.GetExtension(UnittestLite.RepeatedBoolExtensionLite, 0));
+            Assert.AreEqual(ByteString.CopyFromUtf8("123"),
                             copy.GetExtension(UnittestLite.RepeatedBytesExtensionLite, 0));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.RepeatedCordExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedDoubleExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.RepeatedFixed32ExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.RepeatedFixed64ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedFloatExtensionLite, 0));
-            Assert.Equal(ForeignEnumLite.FOREIGN_LITE_BAZ,
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.RepeatedCordExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedDoubleExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.RepeatedFixed32ExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.RepeatedFixed64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedFloatExtensionLite, 0));
+            Assert.AreEqual(ForeignEnumLite.FOREIGN_LITE_BAZ,
                             copy.GetExtension(UnittestLite.RepeatedForeignEnumExtensionLite, 0));
-            Assert.Equal(ImportEnumLite.IMPORT_LITE_BAZ,
+            Assert.AreEqual(ImportEnumLite.IMPORT_LITE_BAZ,
                             copy.GetExtension(UnittestLite.RepeatedImportEnumExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedInt64ExtensionLite, 0));
-            Assert.Equal(TestAllTypesLite.Types.NestedEnum.FOO,
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedInt32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedInt64ExtensionLite, 0));
+            Assert.AreEqual(TestAllTypesLite.Types.NestedEnum.FOO,
                             copy.GetExtension(UnittestLite.RepeatedNestedEnumExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedSfixed32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedSfixed64ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedSint32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.RepeatedSint64ExtensionLite, 0));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.RepeatedStringExtensionLite, 0));
-            Assert.Equal("123", copy.GetExtension(UnittestLite.RepeatedStringPieceExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.RepeatedUint32ExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.RepeatedUint64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedSfixed32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedSfixed64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedSint32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.RepeatedSint64ExtensionLite, 0));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.RepeatedStringExtensionLite, 0));
+            Assert.AreEqual("123", copy.GetExtension(UnittestLite.RepeatedStringPieceExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.RepeatedUint32ExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.RepeatedUint64ExtensionLite, 0));
         }
 
         private TestPackedExtensionsLite BuildPackedExtensions()
@@ -294,36 +294,36 @@ namespace Google.ProtocolBuffers
 
         private void AssertPackedExtensions(TestPackedExtensionsLite copy)
         {
-            Assert.Equal(true, copy.GetExtension(UnittestLite.PackedBoolExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedDoubleExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedFixed32ExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedFixed64ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedFloatExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedInt32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedInt64ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSfixed32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSfixed64ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSint32ExtensionLite, 0));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSint64ExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedUint32ExtensionLite, 0));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedUint64ExtensionLite, 0));
+            Assert.AreEqual(true, copy.GetExtension(UnittestLite.PackedBoolExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedDoubleExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedFixed32ExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedFixed64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedFloatExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedInt32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedInt64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSfixed32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSfixed64ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSint32ExtensionLite, 0));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSint64ExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedUint32ExtensionLite, 0));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedUint64ExtensionLite, 0));
 
-            Assert.Equal(true, copy.GetExtension(UnittestLite.PackedBoolExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedDoubleExtensionLite, 1));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedFixed32ExtensionLite, 1));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedFixed64ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedFloatExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedInt32ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedInt64ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSfixed32ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSfixed64ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSint32ExtensionLite, 1));
-            Assert.Equal(123, copy.GetExtension(UnittestLite.PackedSint64ExtensionLite, 1));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedUint32ExtensionLite, 1));
-            Assert.Equal(123u, copy.GetExtension(UnittestLite.PackedUint64ExtensionLite, 1));
+            Assert.AreEqual(true, copy.GetExtension(UnittestLite.PackedBoolExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedDoubleExtensionLite, 1));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedFixed32ExtensionLite, 1));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedFixed64ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedFloatExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedInt32ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedInt64ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSfixed32ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSfixed64ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSint32ExtensionLite, 1));
+            Assert.AreEqual(123, copy.GetExtension(UnittestLite.PackedSint64ExtensionLite, 1));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedUint32ExtensionLite, 1));
+            Assert.AreEqual(123u, copy.GetExtension(UnittestLite.PackedUint64ExtensionLite, 1));
         }
 
-        [Fact]
+        [Test]
         public void ExtensionWriterTestPacked()
         {
             TestPackedExtensionsLite msg = BuildPackedExtensions();
@@ -335,12 +335,12 @@ namespace Google.ProtocolBuffers
                 TestPackedExtensionsLite.CreateBuilder().MergeFrom(msg.ToByteArray(), registry);
             TestPackedExtensionsLite copy = copyBuilder.Build();
 
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
 
             AssertPackedExtensions(copy);
         }
 
-        [Fact]
+        [Test]
         public void TestUnpackedAndPackedExtensions()
         {
             TestPackedExtensionsLite original = BuildPackedExtensions();
@@ -354,19 +354,19 @@ namespace Google.ProtocolBuffers
 
             TestPackedExtensionsLite packed = TestPackedExtensionsLite.ParseFrom(unpacked.ToByteArray(), registry);
 
-            Assert.Equal(original, packed);
-            Assert.Equal(original.ToByteArray(), packed.ToByteArray());
+            Assert.AreEqual(original, packed);
+            Assert.AreEqual(original.ToByteArray(), packed.ToByteArray());
             AssertPackedExtensions(packed);
         }
 
-        [Fact]
+        [Test]
         public void TestUnpackedFromPackedInput()
         {
             byte[] packedData = BuildPackedExtensions().ToByteArray();
 
             TestUnpackedTypesLite unpacked = TestUnpackedTypesLite.ParseFrom(packedData);
             TestPackedTypesLite packed = TestPackedTypesLite.ParseFrom(unpacked.ToByteArray());
-            Assert.Equal(packedData, packed.ToByteArray());
+            Assert.AreEqual(packedData, packed.ToByteArray());
             
             unpacked = TestUnpackedTypesLite.ParseFrom(packed.ToByteArray());
 

--- a/csharp/src/ProtocolBuffersLite.Test/InteropLiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/InteropLiteTest.cs
@@ -36,27 +36,27 @@
 
 using System;
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class InteropLiteTest
     {
-        [Fact]
+        [Test]
         public void TestConvertFromFullMinimal()
         {
             TestInteropPerson person = TestInteropPerson.CreateBuilder()
                 .SetId(123)
                 .SetName("abc")
                 .Build();
-            Assert.True(person.IsInitialized);
+            Assert.IsTrue(person.IsInitialized);
 
             TestInteropPersonLite copy = TestInteropPersonLite.ParseFrom(person.ToByteArray());
 
-            Assert.Equal(person.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(person.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestConvertFromFullComplete()
         {
             TestInteropPerson person = TestInteropPerson.CreateBuilder()
@@ -72,7 +72,7 @@ namespace Google.ProtocolBuffers
                 .SetExtension(UnittestExtrasFull.EmployeeId,
                               TestInteropEmployeeId.CreateBuilder().SetNumber("123").Build())
                 .Build();
-            Assert.True(person.IsInitialized);
+            Assert.IsTrue(person.IsInitialized);
 
             ExtensionRegistry registry = ExtensionRegistry.CreateInstance();
             UnittestExtrasLite.RegisterAllExtensions(registry);
@@ -81,24 +81,24 @@ namespace Google.ProtocolBuffers
             TestInteropPersonLite copy = TestInteropPersonLite.ParseFrom(fullBytes, registry);
             byte[] liteBytes = copy.ToByteArray();
 
-            Assert.Equal(fullBytes, liteBytes);
+            Assert.AreEqual(fullBytes, liteBytes);
         }
 
-        [Fact]
+        [Test]
         public void TestConvertFromLiteMinimal()
         {
             TestInteropPersonLite person = TestInteropPersonLite.CreateBuilder()
                 .SetId(123)
                 .SetName("abc")
                 .Build();
-            Assert.True(person.IsInitialized);
+            Assert.IsTrue(person.IsInitialized);
 
             TestInteropPerson copy = TestInteropPerson.ParseFrom(person.ToByteArray());
 
-            Assert.Equal(person.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(person.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestConvertFromLiteComplete()
         {
             TestInteropPersonLite person = TestInteropPersonLite.CreateBuilder()
@@ -114,14 +114,14 @@ namespace Google.ProtocolBuffers
                 .SetExtension(UnittestExtrasLite.EmployeeIdLite,
                               TestInteropEmployeeIdLite.CreateBuilder().SetNumber("123").Build())
                 .Build();
-            Assert.True(person.IsInitialized);
+            Assert.IsTrue(person.IsInitialized);
 
             ExtensionRegistry registry = ExtensionRegistry.CreateInstance();
             UnittestExtrasFull.RegisterAllExtensions(registry);
 
             TestInteropPerson copy = TestInteropPerson.ParseFrom(person.ToByteArray(), registry);
 
-            Assert.Equal(person.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(person.ToByteArray(), copy.ToByteArray());
         }
 
         public ByteString AllBytes
@@ -135,7 +135,7 @@ namespace Google.ProtocolBuffers
             }
         }
 
-        [Fact]
+        [Test]
         public void TestCompareStringValues()
         {
             TestInteropPersonLite person = TestInteropPersonLite.CreateBuilder()
@@ -153,14 +153,14 @@ namespace Google.ProtocolBuffers
                 .SetExtension(UnittestExtrasLite.EmployeeIdLite,
                               TestInteropEmployeeIdLite.CreateBuilder().SetNumber("123").Build())
                 .Build();
-            Assert.True(person.IsInitialized);
+            Assert.IsTrue(person.IsInitialized);
 
             ExtensionRegistry registry = ExtensionRegistry.CreateInstance();
             UnittestExtrasFull.RegisterAllExtensions(registry);
 
             TestInteropPerson copy = TestInteropPerson.ParseFrom(person.ToByteArray(), registry);
 
-            Assert.Equal(person.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(person.ToByteArray(), copy.ToByteArray());
 
             TestInteropPerson.Builder copyBuilder = TestInteropPerson.CreateBuilder();
             TextFormat.Merge(
@@ -168,7 +168,7 @@ namespace Google.ProtocolBuffers
                                           "[protobuf_unittest_extra.employee_id]"), registry, copyBuilder);
 
             copy = copyBuilder.Build();
-            Assert.Equal(person.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(person.ToByteArray(), copy.ToByteArray());
 
             string liteText = person.ToString().TrimEnd().Replace("\r", "");
             string fullText = copy.ToString().TrimEnd().Replace("\r", "");
@@ -179,7 +179,7 @@ namespace Google.ProtocolBuffers
             while (fullText.IndexOf("\n ", StringComparison.Ordinal) >= 0)
                 fullText = fullText.Replace("\n ", "\n");
 
-            Assert.Equal(fullText, liteText);
+            Assert.AreEqual(fullText, liteText);
         }
     }
 }

--- a/csharp/src/ProtocolBuffersLite.Test/LiteTest.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/LiteTest.cs
@@ -35,7 +35,7 @@
 #endregion
 
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
@@ -45,7 +45,7 @@ namespace Google.ProtocolBuffers
     /// </summary>
     public class LiteTest
     {
-        [Fact]
+        [Test]
         public void TestLite()
         {
             // Since lite messages are a subset of regular messages, we can mostly
@@ -68,13 +68,13 @@ namespace Google.ProtocolBuffers
 
             TestAllTypesLite message2 = TestAllTypesLite.ParseFrom(data);
 
-            Assert.Equal(123, message2.OptionalInt32);
-            Assert.Equal(1, message2.RepeatedStringCount);
-            Assert.Equal("hello", message2.RepeatedStringList[0]);
-            Assert.Equal(7, message2.OptionalNestedMessage.Bb);
+            Assert.AreEqual(123, message2.OptionalInt32);
+            Assert.AreEqual(1, message2.RepeatedStringCount);
+            Assert.AreEqual("hello", message2.RepeatedStringList[0]);
+            Assert.AreEqual(7, message2.OptionalNestedMessage.Bb);
         }
 
-        [Fact]
+        [Test]
         public void TestLiteExtensions()
         {
             // TODO(kenton):  Unlike other features of the lite library, extensions are
@@ -96,17 +96,17 @@ namespace Google.ProtocolBuffers
             // writing, parsing hasn't been implemented yet.
             TestAllExtensionsLite message2 = message.ToBuilder().Build();
 
-            Assert.Equal(123, (int) message2.GetExtension(
+            Assert.AreEqual(123, (int) message2.GetExtension(
                 UnittestLite.OptionalInt32ExtensionLite));
-            Assert.Equal(1, message2.GetExtensionCount(
+            Assert.AreEqual(1, message2.GetExtensionCount(
                 UnittestLite.RepeatedStringExtensionLite));
-            Assert.Equal(1, message2.GetExtension(
+            Assert.AreEqual(1, message2.GetExtension(
                 UnittestLite.RepeatedStringExtensionLite).Count);
-            Assert.Equal("hello", message2.GetExtension(
+            Assert.AreEqual("hello", message2.GetExtension(
                 UnittestLite.RepeatedStringExtensionLite, 0));
-            Assert.Equal(TestAllTypesLite.Types.NestedEnum.BAZ, message2.GetExtension(
+            Assert.AreEqual(TestAllTypesLite.Types.NestedEnum.BAZ, message2.GetExtension(
                 UnittestLite.OptionalNestedEnumExtensionLite));
-            Assert.Equal(7, message2.GetExtension(
+            Assert.AreEqual(7, message2.GetExtension(
                 UnittestLite.OptionalNestedMessageExtensionLite).Bb);
         }
     }

--- a/csharp/src/ProtocolBuffersLite.Test/ProtocolBuffersLite.Test.csproj
+++ b/csharp/src/ProtocolBuffersLite.Test/ProtocolBuffersLite.Test.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,6 +17,8 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,17 +49,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ProtocolBuffers.Test\Properties\AssemblyInfo.cs">
@@ -90,6 +101,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -98,11 +112,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
 </Project>

--- a/csharp/src/ProtocolBuffersLite.Test/ProtocolBuffersLiteMixed.Test.csproj
+++ b/csharp/src/ProtocolBuffersLite.Test/ProtocolBuffersLiteMixed.Test.csproj
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -49,17 +47,28 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ProtocolBuffers.Test\Properties\AssemblyInfo.cs">
@@ -100,11 +109,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
 </Project>

--- a/csharp/src/ProtocolBuffersLite.Test/TestLiteByApi.cs
+++ b/csharp/src/ProtocolBuffersLite.Test/TestLiteByApi.cs
@@ -35,66 +35,66 @@
 #endregion
 
 using Google.ProtocolBuffers.TestProtos;
-using Xunit;
+using NUnit.Framework;
 
 namespace Google.ProtocolBuffers
 {
     public class TestLiteByApi
     {
-        [Fact]
+        [Test]
         public void TestAllTypesEquality()
         {
             TestAllTypesLite msg = TestAllTypesLite.DefaultInstance;
             TestAllTypesLite copy = msg.ToBuilder().Build();
-            Assert.Equal(msg.GetHashCode(), copy.GetHashCode());
-            Assert.True(msg.Equals(copy));
+            Assert.AreEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsTrue(msg.Equals(copy));
             msg = msg.ToBuilder().SetOptionalString("Hi").Build();
-            Assert.NotEqual(msg.GetHashCode(), copy.GetHashCode());
-            Assert.False(msg.Equals(copy));
+            Assert.AreNotEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsFalse(msg.Equals(copy));
             copy = copy.ToBuilder().SetOptionalString("Hi").Build();
-            Assert.Equal(msg.GetHashCode(), copy.GetHashCode());
-            Assert.True(msg.Equals(copy));
+            Assert.AreEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsTrue(msg.Equals(copy));
         }
 
-        [Fact]
+        [Test]
         public void TestEqualityOnExtensions()
         {
             TestAllExtensionsLite msg = TestAllExtensionsLite.DefaultInstance;
             TestAllExtensionsLite copy = msg.ToBuilder().Build();
-            Assert.Equal(msg.GetHashCode(), copy.GetHashCode());
-            Assert.True(msg.Equals(copy));
+            Assert.AreEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsTrue(msg.Equals(copy));
             msg = msg.ToBuilder().SetExtension(UnittestLite.OptionalStringExtensionLite, "Hi").Build();
-            Assert.NotEqual(msg.GetHashCode(), copy.GetHashCode());
-            Assert.False(msg.Equals(copy));
+            Assert.AreNotEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsFalse(msg.Equals(copy));
             copy = copy.ToBuilder().SetExtension(UnittestLite.OptionalStringExtensionLite, "Hi").Build();
-            Assert.Equal(msg.GetHashCode(), copy.GetHashCode());
-            Assert.True(msg.Equals(copy));
+            Assert.AreEqual(msg.GetHashCode(), copy.GetHashCode());
+            Assert.IsTrue(msg.Equals(copy));
         }
 
-        [Fact]
+        [Test]
         public void TestAllTypesToString()
         {
             TestAllTypesLite msg = TestAllTypesLite.DefaultInstance;
             TestAllTypesLite copy = msg.ToBuilder().Build();
-            Assert.Equal(msg.ToString(), copy.ToString());
-            Assert.Equal(0, msg.ToString().Length);
+            Assert.AreEqual(msg.ToString(), copy.ToString());
+            Assert.AreEqual(0, msg.ToString().Length);
             msg = msg.ToBuilder().SetOptionalInt32(-1).Build();
-            Assert.Equal("optional_int32: -1", msg.ToString().TrimEnd());
+            Assert.AreEqual("optional_int32: -1", msg.ToString().TrimEnd());
             msg = msg.ToBuilder().SetOptionalString("abc123").Build();
-            Assert.Equal("optional_int32: -1\noptional_string: \"abc123\"",
+            Assert.AreEqual("optional_int32: -1\noptional_string: \"abc123\"",
                             msg.ToString().Replace("\r", "").TrimEnd());
         }
 
-        [Fact]
+        [Test]
         public void TestAllTypesDefaultedRoundTrip()
         {
             TestAllTypesLite msg = TestAllTypesLite.DefaultInstance;
-            Assert.True(msg.IsInitialized);
+            Assert.IsTrue(msg.IsInitialized);
             TestAllTypesLite copy = TestAllTypesLite.CreateBuilder().MergeFrom(msg.ToByteArray()).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
 
-        [Fact]
+        [Test]
         public void TestAllTypesModifiedRoundTrip()
         {
             TestAllTypesLite msg = TestAllTypesLite.DefaultInstance;
@@ -114,7 +114,7 @@ namespace Google.ProtocolBuffers
                 .AddRepeatedGroup(TestAllTypesLite.Types.RepeatedGroup.CreateBuilder().SetA('A').Build())
                 ;
             TestAllTypesLite copy = TestAllTypesLite.CreateBuilder().MergeFrom(msg.ToByteArray()).Build();
-            Assert.Equal(msg.ToByteArray(), copy.ToByteArray());
+            Assert.AreEqual(msg.ToByteArray(), copy.ToByteArray());
         }
     }
 }

--- a/csharp/src/ProtocolBuffersLite.Test/packages.config
+++ b/csharp/src/ProtocolBuffersLite.Test/packages.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" userInstalled="true" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" userInstalled="true" />
 </packages>


### PR DESCRIPTION
This includes the NUnit test adapter which allows NUnit tests to be run under VS without any extra plugins.
Unfortunate the compatibility tests using the abstract test fixture class show up as "external" tests, and aren't well presented - but they do run.