### PR TITLE
Remove the OS X checks from travis.sh, instead use excludes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: required
+# Note: travis currently does not support listing more than one language so
+# this cheats and claims to only be cpp.  If they add multiple language
+# support, this should probably get updated to install steps and/or
+# rvm/gemfile/jdk/etc. entries rather than manually doing the work.
 language: cpp
 os:
   - linux
@@ -23,9 +27,27 @@ env:
   - CONFIG=ruby22
   - CONFIG=jruby
 matrix:
-  allow_failures:
+  exclude:
+    # It's nontrivial to programmatically install a new JDK from the command
+    # line on OS X, so we rely on testing on Linux for Java code.
+    - os: osx
+      env: CONFIG=java_jdk6
+    - os: osx
+      env: CONFIG=java_jdk7
+    - os: osx
+      env: CONFIG=java_oracle7
+    - os: osx
+      env: CONFIG=javanano_jdk6
+    - os: osx
+      env: CONFIG=javanano_jdk7
+    - os: osx
+      env: CONFIG=javanano_oracle7
+    # Requires installing mono, currently travis.sh is doing that with apt-get
+    # which doesn't work on OS X.
     - os: osx
       env: CONFIG=csharp
+  allow_failures:
+    # These currently do not work on OS X but are being worked on by @haberman.
     - os: osx
       env: CONFIG=ruby22
     - os: osx

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Note: travis currently does not support testing more than one language so the
+# .travis.yml cheats and claims to only be cpp.  If they add multiple language
+# support, this should probably get updated to install steps and/or
+# rvm/gemfile/jdk/etc. entries rather than manually doing the work.
+
+# .travis.yml uses matrix.exclude to block the cases where app-get can't be
+# use to install things.
+
 build_cpp() {
   ./autogen.sh
   ./configure
@@ -28,12 +36,6 @@ build_csharp() {
 }
 
 use_java() {
-  if [ `uname` != "Linux" ]; then
-    # It's nontrivial to programmatically install a new JDK from the command
-    # line on OS X, so we rely on testing on Linux for Java code.
-    echo "Java not tested on OS X."
-    exit 0  # success
-  fi
   version=$1
   case "$version" in
     jdk6)


### PR DESCRIPTION
The current setup fires up a bunch of tests/VMs to quickly exit or fail when we know they won't work.  This should avoid firing up those tests/VMs instead.