### PR TITLE
Post csharp landing fixup.

### DIFF
--- a/objectivec/google/protobuf/Descriptor.pbobjc.h
+++ b/objectivec/google/protobuf/Descriptor.pbobjc.h
@@ -467,6 +467,7 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
   GPBFileOptions_FieldNumber_JavaStringCheckUtf8 = 27,
   GPBFileOptions_FieldNumber_CcEnableArenas = 31,
   GPBFileOptions_FieldNumber_ObjcClassPrefix = 36,
+  GPBFileOptions_FieldNumber_CsharpNamespace = 37,
   GPBFileOptions_FieldNumber_UninterpretedOptionArray = 999,
 };
 
@@ -564,6 +565,10 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
 // generated classes from this .proto. There is no default.
 @property(nonatomic, readwrite) BOOL hasObjcClassPrefix;
 @property(nonatomic, readwrite, copy) NSString *objcClassPrefix;
+
+// Namespace for generated classes; defaults to the package.
+@property(nonatomic, readwrite) BOOL hasCsharpNamespace;
+@property(nonatomic, readwrite, copy) NSString *csharpNamespace;
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|

--- a/objectivec/google/protobuf/Descriptor.pbobjc.m
+++ b/objectivec/google/protobuf/Descriptor.pbobjc.m
@@ -1105,6 +1105,7 @@ typedef struct GPBMethodDescriptorProto_Storage {
 @dynamic hasDeprecated, deprecated;
 @dynamic hasCcEnableArenas, ccEnableArenas;
 @dynamic hasObjcClassPrefix, objcClassPrefix;
+@dynamic hasCsharpNamespace, csharpNamespace;
 @dynamic uninterpretedOptionArray;
 
 typedef struct GPBFileOptions_Storage {
@@ -1122,6 +1123,7 @@ typedef struct GPBFileOptions_Storage {
   NSString *javaOuterClassname;
   NSString *goPackage;
   NSString *objcClassPrefix;
+  NSString *csharpNamespace;
   NSMutableArray *uninterpretedOptionArray;
 } GPBFileOptions_Storage;
 
@@ -1270,6 +1272,17 @@ typedef struct GPBFileOptions_Storage {
         .flags = GPBFieldOptional,
         .type = GPBTypeString,
         .offset = offsetof(GPBFileOptions_Storage, objcClassPrefix),
+        .defaultValue.valueString = nil,
+        .typeSpecific.className = NULL,
+        .fieldOptions = NULL,
+      },
+      {
+        .name = "csharpNamespace",
+        .number = GPBFileOptions_FieldNumber_CsharpNamespace,
+        .hasIndex = 13,
+        .flags = GPBFieldOptional,
+        .type = GPBTypeString,
+        .offset = offsetof(GPBFileOptions_Storage, csharpNamespace),
         .defaultValue.valueString = nil,
         .typeSpecific.className = NULL,
         .fieldOptions = NULL,

--- a/src/google/protobuf/any.pb.cc
+++ b/src/google/protobuf/any.pb.cc
@@ -82,8 +82,9 @@ void protobuf_AddDesc_google_2fprotobuf_2fany_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\031google/protobuf/any.proto\022\017google.prot"
     "obuf\"&\n\003Any\022\020\n\010type_url\030\001 \001(\t\022\r\n\005value\030\002"
-    " \001(\014B*\n\023com.google.protobufB\010AnyProtoP\001\240"
-    "\001\001\242\002\003GPBb\006proto3", 136);
+    " \001(\014BC\n\023com.google.protobufB\010AnyProtoP\001\240"
+    "\001\001\242\002\003GPB\252\002\026Google.ProtocolBuffersb\006proto"
+    "3", 161);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/any.proto", &protobuf_RegisterTypes);
   Any::default_instance_ = new Any();

--- a/src/google/protobuf/duration.pb.cc
+++ b/src/google/protobuf/duration.pb.cc
@@ -82,8 +82,9 @@ void protobuf_AddDesc_google_2fprotobuf_2fduration_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\036google/protobuf/duration.proto\022\017google"
     ".protobuf\"*\n\010Duration\022\017\n\007seconds\030\001 \001(\003\022\r"
-    "\n\005nanos\030\002 \001(\005B/\n\023com.google.protobufB\rDu"
-    "rationProtoP\001\240\001\001\242\002\003GPBb\006proto3", 150);
+    "\n\005nanos\030\002 \001(\005BH\n\023com.google.protobufB\rDu"
+    "rationProtoP\001\240\001\001\242\002\003GPB\252\002\026Google.Protocol"
+    "Buffersb\006proto3", 175);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/duration.proto", &protobuf_RegisterTypes);
   Duration::default_instance_ = new Duration();

--- a/src/google/protobuf/duration.proto
+++ b/src/google/protobuf/duration.proto
@@ -36,6 +36,7 @@ option java_multiple_files = true;
 option java_outer_classname = "DurationProto";
 option java_package = "com.google.protobuf";
 option csharp_namespace = "Google.ProtocolBuffers";
+option objc_class_prefix = "GPB";
 
 // A Duration represents a signed, fixed-length span of time represented
 // as a count of seconds and fractions of seconds at nanosecond

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -81,8 +81,8 @@ void protobuf_AddDesc_google_2fprotobuf_2ffield_5fmask_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n google/protobuf/field_mask.proto\022\017goog"
     "le.protobuf\"\032\n\tFieldMask\022\r\n\005paths\030\001 \003(\tB"
-    "-\n\023com.google.protobufB\016FieldMaskProtoP\001"
-    "\242\002\003GPBb\006proto3", 134);
+    "F\n\023com.google.protobufB\016FieldMaskProtoP\001"
+    "\242\002\003GPB\252\002\026Google.ProtocolBuffersb\006proto3", 159);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/field_mask.proto", &protobuf_RegisterTypes);
   FieldMask::default_instance_ = new FieldMask();

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -165,8 +165,9 @@ void protobuf_AddDesc_google_2fprotobuf_2fstruct_2eproto() {
     "\000\0220\n\nlist_value\030\006 \001(\0132\032.google.protobuf."
     "ListValueH\000B\006\n\004kind\"3\n\tListValue\022&\n\006valu"
     "es\030\001 \003(\0132\026.google.protobuf.Value*\033\n\tNull"
-    "Value\022\016\n\nNULL_VALUE\020\000B-\n\023com.google.prot"
-    "obufB\013StructProtoP\001\240\001\001\242\002\003GPBb\006proto3", 556);
+    "Value\022\016\n\nNULL_VALUE\020\000BF\n\023com.google.prot"
+    "obufB\013StructProtoP\001\240\001\001\242\002\003GPB\252\002\026Google.Pr"
+    "otocolBuffersb\006proto3", 581);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/struct.proto", &protobuf_RegisterTypes);
   Struct::default_instance_ = new Struct();

--- a/src/google/protobuf/timestamp.pb.cc
+++ b/src/google/protobuf/timestamp.pb.cc
@@ -82,8 +82,9 @@ void protobuf_AddDesc_google_2fprotobuf_2ftimestamp_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\037google/protobuf/timestamp.proto\022\017googl"
     "e.protobuf\"+\n\tTimestamp\022\017\n\007seconds\030\001 \001(\003"
-    "\022\r\n\005nanos\030\002 \001(\005B0\n\023com.google.protobufB\016"
-    "TimestampProtoP\001\240\001\001\242\002\003GPBb\006proto3", 153);
+    "\022\r\n\005nanos\030\002 \001(\005BI\n\023com.google.protobufB\016"
+    "TimestampProtoP\001\240\001\001\242\002\003GPB\252\002\026Google.Proto"
+    "colBuffersb\006proto3", 178);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/timestamp.proto", &protobuf_RegisterTypes);
   Timestamp::default_instance_ = new Timestamp();

--- a/src/google/protobuf/wrappers.pb.cc
+++ b/src/google/protobuf/wrappers.pb.cc
@@ -262,9 +262,9 @@ void protobuf_AddDesc_google_2fprotobuf_2fwrappers_2eproto() {
     "e\030\001 \001(\004\"\033\n\nInt32Value\022\r\n\005value\030\001 \001(\005\"\034\n\013"
     "UInt32Value\022\r\n\005value\030\001 \001(\r\"\032\n\tBoolValue\022"
     "\r\n\005value\030\001 \001(\010\"\034\n\013StringValue\022\r\n\005value\030\001"
-    " \001(\t\"\033\n\nBytesValue\022\r\n\005value\030\001 \001(\014B,\n\023com"
-    ".google.protobufB\rWrappersProtoP\001\242\002\003GPBb"
-    "\006proto3", 367);
+    " \001(\t\"\033\n\nBytesValue\022\r\n\005value\030\001 \001(\014BE\n\023com"
+    ".google.protobufB\rWrappersProtoP\001\242\002\003GPB\252"
+    "\002\026Google.ProtocolBuffersb\006proto3", 392);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/wrappers.proto", &protobuf_RegisterTypes);
   DoubleValue::default_instance_ = new DoubleValue();


### PR DESCRIPTION
Re-add the objc prefix to duration.proto (got removed by accident).
Regenerate the generated descriptors (C++ and ObjC).