### PR TITLE
Expose GetUmbrellaClassName  in csharp_names.h

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -50,7 +50,7 @@ namespace csharp {
 
 std::string GetOutputFile(const google::protobuf::FileDescriptor* file, const std::string file_extension)
 {
-  return GetFileUmbrellaClassname(file) + file_extension;
+  return GetUmbrellaClassUnqualifiedName(file) + file_extension;
 }
 
 void GenerateFile(const google::protobuf::FileDescriptor* file,

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -219,8 +219,7 @@ std::string GetUmbrellaClassName(const FileDescriptor* descriptor) {
   }
   std::string umbrellaNamespace = GetUmbrellaClassNestedNamespace(descriptor);
   if (!umbrellaNamespace.empty()) {
-      result += umbrellaNamespace;
-      result += '.';
+      result += umbrellaNamespace + ".";
   }
   result += GetUmbrellaClassUnqualifiedName(descriptor);
   return "global::" + result;

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -117,21 +117,18 @@ std::string GetFileNamespace(const FileDescriptor* descriptor) {
   return UnderscoresToCamelCase(descriptor->package(), true, true);
 }
 
-std::string GetUmbrellaClassNameInternal(const std::string& proto_file) {
+std::string GetUmbrellaClassUnqualifiedName(const FileDescriptor* descriptor) {
+  // umbrella_classname can no longer be set using message option.
+  std::string proto_file = descriptor->name();
   int lastslash = proto_file.find_last_of("/");
   std::string base = proto_file.substr(lastslash + 1);
   return UnderscoresToPascalCase(StripDotProto(base));
 }
 
-std::string GetFileUmbrellaClassname(const FileDescriptor* descriptor) {
-  // umbrella_classname can no longer be set using message option.
-  return GetUmbrellaClassNameInternal(descriptor->name());
-}
-
-std::string GetFileUmbrellaNamespace(const FileDescriptor* descriptor) {
+std::string GetUmbrellaClassNestedNamespace(const FileDescriptor* descriptor) {
   // TODO(jtattermusch): reintroduce csharp_umbrella_namespace option
   bool collision = false;
-  std::string umbrella_classname = GetFileUmbrellaClassname(descriptor);
+  std::string umbrella_classname = GetUmbrellaClassUnqualifiedName(descriptor);
   for(int i = 0; i < descriptor->message_type_count(); i++) {
     if (descriptor->message_type(i)->name() == umbrella_classname) {
       collision = true;
@@ -215,26 +212,18 @@ std::string ToCSharpName(const std::string& name, const FileDescriptor* file) {
   return "global::" + result;
 }
 
-
-
-std::string GetFullUmbrellaClassName(const FileDescriptor* descriptor) {
+std::string GetUmbrellaClassName(const FileDescriptor* descriptor) {
   std::string result = GetFileNamespace(descriptor);
   if (!result.empty()) {
     result += '.';
   }
-  result += GetQualifiedUmbrellaClassName(descriptor);
-  return "global::" + result;
-}
-
-std::string GetQualifiedUmbrellaClassName(const FileDescriptor* descriptor) {
-  std::string umbrellaNamespace = GetFileUmbrellaNamespace(descriptor);
-  std::string umbrellaClassname = GetFileUmbrellaClassname(descriptor);
-
-  std::string fullName = umbrellaClassname;
+  std::string umbrellaNamespace = GetUmbrellaClassNestedNamespace(descriptor);
   if (!umbrellaNamespace.empty()) {
-    fullName = umbrellaNamespace + "." + umbrellaClassname;
+      result += umbrellaNamespace;
+      result += '.';
   }
-  return fullName;
+  result += GetUmbrellaClassUnqualifiedName(descriptor);
+  return "global::" + result;
 }
 
 std::string GetClassName(const Descriptor* descriptor) {

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -69,13 +69,12 @@ CSharpType GetCSharpType(FieldDescriptor::Type type);
 
 std::string StripDotProto(const std::string& proto_file);
 
-std::string GetFileUmbrellaClassname(const FileDescriptor* descriptor);
+// Gets unqualified name of the umbrella class
+std::string GetUmbrellaClassUnqualifiedName(const FileDescriptor* descriptor);
 
-std::string GetFileUmbrellaNamespace(const FileDescriptor* descriptor);
-
-std::string GetFullUmbrellaClassName(const FileDescriptor* descriptor);
-
-std::string GetQualifiedUmbrellaClassName(const FileDescriptor* descriptor);
+// Gets name of the nested for umbrella class (just the nested part,
+// not including the GetFileNamespace part).
+std::string GetUmbrellaClassNestedNamespace(const FileDescriptor* descriptor);
 
 std::string GetClassName(const Descriptor* descriptor);
 

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -100,7 +100,6 @@ void MessageGenerator::Generate(io::Printer* printer) {
   map<string, string> vars;
   vars["class_name"] = class_name();
   vars["access_level"] = class_access_level();
-  vars["umbrella_class_name"] = GetFullUmbrellaClassName(descriptor_->file());
 
   printer->Print(
     "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
@@ -118,7 +117,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
 
   // Access the message descriptor via the relevant file descriptor or containing message descriptor.
   if (!descriptor_->containing_type()) {
-    vars["descriptor_accessor"] = GetFullUmbrellaClassName(descriptor_->file())
+    vars["descriptor_accessor"] = GetUmbrellaClassName(descriptor_->file())
         + ".Descriptor.MessageTypes[" + SimpleItoa(descriptor_->index()) + "]";
   } else {
     vars["descriptor_accessor"] = GetClassName(descriptor_->containing_type())

--- a/src/google/protobuf/compiler/csharp/csharp_names.h
+++ b/src/google/protobuf/compiler/csharp/csharp_names.h
@@ -65,6 +65,14 @@ string GetFileNamespace(const FileDescriptor* descriptor);
 //   The fully-qualified C# class name.
 string GetClassName(const Descriptor* descriptor);
 
+// Requires:
+//   descriptor != NULL
+//
+// Returns:
+//   The fully-qualified name of the C# class that provides
+//   access to the file descriptor. Proto compiler generates
+//   such class for each .proto file processed.
+std::string GetUmbrellaClassName(const FileDescriptor* descriptor);
 
 }  // namespace csharp
 }  // namespace compiler

--- a/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
@@ -54,8 +54,8 @@ UmbrellaClassGenerator::UmbrellaClassGenerator(const FileDescriptor* file)
     : SourceGeneratorBase(file),
       file_(file) {
   namespace_ = GetFileNamespace(file);
-  umbrellaClassname_ = GetFileUmbrellaClassname(file);
-  umbrellaNamespace_ = GetFileUmbrellaNamespace(file);
+  umbrellaClassname_ = GetUmbrellaClassUnqualifiedName(file);
+  umbrellaNamespace_ = GetUmbrellaClassNestedNamespace(file);
 }
 
 UmbrellaClassGenerator::~UmbrellaClassGenerator() {
@@ -183,7 +183,7 @@ void UmbrellaClassGenerator::WriteDescriptor(io::Printer* printer) {
     printer->Print(
       "$full_umbrella_class_name$.Descriptor, ",
       "full_umbrella_class_name",
-      GetFullUmbrellaClassName(file_->dependency(i)));
+      GetUmbrellaClassName(file_->dependency(i)));
   }
   printer->Print("},\n"
       "    new pbr::GeneratedCodeInfo(");


### PR DESCRIPTION
This is going to be useful for gRPC protoc plugin to be able to expose ServiceDescriptor on each generated service class.

Also, the naming of umbrellaClass-related helper functions was pretty poor, so I did some refactoring and renaming.

@jskeet FYI