### PR TITLE
Add nonnull/nullable/null_resettable markup to ObjC library.

### DIFF
--- a/objectivec/GPBArray.h
+++ b/objectivec/GPBArray.h
@@ -37,6 +37,8 @@
 
 // Note: These are not meant to be subclassed.
 
+NS_ASSUME_NONNULL_BEGIN
+
 //%PDDM-EXPAND DECLARE_ARRAYS()
 // This block of code is generated, do not edit it directly.
 
@@ -321,21 +323,21 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)array;
-+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                    rawValue:(int32_t)value;
 + (instancetype)arrayWithValueArray:(GPBEnumArray *)array;
-+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                    capacity:(NSUInteger)count;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
 
 // Initializes the array, copying the values.
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithValueArray:(GPBEnumArray *)array;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)count;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value at index is not a
@@ -392,6 +394,8 @@
 
 //%PDDM-EXPAND-END DECLARE_ARRAYS()
 
+NS_ASSUME_NONNULL_END
+
 //%PDDM-DEFINE DECLARE_ARRAYS()
 //%ARRAY_INTERFACE_SIMPLE(Int32, int32_t)
 //%ARRAY_INTERFACE_SIMPLE(UInt32, uint32_t)
@@ -444,21 +448,21 @@
 //%@property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 //%
 //%+ (instancetype)array;
-//%+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func;
-//%+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func
+//%+ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+//%+ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                   rawValue:(TYPE)value;
 //%+ (instancetype)arrayWithValueArray:(GPB##NAME##Array *)array;
-//%+ (instancetype)arrayWithValidationFunction:(GPBEnumValidationFunc)func
+//%+ (instancetype)arrayWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                   capacity:(NSUInteger)count;
 //%
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
 //%
 //%// Initializes the array, copying the values.
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                 rawValues:(const TYPE [])values
 //%                                     count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 //%- (instancetype)initWithValueArray:(GPB##NAME##Array *)array;
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                  capacity:(NSUInteger)count;
 //%
 //%// These will return kGPBUnrecognizedEnumeratorValue if the value at index is not a

--- a/objectivec/GPBCodedInputStream.h
+++ b/objectivec/GPBCodedInputStream.h
@@ -33,6 +33,8 @@
 @class GPBMessage;
 @class GPBExtensionRegistry;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Reads and decodes protocol message fields.
 // Subclassing of GPBCodedInputStream is NOT supported.
 @interface GPBCodedInputStream : NSObject
@@ -64,7 +66,7 @@
 
 // Read an embedded message field value from the stream.
 - (void)readMessage:(GPBMessage *)message
-    extensionRegistry:(GPBExtensionRegistry *)extensionRegistry;
+    extensionRegistry:(nullable GPBExtensionRegistry *)extensionRegistry;
 
 // Reads and discards a single field, given its tag value. Returns NO if the
 // tag is an endgroup tag, in which case nothing is skipped.  Otherwise,
@@ -81,3 +83,5 @@
 - (void)checkLastTagWas:(int32_t)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBCodedOutputStream.h
+++ b/objectivec/GPBCodedOutputStream.h
@@ -44,6 +44,8 @@
 @class GPBUInt64Array;
 @class GPBUnknownFieldSet;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GPBCodedOutputStream : NSObject
 
 // Creates a new stream to write into data.  Data must be sized to fit or it
@@ -53,12 +55,10 @@
 + (instancetype)streamWithOutputStream:(NSOutputStream *)output
                             bufferSize:(size_t)bufferSize;
 
-- (instancetype)initWithOutputStream:(NSOutputStream *)output;
 - (instancetype)initWithData:(NSMutableData *)data;
+- (instancetype)initWithOutputStream:(NSOutputStream *)output;
 - (instancetype)initWithOutputStream:(NSOutputStream *)output
                           bufferSize:(size_t)bufferSize;
-- (instancetype)initWithOutputStream:(NSOutputStream *)output
-                                data:(NSMutableData *)data;
 
 - (void)flush;
 
@@ -293,6 +293,8 @@ size_t GPBComputeEnumSize(int32_t fieldNumber, int32_t value)
     __attribute__((const));
 
 CF_EXTERN_C_END
+
+NS_ASSUME_NONNULL_END
 
 // Write methods for types that can be in packed arrays.
 //%PDDM-DEFINE _WRITE_PACKABLE_DECLS(NAME, ARRAY_TYPE, TYPE)

--- a/objectivec/GPBCodedOutputStream.m
+++ b/objectivec/GPBCodedOutputStream.m
@@ -184,6 +184,9 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
   return [self initWithOutputStream:output data:data];
 }
 
+// This initializer isn't exposed, but it is the designated initializer.
+// Setting OutputStream and NSData is to control the buffering behavior/size
+// of the work, but that is more obvious via the bufferSize: version.
 - (instancetype)initWithOutputStream:(NSOutputStream *)output
                                 data:(NSMutableData *)data {
   if ((self = [super init])) {

--- a/objectivec/GPBDescriptor.h
+++ b/objectivec/GPBDescriptor.h
@@ -38,6 +38,8 @@
 @class GPBFileDescriptor;
 @class GPBOneofDescriptor;
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSInteger, GPBFileSyntax) {
   GPBFileSyntaxUnknown = 0,
   GPBFileSyntaxProto2 = 2,
@@ -53,20 +55,20 @@ typedef NS_ENUM(NSInteger, GPBFieldType) {
 @interface GPBDescriptor : NSObject<NSCopying>
 
 @property(nonatomic, readonly, copy) NSString *name;
-@property(nonatomic, readonly, strong) NSArray *fields;
-@property(nonatomic, readonly, strong) NSArray *oneofs;
-@property(nonatomic, readonly, strong) NSArray *enums;
-@property(nonatomic, readonly) const GPBExtensionRange *extensionRanges;
+@property(nonatomic, readonly, strong, nullable) NSArray *fields;
+@property(nonatomic, readonly, strong, nullable) NSArray *oneofs;
+@property(nonatomic, readonly, strong, nullable) NSArray *enums;
+@property(nonatomic, readonly, nullable) const GPBExtensionRange *extensionRanges;
 @property(nonatomic, readonly) NSUInteger extensionRangesCount;
 @property(nonatomic, readonly, assign) GPBFileDescriptor *file;
 
 @property(nonatomic, readonly, getter=isWireFormat) BOOL wireFormat;
 @property(nonatomic, readonly) Class messageClass;
 
-- (GPBFieldDescriptor *)fieldWithNumber:(uint32_t)fieldNumber;
-- (GPBFieldDescriptor *)fieldWithName:(NSString *)name;
-- (GPBOneofDescriptor *)oneofWithName:(NSString *)name;
-- (GPBEnumDescriptor *)enumWithName:(NSString *)name;
+- (nullable GPBFieldDescriptor *)fieldWithNumber:(uint32_t)fieldNumber;
+- (nullable GPBFieldDescriptor *)fieldWithName:(NSString *)name;
+- (nullable GPBOneofDescriptor *)oneofWithName:(NSString *)name;
+- (nullable GPBEnumDescriptor *)enumWithName:(NSString *)name;
 
 @end
 
@@ -81,8 +83,8 @@ typedef NS_ENUM(NSInteger, GPBFieldType) {
 @property(nonatomic, readonly) NSString *name;
 @property(nonatomic, readonly) NSArray *fields;
 
-- (GPBFieldDescriptor *)fieldWithNumber:(uint32_t)fieldNumber;
-- (GPBFieldDescriptor *)fieldWithName:(NSString *)name;
+- (nullable GPBFieldDescriptor *)fieldWithNumber:(uint32_t)fieldNumber;
+- (nullable GPBFieldDescriptor *)fieldWithName:(NSString *)name;
 @end
 
 @interface GPBFieldDescriptor : NSObject
@@ -99,21 +101,21 @@ typedef NS_ENUM(NSInteger, GPBFieldType) {
 @property(nonatomic, readonly) GPBDataType mapKeyDataType;
 @property(nonatomic, readonly, getter=isPackable) BOOL packable;
 
-@property(nonatomic, readonly, assign) GPBOneofDescriptor *containingOneof;
+@property(nonatomic, readonly, assign, nullable) GPBOneofDescriptor *containingOneof;
 
-@property(nonatomic, readonly) GPBFieldOptions *fieldOptions;
+@property(nonatomic, readonly, nullable) GPBFieldOptions *fieldOptions;
 
 // Message properties
-@property(nonatomic, readonly, assign) Class msgClass;
+@property(nonatomic, readonly, assign, nullable) Class msgClass;
 
 // Enum properties
-@property(nonatomic, readonly, strong) GPBEnumDescriptor *enumDescriptor;
+@property(nonatomic, readonly, strong, nullable) GPBEnumDescriptor *enumDescriptor;
 
 - (BOOL)isValidEnumValue:(int32_t)value;
 
 // For now, this will return nil if it doesn't know the name to use for
 // TextFormat.
-- (NSString *)textFormatName;
+- (nullable NSString *)textFormatName;
 
 @end
 
@@ -122,10 +124,10 @@ typedef NS_ENUM(NSInteger, GPBFieldType) {
 @property(nonatomic, readonly, copy) NSString *name;
 @property(nonatomic, readonly) GPBEnumValidationFunc enumVerifier;
 
-- (NSString *)enumNameForValue:(int32_t)number;
-- (BOOL)getValue:(int32_t *)outValue forEnumName:(NSString *)name;
+- (nullable NSString *)enumNameForValue:(int32_t)number;
+- (BOOL)getValue:(nullable int32_t *)outValue forEnumName:(NSString *)name;
 
-- (NSString *)textFormatNameForValue:(int32_t)number;
+- (nullable NSString *)textFormatNameForValue:(int32_t)number;
 
 @end
 
@@ -137,6 +139,8 @@ typedef NS_ENUM(NSInteger, GPBFieldType) {
 @property(nonatomic, readonly, getter=isPackable) BOOL packable;
 @property(nonatomic, readonly, assign) Class msgClass;
 @property(nonatomic, readonly) NSString *singletonName;
-@property(nonatomic, readonly, strong) GPBEnumDescriptor *enumDescriptor;
+@property(nonatomic, readonly, strong, nullable) GPBEnumDescriptor *enumDescriptor;
 @property(nonatomic, readonly) id defaultValue;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBDictionary.h
+++ b/objectivec/GPBDictionary.h
@@ -37,6 +37,8 @@
 
 // Note: These are not meant to be subclassed.
 
+NS_ASSUME_NONNULL_BEGIN
+
 //%PDDM-EXPAND DECLARE_DICTIONARIES()
 // This block of code is generated, do not edit it directly.
 
@@ -61,7 +63,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, uint32_t value, BOOL *stop))block;
@@ -96,7 +98,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block;
@@ -131,7 +133,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, uint64_t value, BOOL *stop))block;
@@ -166,7 +168,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(int64_t *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, int64_t value, BOOL *stop))block;
@@ -201,7 +203,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(BOOL *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, BOOL value, BOOL *stop))block;
@@ -236,7 +238,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(float *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, float value, BOOL *stop))block;
@@ -271,7 +273,7 @@
 - (instancetype)initWithDictionary:(GPBUInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(double *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, double value, BOOL *stop))block;
@@ -293,32 +295,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const uint32_t [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32EnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const uint32_t [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32EnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(uint32_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(uint32_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block;
@@ -326,7 +328,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(uint32_t)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(uint32_t)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(uint32_t key, int32_t rawValue, BOOL *stop))block;
@@ -407,7 +409,7 @@
 - (instancetype)initWithDictionary:(GPBInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, uint32_t value, BOOL *stop))block;
@@ -442,7 +444,7 @@
 - (instancetype)initWithDictionary:(GPBInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block;
@@ -477,7 +479,7 @@
 - (instancetype)initWithDictionary:(GPBInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, uint64_t value, BOOL *stop))block;
@@ -512,7 +514,7 @@
 - (instancetype)initWithDictionary:(GPBInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(int64_t *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, int64_t value, BOOL *stop))block;
@@ -547,7 +549,7 @@
 - (instancetype)initWithDictionary:(GPBInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(BOOL *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, BOOL value, BOOL *stop))block;
@@ -582,7 +584,7 @@
 - (instancetype)initWithDictionary:(GPBInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(float *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, float value, BOOL *stop))block;
@@ -617,7 +619,7 @@
 - (instancetype)initWithDictionary:(GPBInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(double *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, double value, BOOL *stop))block;
@@ -639,32 +641,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const int32_t [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32EnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const int32_t [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32EnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(int32_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(int32_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block;
@@ -672,7 +674,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(int32_t)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(int32_t)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(int32_t key, int32_t rawValue, BOOL *stop))block;
@@ -753,7 +755,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, uint32_t value, BOOL *stop))block;
@@ -788,7 +790,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block;
@@ -823,7 +825,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, uint64_t value, BOOL *stop))block;
@@ -858,7 +860,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(int64_t *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, int64_t value, BOOL *stop))block;
@@ -893,7 +895,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(BOOL *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, BOOL value, BOOL *stop))block;
@@ -928,7 +930,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(float *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, float value, BOOL *stop))block;
@@ -963,7 +965,7 @@
 - (instancetype)initWithDictionary:(GPBUInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(double *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, double value, BOOL *stop))block;
@@ -985,32 +987,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const uint64_t [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64EnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const uint64_t [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64EnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(uint64_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(uint64_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block;
@@ -1018,7 +1020,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(uint64_t)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(uint64_t)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(uint64_t key, int32_t rawValue, BOOL *stop))block;
@@ -1099,7 +1101,7 @@
 - (instancetype)initWithDictionary:(GPBInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, uint32_t value, BOOL *stop))block;
@@ -1134,7 +1136,7 @@
 - (instancetype)initWithDictionary:(GPBInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block;
@@ -1169,7 +1171,7 @@
 - (instancetype)initWithDictionary:(GPBInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, uint64_t value, BOOL *stop))block;
@@ -1204,7 +1206,7 @@
 - (instancetype)initWithDictionary:(GPBInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(int64_t *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, int64_t value, BOOL *stop))block;
@@ -1239,7 +1241,7 @@
 - (instancetype)initWithDictionary:(GPBInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(BOOL *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, BOOL value, BOOL *stop))block;
@@ -1274,7 +1276,7 @@
 - (instancetype)initWithDictionary:(GPBInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(float *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, float value, BOOL *stop))block;
@@ -1309,7 +1311,7 @@
 - (instancetype)initWithDictionary:(GPBInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(double *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, double value, BOOL *stop))block;
@@ -1331,32 +1333,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const int64_t [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64EnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const int64_t [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64EnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(int64_t)key value:(int32_t *)value;
+- (BOOL)valueForKey:(int64_t)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block;
@@ -1364,7 +1366,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(int64_t)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(int64_t)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(int64_t key, int32_t rawValue, BOOL *stop))block;
@@ -1445,7 +1447,7 @@
 - (instancetype)initWithDictionary:(GPBBoolUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, uint32_t value, BOOL *stop))block;
@@ -1480,7 +1482,7 @@
 - (instancetype)initWithDictionary:(GPBBoolInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(int32_t *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block;
@@ -1515,7 +1517,7 @@
 - (instancetype)initWithDictionary:(GPBBoolUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, uint64_t value, BOOL *stop))block;
@@ -1550,7 +1552,7 @@
 - (instancetype)initWithDictionary:(GPBBoolInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(int64_t *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, int64_t value, BOOL *stop))block;
@@ -1585,7 +1587,7 @@
 - (instancetype)initWithDictionary:(GPBBoolBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(BOOL *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, BOOL value, BOOL *stop))block;
@@ -1620,7 +1622,7 @@
 - (instancetype)initWithDictionary:(GPBBoolFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(float *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, float value, BOOL *stop))block;
@@ -1655,7 +1657,7 @@
 - (instancetype)initWithDictionary:(GPBBoolDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(double *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, double value, BOOL *stop))block;
@@ -1677,32 +1679,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const BOOL [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolEnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const BOOL [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolEnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(BOOL)key value:(int32_t *)value;
+- (BOOL)valueForKey:(BOOL)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block;
@@ -1710,7 +1712,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(BOOL)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(BOOL)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(BOOL key, int32_t rawValue, BOOL *stop))block;
@@ -1791,7 +1793,7 @@
 - (instancetype)initWithDictionary:(GPBStringUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(uint32_t *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable uint32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, uint32_t value, BOOL *stop))block;
@@ -1826,7 +1828,7 @@
 - (instancetype)initWithDictionary:(GPBStringInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(int32_t *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block;
@@ -1861,7 +1863,7 @@
 - (instancetype)initWithDictionary:(GPBStringUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(uint64_t *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable uint64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, uint64_t value, BOOL *stop))block;
@@ -1896,7 +1898,7 @@
 - (instancetype)initWithDictionary:(GPBStringInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(int64_t *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable int64_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, int64_t value, BOOL *stop))block;
@@ -1931,7 +1933,7 @@
 - (instancetype)initWithDictionary:(GPBStringBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(BOOL *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable BOOL *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, BOOL value, BOOL *stop))block;
@@ -1966,7 +1968,7 @@
 - (instancetype)initWithDictionary:(GPBStringFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(float *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable float *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, float value, BOOL *stop))block;
@@ -2001,7 +2003,7 @@
 - (instancetype)initWithDictionary:(GPBStringDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(double *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable double *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, double value, BOOL *stop))block;
@@ -2023,32 +2025,32 @@
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         rawValue:(int32_t)rawValue
                                           forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                        rawValues:(const int32_t [])values
                                          forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                                            count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringEnumDictionary *)dictionary;
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
++ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                         capacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                  rawValues:(const int32_t [])values
                                    forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringEnumDictionary *)dictionary;
-- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
                                   capacity:(NSUInteger)numItems;
 
 // These will return kGPBUnrecognizedEnumeratorValue if the value for the key
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(NSString *)key value:(int32_t *)value;
+- (BOOL)valueForKey:(NSString *)key value:(nullable int32_t *)value;
 
 - (void)enumerateKeysAndValuesUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block;
@@ -2056,7 +2058,7 @@
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(NSString *)key rawValue:(int32_t *)rawValue;
+- (BOOL)valueForKey:(NSString *)key rawValue:(nullable int32_t *)rawValue;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(NSString *key, int32_t rawValue, BOOL *stop))block;
@@ -2083,6 +2085,8 @@
 
 //%PDDM-EXPAND-END DECLARE_DICTIONARIES()
 
+NS_ASSUME_NONNULL_END
+
 //%PDDM-DEFINE DECLARE_DICTIONARIES()
 //%DICTIONARY_INTERFACES_FOR_POD_KEY(UInt32, uint32_t)
 //%DICTIONARY_INTERFACES_FOR_POD_KEY(Int32, int32_t)
@@ -2107,7 +2111,7 @@
 //%PDDM-DEFINE DICTIONARY_POD_KEY_TO_OBJECT_INTERFACE(KEY_NAME, KEY_TYPE, VALUE_NAME, VALUE_TYPE)
 //%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, , POD, VALUE_NAME, VALUE_TYPE, OBJECT)
 //%PDDM-DEFINE VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE)
-//%- (BOOL)valueForKey:(KEY_TYPE)key value:(VALUE_TYPE *)value;
+//%- (BOOL)valueForKey:(KEY_TYPE)key value:(nullable VALUE_TYPE *)value;
 //%PDDM-DEFINE VALUE_FOR_KEY_OBJECT(KEY_TYPE, VALUE_TYPE)
 //%- (VALUE_TYPE)valueForKey:(KEY_TYPE)key;
 //%PDDM-DEFINE VALUE_FOR_KEY_Enum(KEY_TYPE, VALUE_TYPE)
@@ -2160,25 +2164,25 @@
 //%@property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
 //%
 //%+ (instancetype)dictionary;
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func;
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
+//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                        rawValue:(VALUE_TYPE)rawValue
 //%                                          forKey:(KEY_TYPE##KisP$S##KisP)key;
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
+//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                       rawValues:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])values
 //%                                         forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[])keys
 //%                                           count:(NSUInteger)count;
 //%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
+//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                        capacity:(NSUInteger)numItems;
 //%
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func;
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func;
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                 rawValues:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])values
 //%                                   forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[])keys
 //%                                     count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 //%- (instancetype)initWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
-//%- (instancetype)initWithValidationFunction:(GPBEnumValidationFunc)func
+//%- (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
 //%                                  capacity:(NSUInteger)numItems;
 //%
 //%// These will return kGPBUnrecognizedEnumeratorValue if the value for the key
@@ -2190,7 +2194,7 @@
 //%// These methods bypass the validationFunc to provide access to values that were not
 //%// known at the time the binary was compiled.
 //%
-//%- (BOOL)valueForKey:(KEY_TYPE##KisP$S##KisP)key rawValue:(VALUE_TYPE *)rawValue;
+//%- (BOOL)valueForKey:(KEY_TYPE##KisP$S##KisP)key rawValue:(nullable VALUE_TYPE *)rawValue;
 //%
 //%- (void)enumerateKeysAndRawValuesUsingBlock:
 //%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE rawValue, BOOL *stop))block;

--- a/objectivec/GPBExtensionRegistry.h
+++ b/objectivec/GPBExtensionRegistry.h
@@ -33,6 +33,8 @@
 @class GPBDescriptor;
 @class GPBExtensionDescriptor;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // A table of known extensions, searchable by name or field number.  When
 // parsing a protocol message that might have extensions, you must provide an
 // ExtensionRegistry in which you have registered any extensions that you want
@@ -57,7 +59,9 @@
 - (void)addExtension:(GPBExtensionDescriptor *)extension;
 - (void)addExtensions:(GPBExtensionRegistry *)registry;
 
-- (GPBExtensionDescriptor *)extensionForDescriptor:(GPBDescriptor *)descriptor
-                                       fieldNumber:(NSInteger)fieldNumber;
+- (nullable GPBExtensionDescriptor *)extensionForDescriptor:(GPBDescriptor *)descriptor
+                                                fieldNumber:(NSInteger)fieldNumber;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBMessage.h
+++ b/objectivec/GPBMessage.h
@@ -40,6 +40,8 @@
 @class GPBFieldDescriptor;
 @class GPBUnknownFieldSet;
 
+NS_ASSUME_NONNULL_BEGIN
+
 CF_EXTERN_C_BEGIN
 
 // NSError domain used for errors.
@@ -66,7 +68,7 @@ CF_EXTERN_C_END
 // The main cases are methods that take no arguments, or setFoo:/hasFoo: type
 // methods.
 
-@property(nonatomic, readonly) GPBUnknownFieldSet *unknownFields;
+@property(nonatomic, copy, nullable) GPBUnknownFieldSet *unknownFields;
 
 // Are all required fields in the message and all embedded messages set.
 @property(nonatomic, readonly, getter=isInitialized) BOOL initialized;
@@ -80,18 +82,18 @@ CF_EXTERN_C_END
 // if one is missing, the parse will fail (returning nil, filling in errorPtr).
 + (instancetype)parseFromData:(NSData *)data error:(NSError **)errorPtr;
 + (instancetype)parseFromData:(NSData *)data
-            extensionRegistry:(GPBExtensionRegistry *)extensionRegistry
+            extensionRegistry:(nullable GPBExtensionRegistry *)extensionRegistry
                         error:(NSError **)errorPtr;
 + (instancetype)parseFromCodedInputStream:(GPBCodedInputStream *)input
                         extensionRegistry:
-                            (GPBExtensionRegistry *)extensionRegistry
+                            (nullable GPBExtensionRegistry *)extensionRegistry
                                     error:(NSError **)errorPtr;
 
 // Create a message based on delimited input.  If there is a data parse
 // error, nil is returned and if not NULL, errorPtr is filled in.
 + (instancetype)parseDelimitedFromCodedInputStream:(GPBCodedInputStream *)input
                                  extensionRegistry:
-                                     (GPBExtensionRegistry *)extensionRegistry
+                                     (nullable GPBExtensionRegistry *)extensionRegistry
                                              error:(NSError **)errorPtr;
 
 // If there is a data parse error, nil is returned and if not NULL, errorPtr is
@@ -100,11 +102,11 @@ CF_EXTERN_C_END
 // if one is missing, the parse will fail (returning nil, filling in errorPtr).
 - (instancetype)initWithData:(NSData *)data error:(NSError **)errorPtr;
 - (instancetype)initWithData:(NSData *)data
-           extensionRegistry:(GPBExtensionRegistry *)extensionRegistry
+           extensionRegistry:(nullable GPBExtensionRegistry *)extensionRegistry
                        error:(NSError **)errorPtr;
 - (instancetype)initWithCodedInputStream:(GPBCodedInputStream *)input
                        extensionRegistry:
-                           (GPBExtensionRegistry *)extensionRegistry
+                           (nullable GPBExtensionRegistry *)extensionRegistry
                                    error:(NSError **)errorPtr;
 
 // Serializes the message and writes it to output.
@@ -121,11 +123,11 @@ CF_EXTERN_C_END
 // while generating the data, nil is returned.
 // NOTE: In DEBUG ONLY, the message is also checked for all required field,
 // if one is missing, nil will be returned.
-- (NSData *)data;
+- (nullable NSData *)data;
 
 // Same as -[data], except a delimiter is added to the start of the data
 // indicating the size of the message data that follows.
-- (NSData *)delimitedData;
+- (nullable NSData *)delimitedData;
 
 // Returns the size of the object if it were serialized.
 // This is not a cached value. If you are following a pattern like this:
@@ -149,15 +151,13 @@ CF_EXTERN_C_END
 // repeated. If the extension is a Message one will be auto created for you
 // and returned similar to fields.
 - (BOOL)hasExtension:(GPBExtensionDescriptor *)extension;
-- (id)getExtension:(GPBExtensionDescriptor *)extension;
-- (void)setExtension:(GPBExtensionDescriptor *)extension value:(id)value;
+- (nullable id)getExtension:(GPBExtensionDescriptor *)extension;
+- (void)setExtension:(GPBExtensionDescriptor *)extension value:(nullable id)value;
 - (void)addExtension:(GPBExtensionDescriptor *)extension value:(id)value;
 - (void)setExtension:(GPBExtensionDescriptor *)extension
                index:(NSUInteger)index
                value:(id)value;
 - (void)clearExtension:(GPBExtensionDescriptor *)extension;
-
-- (void)setUnknownFields:(GPBUnknownFieldSet *)unknownFields;
 
 // Resets all fields to their default values.
 - (void)clear;
@@ -166,10 +166,12 @@ CF_EXTERN_C_END
 // message.
 // NOTE: This will throw if there is an error parsing the data.
 - (void)mergeFromData:(NSData *)data
-    extensionRegistry:(GPBExtensionRegistry *)extensionRegistry;
+    extensionRegistry:(nullable GPBExtensionRegistry *)extensionRegistry;
 
 // Merges the fields from another message (of the same type) into this
 // message.
 - (void)mergeFrom:(GPBMessage *)other;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBRootObject.h
+++ b/objectivec/GPBRootObject.h
@@ -32,6 +32,8 @@
 
 @class GPBExtensionRegistry;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // All Root Objects derive from GPBRootObject. It supplies a registry
 // for derived classes to register their extensions to.
 @interface GPBRootObject : NSObject
@@ -40,3 +42,5 @@
 + (GPBExtensionRegistry *)extensionRegistry;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBRootObject.m
+++ b/objectivec/GPBRootObject.m
@@ -36,6 +36,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 
 #import "GPBDescriptor.h"
+#import "GPBExtensionRegistry.h"
 #import "GPBUtilities_PackagePrivate.h"
 
 @interface GPBExtensionDescriptor (GPBRootObject)
@@ -97,6 +98,7 @@ static CFHashCode GPBRootExtensionKeyHash(const void *value) {
 
 static OSSpinLock gExtensionSingletonDictionaryLock_ = OS_SPINLOCK_INIT;
 static CFMutableDictionaryRef gExtensionSingletonDictionary = NULL;
+static GPBExtensionRegistry *gDefaultExtensionRegistry = NULL;
 
 + (void)initialize {
   // Ensure the global is started up.
@@ -113,6 +115,7 @@ static CFMutableDictionaryRef gExtensionSingletonDictionary = NULL;
     gExtensionSingletonDictionary =
         CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &keyCallBacks,
                                   &kCFTypeDictionaryValueCallBacks);
+    gDefaultExtensionRegistry = [[GPBExtensionRegistry alloc] init];
   }
 
   if ([self superclass] == [GPBRootObject class]) {
@@ -126,7 +129,7 @@ static CFMutableDictionaryRef gExtensionSingletonDictionary = NULL;
 + (GPBExtensionRegistry *)extensionRegistry {
   // Is overridden in all the subclasses that provide extensions to provide the
   // per class one.
-  return nil;
+  return gDefaultExtensionRegistry;
 }
 
 + (void)globallyRegisterExtension:(GPBExtensionDescriptor *)field {

--- a/objectivec/GPBUnknownField.h
+++ b/objectivec/GPBUnknownField.h
@@ -35,6 +35,8 @@
 @class GPBUInt64Array;
 @class GPBUnknownFieldSet;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GPBUnknownField : NSObject<NSCopying>
 
 @property(nonatomic, readonly, assign) int32_t number;
@@ -54,3 +56,5 @@
 - (void)addGroup:(GPBUnknownFieldSet *)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBUnknownFieldSet.h
+++ b/objectivec/GPBUnknownFieldSet.h
@@ -32,10 +32,12 @@
 
 @class GPBUnknownField;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GPBUnknownFieldSet : NSObject<NSCopying>
 
 - (BOOL)hasField:(int32_t)number;
-- (GPBUnknownField *)getField:(int32_t)number;
+- (nullable GPBUnknownField *)getField:(int32_t)number;
 - (NSUInteger)countOfFields;
 
 - (void)addField:(GPBUnknownField *)field;
@@ -44,3 +46,5 @@
 - (NSArray *)sortedFields;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBUtilities.h
+++ b/objectivec/GPBUtilities.h
@@ -36,13 +36,16 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Generates a string that should be a valid "Text Format" for the C++ version
 // of Protocol Buffers. lineIndent can be nil if no additional line indent is
 // needed. The comments provide the names according to the ObjC library, they
 // most likely won't exactly match the original .proto file.
-NSString *GPBTextFormatForMessage(GPBMessage *message, NSString *lineIndent);
+NSString *GPBTextFormatForMessage(GPBMessage *message,
+                                  NSString * __nullable lineIndent);
 NSString *GPBTextFormatForUnknownFieldSet(GPBUnknownFieldSet *unknownSet,
-                                          NSString *lineIndent);
+                                          NSString * __nullable lineIndent);
 
 //
 // Test if the given field is set on a message.
@@ -127,6 +130,8 @@ void GPBSetMessageMapField(GPBMessage *self, GPBFieldDescriptor *field, id dicti
 // to assign them to empty. Prevents allocating a lot of little [NSData data]
 // objects.
 NSData *GPBEmptyNSData(void) __attribute__((pure));
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/GPBUtilities.m
+++ b/objectivec/GPBUtilities.m
@@ -1497,7 +1497,7 @@ static void AppendTextFormatForMessage(GPBMessage *message,
 }
 
 NSString *GPBTextFormatForMessage(GPBMessage *message, NSString *lineIndent) {
-  if (message == nil) return nil;
+  if (message == nil) return @"";
   if (lineIndent == nil) lineIndent = @"";
 
   NSMutableString *buildString = [NSMutableString string];
@@ -1507,7 +1507,7 @@ NSString *GPBTextFormatForMessage(GPBMessage *message, NSString *lineIndent) {
 
 NSString *GPBTextFormatForUnknownFieldSet(GPBUnknownFieldSet *unknownSet,
                                           NSString *lineIndent) {
-  if (unknownSet == nil) return nil;
+  if (unknownSet == nil) return @"";
   if (lineIndent == nil) lineIndent = @"";
 
   NSMutableString *result = [NSMutableString string];

--- a/objectivec/GPBWellKnownTypes.h
+++ b/objectivec/GPBWellKnownTypes.h
@@ -33,6 +33,8 @@
 #import "google/protobuf/Timestamp.pbobjc.h"
 #import "google/protobuf/Duration.pbobjc.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Extension to GPBTimestamp to work with standard Foundation time/date types.
 @interface GPBTimestamp (GBPWellKnownTypes)
 @property(nonatomic, readwrite, strong) NSDate *date;
@@ -46,3 +48,5 @@
 @property(nonatomic, readwrite) NSTimeInterval timeIntervalSince1970;
 - (instancetype)initWithTimeIntervalSince1970:(NSTimeInterval)timeIntervalSince1970;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/objectivec/GPBWireFormat.h
+++ b/objectivec/GPBWireFormat.h
@@ -32,6 +32,8 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef enum {
   GPBWireFormatVarint = 0,
   GPBWireFormatFixed64 = 1,
@@ -64,5 +66,7 @@ GPBWireFormat GPBWireFormatForType(GPBDataType dataType, BOOL isPacked)
 #define GPBWireFormatMessageSetMessageTag               \
   (GPBWireFormatMakeTag(GPBWireFormatMessageSetMessage, \
                         GPBWireFormatLengthDelimited))
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END

--- a/objectivec/Tests/GPBSwiftTests.swift
+++ b/objectivec/Tests/GPBSwiftTests.swift
@@ -446,7 +446,7 @@ class GPBBridgeTests: XCTestCase {
 
     let data = msg.data()
 
-    let msg2 = Message2(data: data, error:nil)
+    let msg2 = Message2(data: data!, error:nil)
     XCTAssertTrue(msg2 !== msg)  // New instance
     XCTAssertEqual(msg.optionalInt32, Int32(100))
     XCTAssertEqual(msg.optionalInt64, Int64(101))

--- a/objectivec/google/protobuf/Any.pbobjc.h
+++ b/objectivec/google/protobuf/Any.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBAnyRoot
 
@@ -88,12 +89,14 @@ typedef GPB_ENUM(GPBAny_FieldNumber) {
 // namespace should use `type.googleapis.com/full.type.name` (without
 // schema and path). A type service will eventually become available which
 // serves those URLs (projected Q2/15).
-@property(nonatomic, readwrite, copy) NSString *typeURL;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *typeURL;
 
 // Must be valid serialized data of the above specified type.
-@property(nonatomic, readwrite, copy) NSData *value;
+@property(nonatomic, readwrite, copy, null_resettable) NSData *value;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Api.pbobjc.h
+++ b/objectivec/google/protobuf/Api.pbobjc.h
@@ -13,6 +13,7 @@ CF_EXTERN_C_BEGIN
 
 @class GPBSourceContext;
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBApiRoot
 
@@ -40,16 +41,16 @@ typedef GPB_ENUM(GPBApi_FieldNumber) {
 
 // The fully qualified name of this api, including package name
 // followed by the api's simple name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // The methods of this api, in unspecified order.
 // |methodsArray| contains |GPBMethod|
-@property(nonatomic, readwrite, strong) NSMutableArray *methodsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *methodsArray;
 @property(nonatomic, readonly) NSUInteger methodsArray_Count;
 
 // Any metadata attached to the API.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 // A version string for this api. If specified, must have the form
@@ -74,12 +75,12 @@ typedef GPB_ENUM(GPBApi_FieldNumber) {
 // experimental, none-GA apis.
 //
 // See also: [design doc](http://go/api-versioning).
-@property(nonatomic, readwrite, copy) NSString *version;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *version;
 
 // Source context for the protocol buffer service represented by this
 // message.
 @property(nonatomic, readwrite) BOOL hasSourceContext;
-@property(nonatomic, readwrite, strong) GPBSourceContext *sourceContext;
+@property(nonatomic, readwrite, strong, null_resettable) GPBSourceContext *sourceContext;
 
 @end
 
@@ -98,26 +99,28 @@ typedef GPB_ENUM(GPBMethod_FieldNumber) {
 @interface GPBMethod : GPBMessage
 
 // The simple name of this method.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // A URL of the input message type.
-@property(nonatomic, readwrite, copy) NSString *requestTypeURL;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *requestTypeURL;
 
 // If true, the request is streamed.
 @property(nonatomic, readwrite) BOOL requestStreaming;
 
 // The URL of the output message type.
-@property(nonatomic, readwrite, copy) NSString *responseTypeURL;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *responseTypeURL;
 
 // If true, the response is streamed.
 @property(nonatomic, readwrite) BOOL responseStreaming;
 
 // Any metadata attached to the method.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Descriptor.pbobjc.h
+++ b/objectivec/google/protobuf/Descriptor.pbobjc.h
@@ -20,6 +20,8 @@ CF_EXTERN_C_BEGIN
 @class GPBServiceOptions;
 @class GPBSourceCodeInfo;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark - Enum GPBFieldDescriptorProto_Type
 
 typedef GPB_ENUM(GPBFieldDescriptorProto_Type) {
@@ -128,7 +130,6 @@ GPBEnumDescriptor *GPBFieldOptions_JSType_EnumDescriptor(void);
 
 BOOL GPBFieldOptions_JSType_IsValidValue(int32_t value);
 
-
 #pragma mark - GPBDescriptorRoot
 
 @interface GPBDescriptorRoot : GPBRootObject
@@ -151,7 +152,7 @@ typedef GPB_ENUM(GPBFileDescriptorSet_FieldNumber) {
 @interface GPBFileDescriptorSet : GPBMessage
 
 // |fileArray| contains |GPBFileDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *fileArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *fileArray;
 @property(nonatomic, readonly) NSUInteger fileArray_Count;
 
 @end
@@ -178,57 +179,57 @@ typedef GPB_ENUM(GPBFileDescriptorProto_FieldNumber) {
 
 // file name, relative to root of source tree
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // e.g. "foo", "foo.bar", etc.
 @property(nonatomic, readwrite) BOOL hasPackage;
-@property(nonatomic, readwrite, copy) NSString *package;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *package;
 
 // Names of files imported by this file.
 // |dependencyArray| contains |NSString|
-@property(nonatomic, readwrite, strong) NSMutableArray *dependencyArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *dependencyArray;
 @property(nonatomic, readonly) NSUInteger dependencyArray_Count;
 
 // Indexes of the public imported files in the dependency list above.
-@property(nonatomic, readwrite, strong) GPBInt32Array *publicDependencyArray;
+@property(nonatomic, readwrite, strong, null_resettable) GPBInt32Array *publicDependencyArray;
 @property(nonatomic, readonly) NSUInteger publicDependencyArray_Count;
 
 // Indexes of the weak imported files in the dependency list.
 // For Google-internal migration only. Do not use.
-@property(nonatomic, readwrite, strong) GPBInt32Array *weakDependencyArray;
+@property(nonatomic, readwrite, strong, null_resettable) GPBInt32Array *weakDependencyArray;
 @property(nonatomic, readonly) NSUInteger weakDependencyArray_Count;
 
 // All top-level definitions in this file.
 // |messageTypeArray| contains |GPBDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *messageTypeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *messageTypeArray;
 @property(nonatomic, readonly) NSUInteger messageTypeArray_Count;
 
 // |enumTypeArray| contains |GPBEnumDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *enumTypeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *enumTypeArray;
 @property(nonatomic, readonly) NSUInteger enumTypeArray_Count;
 
 // |serviceArray| contains |GPBServiceDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *serviceArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *serviceArray;
 @property(nonatomic, readonly) NSUInteger serviceArray_Count;
 
 // |extensionArray| contains |GPBFieldDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *extensionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *extensionArray;
 @property(nonatomic, readonly) NSUInteger extensionArray_Count;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBFileOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBFileOptions *options;
 
 // This field contains optional information about the original source code.
 // You may safely remove this entire field without harming runtime
 // functionality of the descriptors -- the information is needed only by
 // development tools.
 @property(nonatomic, readwrite) BOOL hasSourceCodeInfo;
-@property(nonatomic, readwrite, strong) GPBSourceCodeInfo *sourceCodeInfo;
+@property(nonatomic, readwrite, strong, null_resettable) GPBSourceCodeInfo *sourceCodeInfo;
 
 // The syntax of the proto file.
 // The supported values are "proto2" and "proto3".
 @property(nonatomic, readwrite) BOOL hasSyntax;
-@property(nonatomic, readwrite, copy) NSString *syntax;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *syntax;
 
 @end
 
@@ -251,43 +252,43 @@ typedef GPB_ENUM(GPBDescriptorProto_FieldNumber) {
 @interface GPBDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // |fieldArray| contains |GPBFieldDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *fieldArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *fieldArray;
 @property(nonatomic, readonly) NSUInteger fieldArray_Count;
 
 // |extensionArray| contains |GPBFieldDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *extensionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *extensionArray;
 @property(nonatomic, readonly) NSUInteger extensionArray_Count;
 
 // |nestedTypeArray| contains |GPBDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *nestedTypeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *nestedTypeArray;
 @property(nonatomic, readonly) NSUInteger nestedTypeArray_Count;
 
 // |enumTypeArray| contains |GPBEnumDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *enumTypeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *enumTypeArray;
 @property(nonatomic, readonly) NSUInteger enumTypeArray_Count;
 
 // |extensionRangeArray| contains |GPBDescriptorProto_ExtensionRange|
-@property(nonatomic, readwrite, strong) NSMutableArray *extensionRangeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *extensionRangeArray;
 @property(nonatomic, readonly) NSUInteger extensionRangeArray_Count;
 
 // |oneofDeclArray| contains |GPBOneofDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *oneofDeclArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *oneofDeclArray;
 @property(nonatomic, readonly) NSUInteger oneofDeclArray_Count;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBMessageOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBMessageOptions *options;
 
 // |reservedRangeArray| contains |GPBDescriptorProto_ReservedRange|
-@property(nonatomic, readwrite, strong) NSMutableArray *reservedRangeArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *reservedRangeArray;
 @property(nonatomic, readonly) NSUInteger reservedRangeArray_Count;
 
 // Reserved field names, which may not be used by fields in the same message.
 // A given name may only be reserved once.
 // |reservedNameArray| contains |NSString|
-@property(nonatomic, readwrite, strong) NSMutableArray *reservedNameArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *reservedNameArray;
 @property(nonatomic, readonly) NSUInteger reservedNameArray_Count;
 
 @end
@@ -349,7 +350,7 @@ typedef GPB_ENUM(GPBFieldDescriptorProto_FieldNumber) {
 @interface GPBFieldDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 @property(nonatomic, readwrite) BOOL hasNumber;
 @property(nonatomic, readwrite) int32_t number;
@@ -368,12 +369,12 @@ typedef GPB_ENUM(GPBFieldDescriptorProto_FieldNumber) {
 // message are searched, then within the parent, on up to the root
 // namespace).
 @property(nonatomic, readwrite) BOOL hasTypeName;
-@property(nonatomic, readwrite, copy) NSString *typeName;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *typeName;
 
 // For extensions, this is the name of the type being extended.  It is
 // resolved in the same manner as type_name.
 @property(nonatomic, readwrite) BOOL hasExtendee;
-@property(nonatomic, readwrite, copy) NSString *extendee;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *extendee;
 
 // For numeric types, contains the original text representation of the value.
 // For booleans, "true" or "false".
@@ -381,7 +382,7 @@ typedef GPB_ENUM(GPBFieldDescriptorProto_FieldNumber) {
 // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
 // TODO(kenton):  Base-64 encode?
 @property(nonatomic, readwrite) BOOL hasDefaultValue;
-@property(nonatomic, readwrite, copy) NSString *defaultValue;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *defaultValue;
 
 // If set, gives the index of a oneof in the containing type's oneof_decl
 // list.  This field is a member of that oneof.
@@ -389,7 +390,7 @@ typedef GPB_ENUM(GPBFieldDescriptorProto_FieldNumber) {
 @property(nonatomic, readwrite) int32_t oneofIndex;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBFieldOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBFieldOptions *options;
 
 @end
 
@@ -403,7 +404,7 @@ typedef GPB_ENUM(GPBOneofDescriptorProto_FieldNumber) {
 @interface GPBOneofDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 @end
 
@@ -419,14 +420,14 @@ typedef GPB_ENUM(GPBEnumDescriptorProto_FieldNumber) {
 @interface GPBEnumDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // |valueArray| contains |GPBEnumValueDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *valueArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *valueArray;
 @property(nonatomic, readonly) NSUInteger valueArray_Count;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBEnumOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBEnumOptions *options;
 
 @end
 
@@ -442,13 +443,13 @@ typedef GPB_ENUM(GPBEnumValueDescriptorProto_FieldNumber) {
 @interface GPBEnumValueDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 @property(nonatomic, readwrite) BOOL hasNumber;
 @property(nonatomic, readwrite) int32_t number;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBEnumValueOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBEnumValueOptions *options;
 
 @end
 
@@ -464,14 +465,14 @@ typedef GPB_ENUM(GPBServiceDescriptorProto_FieldNumber) {
 @interface GPBServiceDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // |methodArray| contains |GPBMethodDescriptorProto|
-@property(nonatomic, readwrite, strong) NSMutableArray *methodArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *methodArray;
 @property(nonatomic, readonly) NSUInteger methodArray_Count;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBServiceOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBServiceOptions *options;
 
 @end
 
@@ -490,18 +491,18 @@ typedef GPB_ENUM(GPBMethodDescriptorProto_FieldNumber) {
 @interface GPBMethodDescriptorProto : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasName;
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // Input and output type names.  These are resolved in the same way as
 // FieldDescriptorProto.type_name, but must refer to a message type.
 @property(nonatomic, readwrite) BOOL hasInputType;
-@property(nonatomic, readwrite, copy) NSString *inputType;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *inputType;
 
 @property(nonatomic, readwrite) BOOL hasOutputType;
-@property(nonatomic, readwrite, copy) NSString *outputType;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *outputType;
 
 @property(nonatomic, readwrite) BOOL hasOptions;
-@property(nonatomic, readwrite, strong) GPBMethodOptions *options;
+@property(nonatomic, readwrite, strong, null_resettable) GPBMethodOptions *options;
 
 // Identifies if client streams multiple client messages
 @property(nonatomic, readwrite) BOOL hasClientStreaming;
@@ -540,7 +541,7 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
 // inappropriate because proto packages do not normally start with backwards
 // domain names.
 @property(nonatomic, readwrite) BOOL hasJavaPackage;
-@property(nonatomic, readwrite, copy) NSString *javaPackage;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *javaPackage;
 
 // If set, all the classes from the .proto file are wrapped in a single
 // outer class with the given name.  This applies to both Proto1
@@ -548,7 +549,7 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
 // a .proto always translates to a single class, but you may want to
 // explicitly choose the class name).
 @property(nonatomic, readwrite) BOOL hasJavaOuterClassname;
-@property(nonatomic, readwrite, copy) NSString *javaOuterClassname;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *javaOuterClassname;
 
 // If set true, then the Java code generator will generate a separate .java
 // file for each top-level message, enum, and service defined in the .proto
@@ -590,7 +591,7 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
 //   - Otherwise, the package statement in the .proto file, if present.
 //   - Otherwise, the basename of the .proto file, without extension.
 @property(nonatomic, readwrite) BOOL hasGoPackage;
-@property(nonatomic, readwrite, copy) NSString *goPackage;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *goPackage;
 
 // Should generic services be generated in each language?  "Generic" services
 // are not specific to any particular RPC system.  They are generated by the
@@ -626,15 +627,15 @@ typedef GPB_ENUM(GPBFileOptions_FieldNumber) {
 // Sets the objective c class prefix which is prepended to all objective c
 // generated classes from this .proto. There is no default.
 @property(nonatomic, readwrite) BOOL hasObjcClassPrefix;
-@property(nonatomic, readwrite, copy) NSString *objcClassPrefix;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *objcClassPrefix;
 
 // Namespace for generated classes; defaults to the package.
 @property(nonatomic, readwrite) BOOL hasCsharpNamespace;
-@property(nonatomic, readwrite, copy) NSString *csharpNamespace;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *csharpNamespace;
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -711,7 +712,7 @@ typedef GPB_ENUM(GPBMessageOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -801,7 +802,7 @@ typedef GPB_ENUM(GPBFieldOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -830,7 +831,7 @@ typedef GPB_ENUM(GPBEnumOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -853,7 +854,7 @@ typedef GPB_ENUM(GPBEnumValueOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -876,7 +877,7 @@ typedef GPB_ENUM(GPBServiceOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -899,7 +900,7 @@ typedef GPB_ENUM(GPBMethodOptions_FieldNumber) {
 
 // The parser stores options it doesn't recognize here. See above.
 // |uninterpretedOptionArray| contains |GPBUninterpretedOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *uninterpretedOptionArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *uninterpretedOptionArray;
 @property(nonatomic, readonly) NSUInteger uninterpretedOptionArray_Count;
 
 @end
@@ -925,13 +926,13 @@ typedef GPB_ENUM(GPBUninterpretedOption_FieldNumber) {
 @interface GPBUninterpretedOption : GPBMessage
 
 // |nameArray| contains |GPBUninterpretedOption_NamePart|
-@property(nonatomic, readwrite, strong) NSMutableArray *nameArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *nameArray;
 @property(nonatomic, readonly) NSUInteger nameArray_Count;
 
 // The value of the uninterpreted option, in whatever type the tokenizer
 // identified it as during parsing. Exactly one of these should be set.
 @property(nonatomic, readwrite) BOOL hasIdentifierValue;
-@property(nonatomic, readwrite, copy) NSString *identifierValue;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *identifierValue;
 
 @property(nonatomic, readwrite) BOOL hasPositiveIntValue;
 @property(nonatomic, readwrite) uint64_t positiveIntValue;
@@ -943,10 +944,10 @@ typedef GPB_ENUM(GPBUninterpretedOption_FieldNumber) {
 @property(nonatomic, readwrite) double doubleValue;
 
 @property(nonatomic, readwrite) BOOL hasStringValue;
-@property(nonatomic, readwrite, copy) NSData *stringValue;
+@property(nonatomic, readwrite, copy, null_resettable) NSData *stringValue;
 
 @property(nonatomic, readwrite) BOOL hasAggregateValue;
-@property(nonatomic, readwrite, copy) NSString *aggregateValue;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *aggregateValue;
 
 @end
 
@@ -965,7 +966,7 @@ typedef GPB_ENUM(GPBUninterpretedOption_NamePart_FieldNumber) {
 @interface GPBUninterpretedOption_NamePart : GPBMessage
 
 @property(nonatomic, readwrite) BOOL hasNamePart;
-@property(nonatomic, readwrite, copy) NSString *namePart;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *namePart;
 
 @property(nonatomic, readwrite) BOOL hasIsExtension;
 @property(nonatomic, readwrite) BOOL isExtension;
@@ -1026,7 +1027,7 @@ typedef GPB_ENUM(GPBSourceCodeInfo_FieldNumber) {
 //   ignore those that it doesn't understand, as more types of locations could
 //   be recorded in the future.
 // |locationArray| contains |GPBSourceCodeInfo_Location|
-@property(nonatomic, readwrite, strong) NSMutableArray *locationArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *locationArray;
 @property(nonatomic, readonly) NSUInteger locationArray_Count;
 
 @end
@@ -1066,7 +1067,7 @@ typedef GPB_ENUM(GPBSourceCodeInfo_Location_FieldNumber) {
 //   [ 4, 3, 2, 7 ]
 // this path refers to the whole field declaration (from the beginning
 // of the label to the terminating semicolon).
-@property(nonatomic, readwrite, strong) GPBInt32Array *pathArray;
+@property(nonatomic, readwrite, strong, null_resettable) GPBInt32Array *pathArray;
 @property(nonatomic, readonly) NSUInteger pathArray_Count;
 
 // Always has exactly three or four elements: start line, start column,
@@ -1074,7 +1075,7 @@ typedef GPB_ENUM(GPBSourceCodeInfo_Location_FieldNumber) {
 // These are packed into a single field for efficiency.  Note that line
 // and column numbers are zero-based -- typically you will want to add
 // 1 to each before displaying to a user.
-@property(nonatomic, readwrite, strong) GPBInt32Array *spanArray;
+@property(nonatomic, readwrite, strong, null_resettable) GPBInt32Array *spanArray;
 @property(nonatomic, readonly) NSUInteger spanArray_Count;
 
 // If this SourceCodeInfo represents a complete declaration, these are any
@@ -1125,16 +1126,18 @@ typedef GPB_ENUM(GPBSourceCodeInfo_Location_FieldNumber) {
 //
 //   // ignored detached comments.
 @property(nonatomic, readwrite) BOOL hasLeadingComments;
-@property(nonatomic, readwrite, copy) NSString *leadingComments;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *leadingComments;
 
 @property(nonatomic, readwrite) BOOL hasTrailingComments;
-@property(nonatomic, readwrite, copy) NSString *trailingComments;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *trailingComments;
 
 // |leadingDetachedCommentsArray| contains |NSString|
-@property(nonatomic, readwrite, strong) NSMutableArray *leadingDetachedCommentsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *leadingDetachedCommentsArray;
 @property(nonatomic, readonly) NSUInteger leadingDetachedCommentsArray_Count;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Duration.pbobjc.h
+++ b/objectivec/google/protobuf/Duration.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBDurationRoot
 
@@ -85,6 +86,8 @@ typedef GPB_ENUM(GPBDuration_FieldNumber) {
 @property(nonatomic, readwrite) int32_t nanos;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Empty.pbobjc.h
+++ b/objectivec/google/protobuf/Empty.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBEmptyRoot
 
@@ -35,6 +36,8 @@ CF_EXTERN_C_BEGIN
 @interface GPBEmpty : GPBMessage
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/FieldMask.pbobjc.h
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBFieldMaskRoot
 
@@ -151,10 +152,12 @@ typedef GPB_ENUM(GPBFieldMask_FieldNumber) {
 
 // The set of field mask paths.
 // |pathsArray| contains |NSString|
-@property(nonatomic, readwrite, strong) NSMutableArray *pathsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *pathsArray;
 @property(nonatomic, readonly) NSUInteger pathsArray_Count;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/SourceContext.pbobjc.h
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBSourceContextRoot
 
@@ -35,9 +36,11 @@ typedef GPB_ENUM(GPBSourceContext_FieldNumber) {
 
 // The path-qualified name of the .proto file that contained the associated
 // protobuf element.  For example: `"google/protobuf/source.proto"`.
-@property(nonatomic, readwrite, copy) NSString *fileName;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *fileName;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Struct.pbobjc.h
+++ b/objectivec/google/protobuf/Struct.pbobjc.h
@@ -14,6 +14,8 @@ CF_EXTERN_C_BEGIN
 @class GPBListValue;
 @class GPBStruct;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark - Enum GPBNullValue
 
 // `NullValue` is a singleton enumeration to represent the null
@@ -27,7 +29,6 @@ typedef GPB_ENUM(GPBNullValue) {
 GPBEnumDescriptor *GPBNullValue_EnumDescriptor(void);
 
 BOOL GPBNullValue_IsValidValue(int32_t value);
-
 
 #pragma mark - GPBStructRoot
 
@@ -56,7 +57,7 @@ typedef GPB_ENUM(GPBStruct_FieldNumber) {
 
 // Map of dynamically typed values.
 // |fields| values are |GPBValue|
-@property(nonatomic, readwrite, strong) NSMutableDictionary *fields;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableDictionary *fields;
 @property(nonatomic, readonly) NSUInteger fields_Count;
 
 @end
@@ -97,16 +98,16 @@ typedef GPB_ENUM(GPBValue_Kind_OneOfCase) {
 @property(nonatomic, readwrite) double numberValue;
 
 // Represents a string value.
-@property(nonatomic, readwrite, copy) NSString *stringValue;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *stringValue;
 
 // Represents a boolean value.
 @property(nonatomic, readwrite) BOOL boolValue;
 
 // Represents a structured value.
-@property(nonatomic, readwrite, strong) GPBStruct *structValue;
+@property(nonatomic, readwrite, strong, null_resettable) GPBStruct *structValue;
 
 // Represents a repeated `Value`.
-@property(nonatomic, readwrite, strong) GPBListValue *listValue;
+@property(nonatomic, readwrite, strong, null_resettable) GPBListValue *listValue;
 
 @end
 
@@ -126,10 +127,12 @@ typedef GPB_ENUM(GPBListValue_FieldNumber) {
 
 // Repeated field of dynamically typed values.
 // |valuesArray| contains |GPBValue|
-@property(nonatomic, readwrite, strong) NSMutableArray *valuesArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *valuesArray;
 @property(nonatomic, readonly) NSUInteger valuesArray_Count;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Timestamp.pbobjc.h
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBTimestampRoot
 
@@ -96,6 +97,8 @@ typedef GPB_ENUM(GPBTimestamp_FieldNumber) {
 @property(nonatomic, readwrite) int32_t nanos;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Type.pbobjc.h
+++ b/objectivec/google/protobuf/Type.pbobjc.h
@@ -14,6 +14,8 @@ CF_EXTERN_C_BEGIN
 @class GPBAny;
 @class GPBSourceContext;
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark - Enum GPBField_Kind
 
 // Kind represents a basic field type.
@@ -101,7 +103,6 @@ GPBEnumDescriptor *GPBField_Cardinality_EnumDescriptor(void);
 
 BOOL GPBField_Cardinality_IsValidValue(int32_t value);
 
-
 #pragma mark - GPBTypeRoot
 
 @interface GPBTypeRoot : GPBRootObject
@@ -127,27 +128,27 @@ typedef GPB_ENUM(GPBType_FieldNumber) {
 @interface GPBType : GPBMessage
 
 // The fully qualified message name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // The list of fields.
 // |fieldsArray| contains |GPBField|
-@property(nonatomic, readwrite, strong) NSMutableArray *fieldsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *fieldsArray;
 @property(nonatomic, readonly) NSUInteger fieldsArray_Count;
 
 // The list of oneof definitions.
 // The list of oneofs declared in this Type
 // |oneofsArray| contains |NSString|
-@property(nonatomic, readwrite, strong) NSMutableArray *oneofsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *oneofsArray;
 @property(nonatomic, readonly) NSUInteger oneofsArray_Count;
 
 // The proto options.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 // The source context.
 @property(nonatomic, readwrite) BOOL hasSourceContext;
-@property(nonatomic, readwrite, strong) GPBSourceContext *sourceContext;
+@property(nonatomic, readwrite, strong, null_resettable) GPBSourceContext *sourceContext;
 
 @end
 
@@ -177,11 +178,11 @@ typedef GPB_ENUM(GPBField_FieldNumber) {
 @property(nonatomic, readwrite) int32_t number;
 
 // The field name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // The type URL (without the scheme) when the type is MESSAGE or ENUM,
 // such as `type.googleapis.com/google.protobuf.Empty`.
-@property(nonatomic, readwrite, copy) NSString *typeURL;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *typeURL;
 
 // Index in Type.oneofs. Starts at 1. Zero means no oneof mapping.
 @property(nonatomic, readwrite) int32_t oneofIndex;
@@ -191,7 +192,7 @@ typedef GPB_ENUM(GPBField_FieldNumber) {
 
 // The proto options.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 @end
@@ -215,21 +216,21 @@ typedef GPB_ENUM(GPBEnum_FieldNumber) {
 @interface GPBEnum : GPBMessage
 
 // Enum type name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // Enum value definitions.
 // |enumvalueArray| contains |GPBEnumValue|
-@property(nonatomic, readwrite, strong) NSMutableArray *enumvalueArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *enumvalueArray;
 @property(nonatomic, readonly) NSUInteger enumvalueArray_Count;
 
 // Proto options for the enum type.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 // The source context.
 @property(nonatomic, readwrite) BOOL hasSourceContext;
-@property(nonatomic, readwrite, strong) GPBSourceContext *sourceContext;
+@property(nonatomic, readwrite, strong, null_resettable) GPBSourceContext *sourceContext;
 
 @end
 
@@ -245,14 +246,14 @@ typedef GPB_ENUM(GPBEnumValue_FieldNumber) {
 @interface GPBEnumValue : GPBMessage
 
 // Enum value name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // Enum value number.
 @property(nonatomic, readwrite) int32_t number;
 
 // Proto options for the enum value.
 // |optionsArray| contains |GPBOption|
-@property(nonatomic, readwrite, strong) NSMutableArray *optionsArray;
+@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray *optionsArray;
 @property(nonatomic, readonly) NSUInteger optionsArray_Count;
 
 @end
@@ -268,13 +269,15 @@ typedef GPB_ENUM(GPBOption_FieldNumber) {
 @interface GPBOption : GPBMessage
 
 // Proto option name.
-@property(nonatomic, readwrite, copy) NSString *name;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
 
 // Proto option value.
 @property(nonatomic, readwrite) BOOL hasValue;
-@property(nonatomic, readwrite, strong) GPBAny *value;
+@property(nonatomic, readwrite, strong, null_resettable) GPBAny *value;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/objectivec/google/protobuf/Wrappers.pbobjc.h
+++ b/objectivec/google/protobuf/Wrappers.pbobjc.h
@@ -11,6 +11,7 @@
 
 CF_EXTERN_C_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - GPBWrappersRoot
 
@@ -131,7 +132,7 @@ typedef GPB_ENUM(GPBStringValue_FieldNumber) {
 @interface GPBStringValue : GPBMessage
 
 // The string value.
-@property(nonatomic, readwrite, copy) NSString *value;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *value;
 
 @end
 
@@ -145,9 +146,11 @@ typedef GPB_ENUM(GPBBytesValue_FieldNumber) {
 @interface GPBBytesValue : GPBMessage
 
 // The bytes value.
-@property(nonatomic, readwrite, copy) NSData *value;
+@property(nonatomic, readwrite, copy, null_resettable) NSData *value;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 CF_EXTERN_C_END
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -331,7 +331,7 @@ void ObjCObjFieldGenerator::GeneratePropertyDeclaration(
   }
   printer->Print(
       variables_,
-      "@property(nonatomic, readwrite, $property_storage_attribute$) $property_type$ *$name$$storage_attribute$;\n");
+      "@property(nonatomic, readwrite, $property_storage_attribute$, null_resettable) $property_type$ *$name$$storage_attribute$;\n");
   if (IsInitName(variables_.find("name")->second)) {
     // If property name starts with init we need to annotate it to get past ARC.
     // http://stackoverflow.com/questions/18723226/how-do-i-annotate-an-objective-c-property-with-an-objc-method-family/18723227#18723227
@@ -379,7 +379,7 @@ void RepeatedFieldGenerator::GeneratePropertyDeclaration(
       variables_,
       "$comments$"
       "$array_comment$"
-      "@property(nonatomic, readwrite, strong) $array_storage_type$ *$name$$storage_attribute$;\n"
+      "@property(nonatomic, readwrite, strong, null_resettable) $array_storage_type$ *$name$$storage_attribute$;\n"
       "@property(nonatomic, readonly) NSUInteger $name$_Count;\n");
   if (IsInitName(variables_.find("name")->second)) {
     // If property name starts with init we need to annotate it to get past ARC.

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -117,9 +117,9 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
 
   printer->Print(
       "// @@protoc_insertion_point(imports)\n"
+      "\n"
+      "CF_EXTERN_C_BEGIN\n"
       "\n");
-
-  printer->Print("CF_EXTERN_C_BEGIN\n\n");
 
   set<string> fwd_decls;
   for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
@@ -133,6 +133,10 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
   if (fwd_decls.begin() != fwd_decls.end()) {
     printer->Print("\n");
   }
+
+  printer->Print(
+      "NS_ASSUME_NONNULL_BEGIN\n"
+      "\n");
 
   // need to write out all enums first
   for (vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
@@ -148,7 +152,6 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
   // For extensions to chain together, the Root gets created even if there
   // are no extensions.
   printer->Print(
-      "\n"
       "#pragma mark - $root_class_name$\n"
       "\n"
       "@interface $root_class_name$ : GPBRootObject\n"
@@ -182,11 +185,12 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
     (*iter)->GenerateMessageHeader(printer);
   }
 
-  printer->Print("CF_EXTERN_C_END\n");
-
   printer->Print(
-    "\n"
-    "// @@protoc_insertion_point(global_scope)\n");
+      "NS_ASSUME_NONNULL_END\n"
+      "\n"
+      "CF_EXTERN_C_END\n"
+      "\n"
+      "// @@protoc_insertion_point(global_scope)\n");
 }
 
 void FileGenerator::GenerateSource(io::Printer *printer) {


### PR DESCRIPTION
Add the clang annotations to the objc library and generated code to help with Swift bridging and compiler checks.