### PR TITLE
JavaNano: improved encoding performance

### DIFF
--- a/javanano/src/main/java/com/google/protobuf/nano/CodedOutputByteBufferNano.java
+++ b/javanano/src/main/java/com/google/protobuf/nano/CodedOutputByteBufferNano.java
@@ -31,10 +31,6 @@
 package com.google.protobuf.nano;
 
 import java.io.IOException;
-import java.nio.BufferOverflowException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.ReadOnlyBufferException;
 
 /**
  * Encodes and writes protocol message fields.


### PR DESCRIPTION
Pull request for fixing #511 

I've modified writeStringNoTag to work on byte[] and reverted writeRawLittleEndian32 to what it used to be. Note that I've left all the behavior the same as before, but I believe that the position() getter is a bit odd.
