### PR TITLE
Add Bazel target for the Objective-C protobuf runtime

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,10 @@
 
 licenses(["notice"])
 
+################################################################################
+# Protobuf Runtime Library
+################################################################################
+
 COPTS = [
     "-DHAVE_PTHREAD",
     "-Wall",
@@ -109,6 +113,34 @@ cc_library(
     deps = [":protobuf_lite"],
 )
 
+objc_library(
+    name = "protobuf_objc",
+    hdrs = ["objectivec/GPBProtocolBuffers.h"],
+    includes = ["objectivec"],
+    non_arc_srcs = ["objectivec/GPBProtocolBuffers.m"],
+    visibility = ["//visibility:public"],
+)
+
+WELL_KNOWN_PROTOS = [
+    # AUTOGEN(well_known_protos)
+    "google/protobuf/any.proto",
+    "google/protobuf/api.proto",
+    "google/protobuf/compiler/plugin.proto",
+    "google/protobuf/descriptor.proto",
+    "google/protobuf/duration.proto",
+    "google/protobuf/empty.proto",
+    "google/protobuf/field_mask.proto",
+    "google/protobuf/source_context.proto",
+    "google/protobuf/struct.proto",
+    "google/protobuf/timestamp.proto",
+    "google/protobuf/type.proto",
+    "google/protobuf/wrappers.proto",
+]
+
+################################################################################
+# Protocol Buffers Compiler
+################################################################################
+
 cc_library(
     name = "protoc_lib",
     srcs = [
@@ -215,22 +247,6 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [":protoc_lib"],
 )
-
-WELL_KNOWN_PROTOS = [
-    # AUTOGEN(well_known_protos)
-    "google/protobuf/any.proto",
-    "google/protobuf/api.proto",
-    "google/protobuf/compiler/plugin.proto",
-    "google/protobuf/descriptor.proto",
-    "google/protobuf/duration.proto",
-    "google/protobuf/empty.proto",
-    "google/protobuf/field_mask.proto",
-    "google/protobuf/source_context.proto",
-    "google/protobuf/struct.proto",
-    "google/protobuf/timestamp.proto",
-    "google/protobuf/type.proto",
-    "google/protobuf/wrappers.proto",
-]
 
 ################################################################################
 # Tests
@@ -403,3 +419,4 @@ cc_test(
         "//external:gtest_main",
     ],
 )
+

--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -11,25 +11,11 @@ Pod::Spec.new do |s|
   s.license  = 'New BSD'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
-  s.source_files = 'objectivec/*.{h,m}',
-                   'objectivec/google/protobuf/Any.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/Api.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/Descriptor.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/Duration.pbobjc.h',
-                   'objectivec/google/protobuf/Empty.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/FieldMask.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/SourceContext.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/Struct.pbobjc.{h,m}',
-                   'objectivec/google/protobuf/Timestamp.pbobjc.h',
-                   'objectivec/google/protobuf/Type.pbobjc.{h,m}'
-                   'objectivec/google/protobuf/Wrappers.pbobjc.{h,m}'
-  # Timestamp.pbobjc.m and Duration.pbobjc.m are #imported by GPBWellKnownTypes.m. So we can't
-  # compile them (duplicate symbols), but we need them available for the importing:
-  s.preserve_paths = 'objectivec/google/protobuf/Duration.pbobjc.m',
-                     'objectivec/google/protobuf/Timestamp.pbobjc.m'
-  # The following would cause duplicate symbol definitions. GPBProtocolBuffers is expected to be
-  # left out, as it's an umbrella implementation file.
-  s.exclude_files = 'objectivec/GPBProtocolBuffers.m'
+  s.source_files = 'objectivec/GPBProtocolBuffers.{h,m}'
+  # GPBProtocolBuffers.{h,m} are umbrella files. We need Cocoapods to preserve the files imported by
+  # them.
+  s.preserve_paths = 'objectivec/*.{h,m}',
+                     'objectivec/google/protobuf/*.pbobjc.{h,m}'
   s.header_mappings_dir = 'objectivec'
 
   s.ios.deployment_target = '6.0'

--- a/objectivec/GPBProtocolBuffers.h
+++ b/objectivec/GPBProtocolBuffers.h
@@ -42,3 +42,15 @@
 #import "GPBUnknownFieldSet.h"
 #import "GPBUtilities.h"
 #import "GPBWireFormat.h"
+
+// Well-known proto types
+#import "google/protobuf/Any.pbobjc.h"
+#import "google/protobuf/Api.pbobjc.h"
+#import "google/protobuf/Duration.pbobjc.h"
+#import "google/protobuf/Empty.pbobjc.h"
+#import "google/protobuf/FieldMask.pbobjc.h"
+#import "google/protobuf/SourceContext.pbobjc.h"
+#import "google/protobuf/Struct.pbobjc.h"
+#import "google/protobuf/Timestamp.pbobjc.h"
+#import "google/protobuf/Type.pbobjc.h"
+#import "google/protobuf/Wrappers.pbobjc.h"


### PR DESCRIPTION
Also add WKT headers to the umbrella file, and simplify Podspec with it.
Plus some layout improvements to the BUILD file.

This is a dependency of the Bazel target for the ObjC gRPC runtime.

Part of https://github.com/grpc/grpc/issues/2120