### PR TITLE
Add protoc path detection for Mac OS

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -53,6 +53,10 @@
 #include <google/protobuf/stubs/shared_ptr.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/stringprintf.h>
 #include <google/protobuf/compiler/importer.h>
@@ -186,6 +190,16 @@ bool GetProtocAbsolutePath(string* path) {
 #ifdef _WIN32
   char buffer[MAX_PATH];
   int len = GetModuleFileName(NULL, buffer, MAX_PATH);
+#elif __APPLE__
+  char buffer[PATH_MAX];
+  int len = 0;
+
+  char dirtybuffer[PATH_MAX];
+  uint32_t size = sizeof(dirtybuffer);
+  if (_NSGetExecutablePath(dirtybuffer, &size) == 0) {
+    realpath(dirtybuffer, buffer);
+    len = strlen(buffer);
+  }
 #else
   char buffer[PATH_MAX];
   int len = readlink("/proc/self/exe", buffer, PATH_MAX);


### PR DESCRIPTION
This adds Mac OS support to the default import path feature added in #411.