### PR TITLE
Install missing headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,6 +71,7 @@ nobase_include_HEADERS =                                        \
   google/protobuf/stubs/atomicops_internals_tsan.h              \
   google/protobuf/stubs/atomicops_internals_x86_gcc.h           \
   google/protobuf/stubs/atomicops_internals_x86_msvc.h          \
+  google/protobuf/stubs/bytestream.h                            \
   google/protobuf/stubs/casts.h                                 \
   google/protobuf/stubs/common.h                                \
   google/protobuf/stubs/fastmem.h                               \
@@ -79,7 +80,9 @@ nobase_include_HEADERS =                                        \
   google/protobuf/stubs/platform_macros.h                       \
   google/protobuf/stubs/shared_ptr.h                            \
   google/protobuf/stubs/singleton.h                             \
+  google/protobuf/stubs/status.h                                \
   google/protobuf/stubs/stl_util.h                              \
+  google/protobuf/stubs/stringpiece.h                           \
   google/protobuf/stubs/template_util.h                         \
   google/protobuf/stubs/type_traits.h                           \
   google/protobuf/any.pb.h                                      \


### PR DESCRIPTION
Install google/protobuf/stubs/status.h, and google/protobuf/stubs/stringpiece.h -- these are required in order to include google/protobuf/util/type_resolver.h.

Install google/protobuf/stubs/bytestream.h -- this is required in order to include google/protobuf/util/json_util.h.