### PR TITLE
Remove the struct-based iterator for RepeatedField.

### DIFF
--- a/csharp/src/ProtocolBuffers.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/ProtocolBuffers.Test/Collections/RepeatedFieldTest.cs
@@ -241,18 +241,12 @@ namespace Google.Protobuf.Collections
             var list = new RepeatedField<string> { "first", "second" };
             using (var enumerator = list.GetEnumerator())
             {
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
                 Assert.IsTrue(enumerator.MoveNext());
                 Assert.AreEqual("first", enumerator.Current);
                 Assert.IsTrue(enumerator.MoveNext());
                 Assert.AreEqual("second", enumerator.Current);
                 Assert.IsFalse(enumerator.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
                 Assert.IsFalse(enumerator.MoveNext());
-                enumerator.Reset();
-                Assert.Throws<InvalidOperationException>(() => enumerator.Current.GetHashCode());
-                Assert.IsTrue(enumerator.MoveNext());
-                Assert.AreEqual("first", enumerator.Current);
             }
         }
 

--- a/csharp/src/ProtocolBuffers/Collections/RepeatedField.cs
+++ b/csharp/src/ProtocolBuffers/Collections/RepeatedField.cs
@@ -288,14 +288,12 @@ namespace Google.Protobuf.Collections
             }
         }
 
-        public RepeatedField<T>.Enumerator GetEnumerator()
+        public IEnumerator<T> GetEnumerator()
         {
-            return new Enumerator(this);
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return GetEnumerator();
+            for (int i = 0; i < count; i++)
+            {
+                yield return array[i];
+            }
         }
 
         public override bool Equals(object obj)
@@ -467,55 +465,6 @@ namespace Google.Protobuf.Collections
             }
             Remove((T)value);
         }
-        #endregion
-
-        public struct Enumerator : IEnumerator<T>
-        {
-            private int index;
-            private readonly RepeatedField<T> field;
-
-            public Enumerator(RepeatedField<T> field)
-            {
-                this.field = field;
-                this.index = -1;
-            }
-
-            public bool MoveNext()
-            {
-                if (index + 1 >= field.Count)
-                {
-                    index = field.Count;
-                    return false;
-                }
-                index++;
-                return true;
-            }
-
-            public void Reset()
-            {
-                index = -1;
-            }
-
-            public T Current
-            {
-                get
-                {
-                    if (index == -1 || index >= field.count)
-                    {
-                        throw new InvalidOperationException();
-                    }
-                    return field.array[index];
-                }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return Current; }
-            }
-
-            public void Dispose()
-            {
-            }
-        }
+        #endregion        
     }
 }


### PR DESCRIPTION
We don't use it in the runtime or generated code anywhere now, so the extra small performance boost isn't as critical, and it has some undesirable consequences.

The tests have needed to change as iterator block enumerators don't throw when we might expect them to.

Will merge this as soon as it's been through CI, as this is one of the approaches @jtattermusch and I have already discussed.