### PR TITLE
Fixed bug in GOOGLE_PREDICT_FALSE.

### DIFF
--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -258,7 +258,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 #ifndef GOOGLE_PREDICT_FALSE
 #ifdef __GNUC__
 // Provided at least since GCC 3.0.
-#define GOOGLE_PREDICT_FALSE(x) (__builtin_expect(!!(x), 1))
+#define GOOGLE_PREDICT_FALSE(x) (__builtin_expect(x, 0))
 #else
 #define GOOGLE_PREDICT_FALSE
 #endif


### PR DESCRIPTION
The GOOGLE_PREDICT_FALSE macro is both incorrect, and doesn't match
the macro definition in glog, which causes conflicts when including
both libraries.  This commit fixes that by making it identical to
what is in glog.