### PR TITLE
Fix gcc C++11 build

### DIFF
--- a/src/google/protobuf/util/field_comparator_test.cc
+++ b/src/google/protobuf/util/field_comparator_test.cc
@@ -34,8 +34,8 @@
 
 #include <google/protobuf/unittest.pb.h>
 #include <google/protobuf/descriptor.h>
-#include <gtest/gtest.h>
 #include <google/protobuf/stubs/mathutil.h>
+#include <gtest/gtest.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/util/internal/utility.cc
+++ b/src/google/protobuf/util/internal/utility.cc
@@ -30,10 +30,6 @@
 
 #include <google/protobuf/util/internal/utility.h>
 
-#include <cmath>
-#include <algorithm>
-#include <utility>
-
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/wrappers.pb.h>
 #include <google/protobuf/descriptor.pb.h>
@@ -301,8 +297,8 @@ bool IsMap(const google::protobuf::Field& field,
 }
 
 string DoubleAsString(double value) {
-  if (value == std::numeric_limits<double>::infinity()) return "Infinity";
-  if (value == -std::numeric_limits<double>::infinity()) return "-Infinity";
+  if (google::protobuf::MathLimits<double>::IsPosInf(value)) return "Infinity";
+  if (google::protobuf::MathLimits<double>::IsNegInf(value)) return "-Infinity";
   if (google::protobuf::MathLimits<double>::IsNaN(value)) return "NaN";
 
   return SimpleDtoa(value);
@@ -320,8 +316,7 @@ bool SafeStrToFloat(StringPiece str, float *value) {
   }
   *value = static_cast<float>(double_value);
 
-  if ((*value ==  numeric_limits<float>::infinity()) ||
-      (*value == -numeric_limits<float>::infinity())) {
+  if (google::protobuf::MathLimits<float>::IsInf(*value)) {
     return false;
   }
   return true;


### PR DESCRIPTION
gcc with -std=c++11 failed because of conflicts between **google/protobuf/stubs/mathutil.h** and **cmath**.

```
cmake -GNinja -DCMAKE_CXX_FLAGS="-std=c++11 -DLANG_CXX11" ../cmake && ninja

[83/345] Building CXX object CMakeFiles/libprotobuf.dir/var/local/protobuf/src/google/protobuf/util/internal/utility.cc.o
FAILED: /usr/bin/c++   -DGOOGLE_PROTOBUF_CMAKE_BUILD -DHAVE_PTHREAD -DLIBPROTOBUF_EXPORTS -std=c++11 -DLANG_CXX11 -I. -I/var/local/protobuf/src -I/var/local/protobuf/gmock -I/var/local/protobuf/gmock/gtest -I/var/local/protobuf/gmock/gtest/include -I/var/local/protobuf/gmock/include -MMD -MT CMakeFiles/libprotobuf.dir/var/local/protobuf/src/google/protobuf/util/internal/utility.cc.o -MF "CMakeFiles/libprotobuf.dir/var/local/protobuf/src/google/protobuf/util/internal/utility.cc.o.d" -o CMakeFiles/libprotobuf.dir/var/local/protobuf/src/google/protobuf/util/internal/utility.cc.o -c /var/local/protobuf/src/google/protobuf/util/internal/utility.cc
In file included from /var/local/protobuf/src/google/protobuf/util/internal/utility.cc:44:0:
/var/local/protobuf/src/google/protobuf/stubs/mathlimits.h: In static member function 'static bool google::protobuf::MathLimits<double>::IsFinite(google::protobuf::MathLimits<double>::Type)':
/var/local/protobuf/src/google/protobuf/stubs/mathlimits.h:233:55: error: call of overloaded 'isinf(const Type&)' is ambiguous
   static bool IsFinite(const Type x) { return !isinf(x)  &&  !isnan(x); } \
...
```
(should be reproducible on plain ubuntu 14.04 with default gcc 4.8)

The incompatibility was already documented in the mathutil.h header comment and could be worked around by avoiding any direct or indirect **cmath** includes before **mathutil.h**.