### PR TITLE
ObjC fixup for the branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,8 @@ objectivec/ProtocolBuffers_OSX.xcodeproj/xcuserdata/
 objectivec/ProtocolBuffers_iOS.xcodeproj/project.xcworkspace/xcuserdata/
 objectivec/ProtocolBuffers_iOS.xcodeproj/project.xcworkspace/xcshareddata/ProtocolBuffers_iOS.xccheckout
 objectivec/ProtocolBuffers_iOS.xcodeproj/xcuserdata/
-objectivec/**/.DS_Store
+# OS X's Finder creates these for state about opened windows/etc.
+**/.DS_Store
 
 # Comformance test output
 conformance/.libs/

--- a/objectivec/ProtocolBuffers_OSX.xcodeproj/project.pbxproj
+++ b/objectivec/ProtocolBuffers_OSX.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				INFOPLIST_FILE = "Tests/UnitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = UnitTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/UnitTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -742,7 +742,7 @@
 				INFOPLIST_FILE = "Tests/UnitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = UnitTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/UnitTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnitTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/objectivec/ProtocolBuffers_iOS.xcodeproj/project.pbxproj
+++ b/objectivec/ProtocolBuffers_iOS.xcodeproj/project.pbxproj
@@ -875,7 +875,7 @@
 					"\"$(DEVELOPER_DIR)/usr/lib\"",
 				);
 				PRODUCT_NAME = UnitTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/UnitTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSTestHarness.app/iOSTestHarness";
@@ -903,7 +903,7 @@
 					"\"$(DEVELOPER_DIR)/usr/lib\"",
 				);
 				PRODUCT_NAME = UnitTests;
-				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/UnitTests-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnitTests-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSTestHarness.app/iOSTestHarness";
 			};

--- a/objectivec/Tests/unittest_runtime_proto2.proto
+++ b/objectivec/Tests/unittest_runtime_proto2.proto
@@ -78,9 +78,8 @@ message Message2 {
   repeated group RepeatedGroup = 46 {
     optional int32 a = 47;
   }
-  repeated Message2 repeated_message     = 48;
-  repeated Enum     repeated_enum        = 49;
-  repeated Enum     repeated_packed_enum = 50 [packed=true];
+  repeated Message2 repeated_message  = 48;
+  repeated Enum     repeated_enum     = 49;
 
   oneof o {
        int32 oneof_int32    = 51 [default = 100];

--- a/objectivec/Tests/unittest_runtime_proto3.proto
+++ b/objectivec/Tests/unittest_runtime_proto3.proto
@@ -75,11 +75,7 @@ message Message3 {
   repeated    bytes repeated_bytes    = 45;
   // No 'group' in proto3.
   repeated Message3 repeated_message  = 48;
-  // TODO(teboring): In proto3, repeated primitive field is packed by default.
-  // testProto2UnknownEnumToUnknownField needs repeated_enum to be unpacked.
-  // Remove this option when testProto2UnknownEnumToUnknownField.
-  repeated     Enum repeated_enum     = 49 [packed=false];
-  repeated     Enum repeated_packed_enum = 50 [packed=true];
+  repeated     Enum repeated_enum     = 49;
 
   oneof o {
        int32 oneof_int32    = 51;


### PR DESCRIPTION
- Shouldn't need SRCROOT in the project since Xcode should be setting the working directory to where the project lives.
- Remove the packed/unpacked repeated enum field in the tests and update the code to handle the defaults.
- Move up the ignore to cover .DS_Store files in src also.