### PR TITLE
Fix bug when parsing from non-seekable streams.

### DIFF
--- a/csharp/src/ProtocolBuffers/CodedInputStream.cs
+++ b/csharp/src/ProtocolBuffers/CodedInputStream.cs
@@ -1813,7 +1813,8 @@ namespace Google.ProtocolBuffers
                 byte[] skipBuffer = new byte[1024];
                 while (amountToSkip > 0)
                 {
-                    int bytesRead = input.Read(skipBuffer, 0, skipBuffer.Length);
+                    int bytesRead = input.Read(
+                        skipBuffer, 0, Math.Min(skipBuffer.Length, amountToSkip));
                     if (bytesRead <= 0)
                     {
                         throw InvalidProtocolBufferException.TruncatedMessage();


### PR DESCRIPTION
Note that this isn't as much of an edge case as it looks like, since LimitedInputStream (used by MergeDelimitedFrom) is not seekable. A simple test case is to call SomeType.MergeDelimitedFrom(stream), where the stream source uses newer .proto files than the sink.