### PR TITLE
Give descriptor.proto a go package

### DIFF
--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -753,9 +753,10 @@ void protobuf_AddDesc_google_2fprotobuf_2fdescriptor_2eproto() {
     "ion\032\206\001\n\010Location\022\020\n\004path\030\001 \003(\005B\002\020\001\022\020\n\004sp"
     "an\030\002 \003(\005B\002\020\001\022\030\n\020leading_comments\030\003 \001(\t\022\031"
     "\n\021trailing_comments\030\004 \001(\t\022!\n\031leading_det"
-    "ached_comments\030\006 \003(\tBY\n\023com.google.proto"
-    "bufB\020DescriptorProtosH\001\242\002\003GPB\252\002\'Google.P"
-    "rotocolBuffers.DescriptorProtos", 4951);
+    "ached_comments\030\006 \003(\tBe\n\023com.google.proto"
+    "bufB\020DescriptorProtosH\001Z\ndescriptor\242\002\003GP"
+    "B\252\002\'Google.ProtocolBuffers.DescriptorPro"
+    "tos", 4963);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "google/protobuf/descriptor.proto", &protobuf_RegisterTypes);
   FileDescriptorSet::default_instance_ = new FileDescriptorSet();

--- a/src/google/protobuf/descriptor.proto
+++ b/src/google/protobuf/descriptor.proto
@@ -40,6 +40,7 @@
 syntax = "proto2";
 
 package google.protobuf;
+option go_package = "descriptor";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.ProtocolBuffers.DescriptorProtos";


### PR DESCRIPTION
This is currently done in golang/protobuf using `sed`. This change
should simplify things.