### PR TITLE
Remove std::is_trivially_default_constructible.

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -413,12 +413,6 @@ class LIBPROTOBUF_EXPORT Arena {
   // trivially destructible.
   template <typename T> GOOGLE_ATTRIBUTE_ALWAYS_INLINE
   static T* CreateArray(::google::protobuf::Arena* arena, size_t num_elements) {
-#if __cplusplus >= 201103L
-    static_assert(std::is_trivially_default_constructible<T>::value,
-                  "CreateArray requires a trivially constructible type");
-    static_assert(std::is_trivially_destructible<T>::value,
-                  "CreateArray requires a trivially destructible type");
-#endif
     if (arena == NULL) {
       return static_cast<T*>(::operator new[](num_elements * sizeof(T)));
     } else {


### PR DESCRIPTION
This type_traits is only added after g++ 5.1.0 but we need to support g++ 4+.

Fixes https://github.com/google/protobuf/issues/417

@TeBoring to review.