### PR TITLE
Fix build failure on Windows when Unicode build is enabled.

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -189,7 +189,7 @@ bool TryCreateParentDirectory(const string& prefix, const string& filename) {
 bool GetProtocAbsolutePath(string* path) {
 #ifdef _WIN32
   char buffer[MAX_PATH];
-  int len = GetModuleFileName(NULL, buffer, MAX_PATH);
+  int len = GetModuleFileNameA(NULL, buffer, MAX_PATH);
 #elif __APPLE__
   char buffer[PATH_MAX];
   int len = 0;


### PR DESCRIPTION
This is a follow up CL for e9abc404df99ef85d3e25aaaccd4aa83e381,
which breaks build when UNICODE macro is defined.

protoc has explicitly called MBCS version of APIs / funcsions
rather than UTF-16 (wchar_t) version of them regardless of
UNICODE macro definition (and it indeed works as expected).
Hence it makes sense to call [GetModuleFileNameA](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683197.aspx) explicitly.