### PR TITLE
Make generate_protos.sh Windows-friendly.

### DIFF
--- a/csharp/generate_protos.sh
+++ b/csharp/generate_protos.sh
@@ -8,8 +8,22 @@ set -ex
 # cd to repository root
 cd $(dirname $0)/..
 
-# protocol buffer compiler to use
-PROTOC=src/protoc
+# Protocol buffer compiler to use. If the PROTOC variable is set,
+# use that. Otherwise, probe for expected locations under both
+# Windows and Unix.
+if [ -z "$PROTOC" ]; then
+  # TODO(jonskeet): Use an array and a for loop instead?
+  if [ -x vsprojects/Debug/protoc.exe ]; then
+    PROTOC=vsprojects/Debug/protoc.exe
+  elif [ -x vsprojects/Release/protoc.exe ]; then
+    PROTOC=vsprojects/Release/protoc.exe
+  elif [ -x src/protoc ]; then
+    PROTOC=src/protoc
+  else
+    echo "Unable to find protocol buffer compiler."
+    exit 1
+  fi
+fi
 
 # Descriptor proto
 #TODO(jtattermusch): generate descriptor.proto
@@ -48,3 +62,7 @@ $PROTOC -Isrc --csharp_out=csharp/src/ProtocolBuffersLite.Test/TestProtos \
 $PROTOC -Icsharp/protos/extest --csharp_out=csharp/src/ProtocolBuffersLite.Test/TestProtos \
     csharp/protos/extest/unittest_extras_full.proto \
     csharp/protos/extest/unittest_extras_lite.proto
+
+# AddressBook sample protos
+$PROTOC -Iexamples --csharp_out=csharp/src/AddressBook \
+    examples/addressbook.proto

--- a/csharp/src/ProtocolBuffers.Test/TestProtos/UnittestCustomOptions.cs
+++ b/csharp/src/ProtocolBuffers.Test/TestProtos/UnittestCustomOptions.cs
@@ -62,12 +62,10 @@ namespace Google.ProtocolBuffers.TestProtos {
     #endregion
     #region Extensions
     public const int FileOpt1FieldNumber = 7736974;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<ulong> FileOpt1;
     public const int MessageOpt1FieldNumber = 7739036;
     public static pb::GeneratedExtensionBase<int> MessageOpt1;
     public const int FieldOpt1FieldNumber = 7740936;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<ulong> FieldOpt1;
     public const int FieldOpt2FieldNumber = 7753913;
     public static pb::GeneratedExtensionBase<int> FieldOpt2;
@@ -86,20 +84,16 @@ namespace Google.ProtocolBuffers.TestProtos {
     public const int Int64OptFieldNumber = 7705542;
     public static pb::GeneratedExtensionBase<long> Int64Opt;
     public const int Uint32OptFieldNumber = 7704880;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<uint> Uint32Opt;
     public const int Uint64OptFieldNumber = 7702367;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<ulong> Uint64Opt;
     public const int Sint32OptFieldNumber = 7701568;
     public static pb::GeneratedExtensionBase<int> Sint32Opt;
     public const int Sint64OptFieldNumber = 7700863;
     public static pb::GeneratedExtensionBase<long> Sint64Opt;
     public const int Fixed32OptFieldNumber = 7700307;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<uint> Fixed32Opt;
     public const int Fixed64OptFieldNumber = 7700194;
-    [global::System.CLSCompliant(false)]
     public static pb::GeneratedExtensionBase<ulong> Fixed64Opt;
     public const int Sfixed32OptFieldNumber = 7698645;
     public static pb::GeneratedExtensionBase<int> Sfixed32Opt;

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -1,9 +1,12 @@
 // See README.txt for information and build instructions.
 
+syntax = "proto2";
+
 package tutorial;
 
 option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
+option csharp_namespace = "Google.ProtocolBuffers.Examples.AddressBook";
 
 message Person {
   required string name = 1;


### PR DESCRIPTION
To my surprise, executing generate_protos.sh used the version of Bash installed with Git for Windows by default.
After a few modifications to detect the most appropriate protoc to use, this worked pretty simply.
This change also:
- adds generation of the address book tutorial proto,
- fixes the addressbook.proto to specify proto2 explicitly (to avoid a warning from protoc; I don't think we want warnings...)
- fixes the addressbook.proto C# namespace (which I thought I'd done before, but apparently hadn't)
- includes the regenerated UnittestCustomOptions.cs apart from the DescriptorProtoFIle => Descriptor change