### PR TITLE
Introduces Printer::Shrink

### DIFF
--- a/src/google/protobuf/io/printer.cc
+++ b/src/google/protobuf/io/printer.cc
@@ -50,10 +50,15 @@ Printer::Printer(ZeroCopyOutputStream* output, char variable_delimiter)
 }
 
 Printer::~Printer() {
+  Shrink();
+}
+
+void Printer::Shrink() {
   // Only BackUp() if we have called Next() at least once and never failed.
   if (buffer_size_ > 0 && !failed_) {
     output_->BackUp(buffer_size_);
   }
+  buffer_size_ = 0;
 }
 
 void Printer::Print(const map<string, string>& variables, const char* text) {

--- a/src/google/protobuf/io/printer.h
+++ b/src/google/protobuf/io/printer.h
@@ -148,6 +148,9 @@ class LIBPROTOBUF_EXPORT Printer {
   // error.)
   bool failed() const { return failed_; }
 
+  // Back up the underlying ZeroCopyOutputStream to its minimal possible size.
+  void Shrink();
+
  private:
   const char variable_delimiter_;
 


### PR DESCRIPTION
Introduces Printer::Shrink, to let the user avoid an assert if its output stream will disappear before our destructor.

The idea here is that if you do this:

```
std::string SomePrinterFunction() {
  std::string output;
  google::protobuf::io::StringOutputStream output_stream(&output);
  google::protobuf::io::Printer printer(&output_stream, '$');

  printer.Print("Foo");

  return output;
}
```

Then depending on your compiler, it may decide to call the move operator of std::string on that return statement. At that point, `output` is becoming empty, and its size becomes zero. Meaning that this assert here will fire, during the actual destruction of `printer`:

https://github.com/google/protobuf/blob/master/src/google/protobuf/io/zero_copy_stream_impl_lite.cc#L190

This is currently causing this issue on grpc: grpc/grpc#1769.

I would also argue that the right thing to do would be to avoid calling `Shrink` altogether in the destructor of `Printer`, and let the user do that manually, but I didn't want to change actual code behavior at that point.