### PR TITLE
Expose original binary data for file descriptor

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Reflection/DescriptorsTest.cs
@@ -82,6 +82,8 @@ namespace Google.Protobuf.Reflection
             {
                 Assert.AreEqual(i, file.EnumTypes[i].Index);
             }
+
+            Assert.AreEqual(10, file.SerializedData[0]);
         }
 
         [Test]


### PR DESCRIPTION
FileDescriptorProto is internal, so this provides a way to access the original serialized for of a filedescriptor.