### PR TITLE
Workaround for MSVC's string literal compiler limit.

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -25,6 +25,7 @@ set(tests_protos
   google/protobuf/unittest_drop_unknown_fields.proto
   google/protobuf/unittest_embed_optimize_for.proto
   google/protobuf/unittest_empty.proto
+  google/protobuf/unittest_enormous_descriptor.proto
   google/protobuf/unittest_import.proto
   google/protobuf/unittest_import_public.proto
   google/protobuf/unittest_lite_imports_nonlite.proto

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -412,6 +412,7 @@ protoc_inputs =                                                \
   google/protobuf/unittest_drop_unknown_fields.proto           \
   google/protobuf/unittest_embed_optimize_for.proto            \
   google/protobuf/unittest_empty.proto                         \
+  google/protobuf/unittest_enormous_descriptor.proto           \
   google/protobuf/unittest_import_lite.proto                   \
   google/protobuf/unittest_import.proto                        \
   google/protobuf/unittest_import_public_lite.proto            \
@@ -453,8 +454,7 @@ EXTRA_DIST =                                                   \
   google/protobuf/compiler/ruby/ruby_generated_code.proto      \
   google/protobuf/compiler/ruby/ruby_generated_code.rb         \
   google/protobuf/compiler/package_info.h                      \
-  google/protobuf/compiler/zip_output_unittest.sh              \
-  google/protobuf/unittest_enormous_descriptor.proto
+  google/protobuf/compiler/zip_output_unittest.sh
 
 protoc_lite_outputs =                                          \
   google/protobuf/map_lite_unittest.pb.cc                      \
@@ -486,6 +486,8 @@ protoc_outputs =                                               \
   google/protobuf/unittest_embed_optimize_for.pb.h             \
   google/protobuf/unittest_empty.pb.cc                         \
   google/protobuf/unittest_empty.pb.h                          \
+  google/protobuf/unittest_enormous_descriptor.pb.cc           \
+  google/protobuf/unittest_enormous_descriptor.pb.h            \
   google/protobuf/unittest_import.pb.cc                        \
   google/protobuf/unittest_import.pb.h                         \
   google/protobuf/unittest_import_public.pb.cc                 \

--- a/src/google/protobuf/compiler/cpp/cpp_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_unittest.cc
@@ -55,6 +55,7 @@
 #include <google/protobuf/unittest.pb.h>
 #include <google/protobuf/unittest_optimize_for.pb.h>
 #include <google/protobuf/unittest_embed_optimize_for.pb.h>
+#include <google/protobuf/unittest_enormous_descriptor.pb.h>
 #include <google/protobuf/unittest_no_generic_services.pb.h>
 #include <google/protobuf/test_util.h>
 #include <google/protobuf/compiler/cpp/cpp_helpers.h>
@@ -128,6 +129,17 @@ TEST(GeneratedDescriptorTest, IdenticalDescriptors) {
 
   EXPECT_EQ(parsed_descriptor_proto.DebugString(),
             generated_decsriptor_proto.DebugString());
+}
+
+// Test that generated code has proper descriptors:
+// Touch a descriptor generated from an enormous message to validate special
+// handling for descriptors exceeding the C++ standard's recommended minimum
+// limit for string literal size
+TEST(GeneratedDescriptorTest, EnormousDescriptor) {
+  const Descriptor* generated_descriptor =
+    TestEnormousDescriptor::descriptor();
+
+  EXPECT_TRUE(generated_descriptor != NULL);
 }
 
 #endif  // !PROTOBUF_TEST_NO_DESCRIPTORS


### PR DESCRIPTION
This change declares a static array of characters for the built-in descriptor rather than using a string literal when the size of the descriptor is larger than MSVC's maximum string literal size, which prevents a compiler error. This occurred for us when defining an enum with a large number of values with long names.