### PR TITLE
Run C# tests on Appveyor

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -1,0 +1,29 @@
+setlocal
+
+IF %language%==cpp GOTO build_cpp
+IF %language%==csharp GOTO build_csharp
+
+echo Unsupported language %language%. Exiting.
+goto :error
+
+:build_cpp
+echo Building C++
+mkdir build_msvc
+cd build_msvc
+cmake -G "%generator%" -DBUILD_SHARED_LIBS=%BUILD_DLL% ../cmake
+msbuild protobuf.sln /p:Platform=%vcplatform% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || goto error
+cd %configuration%
+tests.exe || goto error
+goto :EOF
+
+:build_csharp
+echo Building C#
+cd csharp\src
+nuget restore
+msbuild ProtocolBuffers.sln /p:Platform="Any CPU" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || goto error
+nunit-console ProtocolBuffers.Test\bin\%configuration%\Google.Protobuf.Test.dll || goto error
+goto :EOF
+
+:error
+echo Failed!
+EXIT /b %ERRORLEVEL%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,10 @@ configuration:
 
 environment:
   matrix:
-    - BUILD_DLL: ON
+    - language: cpp
+      BUILD_DLL: ON
+
+    - language: csharp
 
 install:
   - ps: Start-FileDownload https://googlemock.googlecode.com/files/gmock-1.7.0.zip
@@ -23,12 +26,7 @@ before_build:
   - if %platform%==Win64 set vcplatform=x64
 
 build_script:
-  - mkdir build_msvc
-  - cd build_msvc
-  - cmake -G "%generator%" -DBUILD_SHARED_LIBS=%BUILD_DLL% ../cmake
-  - msbuild protobuf.sln /p:Platform=%vcplatform% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - cd %configuration%
-  - tests.exe
+  - CALL appveyor.bat
 
 skip_commits:
   message: /.*\[skip appveyor\].*/


### PR DESCRIPTION
Adds C# to appveyor. C# builds much faster than C++, so this shouldn't have negative impact on appveyor throughput.

To be merged after PR #606 is in.

Test Google.Protobuf.Collections.RepeatedFieldTest.Enumerator fails on appveyor, but I suspect this is because of the issue that is addressed by #603.

Fixes #537.