### PR TITLE
Workaround for MSVC's string literal compiler limit.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -434,20 +434,53 @@ void FileGenerator::GenerateBuildDescriptors(io::Printer* printer) {
     string file_data;
     file_proto.SerializeToString(&file_data);
 
-    printer->Print(
-      "::google::protobuf::DescriptorPool::InternalAddGeneratedFile(");
+    // Workaround for MSVC: "Error C1091: compiler limit: string exceeds 65535
+    // bytes in length". Declare a static array of characters rather than use a
+    // string literal.
+    size_t literal_size = EscapeTrigraphs(CEscape(file_data)).size();
+    if (literal_size > 65535) {
+      printer->Print(
+        "static const char descriptor[] = {\n");
+      printer->Indent();
 
-    // Only write 40 bytes per line.
-    static const int kBytesPerLine = 40;
-    for (int i = 0; i < file_data.size(); i += kBytesPerLine) {
-      printer->Print("\n  \"$data$\"",
-                     "data",
-                     EscapeTrigraphs(
-                         CEscape(file_data.substr(i, kBytesPerLine))));
+      // Only write 25 bytes per line.
+      static const int kBytesPerLine = 25;
+      for (int i = 0; i < file_data.size();) {
+          for (int j = 0; j < kBytesPerLine && i < file_data.size(); ++i, ++j) {
+            printer->Print(
+              "$char$, ",
+              "char", SimpleItoa(file_data[i]));
+          }
+          printer->Print(
+            "\n");
+      }
+
+      printer->Outdent();
+      printer->Print(
+        "};\n");
+
+      printer->Print(
+        "::google::protobuf::DescriptorPool::InternalAddGeneratedFile(descriptor, $size$);\n",
+        "size", SimpleItoa(file_data.size()));
+
+    } else {
+
+      printer->Print(
+        "::google::protobuf::DescriptorPool::InternalAddGeneratedFile(");
+  
+      // Only write 40 bytes per line.
+      static const int kBytesPerLine = 40;
+      for (int i = 0; i < file_data.size(); i += kBytesPerLine) {
+        printer->Print("\n  \"$data$\"",
+                       "data",
+                       EscapeTrigraphs(
+                           CEscape(file_data.substr(i, kBytesPerLine))));
+      }
+      printer->Print(
+          ", $size$);\n",
+        "size", SimpleItoa(file_data.size()));
+  
     }
-    printer->Print(
-        ", $size$);\n",
-      "size", SimpleItoa(file_data.size()));
 
     // Call MessageFactory::InternalRegisterGeneratedFile().
     printer->Print(


### PR DESCRIPTION
Conventional wisdom for this issue has been "don't make proto messages that have such long descriptors" but this issue also occurs for enums that have a large number of values with relatively long names. This seems like a valid usage model.

This code escapes the entire protobuf descriptor prior to embedding. More conservative checking could be applied at the cost of code complexity.
