### PR TITLE
Adds a podspec for the proto3 Objective-C runtime.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -318,7 +318,8 @@ objectivec_EXTRA_DIST=                                                       \
   objectivec/Tests/unittest_runtime_proto2.proto                              \
   objectivec/Tests/unittest_runtime_proto3.proto                              \
   objectivec/Tests/UnitTests-Bridging-Header.h                                \
-  objectivec/Tests/UnitTests-Info.plist
+  objectivec/Tests/UnitTests-Info.plist                                       \
+  Protobuf.podspec
 
 python_EXTRA_DIST=                                                           \
   python/google/protobuf/internal/api_implementation.cc                      \

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name     = 'Protobuf'
+  s.version  = '3.0.0'
+  s.summary  = 'Protocol Buffers v.3 runtime library for Objective-C.'
+  s.homepage = 'https://github.com/google/protobuf'
+  s.license  = 'New BSD'
+  s.authors  = { 'The Protocol Buffers contributors'   => 'protobuf@googlegroups.com' }
+
+  s.source_files = 'objectivec/*.{h,m}', 'objectivec/google/protobuf/*.pbobjc.h', 'objectivec/google/protobuf/Descriptor.pbobjc.m'
+  s.public_header_files = 'objectivec/*.h', 'objectivec/google/protobuf/*.pbobjc.h'
+  # The following is a .m umbrella file, and would cause duplicate symbol
+  # definitions:
+  s.exclude_files = 'objectivec/GPBProtocolBuffers.m'
+  # The .m's of the proto Well-Known-Types under google/protobuf are #imported
+  # by GPBWellKnownTypes.m. So we can't compile them (duplicate symbols), but we
+  # need them available for the importing:
+  s.preserve_paths = 'objectivec/google/protobuf/*.pbobjc.m'
+  s.header_mappings_dir = 'objectivec'
+
+  s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
+  s.requires_arc = false
+end

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
   s.source_files = 'objectivec/*.{h,m}', 'objectivec/google/protobuf/*.pbobjc.h', 'objectivec/google/protobuf/Descriptor.pbobjc.m'
-  s.public_header_files = 'objectivec/GPBProtocolBuffers.h', 'objectivec/GPBProtocolBuffers_RuntimeSupport.h'
   # The following is a .m umbrella file, and would cause duplicate symbol
   # definitions:
   s.exclude_files = 'objectivec/GPBProtocolBuffers.m'

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -4,10 +4,10 @@ Pod::Spec.new do |s|
   s.summary  = 'Protocol Buffers v.3 runtime library for Objective-C.'
   s.homepage = 'https://github.com/google/protobuf'
   s.license  = 'New BSD'
-  s.authors  = { 'The Protocol Buffers contributors'   => 'protobuf@googlegroups.com' }
+  s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
   s.source_files = 'objectivec/*.{h,m}', 'objectivec/google/protobuf/*.pbobjc.h', 'objectivec/google/protobuf/Descriptor.pbobjc.m'
-  s.public_header_files = 'objectivec/*.h', 'objectivec/google/protobuf/*.pbobjc.h'
+  s.private_header_files = 'objectivec/*_PackagePrivate.h'
   # The following is a .m umbrella file, and would cause duplicate symbol
   # definitions:
   s.exclude_files = 'objectivec/GPBProtocolBuffers.m'

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
   s.source_files = 'objectivec/*.{h,m}', 'objectivec/google/protobuf/*.pbobjc.h', 'objectivec/google/protobuf/Descriptor.pbobjc.m'
-  s.private_header_files = 'objectivec/*_PackagePrivate.h'
+  s.public_header_files = 'objectivec/GPBProtocolBuffers.h', 'objectivec/GPBProtocolBuffers_RuntimeSupport.h'
   # The following is a .m umbrella file, and would cause duplicate symbol
   # definitions:
   s.exclude_files = 'objectivec/GPBProtocolBuffers.m'


### PR DESCRIPTION
Users that manage their dependencies with Cocoapods need this to be able and use libraries generated by protoc.