### PR TITLE
Fixed link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,4 +190,4 @@ Usage
 The complete documentation for Protocol Buffers is available via the
 web at:
 
-    https://developers.google.com/protocol-buffers/
+https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
The URI isn't code, so should not be indented.
Formatting it as code breaks the link when converting to HTML (like on Github).