### PR TITLE
Fix "sometimes-uninitialized" warning on Windows Clang.

### DIFF
--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -171,7 +171,7 @@ bool Subprocess::Communicate(const Message& input, Message* output,
     DWORD wait_result =
         WaitForMultipleObjects(handle_count, handles, FALSE, INFINITE);
 
-    HANDLE signaled_handle;
+    HANDLE signaled_handle = NULL;
     if (wait_result >= WAIT_OBJECT_0 &&
         wait_result < WAIT_OBJECT_0 + handle_count) {
       signaled_handle = handles[wait_result - WAIT_OBJECT_0];


### PR DESCRIPTION
The warning appears in Windows-specific code. (Apparently, Clang is not smart enough to realise that `GOOGLE_LOG(FATAL)` terminates execution.)

This came up trying to build Chromium on Windows with Clang (see http://crbug.com/505307).