### PR TITLE
Basic support for "user-defined types" in Ruby.

### DIFF
--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -168,7 +168,7 @@ static size_t stringdata_handler(void* closure, const void* hd,
   return len;
 }
 
-// Appends a submessage to a repeated field (a regular Ruby array for now).
+// Appends a submessage to a repeated field.
 static void *appendsubmsg_handler(void *closure, const void *hd) {
   VALUE ary = (VALUE)closure;
   const submsg_handlerdata_t *submsgdata = hd;
@@ -177,7 +177,7 @@ static void *appendsubmsg_handler(void *closure, const void *hd) {
   VALUE subklass = Descriptor_msgclass(subdesc);
 
   VALUE submsg_rb = rb_class_new_instance(0, NULL, subklass);
-  RepeatedField_push(ary, submsg_rb);
+  RepeatedField_push_native(ary, &submsg_rb);
 
   MessageHeader* submsg;
   TypedData_Get_Struct(submsg_rb, MessageHeader, &Message_type, submsg);
@@ -213,6 +213,8 @@ typedef struct {
   // same lifetime as the upb_handlers struct, and the upb_handlers struct holds
   // a reference to the upb_msgdef, which in turn has references to its subdefs.
   const upb_def* value_field_subdef;
+  // If value field is a message, this is a cached poitner to its Descriptor.
+  Descriptor* value_subdesc;
 } map_handlerdata_t;
 
 // Temporary frame for map parsing: at the beginning of a map entry message, a
@@ -250,8 +252,11 @@ static bool endmap_handler(void *closure, const void *hd, upb_status* s) {
   const map_handlerdata_t* mapdata = hd;
 
   VALUE key = native_slot_get(
-      mapdata->key_field_type, Qnil,
-      &frame->key_storage);
+      mapdata->key_field_type,
+      Qnil,
+      NULL,
+      &frame->key_storage,
+      false);
 
   VALUE value_field_typeclass = Qnil;
   if (mapdata->value_field_type == UPB_TYPE_MESSAGE ||
@@ -260,8 +265,11 @@ static bool endmap_handler(void *closure, const void *hd, upb_status* s) {
   }
 
   VALUE value = native_slot_get(
-      mapdata->value_field_type, value_field_typeclass,
-      &frame->value_storage);
+      mapdata->value_field_type,
+      value_field_typeclass,
+      mapdata->value_subdesc,
+      &frame->value_storage,
+      NULL);
 
   Map_index_set(frame->map, key, value);
   free(frame);
@@ -292,6 +300,11 @@ static map_handlerdata_t* new_map_handlerdata(
   assert(value_field != NULL);
   hd->value_field_type = upb_fielddef_type(value_field);
   hd->value_field_subdef = upb_fielddef_subdef(value_field);
+  if (hd->value_field_type == UPB_TYPE_MESSAGE) {
+    hd->value_subdesc = ruby_to_Descriptor(get_def_obj(hd->value_field_subdef));
+  } else {
+    hd->value_subdesc = NULL;
+  }
 
   return hd;
 }
@@ -622,6 +635,64 @@ static const upb_pbdecodermethod *msgdef_decodermethod(Descriptor* desc) {
   return desc->fill_method;
 }
 
+// Converts any fields that are UDTs from wire types to user types, then
+// converts this message from wire type to user type if applicable.
+VALUE udt_parse_convert(Descriptor* desc, VALUE msg_rb) {
+  MessageHeader* msg;
+  TypedData_Get_Struct(msg_rb, MessageHeader, &Message_type, msg);
+
+  upb_msg_field_iter i;
+  for (upb_msg_field_begin(&i, desc->msgdef);
+       !upb_msg_field_done(&i);
+       upb_msg_field_next(&i)) {
+    const upb_fielddef* f = upb_msg_iter_field(&i);
+    size_t offset = desc->layout->fields[upb_fielddef_index(f)].offset +
+        sizeof(MessageHeader);
+    size_t oneof_case_offset =
+        desc->layout->fields[upb_fielddef_index(f)].case_offset +
+        sizeof(MessageHeader);
+
+    if (upb_fielddef_containingoneof(f) != NULL &&
+        DEREF(msg, oneof_case_offset, uint32_t) != upb_fielddef_number(f)) {
+      continue;
+    }
+    if (is_map_field(f)) {
+      // Map value-field UDT conversion is handled separately.
+      continue;
+    }
+
+    if (upb_fielddef_type(f) == UPB_TYPE_MESSAGE) {
+      if (DEREF(msg, offset, VALUE) == Qnil) {
+        continue;
+      }
+
+      const upb_msgdef* submsgdef = upb_fielddef_msgsubdef(f);
+      Descriptor* subdesc = ruby_to_Descriptor(get_def_obj(submsgdef));
+
+      if (upb_fielddef_isseq(f)) {
+        VALUE rptfield_rb = DEREF(msg, offset, VALUE);
+        RepeatedField* rptfield = ruby_to_RepeatedField(rptfield_rb);
+        VALUE* elemslot = (VALUE *)rptfield->elements;
+        for (int i = 0; i < rptfield->size; i++) {
+          VALUE elem = *elemslot;
+          elem = udt_parse_convert(subdesc, elem);
+          *elemslot++ = elem;
+        }
+      } else {
+        VALUE submsg = DEREF(msg, offset, VALUE);
+        submsg = udt_parse_convert(subdesc, submsg);
+        DEREF(msg, offset, VALUE) = submsg;
+      }
+    }
+  }
+
+  if (Descriptor_is_udt(desc) && msg_rb != Qnil) {
+    msg_rb = rb_funcall(desc->udt_parse_hook, rb_intern("call"),
+                        1, msg_rb);
+  }
+
+  return msg_rb;
+}
 
 // Stack-allocated context during an encode/decode operation. Contains the upb
 // environment and its stack-based allocator, an initial buffer for allocations
@@ -700,6 +771,12 @@ VALUE Message_decode(VALUE klass, VALUE data) {
 
   stackenv_uninit(&se);
 
+  if (desc->has_udts_transitively) {
+    // Convert any user-defined types (UDTs) to their user types in this message
+    // and (recursively) its submessages.
+    msg_rb = udt_parse_convert(desc, msg_rb);
+  }
+
   return msg_rb;
 }
 
@@ -737,6 +814,12 @@ VALUE Message_decode_json(VALUE klass, VALUE data) {
                     upb_json_parser_input(parser));
 
   stackenv_uninit(&se);
+
+  if (desc->has_udts_transitively) {
+    // Convert any user-defined types (UDTs) to their user types in this message
+    // and (recursively) its submessages.
+    msg_rb = udt_parse_convert(desc, msg_rb);
+  }
 
   return msg_rb;
 }
@@ -966,7 +1049,7 @@ static void putmap(VALUE map, const upb_fielddef *f, upb_sink *sink,
   Map_iter it;
   for (Map_begin(map, &it); !Map_done(&it); Map_next(&it)) {
     VALUE key = Map_iter_key(&it);
-    VALUE value = Map_iter_value(&it);
+    VALUE value = Map_iter_value_for_serialize(&it);
 
     upb_sink entry_sink;
     upb_sink_startsubmsg(&subsink, getsel(f, UPB_HANDLER_STARTSUBMSG),
@@ -1092,6 +1175,73 @@ static const upb_handlers* msgdef_json_serialize_handlers(Descriptor* desc) {
   return desc->json_serialize_handlers;
 }
 
+// Converts this message from user type to wire type, if it is a UDT, then
+// recursively performs the same transform on submessage fields.
+VALUE udt_serialize_convert(Descriptor* desc, VALUE msg_rb, int depth) {
+  if (depth > ENCODE_MAX_NESTING) {
+    // Just return the original -- the error will be reported during the actual
+    // serialization pass.
+    return msg_rb;
+  }
+
+  if (Descriptor_is_udt(desc)) {
+    if (msg_rb != Qnil) {
+      msg_rb = rb_funcall(desc->udt_serialize_hook, rb_intern("call"),
+                          2, msg_rb, desc->klass);
+    }
+  }
+
+  MessageHeader* msg;
+  TypedData_Get_Struct(msg_rb, MessageHeader, &Message_type, msg);
+
+  upb_msg_field_iter i;
+  for (upb_msg_field_begin(&i, desc->msgdef);
+       !upb_msg_field_done(&i);
+       upb_msg_field_next(&i)) {
+    const upb_fielddef* f = upb_msg_iter_field(&i);
+    size_t offset = desc->layout->fields[upb_fielddef_index(f)].offset +
+        sizeof(MessageHeader);
+    size_t oneof_case_offset =
+        desc->layout->fields[upb_fielddef_index(f)].case_offset +
+        sizeof(MessageHeader);
+
+    if (upb_fielddef_containingoneof(f) != NULL &&
+        DEREF(msg, oneof_case_offset, uint32_t) != upb_fielddef_number(f)) {
+      continue;
+    }
+    if (is_map_field(f)) {
+      // Map-value UDT conversion is handled separately in `putmap()`.
+      continue;
+    }
+
+    if (upb_fielddef_type(f) == UPB_TYPE_MESSAGE) {
+      if (DEREF(msg, offset, VALUE) == Qnil) {
+        continue;
+      }
+
+      const upb_msgdef* submsgdef = upb_fielddef_msgsubdef(f);
+      Descriptor* subdesc = ruby_to_Descriptor(get_def_obj(submsgdef));
+
+      if (upb_fielddef_isseq(f)) {
+        VALUE rptfield_rb = DEREF(msg, offset, VALUE);
+        RepeatedField* rptfield = ruby_to_RepeatedField(rptfield_rb);
+        VALUE* elemslot = (VALUE *)rptfield->elements;
+        for (int i = 0; i < rptfield->size; i++) {
+          VALUE elem = *elemslot;
+          elem = udt_serialize_convert(subdesc, elem, depth + 1);
+          *elemslot++ = elem;
+        }
+      } else {
+        VALUE submsg = DEREF(msg, offset, VALUE);
+        submsg = udt_serialize_convert(subdesc, submsg, depth + 1);
+        DEREF(msg, offset, VALUE) = submsg;
+      }
+    }
+  }
+
+  return msg_rb;
+}
+
 /*
  * call-seq:
  *     MessageClass.encode(msg) => bytes
@@ -1102,6 +1252,12 @@ static const upb_handlers* msgdef_json_serialize_handlers(Descriptor* desc) {
 VALUE Message_encode(VALUE klass, VALUE msg_rb) {
   VALUE descriptor = rb_ivar_get(klass, descriptor_instancevar_interned);
   Descriptor* desc = ruby_to_Descriptor(descriptor);
+
+  if (desc->has_udts_transitively) {
+    // We need to do a deep copy because `udt_serialize_convert` mutates VALUE
+    // pointers.
+    msg_rb = udt_serialize_convert(desc, Message_deep_copy(msg_rb), 0);
+  }
 
   stringsink sink;
   stringsink_init(&sink);
@@ -1133,6 +1289,12 @@ VALUE Message_encode(VALUE klass, VALUE msg_rb) {
 VALUE Message_encode_json(VALUE klass, VALUE msg_rb) {
   VALUE descriptor = rb_ivar_get(klass, descriptor_instancevar_interned);
   Descriptor* desc = ruby_to_Descriptor(descriptor);
+
+  if (desc->has_udts_transitively) {
+    // We need to do a deep copy because `udt_serialize_convert` mutates VALUE
+    // pointers.
+    msg_rb = udt_serialize_convert(desc, Message_deep_copy(msg_rb), 0);
+  }
 
   stringsink sink;
   stringsink_init(&sink);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -114,10 +114,16 @@ struct Descriptor {
   const upb_pbdecodermethod* fill_method;
   const upb_handlers* pb_serialize_handlers;
   const upb_handlers* json_serialize_handlers;
-  // Handlers hold type class references for sub-message fields directly in some
-  // cases. We need to keep these rooted because they might otherwise be
-  // collected.
-  VALUE typeclass_references;
+
+  // user-defined type handlers.
+  VALUE udt_parse_hook;      // Convert to user type on parse
+  VALUE udt_serialize_hook;  // Convert to wire type on serialize
+  VALUE udt_verify_hook;     // Verify a newly-assigned value
+
+  // Computed at the same time as `layout`: does a Message of this type have any
+  // user-defined types in itself or submessages? This determines whether an
+  // additional pre/postpass is required at serialize/parse time (respectively).
+  bool has_udts_transitively;
 };
 
 struct FieldDescriptor {
@@ -191,6 +197,11 @@ VALUE Descriptor_add_oneof(VALUE _self, VALUE obj);
 VALUE Descriptor_each_oneof(VALUE _self);
 VALUE Descriptor_lookup_oneof(VALUE _self, VALUE name);
 VALUE Descriptor_msgclass(VALUE _self);
+VALUE Descriptor_udt_parse_hook(VALUE _self);
+VALUE Descriptor_udt_serialize_hook(VALUE _self);
+VALUE Descriptor_udt_verify_hook(VALUE _self);
+bool Descriptor_is_udt(Descriptor* desc);
+bool Descriptor_recursively_has_udts(Descriptor* desc);
 extern const rb_data_type_t _Descriptor_type;
 
 void FieldDescriptor_mark(void* _self);
@@ -251,6 +262,9 @@ VALUE MessageBuilderContext_required(int argc, VALUE* argv, VALUE _self);
 VALUE MessageBuilderContext_repeated(int argc, VALUE* argv, VALUE _self);
 VALUE MessageBuilderContext_map(int argc, VALUE* argv, VALUE _self);
 VALUE MessageBuilderContext_oneof(VALUE _self, VALUE name);
+VALUE MessageBuilderContext_udt_parse_hook(VALUE _self);
+VALUE MessageBuilderContext_udt_serialize_hook(VALUE _self);
+VALUE MessageBuilderContext_udt_verify_hook(VALUE _self);
 
 void OneofBuilderContext_mark(void* _self);
 void OneofBuilderContext_free(void* _self);
@@ -285,27 +299,47 @@ VALUE Builder_finalize_to_pool(VALUE _self, VALUE pool_rb);
 
 #define NATIVE_SLOT_MAX_SIZE sizeof(uint64_t)
 
+// The native-slot abstraction requires |subdesc| to be passed to most of these
+// functions because the field being stored might be a "UDT", or user-defined
+// type. A UDT is defined by from-wire-submessage and to-wire-submessage
+// converter functions provided by the user that convert between a message type
+// on the wire and an arbitrary Ruby value as seen by the user. (In addition,
+// validator and default-value hooks are supported.)
+//
+// When a native slot holds a UDT, the value stored is always the user type, and
+// native_slot_get() and native_slot_set() convert to/from the submessage type
+// as necessary when called from parse/serialize paths.
+
 size_t native_slot_size(upb_fieldtype_t type);
 void native_slot_set(upb_fieldtype_t type,
                      VALUE type_class,
+                     Descriptor* subdesc,
                      void* memory,
-                     VALUE value);
+                     VALUE value,
+                     bool is_from_parse);
 // Atomically (with respect to Ruby VM calls) either update the value and set a
 // oneof case, or do neither. If |case_memory| is null, then no case value is
 // set.
 void native_slot_set_value_and_case(upb_fieldtype_t type,
                                     VALUE type_class,
+                                    Descriptor* subdesc,
                                     void* memory,
                                     VALUE value,
                                     uint32_t* case_memory,
-                                    uint32_t case_number);
+                                    uint32_t case_number,
+                                    bool is_from_parse);
 VALUE native_slot_get(upb_fieldtype_t type,
                       VALUE type_class,
-                      const void* memory);
+                      Descriptor* subdesc,
+                      const void* memory,
+                      bool is_from_serialize);
 void native_slot_init(upb_fieldtype_t type, void* memory);
 void native_slot_mark(upb_fieldtype_t type, void* memory);
-void native_slot_dup(upb_fieldtype_t type, void* to, void* from);
-void native_slot_deep_copy(upb_fieldtype_t type, void* to, void* from);
+void native_slot_dup(upb_fieldtype_t type,
+                     void* to, void* from);
+void native_slot_deep_copy(upb_fieldtype_t type,
+                           Descriptor* subdesc,
+                           void* to, void* from);
 bool native_slot_eq(upb_fieldtype_t type, void* mem1, void* mem2);
 
 void native_slot_validate_string_encoding(upb_fieldtype_t type, VALUE value);
@@ -316,6 +350,7 @@ extern rb_encoding* kRubyStringASCIIEncoding;
 extern rb_encoding* kRubyString8bitEncoding;
 
 VALUE field_type_class(const upb_fielddef* field);
+Descriptor* field_subdesc(const upb_fielddef* field);
 
 #define MAP_KEY_FIELD 1
 #define MAP_VALUE_FIELD 2
@@ -342,6 +377,7 @@ const upb_fielddef* map_entry_value(const upb_msgdef* msgdef);
 typedef struct {
   upb_fieldtype_t field_type;
   VALUE field_type_class;
+  Descriptor* subdesc;
   void* elements;
   int size;
   int capacity;
@@ -379,7 +415,7 @@ VALUE RepeatedField_inspect(VALUE _self);
 VALUE RepeatedField_plus(VALUE _self, VALUE list);
 
 // Defined in repeated_field.c; also used by Map.
-void validate_type_class(upb_fieldtype_t type, VALUE klass);
+VALUE validate_type_class(upb_fieldtype_t type, VALUE klass);
 
 // -----------------------------------------------------------------------------
 // Map container type.
@@ -389,6 +425,7 @@ typedef struct {
   upb_fieldtype_t key_type;
   upb_fieldtype_t value_type;
   VALUE value_type_class;
+  Descriptor* value_subdesc;
   upb_strtable table;
 } Map;
 
@@ -430,12 +467,14 @@ void Map_next(Map_iter* iter);
 bool Map_done(Map_iter* iter);
 VALUE Map_iter_key(Map_iter* iter);
 VALUE Map_iter_value(Map_iter* iter);
+VALUE Map_iter_value_for_serialize(Map_iter* iter);
 
 // -----------------------------------------------------------------------------
 // Message layout / storage.
 // -----------------------------------------------------------------------------
 
 #define MESSAGE_FIELD_NO_CASE ((size_t)-1)
+#define MESSAGE_FIELD_NO_UDT  ((size_t)-1)
 
 struct MessageField {
   size_t offset;
@@ -452,11 +491,13 @@ MessageLayout* create_layout(const upb_msgdef* msgdef);
 void free_layout(MessageLayout* layout);
 VALUE layout_get(MessageLayout* layout,
                  const void* storage,
-                 const upb_fielddef* field);
+                 const upb_fielddef* field,
+                 bool is_from_serialize);
 void layout_set(MessageLayout* layout,
                 void* storage,
                 const upb_fielddef* field,
-                VALUE val);
+                VALUE val,
+                bool is_from_parse);
 void layout_init(MessageLayout* layout, void* storage);
 void layout_mark(MessageLayout* layout, void* storage);
 void layout_dup(MessageLayout* layout, void* to, void* from);
@@ -508,6 +549,32 @@ const upb_pbdecodermethod *new_fillmsg_decodermethod(
 // Maximum depth allowed during encoding, to avoid stack overflows due to
 // cycles.
 #define ENCODE_MAX_NESTING 63
+
+// -----------------------------------------------------------------------------
+// Encode/decode utility functions to support User-Defined Types (UDTs).
+// -----------------------------------------------------------------------------
+
+// After parsing, recursively convert any fields of this message which are
+// user-defined types to their user values, then convert this message to its
+// user value if it is a UDT.
+//
+// Assumes that parsing has directly stored VALUE pointers in the storage slots
+// for UDTs, which will be corrected by use of `native_slot_set` in this
+// function.
+//
+// Converted message value is returned.
+VALUE udt_parse_convert(Descriptor* desc, VALUE msg);
+
+// Before serializing, convert this message to its wire type if it is a UDT,
+// then recurisvely convert any fields of this message which are user-defined
+// types to their wire types.
+//
+// Assumes that the message tree has VALUEs in user-type form, as they are at
+// rest when in memory, and returns a message tree with VALUEs set to raw
+// message objects as they will go on the wire.
+//
+// Converted message value is returned.
+VALUE udt_serialize_convert(Descriptor* desc, VALUE msg, int depth);
 
 // -----------------------------------------------------------------------------
 // Global map from upb {msg,enum}defs to wrapper Descriptor/EnumDescriptor

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMap.java
@@ -148,6 +148,9 @@ public class RubyMap extends RubyObject {
      */
     @JRubyMethod(name = "[]=")
     public IRubyObject indexSet(ThreadContext context, IRubyObject key, IRubyObject value) {
+        if (value == context.runtime.getNil()) {
+            throw context.runtime.newTypeError("Cannot set Map entry to nil");
+        }
         Utils.checkType(context, keyType, key, (RubyModule) valueTypeClass);
         Utils.checkType(context, valueType, value, (RubyModule) valueTypeClass);
         IRubyObject symbol;

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyRepeatedField.java
@@ -109,6 +109,9 @@ public class RubyRepeatedField extends RubyObject {
      */
     @JRubyMethod(name = "[]=")
     public IRubyObject indexSet(ThreadContext context, IRubyObject index, IRubyObject value) {
+        if (value == context.runtime.getNil()) {
+            throw context.runtime.newTypeError("Cannot set repeated field entry to nil");
+        }
         int arrIndex = normalizeArrayIndex(index);
         Utils.checkType(context, fieldType, value, (RubyModule) typeClass);
         IRubyObject defaultValue = defaultValue(context);
@@ -164,6 +167,9 @@ public class RubyRepeatedField extends RubyObject {
      */
     @JRubyMethod(name = {"push", "<<"})
     public IRubyObject push(ThreadContext context, IRubyObject value) {
+        if (value == context.runtime.getNil()) {
+            throw context.runtime.newTypeError("Cannot add nil to repeated field");
+        }
         if (!(fieldType == Descriptors.FieldDescriptor.Type.MESSAGE &&
             value == context.runtime.getNil())) {
             Utils.checkType(context, fieldType, value, (RubyModule) typeClass);

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -1,4 +1,32 @@
-#!/usr/bin/ruby
+# Protocol Buffers - Google's data interchange format
+# Copyright 2014 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'google/protobuf'
 require 'test/unit'
@@ -358,6 +386,10 @@ module BasicTest
       assert l4.count == 2
       new_msg.optional_int32 = 1000
       assert l4[1].optional_int32 == 1000
+
+      assert_raise TypeError do
+        l.push nil
+      end
     end
 
     def test_rptfield_enum
@@ -558,6 +590,10 @@ module BasicTest
           "b" => TestMessage.new(:optional_int32 => 84) })
       assert m.length == 2
       assert m.values.map{|msg| msg.optional_int32}.sort == [42, 84]
+
+      assert_raise TypeError do
+        m["c"] = nil
+      end
 
       m = Google::Protobuf::Map.new(:string, :enum, TestEnum,
                                     { "x" => :A, "y" => :B, "z" => :C })

--- a/ruby/tests/generated_code_test.rb
+++ b/ruby/tests/generated_code_test.rb
@@ -1,4 +1,32 @@
-#!/usr/bin/ruby
+# Protocol Buffers - Google's data interchange format
+# Copyright 2014 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # generated_code.rb is in the same directory as this test.
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -1,4 +1,32 @@
-#!/usr/bin/ruby
+# Protocol Buffers - Google's data interchange format
+# Copyright 2014 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'google/protobuf'
 require 'test/unit'
@@ -321,18 +349,6 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
     check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
       arr.collect!.with_index{|x, i| x[0...i] }
-    end
-  end
-
-  def test_compact!
-    m = TestMessage.new
-    m.repeated_msg << TestMessage2.new(:foo => 1)
-    m.repeated_msg << nil
-    m.repeated_msg << TestMessage2.new(:foo => 2)
-    reference_arr = m.repeated_string.to_a
-
-    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
-      arr.compact!
     end
   end
 

--- a/ruby/tests/stress.rb
+++ b/ruby/tests/stress.rb
@@ -1,4 +1,32 @@
-#!/usr/bin/ruby
+# Protocol Buffers - Google's data interchange format
+# Copyright 2014 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'google/protobuf'
 require 'test/unit'

--- a/ruby/tests/udt.rb
+++ b/ruby/tests/udt.rb
@@ -1,0 +1,268 @@
+# Protocol Buffers - Google's data interchange format
+# Copyright 2014 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'google/protobuf'
+require 'test/unit'
+
+require 'time'  # for Time UDT below
+
+# TODO: implement UDT API in JRuby extension as well!
+if RUBY_PLATFORM != "java"
+  module UdtTest
+    Epoch = Time.parse('1970-01-01 00:00:00 UTC')
+
+    pool = Google::Protobuf::DescriptorPool.new
+    pool.build do
+      add_message "Container" do
+        optional :optional, :message, 1, "ProtoTime"
+        repeated :repeated, :message, 2, "ProtoTime"
+        map :map, :string, :message, 3, "ProtoTime"
+      end
+
+      add_message "ProtoTime" do
+        optional :rfc822, :string, 1
+
+        udt_parse_hook do |wiremsg|
+          # Parse the `rfc822` string field from the wire message into a Ruby
+          # `Time` object and return that.
+          Time.parse(wiremsg.rfc822)
+        end
+        udt_serialize_hook do |t, klass|
+          # Create a new ProtoTime message from `t`, which is a ruby `Time`
+          # object, using `Time#rfc822` to get an RFC-822 string.
+          klass.new(:rfc822 => t.rfc822)
+        end
+        udt_verify_hook do |t|
+          if t.class != Time
+            raise TypeError.new('Invalid type for ProtoTime field')
+          end
+        end
+      end
+
+      # UDT containing embedded UDTs. This tests the conversion order: at parse,
+      # submessages should be converted from wire to user types first, so the
+      # parent message sees user types. At serialize, submessages should be
+      # converted from user to wire types last, so the parent message can produce
+      # user types and they will be consumed properly.
+      #
+      # The corresponding user type for this message class is a simple Ruby hash
+      # with :start_time and :end_time keys, but it could easily be some more
+      # elaborate `Duration` or `TimeSpan` class.
+      add_message "ProtoTimeSpan" do
+        optional :start, :message, 1, "ProtoTime"
+        optional :end, :message, 2, "ProtoTime"
+
+        udt_parse_hook do |wiremsg|
+          # note that `wiremsg.start` and `wiremsg.end` are already converted to
+          # their user types (Ruby `Time` objects) at this point.
+          { :start_time => wiremsg.start || Epoch,
+            :end_time => wiremsg.end || Epoch }
+        end
+        udt_serialize_hook do |t, klass|
+          klass.new(:start => t[:start_time] || Epoch,
+                    :end => t[:end_time] || Epoch)
+        end
+        udt_verify_hook do |t|
+          if t[:start_time].class != Time || t[:end_time].class != Time
+            raise TypeError.new('Invalid value for ProtoTimeSpan field')
+          end
+          if t[:end_time] < t[:start_time]
+            raise ArgumentError.new('TimeSpan start/end times are reversed')
+          end
+        end
+      end
+
+      add_message "ProtoTimeSpanContainer" do
+        optional :m, :message, 1, "ProtoTimeSpan"
+      end
+    end
+
+    Container = pool.lookup("Container").msgclass
+    ProtoTime = pool.lookup("ProtoTime").msgclass
+    ProtoTimeSpan = pool.lookup("ProtoTimeSpan").msgclass
+    ProtoTimeSpanContainer = pool.lookup("ProtoTimeSpanContainer").msgclass
+
+  # ------------ test cases ---------------
+
+    class UDTTest < Test::Unit::TestCase
+      def test_udt_defaults
+        # Creating a message with UDT-typed fields gives default-valued (nil)
+        # fields.
+        c = Container.new
+        assert_equal c.optional, nil
+        assert_equal c.repeated, []
+        assert_equal c.map.length, 0
+
+        # Creating the UDT directly still gives us the raw class.
+        p = ProtoTime.new
+        assert_equal p.class, ProtoTime
+
+        c = ProtoTimeSpanContainer.new
+        assert_equal c.m, nil
+      end
+
+      def test_udt_ctor_arg
+        t1 = Time.parse('2015-01-01 12:34:56 -0800')
+        t2 = Time.parse('2015-01-01 12:35:00 -0800')
+        c = Container.new(:optional => t1, :repeated => [t2, t1],
+                          :map => { "a" => t1, "b" => t2 })
+        assert_equal c.optional, t1
+        assert_equal c.repeated.to_a, [t2, t1]
+        assert_equal c.map["a"], t1
+        assert_equal c.map["b"], t2
+      end
+
+      def test_inspect
+        t1 = Time.parse('2015-01-01 12:34:56 -0800')
+        t2 = Time.parse('2015-01-01 12:35:00 -0800')
+        c = Container.new(:optional => t1, :repeated => [t2, t1],
+                          # only one map arg for deterministic output
+                          :map => { "a" => t1 })
+        assert_equal c.inspect,
+          '<UdtTest::Container: optional: 2015-01-01 12:34:56 -0800, ' +
+          'repeated: [2015-01-01 12:35:00 -0800, 2015-01-01 12:34:56 -0800], ' +
+          'map: {"a"=>2015-01-01 12:34:56 -0800}>'
+      end
+
+      def test_udt_nil
+        c = Container.new
+        assert_equal c.optional, nil
+        t1 = Time.parse('2015-01-01 12:34:56 -0800')
+        c.optional = t1
+        assert_equal(c.optional, t1)
+        c.optional = nil
+        assert_equal(c.optional, nil)
+
+        assert_raise TypeError do
+          c.repeated.push nil
+        end
+        assert_raise TypeError do
+          c.map["a"] = nil
+        end
+      end
+
+      def test_udt_fieldassign
+        c = Container.new
+        t1 = Time.parse('2015-01-01 12:34:56 -0800')
+        c.optional = t1
+        assert_equal c.optional, t1
+        c.repeated.push t1
+        assert_equal c.repeated.to_a, [t1]
+        c.repeated.replace([t1, t1, t1])
+        assert_equal c.repeated.to_a, [t1, t1, t1]
+        c.map["a"] = t1
+        assert_equal c.map["a"], t1
+
+        assert_raise TypeError do
+          # *only* user-visible types are valid on this side of the
+          # parse/serialize converter hooks
+          c.optional = ProtoTime.new
+        end
+      end
+
+      def test_udt_rptfield
+        r = Google::Protobuf::RepeatedField.new(:message, ProtoTime)
+        r.push(Time.parse('1970-07-01 00:00:00'))
+        r.push(Time.parse('1980-07-01 00:00:00'))
+        assert_equal r.length, 2
+        assert_equal r[0].year, 1970
+        assert_equal r[1].year, 1980
+        assert_raise TypeError do
+          r[0] = "asdf"
+        end
+        assert_raise TypeError do
+          # *only* user-visible types are valid on this side of the
+          # parse/serialize converter hooks
+          r[0] = ProtoTime.new
+        end
+      end
+
+      def test_udt_map
+        m = Google::Protobuf::Map.new(:string, :message, ProtoTime)
+        m["a"] = Time.parse('1970-07-01 00:00:00')
+        m["b"] = Time.parse('1980-07-01 00:00:00')
+        assert_equal m.length, 2
+        assert_equal m["a"].year, 1970
+        assert_equal m["b"].year, 1980
+        assert_raise TypeError do
+          m["c"] = "asdf"
+        end
+        assert_raise TypeError do
+          # *only* user-visible types are valid on this side of the
+          # parse/serialize converter hooks
+          m["c"] = ProtoTime.new
+        end
+      end
+
+      def test_udt_verify
+        t1 = Time.parse('1970-07-01 00:00:00')
+        t2 = Time.parse('1970-08-01 00:00:00')
+        c = ProtoTimeSpanContainer.new
+        c.m = { :start_time => t1, :end_time => t2 }
+        assert_raise TypeError do
+          c.m = { :start_time => nil, :end_time => t2 }
+        end
+        assert_raise TypeError do
+          c.m = { :start_time => "asdf", :end_time => t2 }
+        end
+        assert_raise ArgumentError do
+          # reversed start/end
+          c.m = { :start_time => t2, :end_time => t1 }
+        end
+      end
+
+      def test_udt_roundtrip
+        t1 = Time.parse('1970-07-01 00:00:00')
+        t2 = Time.parse('1970-08-01 00:00:00')
+        c = ProtoTimeSpanContainer.new(
+          :m => { :start_time => t1, :end_time => t2 }
+        )
+        encoded = ProtoTimeSpanContainer.encode(c)
+        decoded = ProtoTimeSpanContainer.decode(encoded)
+        assert_equal c, decoded
+      end
+
+      def test_incomplete_hooks
+        p = Google::Protobuf::DescriptorPool.new
+        assert_raise RuntimeError do
+          p.build do
+            add_message "MyUDT" do
+              optional :foo, :int32, 1
+              udt_verify_hook do |t|
+              end
+              # no udt_parse_hook or udt_serialize_hook
+            end
+          end
+          udt = p.lookup("MyUDT").msgclass
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is meant for discussion; probably DO NOT MERGE as-is.

This commit adds a notion of a "UDT", or "user-defined type", to the
Ruby C extension. A UDT is defined by a set of hooks attached to a
message type, and it overlays a notion of "user value", an arbitrary
Ruby value, over the "wire type", or actual protobuf message that is
being wrapped. When a UDT is parsed, a user-defined parse-time hook is
invoked that converts the wire type to the user value, and the user
value is then the only value stored in memory. It is seen by and can be
manipulated by the user as desired. (A "verify hook" is invoked whenever
the user sets a UDT-typed field to a new value so the UDT implementer
may also enforce strong typing.) Finally, at serialize time, a
user-defined serialization hook is invoked to convert the user value
back to a wire-type message that is then serialized to the wire.

The intent is for UDTs to serve as the basis for Well-Known Types
(WKTs), as added in proto3. We should implement the UDT API in the JRuby
extension as well, and then define UDT handlers for Date/Time, primitive
wrappers, etc.

The implementation works by actually storing user values in VALUE slots
where message references would have gone, and adding a
post-parse/pre-serialize pass that converts all pointers in the message
tree. The separate-pass approach is necessary at least at parse time
because submessages may be amended by wire data an arbitrary number of
times, so (for example) a streaming implementation that converts as soon
as a submessage ends would not be sufficient: the user hook must see the
entire submessage as it would be at the end of the parse. (Map fields
are handled a little differently now, and we may want to refactor that.)

Because of the pre-pass at serialize time, a message deep copy is
required whenever any UDT fields are transitively present anywhere in
the message tree. This is suboptimal, and a deeper integration into the
serialization routines would avoid this, at the cost of additional
complexity. The copy is at least avoided unless UDTs are introduced.

Also: modified RepeatedField and Map so that `nil` cannot be added when
the value type is a message type. This should have already been the case
already, but we had not implemented this typecheck.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/protobuf/409)

<!-- Reviewable:end -->
