### PR TITLE
fix compiler warnings.

### DIFF
--- a/src/google/protobuf/util/field_comparator.cc
+++ b/src/google/protobuf/util/field_comparator.cc
@@ -106,6 +106,7 @@ FieldComparator::ComparisonResult DefaultFieldComparator::Compare(
     default:
       GOOGLE_LOG(FATAL) << "No comparison code for field " << field->full_name()
                  << " of CppType = " << field->cpp_type();
+      return DIFFERENT;
   }
 }
 

--- a/src/google/protobuf/util/internal/type_info_test_helper.cc
+++ b/src/google/protobuf/util/internal/type_info_test_helper.cc
@@ -97,6 +97,7 @@ ProtoStreamObjectSource* TypeInfoTestHelper::NewProtoSource(
     }
   }
   GOOGLE_LOG(FATAL) << "Can not reach here.";
+  return NULL;
 }
 
 ProtoStreamObjectWriter* TypeInfoTestHelper::NewProtoWriter(
@@ -110,6 +111,7 @@ ProtoStreamObjectWriter* TypeInfoTestHelper::NewProtoWriter(
     }
   }
   GOOGLE_LOG(FATAL) << "Can not reach here.";
+  return NULL;
 }
 
 DefaultValueObjectWriter* TypeInfoTestHelper::NewDefaultValueWriter(
@@ -121,6 +123,7 @@ DefaultValueObjectWriter* TypeInfoTestHelper::NewDefaultValueWriter(
     }
   }
   GOOGLE_LOG(FATAL) << "Can not reach here.";
+  return NULL;
 }
 
 }  // namespace testing

--- a/src/google/protobuf/util/message_differencer.h
+++ b/src/google/protobuf/util/message_differencer.h
@@ -289,20 +289,11 @@ class LIBPROTOBUF_EXPORT MessageDifferencer {
     MapKeyComparator();
     virtual ~MapKeyComparator();
 
-    // The first IsMatch without parent_fields is only for backward
-    // compatibility. New users should override the second one instead.
-    //
-    // Deprecated.
-    // TODO(ykzhu): remove this function.
-    virtual bool IsMatch(const Message& message1,
-                         const Message& message2) const {
-      GOOGLE_CHECK(false) << "This function shouldn't get called";
-      return false;
-    }
     virtual bool IsMatch(const Message& message1,
                          const Message& message2,
                          const vector<SpecificField>& parent_fields) const {
-      return IsMatch(message1, message2);
+      GOOGLE_CHECK(false) << "IsMatch() is not implemented.";
+      return false;
     }
 
    private:


### PR DESCRIPTION
- control reaches end of non-void function.
- remove a deprecated IsMatch, which causes overloaded-virtual warning. This shouldn't be released anyway.