### PR TITLE
Refactor Travis tests: split configs and run in parallel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
-sudo: false
-language: java
-jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk7
+sudo: required
+language: cpp
 os:
   - linux
   - osx
 script:
-  - ./autogen.sh && ./configure && make -j2
-  - cd java && mvn test && cd ..
-  - cd javanano && mvn test && cd ..
-  - cd python && python setup.py build && python setup.py test && cd ..
-  - export LD_LIBRARY_PATH=../src/.libs
-  - cd python && python setup.py build --cpp_implementation && python setup.py test --cpp_implementation && cd ..
-  - cd ruby && sh travis-test.sh && cd ..
-  - cd conformance && make test_java && cd ..
-  - make distcheck -j2
+  - ./travis.sh $CONFIG
+env:
+  - CONFIG=cpp
+  - CONFIG=cpp_distcheck
+  - CONFIG=java_jdk6
+  - CONFIG=java_jdk7
+  - CONFIG=java_oracle7
+  - CONFIG=javanano_jdk6
+  - CONFIG=javanano_jdk7
+  - CONFIG=javanano_oracle7
+  - CONFIG=python
+  - CONFIG=python_cpp
+  - CONFIG=ruby19
+  - CONFIG=ruby20
+  - CONFIG=ruby21
+  - CONFIG=ruby22
+  - CONFIG=jruby
 notifications:
   email: false

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -12,8 +12,4 @@ test_version() {
      rake test"
 }
 
-test_version ruby-1.9
-test_version ruby-2.0
-test_version ruby-2.1
-test_version ruby-2.2
-test_version jruby
+test_version $1

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+build_cpp() {
+  ./autogen.sh
+  ./configure
+  make -j2
+  make check -j2
+  cd conformance && make test_cpp && cd ..
+}
+
+build_cpp_distcheck() {
+  ./autogen.sh
+  ./configure
+  make distcheck -j2
+}
+
+use_java() {
+  if [ `uname` != "Linux" ]; then
+    # It's nontrivial to programmatically install a new JDK from the command
+    # line on OS X, so we rely on testing on Linux for Java code.
+    echo "Java not tested on OS X."
+    exit 0  # success
+  fi
+  version=$1
+  case "$version" in
+    jdk6)
+      sudo apt-get install openjdk-6-jdk
+      export PATH=/usr/lib/jvm/java-6-openjdk-amd64/bin:$PATH
+      ;;
+    jdk7)
+      sudo apt-get install openjdk-7-jdk
+      export PATH=/usr/lib/jvm/java-7-openjdk-amd64/bin:$PATH
+      ;;
+    oracle7)
+      sudo apt-get install python-software-properties # for apt-add-repository
+      echo "oracle-java7-installer shared/accepted-oracle-license-v1-1 select true" | \
+        sudo debconf-set-selections
+      yes | sudo apt-add-repository ppa:webupd8team/java
+      yes | sudo apt-get install oracle-java7-installer
+      export PATH=/usr/lib/jvm/java-7-oracle/bin:$PATH
+      ;;
+  esac
+
+  which java
+  java -version
+}
+
+build_java() {
+  # Java build needs `protoc`.
+  ./autogen.sh
+  ./configure
+  make -j2
+  cd java && mvn test && cd ..
+  cd conformance && make test_java && cd ..
+}
+
+build_javanano() {
+  # Java build needs `protoc`.
+  ./autogen.sh
+  ./configure
+  make -j2
+  cd javanano && mvn test && cd ..
+}
+
+build_java_jdk6() {
+  use_java jdk6
+  build_java
+}
+build_java_jdk7() {
+  use_java jdk7
+  build_java
+}
+build_java_oracle7() {
+  use_java oracle7
+  build_java
+}
+
+build_javanano_jdk6() {
+  use_java jdk6
+  build_javanano
+}
+build_javanano_jdk7() {
+  use_java jdk7
+  build_javanano
+}
+build_javanano_oracle7() {
+  use_java oracle7
+  build_javanano
+}
+
+build_python() {
+  ./autogen.sh
+  ./configure
+  make -j2
+  cd python
+  python setup.py build
+  python setup.py test
+  cd ..
+}
+
+build_python_cpp() {
+  ./autogen.sh
+  ./configure
+  make -j2
+  export LD_LIBRARY_PATH=../src/.libs
+  cd python
+  python setup.py build --cpp_implementation
+  python setup.py test --cpp_implementation
+  cd ..
+}
+
+build_ruby19() {
+  cd ruby && bash travis-test.sh ruby-1.9 && cd ..
+}
+build_ruby20() {
+  cd ruby && bash travis-test.sh ruby-2.0 && cd ..
+}
+build_ruby21() {
+  cd ruby && bash travis-test.sh ruby-2.1 && cd ..
+}
+build_ruby22() {
+  cd ruby && bash travis-test.sh ruby-2.2 && cd ..
+}
+build_jruby() {
+  cd ruby && bash travis-test.sh jruby && cd ..
+}
+
+# -------- main --------
+
+if [ "$#" -ne 1 ]; then
+  echo "
+Usage: $0 { cpp |
+            java_jdk6 |
+            java_jdk7 |
+            java_oracle7 |
+            javanano_jdk6 |
+            javanano_jdk7 |
+            javanano_oracle7 |
+            python |
+            python_cpp |
+            ruby_19 |
+            ruby_20 |
+            ruby_21 |
+            ruby_22 |
+            jruby }
+"
+  exit 1
+fi
+
+set -e  # exit immediately on error
+set -x  # display all commands
+eval "build_$1"


### PR DESCRIPTION
This PR splits Travis tests into per-{language x configuration} tests, each of which is independent, and configures Travis to run them all as separate jobs within the build.

It removes Java as the special top-level language, instead scripting the JDK installs as part of the test driver script. This is necessary because it appears that Travis does not support multiple top-level languages for a single project.