### PR TITLE
Exclude 3 failing tests on osx from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,13 @@ env:
   - CONFIG=ruby21
   - CONFIG=ruby22
   - CONFIG=jruby
+matrix:
+  allow_failures:
+    - os: osx
+      env: CONFIG=csharp
+    - os: osx
+      env: CONFIG=ruby22
+    - os: osx
+      env: CONFIG=jruby
 notifications:
   email: false


### PR DESCRIPTION
It seems travis start to run osx tests for our project only very recently and since then 3 tests on osx have always been failing:

osx is added to .traivis.yml here: https://github.com/google/protobuf/pull/248

the first failing test occurred in this build: https://travis-ci.org/google/protobuf/builds/65636924

This PR lists these failing tests as "allowed_failures" so they don't block new submissions.