### PR TITLE
fix RepeatedFieldTest.Enumerator test

### DIFF
--- a/csharp/src/ProtocolBuffers.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/Collections/RepeatedFieldTest.cs
@@ -239,21 +239,19 @@ namespace Google.Protobuf.Collections
         public void Enumerator()
         {
             var list = new RepeatedField<string> { "first", "second" };
-            using (var enumerator = list.GetEnumerator())
-            {
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
-                Assert.IsTrue(enumerator.MoveNext());
-                Assert.AreEqual("first", enumerator.Current);
-                Assert.IsTrue(enumerator.MoveNext());
-                Assert.AreEqual("second", enumerator.Current);
-                Assert.IsFalse(enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
-                Assert.IsFalse(enumerator.MoveNext());
-                enumerator.Reset();
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
-                Assert.IsTrue(enumerator.MoveNext());
-                Assert.AreEqual("first", enumerator.Current);
-            }
+            var enumerator = list.GetEnumerator();
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual("first", enumerator.Current);
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual("second", enumerator.Current);
+            Assert.IsFalse(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
+            Assert.IsFalse(enumerator.MoveNext());
+            enumerator.Reset();
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
+            Assert.IsTrue(enumerator.MoveNext());
+            Assert.AreEqual("first", enumerator.Current);
         }
 
         [Test]


### PR DESCRIPTION
on my Windows machine RepeatedFieldTest.Enumerator is failing with error:

```
Test FullName:	Google.Protobuf.Collections.RepeatedFieldTest.Enumerator
Test Source:	c:\Users\jtattermusch\github\protobuf\csharp\src\ProtocolBuffers.Test\Collections\RepeatedFieldTest.cs : line 240
Result Message:	System.InvalidOperationException : Operation is not valid due to the current state of the object.
Result StackTrace:	
at Google.Protobuf.Collections.RepeatedField`1.Enumerator.get_Current() in c:\Users\jtattermusch\github\protobuf\csharp\src\ProtocolBuffers\Collections\RepeatedField.cs:line 506
at Google.Protobuf.Collections.RepeatedFieldTest.Enumerator() in c:\Users\jtattermusch\github\protobuf\csharp\src\ProtocolBuffers.Test\Collections\RepeatedFieldTest.cs:line 246
```

it looks like all changes to the enumerator variable in that test are immediately forgotten.
I eventually found the cause, which seems to be:
http://stackoverflow.com/questions/4642665/why-does-capturing-a-mutable-struct-variable-inside-a-closure-within-a-using-sta
and this bug report
https://connect.microsoft.com/VisualStudio/feedback/details/635745

Just removing the using block fixes the problem (as well are removing the lambda would), but it makes me wondering if we actually want RepeatedField.Enumerator to be a struct. Exposing enumerator struct makes as susceptible to subtle issues like these:
https://www.simple-talk.com/blogs/2010/05/19/why-enumerator-structs-are-a-really-bad-idea/
https://www.simple-talk.com/blogs/2010/05/20/why-enumerator-structs-are-a-really-bad-idea-redux/

(I think with Reset() method we are actually fine, because we don't implement IEnumerator<T>.Reset() explicitly, unlike System.Collections.Generic.List<T>, but I am wondering how much of a performance gain the struct-based enumerator actually is.

Switching the enumerator to private class might save us some headache in the future (MapField already has an enumerator class).