### PR TITLE
Let GOOGLE_COMPILE_ASSERT use static_assert if available.

### DIFF
--- a/src/google/protobuf/stubs/macros.h
+++ b/src/google/protobuf/stubs/macros.h
@@ -113,12 +113,13 @@ struct CompileAssert {
 }  // namespace internal
 
 #undef GOOGLE_COMPILE_ASSERT
+#if __cplusplus >= 201103L
+#define GOOGLE_COMPILE_ASSERT(expr, msg) static_assert(expr, #msg)
+#else
 #define GOOGLE_COMPILE_ASSERT(expr, msg) \
   ::google::protobuf::internal::CompileAssert<(bool(expr))> \
           msg[bool(expr) ? 1 : -1]; \
   (void)msg
-
-
 // Implementation details of COMPILE_ASSERT:
 //
 // - COMPILE_ASSERT works by defining an array type that has -1
@@ -159,6 +160,7 @@ struct CompileAssert {
 //
 //   This is to avoid running into a bug in MS VC 7.1, which
 //   causes ((0.0) ? 1 : -1) to incorrectly evaluate to 1.
+#endif  // __cplusplus >= 201103L
 
 }  // namespace protobuf
 }  // namespace google


### PR DESCRIPTION
The motivation is that gcc 4.8+ and clang trunk warn on unused local
typedefs, which COMPILE_ASSERT adds. After this change, the warning
will be happy at least in C++11 builds. static_assert also produces a
slighly nicer diagnostic than the typedef method.

https://github.com/google/re2/commit/eb93e8bc43ac8d05322fb3e9fc885898ad924f8a
did the same change in re2.