### PR TITLE
Getting the ObjC generator building on Windows.

### DIFF
--- a/objectivec/DevTools/check_version_stamps.sh
+++ b/objectivec/DevTools/check_version_stamps.sh
@@ -25,7 +25,7 @@ readonly ConstantName=GOOGLE_PROTOBUF_OBJC_GEN_VERSION
 readonly PluginSrc="${ProtoRootDir}/src/google/protobuf/compiler/objectivec/objectivec_file.cc"
 readonly PluginVersion=$( \
     cat "${PluginSrc}" \
-        | sed -n -e "s:const int32_t ${ConstantName} = \([0-9]*\);:\1:p"
+        | sed -n -e "s:const int32 ${ConstantName} = \([0-9]*\);:\1:p"
 )
 
 if [[ -z "${PluginVersion}" ]] ; then

--- a/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -77,7 +77,6 @@ ExtensionGenerator::ExtensionGenerator(const string& root_class_name,
 ExtensionGenerator::~ExtensionGenerator() {}
 
 void ExtensionGenerator::GenerateMembersHeader(io::Printer* printer) {
-  WriteClassNameToClassList(root_class_and_method_name_);
   if (IsFiltered()) {
     printer->Print("// $filter_reason$\n\n", "filter_reason", filter_reason_);
     return;

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -39,10 +39,6 @@
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/strutil.h>
 
-#ifndef htonl
-#include <netinet/in.h>
-#endif
-
 namespace google {
 namespace protobuf {
 namespace compiler {
@@ -107,7 +103,7 @@ void SetCommonFieldVariables(const FieldDescriptor* descriptor,
   string field_options = descriptor->options().SerializeAsString();
   // Must convert to a standard byte order for packing length into
   // a cstring.
-  uint32_t length = htonl(field_options.length());
+  uint32 length = ghtonl(field_options.length());
   if (length > 0) {
     string bytes((const char*)&length, sizeof(length));
     bytes.append(field_options);

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -40,13 +40,14 @@
 #include <google/protobuf/stubs/strutil.h>
 #include <sstream>
 
+namespace google {
+namespace protobuf {
+
 // This is also found in GPBBootstrap.h, and needs to be kept in sync.  It
 // is the version check done to ensure generated code works with the current
 // runtime being used.
-const int32_t GOOGLE_PROTOBUF_OBJC_GEN_VERSION = 30000;
+const int32 GOOGLE_PROTOBUF_OBJC_GEN_VERSION = 30000;
 
-namespace google {
-namespace protobuf {
 namespace compiler {
 namespace objectivec {
 FileGenerator::FileGenerator(const FileDescriptor *file)

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -82,10 +82,6 @@ bool ObjectiveCGenerator::Generate(const FileDescriptor* file,
     file_generator.GenerateSource(&printer);
   }
 
-  if (!WriteClassList(error)) {
-    return false;
-  }
-
   return true;
 }
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -142,9 +142,6 @@ string BuildFlagsString(const vector<string>& strings);
 
 string BuildCommentsString(const SourceLocation& location);
 
-bool WriteClassList(string* error);
-void WriteClassNameToClassList(const string& name);
-
 bool InitializeClassWhitelist(string* error);
 bool FilterClass(const string& name);
 
@@ -154,7 +151,7 @@ class TextFormatDecodeData {
  public:
   TextFormatDecodeData() {}
 
-  void AddString(int32_t key, const string& input_for_decode,
+  void AddString(int32 key, const string& input_for_decode,
                  const string& desired_output);
   size_t num_entries() const { return entries_.size(); }
   string Data() const;
@@ -165,7 +162,7 @@ class TextFormatDecodeData {
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(TextFormatDecodeData);
 
-  typedef std::pair<int32_t, string> DataEntry;
+  typedef std::pair<int32, string> DataEntry;
   vector<DataEntry> entries_;
 };
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers_unittest.cc
@@ -150,7 +150,7 @@ TEST(ObjCHelper, TextFormatDecodeData_RawStrings) {
 
   EXPECT_EQ(4, decode_data.num_entries());
 
-  uint8_t expected_data[] = {
+  uint8 expected_data[] = {
       0x4,
       0x1, 0x0, 'z', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'I', 'J', 0x0,
       0x3, 0x0, 'a', 'b', 'c', 'd', 'e', 'z', 'g', 'h', 'I', 'J', 0x0,
@@ -175,7 +175,7 @@ TEST(ObjCHelper, TextFormatDecodeData_ByteCodes) {
 
   EXPECT_EQ(5, decode_data.num_entries());
 
-  uint8_t expected_data[] = {
+  uint8 expected_data[] = {
       0x5,
       // All as is (00 op)
       0x1,  0x0A, 0x0,

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -119,6 +119,9 @@ int OrderGroupForFieldDescriptor(const FieldDescriptor* descriptor) {
     case FieldDescriptor::TYPE_BOOL:
       return 1;
   }
+
+  GOOGLE_LOG(FATAL) << "Can't get here.";
+  return 0;
 }
 
 struct FieldOrderingByStorageSize {
@@ -302,8 +305,6 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
     }
     return;
   }
-
-  WriteClassNameToClassList(class_name_);
 
   if (IsFiltered()) {
     printer->Print("// $filter_reason$\n\n",

--- a/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
@@ -76,6 +76,9 @@ const char* PrimitiveTypeName(const FieldDescriptor* descriptor) {
     case OBJECTIVECTYPE_MESSAGE:
       return NULL;
   }
+
+  GOOGLE_LOG(FATAL) << "Can't get here.";
+  return NULL;
 }
 
 const char* PrimitiveArrayTypeName(const FieldDescriptor* descriptor) {
@@ -104,6 +107,9 @@ const char* PrimitiveArrayTypeName(const FieldDescriptor* descriptor) {
     case OBJECTIVECTYPE_MESSAGE:
       return "";  // Want NSArray
   }
+
+  GOOGLE_LOG(FATAL) << "Can't get here.";
+  return NULL;
 }
 
 void SetPrimitiveVariables(const FieldDescriptor* descriptor,
@@ -154,7 +160,6 @@ void RepeatedPrimitiveFieldGenerator::FinishInitialization(void) {
     variables_["array_comment"] = "";
   }
 }
-
 
 }  // namespace objectivec
 }  // namespace compiler

--- a/vsprojects/libprotoc.vcproj
+++ b/vsprojects/libprotoc.vcproj
@@ -372,6 +372,54 @@
       <File RelativePath="..\src\google\protobuf\compiler\javanano\javanano_params.h"></File>
       <File RelativePath="..\src\google\protobuf\compiler\javanano\javanano_primitive_field.h"></File>
       <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_enum.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_enum_field.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_extension.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_field.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_file.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_generator.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_helpers.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_map_field.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_message.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_message_field.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_oneof.h"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_primitive_field.h"
+        >
+      </File>
+      <File
         RelativePath="..\src\google\protobuf\compiler\python\python_generator.h"
         >
       </File>
@@ -633,6 +681,54 @@
       </File>
       <File
         RelativePath="..\src\google\protobuf\compiler\javanano\javanano_primitive_field.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_enum.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_enum_field.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_extension.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_field.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_file.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_generator.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_helpers.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_map_field.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_message.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_message_field.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_oneof.cc"
+        >
+      </File>
+      <File
+        RelativePath="..\src\google\protobuf\compiler\objectivec\objectivec_primitive_field.cc"
         >
       </File>
       <File


### PR DESCRIPTION
Remove the ClassList support (maybe bring it back in the future).
Trim the includes to hopefully get a working Window build.
Add some more returns after switches for compilers that warn even when all values of the enum are handled.
Use ghtonl instead of htonl.
Change the use of [u]int(8,32)_t within the ObjC generator code to [u]int(8,32) to match the rest of the compiler.
Add objective-c generator files to Visual Studio project.

Fixes #395 ObjC plugin building on Windows.
