### PR TITLE
Conformance tests can now be excluded based on their names.

### DIFF
--- a/conformance/Makefile.am
+++ b/conformance/Makefile.am
@@ -57,7 +57,7 @@ conformance-java: javac_middleman
 
 # Targets for actually running tests.
 test_cpp: protoc_middleman conformance-test-runner conformance-cpp
-	./conformance-test-runner ./conformance-cpp
+	./conformance-test-runner --failure_list failure_list_cpp.txt ./conformance-cpp
 
 test_java: protoc_middleman conformance-test-runner conformance-java
 	./conformance-test-runner ./conformance-java

--- a/conformance/conformance.proto
+++ b/conformance/conformance.proto
@@ -57,11 +57,13 @@ option java_package = "com.google.protobuf.conformance";
 //   2. parse the protobuf or JSON payload in "payload" (which may fail)
 //   3. if the parse succeeded, serialize the message in the requested format.
 message ConformanceRequest {
+  string test_name = 1;
+
   // The payload (whether protobuf of JSON) is always for a TestAllTypes proto
   // (see below).
   oneof payload {
-    bytes protobuf_payload = 1;
-    string json_payload = 2;
+    bytes protobuf_payload = 2;
+    string json_payload = 3;
   }
 
   enum RequestedOutput {
@@ -71,7 +73,7 @@ message ConformanceRequest {
   }
 
   // Which format should the testee serialize its message to?
-  RequestedOutput requested_output = 3;
+  RequestedOutput requested_output = 4;
 }
 
 // Represents a single test case's output.

--- a/conformance/conformance.proto
+++ b/conformance/conformance.proto
@@ -57,13 +57,11 @@ option java_package = "com.google.protobuf.conformance";
 //   2. parse the protobuf or JSON payload in "payload" (which may fail)
 //   3. if the parse succeeded, serialize the message in the requested format.
 message ConformanceRequest {
-  string test_name = 1;
-
   // The payload (whether protobuf of JSON) is always for a TestAllTypes proto
   // (see below).
   oneof payload {
-    bytes protobuf_payload = 2;
-    string json_payload = 3;
+    bytes protobuf_payload = 1;
+    string json_payload = 2;
   }
 
   enum RequestedOutput {
@@ -73,7 +71,7 @@ message ConformanceRequest {
   }
 
   // Which format should the testee serialize its message to?
-  RequestedOutput requested_output = 4;
+  RequestedOutput requested_output = 3;
 }
 
 // Represents a single test case's output.

--- a/conformance/conformance_test.h
+++ b/conformance/conformance_test.h
@@ -99,7 +99,8 @@ class ConformanceTestSuite {
  private:
   void ReportSuccess(const std::string& test_name);
   void ReportFailure(const std::string& test_name, const char* fmt, ...);
-  void RunTest(const conformance::ConformanceRequest& request,
+  void RunTest(const std::string& test_name,
+               const conformance::ConformanceRequest& request,
                conformance::ConformanceResponse* response);
   void ExpectParseFailureForProto(const std::string& proto,
                                   const std::string& test_name);

--- a/conformance/conformance_test.h
+++ b/conformance/conformance_test.h
@@ -83,24 +83,49 @@ class ConformanceTestSuite {
  public:
   ConformanceTestSuite() : verbose_(false) {}
 
+  // Sets the list of tests that are expected to fail when RunSuite() is called.
+  // RunSuite() will fail unless the set of failing tests is exactly the same
+  // as this list.
+  void SetFailureList(const std::vector<std::string>& failure_list);
+
   // Run all the conformance tests against the given test runner.
   // Test output will be stored in "output".
-  void RunSuite(ConformanceTestRunner* runner, std::string* output);
+  //
+  // Returns true if the set of failing tests was exactly the same as the
+  // failure list.  If SetFailureList() was not called, returns true if all
+  // tests passed.
+  bool RunSuite(ConformanceTestRunner* runner, std::string* output);
 
  private:
-  void ReportSuccess();
-  void ReportFailure(const char* fmt, ...);
+  void ReportSuccess(const std::string& test_name);
+  void ReportFailure(const std::string& test_name, const char* fmt, ...);
   void RunTest(const conformance::ConformanceRequest& request,
                conformance::ConformanceResponse* response);
-  void DoExpectParseFailureForProto(const std::string& proto, int line);
-  void TestPrematureEOFForType(
-      google::protobuf::internal::WireFormatLite::FieldType type);
-
+  void ExpectParseFailureForProto(const std::string& proto,
+                                  const std::string& test_name);
+  void ExpectHardParseFailureForProto(const std::string& proto,
+                                      const std::string& test_name);
+  void TestPrematureEOFForType(google::protobuf::FieldDescriptor::Type type);
+  bool CheckSetEmpty(const set<string>& set_to_check, const char* msg);
   ConformanceTestRunner* runner_;
   int successes_;
   int failures_;
   bool verbose_;
   std::string output_;
+
+  // The set of test names that are expected to fail in this run, but haven't
+  // failed yet.
+  std::set<std::string> expected_to_fail_;
+
+  // The set of test names that have been run.  Used to ensure that there are no
+  // duplicate names in the suite.
+  std::set<std::string> test_names_;
+
+  // The set of tests that failed, but weren't expected to.
+  std::set<std::string> unexpected_failing_tests_;
+
+  // The set of tests that succeeded, but weren't expected to.
+  std::set<std::string> unexpected_succeeding_tests_;
 };
 
 }  // namespace protobuf

--- a/conformance/failure_list_cpp.txt
+++ b/conformance/failure_list_cpp.txt
@@ -5,7 +5,7 @@
 # that we don't introduce regressions in other tests.
 #
 # TODO(haberman): insert links to corresponding bugs tracking the issue.
-# Should we use GitHub issues or the Google-internal bug tracker.
+# Should we use GitHub issues or the Google-internal bug tracker?
 
 PrematureEofBeforeKnownRepeatedValue.MESSAGE
 PrematureEofInDelimitedDataForKnownNonRepeatedValue.MESSAGE

--- a/conformance/failure_list_cpp.txt
+++ b/conformance/failure_list_cpp.txt
@@ -1,0 +1,21 @@
+# This is the list of conformance tests that are known to fail for the C++
+# implementation right now.  These should be fixed.
+#
+# By listing them here we can keep tabs on which ones are failing and be sure
+# that we don't introduce regressions in other tests.
+#
+# TODO(haberman): insert links to corresponding bugs tracking the issue.
+# Should we use GitHub issues or the Google-internal bug tracker.
+
+PrematureEofBeforeKnownRepeatedValue.MESSAGE
+PrematureEofInDelimitedDataForKnownNonRepeatedValue.MESSAGE
+PrematureEofInDelimitedDataForKnownRepeatedValue.MESSAGE
+PrematureEofInPackedField.BOOL
+PrematureEofInPackedField.ENUM
+PrematureEofInPackedField.INT32
+PrematureEofInPackedField.INT64
+PrematureEofInPackedField.SINT32
+PrematureEofInPackedField.SINT64
+PrematureEofInPackedField.UINT32
+PrematureEofInPackedField.UINT64
+PrematureEofInsideKnownRepeatedValue.MESSAGE


### PR DESCRIPTION
This allows us to enable conformance tests even when we know
that some tests are failing and need to be fixed.

Change-Id: I372f43663008747db6f2b2cf06e6ffa4c6d85b2d