### PR TITLE
Solves AOT compilation issue for Unity - iOS

### DIFF
--- a/csharp/src/ProtocolBuffers/ExtensionRegistryLite.cs
+++ b/csharp/src/ProtocolBuffers/ExtensionRegistryLite.cs
@@ -94,9 +94,10 @@ namespace Google.ProtocolBuffers
     /// </remarks>
     public sealed partial class ExtensionRegistry
     {
+
         private static readonly ExtensionRegistry empty = new ExtensionRegistry(
             new ExtensionByNameMap(),
-            new ExtensionByIdMap(),
+            new ExtensionByIdMap(new ExtensionIntPairEqualityComparer()),
             true);
 
         private readonly ExtensionByNameMap extensionsByName;
@@ -116,7 +117,7 @@ namespace Google.ProtocolBuffers
         /// </summary>
         public static ExtensionRegistry CreateInstance()
         {
-            return new ExtensionRegistry(new ExtensionByNameMap(), new ExtensionByIdMap(), false);
+            return new ExtensionRegistry(new ExtensionByNameMap(), new ExtensionByIdMap(new ExtensionIntPairEqualityComparer()), false);
         }
 
         public ExtensionRegistry AsReadOnly()
@@ -214,6 +215,18 @@ namespace Google.ProtocolBuffers
             public bool Equals(ExtensionIntPair other)
             {
                 return msgType.Equals(other.msgType) && number == other.number;
+            }
+        }
+
+        internal class ExtensionIntPairEqualityComparer : IEqualityComparer<ExtensionIntPair>
+        {
+            public bool Equals (ExtensionIntPair x, ExtensionIntPair y)
+            {
+                return x.Equals (y);
+            }
+            public int GetHashCode (ExtensionIntPair obj)
+            {
+                return obj.GetHashCode ();
             }
         }
     }


### PR DESCRIPTION
When using protobuf c# in unity for building iOS there is an issue with AOT compilation

---> System.TypeInitializationException: An exception was thrown by the type initializer for System.Collections.Generic.EqualityComparer`1 
---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. 
---> System.ExecutionEngineException: Attempting to JIT compile method 'System.Collections.Generic.GenericEqualityComparer`1<Google.ProtocolBuffers.ExtensionRegistry/ExtensionIntPair>:.ctor ()' while running with --aot-only.

The solution is to provide a concrete implementation of  IEqualityComparer<ExtensionIntPair> to avoid AOT compilation.

More references for this issue: 
http://stackoverflow.com/questions/24368929/exception-attempting-to-jit-compile-method-while-running-with-aot-only-with
https://code.google.com/p/protobuf-csharp-port/issues/detail?id=98