### PR TITLE
Update addressbook.proto and examples code to proto3

### DIFF
--- a/examples/AddPerson.java
+++ b/examples/AddPerson.java
@@ -80,7 +80,7 @@ class AddPerson {
     }
 
     // Add an address.
-    addressBook.addPersons(
+    addressBook.addPeople(
       PromptForAddress(new BufferedReader(new InputStreamReader(System.in)),
                        System.out));
 

--- a/examples/AddPerson.java
+++ b/examples/AddPerson.java
@@ -50,7 +50,7 @@ class AddPerson {
         stdout.println("Unknown phone type.  Using default.");
       }
 
-      person.addPhone(phoneNumber);
+      person.addPhones(phoneNumber);
     }
 
     return person.build();
@@ -80,7 +80,7 @@ class AddPerson {
     }
 
     // Add an address.
-    addressBook.addPerson(
+    addressBook.addPersons(
       PromptForAddress(new BufferedReader(new InputStreamReader(System.in)),
                        System.out));
 

--- a/examples/ListPeople.java
+++ b/examples/ListPeople.java
@@ -9,14 +9,14 @@ import java.io.PrintStream;
 class ListPeople {
   // Iterates though all people in the AddressBook and prints info about them.
   static void Print(AddressBook addressBook) {
-    for (Person person: addressBook.getPersonList()) {
+    for (Person person: addressBook.getPersonsList()) {
       System.out.println("Person ID: " + person.getId());
       System.out.println("  Name: " + person.getName());
-      if (person.hasEmail()) {
+      if (!person.getEmail().isEmpty()) {
         System.out.println("  E-mail address: " + person.getEmail());
       }
 
-      for (Person.PhoneNumber phoneNumber : person.getPhoneList()) {
+      for (Person.PhoneNumber phoneNumber : person.getPhonesList()) {
         switch (phoneNumber.getType()) {
           case MOBILE:
             System.out.print("  Mobile phone #: ");

--- a/examples/ListPeople.java
+++ b/examples/ListPeople.java
@@ -9,7 +9,7 @@ import java.io.PrintStream;
 class ListPeople {
   // Iterates though all people in the AddressBook and prints info about them.
   static void Print(AddressBook addressBook) {
-    for (Person person: addressBook.getPersonsList()) {
+    for (Person person: addressBook.getPeopleList()) {
       System.out.println("Person ID: " + person.getId());
       System.out.println("  Name: " + person.getName());
       if (!person.getEmail().isEmpty()) {

--- a/examples/add_person.cc
+++ b/examples/add_person.cc
@@ -32,7 +32,7 @@ void PromptForAddress(tutorial::Person* person) {
       break;
     }
 
-    tutorial::Person::PhoneNumber* phone_number = person->add_phone();
+    tutorial::Person::PhoneNumber* phone_number = person->add_phones();
     phone_number->set_number(number);
 
     cout << "Is this a mobile, home, or work phone? ";
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Add an address.
-  PromptForAddress(address_book.add_person());
+  PromptForAddress(address_book.add_persons());
 
   {
     // Write the new address book back to disk.

--- a/examples/add_person.cc
+++ b/examples/add_person.cc
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Add an address.
-  PromptForAddress(address_book.add_persons());
+  PromptForAddress(address_book.add_people());
 
   {
     // Write the new address book back to disk.

--- a/examples/add_person.py
+++ b/examples/add_person.py
@@ -19,7 +19,7 @@ def PromptForAddress(person):
     if number == "":
       break
 
-    phone_number = person.phone.add()
+    phone_number = person.phones.add()
     phone_number.number = number
 
     type = raw_input("Is this a mobile, home, or work phone? ")
@@ -50,7 +50,7 @@ except IOError:
   print sys.argv[1] + ": File not found.  Creating a new file."
 
 # Add an address.
-PromptForAddress(address_book.person.add())
+PromptForAddress(address_book.persons.add())
 
 # Write the new address book back to disk.
 f = open(sys.argv[1], "wb")

--- a/examples/add_person.py
+++ b/examples/add_person.py
@@ -50,7 +50,7 @@ except IOError:
   print sys.argv[1] + ": File not found.  Creating a new file."
 
 # Add an address.
-PromptForAddress(address_book.persons.add())
+PromptForAddress(address_book.people.add())
 
 # Write the new address book back to disk.
 f = open(sys.argv[1], "wb")

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -29,5 +29,5 @@ message Person {
 
 // Our address book file is just one of these.
 message AddressBook {
-  repeated Person persons = 1;
+  repeated Person people = 1;
 }

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -1,6 +1,6 @@
 // See README.txt for information and build instructions.
 
-syntax = "proto2";
+syntax = "proto3";
 
 package tutorial;
 
@@ -9,9 +9,9 @@ option java_outer_classname = "AddressBookProtos";
 option csharp_namespace = "Google.ProtocolBuffers.Examples.AddressBook";
 
 message Person {
-  required string name = 1;
-  required int32 id = 2;        // Unique ID number for this person.
-  optional string email = 3;
+  string name = 1;
+  int32 id = 2;        // Unique ID number for this person.
+  string email = 3;
 
   enum PhoneType {
     MOBILE = 0;
@@ -20,14 +20,14 @@ message Person {
   }
 
   message PhoneNumber {
-    required string number = 1;
-    optional PhoneType type = 2 [default = HOME];
+    string number = 1;
+    PhoneType type = 2;
   }
 
-  repeated PhoneNumber phone = 4;
+  repeated PhoneNumber phones = 4;
 }
 
 // Our address book file is just one of these.
 message AddressBook {
-  repeated Person person = 1;
+  repeated Person persons = 1;
 }

--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -6,7 +6,7 @@ package tutorial;
 
 option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
-option csharp_namespace = "Google.ProtocolBuffers.Examples.AddressBook";
+option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
 
 message Person {
   string name = 1;

--- a/examples/list_people.cc
+++ b/examples/list_people.cc
@@ -8,8 +8,8 @@ using namespace std;
 
 // Iterates though all people in the AddressBook and prints info about them.
 void ListPeople(const tutorial::AddressBook& address_book) {
-  for (int i = 0; i < address_book.persons_size(); i++) {
-    const tutorial::Person& person = address_book.persons(i);
+  for (int i = 0; i < address_book.people_size(); i++) {
+    const tutorial::Person& person = address_book.people(i);
 
     cout << "Person ID: " << person.id() << endl;
     cout << "  Name: " << person.name() << endl;

--- a/examples/list_people.cc
+++ b/examples/list_people.cc
@@ -8,17 +8,17 @@ using namespace std;
 
 // Iterates though all people in the AddressBook and prints info about them.
 void ListPeople(const tutorial::AddressBook& address_book) {
-  for (int i = 0; i < address_book.person_size(); i++) {
-    const tutorial::Person& person = address_book.person(i);
+  for (int i = 0; i < address_book.persons_size(); i++) {
+    const tutorial::Person& person = address_book.persons(i);
 
     cout << "Person ID: " << person.id() << endl;
     cout << "  Name: " << person.name() << endl;
-    if (person.has_email()) {
+    if (person.email() != "") {
       cout << "  E-mail address: " << person.email() << endl;
     }
 
-    for (int j = 0; j < person.phone_size(); j++) {
-      const tutorial::Person::PhoneNumber& phone_number = person.phone(j);
+    for (int j = 0; j < person.phones_size(); j++) {
+      const tutorial::Person::PhoneNumber& phone_number = person.phones(j);
 
       switch (phone_number.type()) {
         case tutorial::Person::MOBILE:

--- a/examples/list_people.py
+++ b/examples/list_people.py
@@ -7,7 +7,7 @@ import sys
 
 # Iterates though all people in the AddressBook and prints info about them.
 def ListPeople(address_book):
-  for person in address_book.persons:
+  for person in address_book.people:
     print "Person ID:", person.id
     print "  Name:", person.name
     if person.email != "":

--- a/examples/list_people.py
+++ b/examples/list_people.py
@@ -7,13 +7,13 @@ import sys
 
 # Iterates though all people in the AddressBook and prints info about them.
 def ListPeople(address_book):
-  for person in address_book.person:
+  for person in address_book.persons:
     print "Person ID:", person.id
     print "  Name:", person.name
-    if person.HasField('email'):
+    if person.email != "":
       print "  E-mail address:", person.email
 
-    for phone_number in person.phone:
+    for phone_number in person.phones:
       if phone_number.type == addressbook_pb2.Person.MOBILE:
         print "  Mobile phone #:",
       elif phone_number.type == addressbook_pb2.Person.HOME:


### PR DESCRIPTION
We need this to address issue #565 (which is blocking merging C# into master).

This also reveals that despite style guide says that repeated fields should use name in plural form, the generated code doesn't really reflect that (in sense providing sane names for the generated members). Correct naming of fields in addressbook.proto ("phones" and "persons") results in code that's a bit wierd (e.g. method addPersons adds a single person)
https://sites.google.com/a/google.com/protocol-buffers/user-docs/style-guide#Naming_convention_for_repeated_e

@jskeet  FYI