### PR TITLE
On x64 MSVC platform, macro PROTOBUF_LITTLE_ENDIAN won't be set

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -112,7 +112,7 @@
 #include <string>
 #include <utility>
 #ifdef _MSC_VER
-  #if defined(_M_IX86) && \
+  #if (defined(_M_IX86) || defined(_M_AMD64)) && \
       !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)
     #define PROTOBUF_LITTLE_ENDIAN 1
   #endif

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -112,8 +112,8 @@
 #include <string>
 #include <utility>
 #ifdef _MSC_VER
-  #if (defined(_M_IX86) || defined(_M_AMD64)) && \
-      !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)
+  // Assuming windows is always little-endian.
+  #if !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)
     #define PROTOBUF_LITTLE_ENDIAN 1
   #endif
   #if _MSC_VER >= 1300


### PR DESCRIPTION
Is this intentional?
The cause is that _M_IX86 is undefined when target x64 processor.
The relative code is in File io/coded_stream.h, Line 115