### PR TITLE
Fix two issues on vs2010.

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -176,14 +176,12 @@ class Map {
 
     template<class NodeType>
     void destroy(NodeType* p) {
-      if (arena_ == NULL) p->~NodeType();
+      p->~NodeType();
     }
 #else
     void construct(pointer p, const_reference t) { new (p) value_type(t); }
 
-    void destroy(pointer p) {
-      if (arena_ == NULL) p->~value_type();
-    }
+    void destroy(pointer p) { p->~value_type(); }
 #endif
 
     template <typename X>
@@ -201,10 +199,10 @@ class Map {
       return arena_ != other.arena_;
     }
 
-	// To support Visual Studio 2008
-	size_type max_size() const {
-		return std::numeric_limits<size_type>::max();
-	}
+    // To support Visual Studio 2008
+    size_type max_size() const {
+      return std::numeric_limits<size_type>::max();
+    }
 
    private:
     Arena* arena_;

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -1125,7 +1125,9 @@ template <typename Element>
 inline typename RepeatedField<Element>::iterator RepeatedField<Element>::erase(
     const_iterator first, const_iterator last) {
   size_type first_offset = first - cbegin();
-  Truncate(std::copy(last, cend(), begin() + first_offset) - cbegin());
+  if (first != last) {
+    Truncate(std::copy(last, cend(), begin() + first_offset) - cbegin());
+  }
   return begin() + first_offset;
 }
 


### PR DESCRIPTION
Fix 1: MapAllocator::destroy() should always call the destructor because the caller (hash_map implementation) may rely on the destructor to do required clean-ups. Not calling the destructor causes unit tests to hang with vs2010 debug build (Fixes https://github.com/google/protobuf/issues/442)

Fix 2: Only call std::copy() if the range is not empty in RepeatedField::erase().

@TeBoring to review.