### PR TITLE
Optimize CodedInputStream.readByteBuffer() for LiteralByteString

### DIFF
--- a/java/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -543,10 +543,17 @@ public final class CodedInputStream {
       // into the underlying byte array without copy if the CodedInputStream is
       // constructed from a byte array. If aliasing is disabled or the input is
       // from an InputStream or ByteString, we have to make a copy of the bytes.
-      ByteBuffer result = input == null && !bufferIsImmutable && enableAliasing
-          ? ByteBuffer.wrap(buffer, bufferPos, size).slice()
-          : ByteBuffer.wrap(Arrays.copyOfRange(
-              buffer, bufferPos, bufferPos + size));
+      ByteBuffer result;
+      if (input == null && enableAliasing) {
+        if (bufferIsImmutable) {
+          result = ByteBuffer.wrap(buffer, bufferPos, size).asReadOnlyBuffer().slice();
+        } else {
+          result = ByteBuffer.wrap(buffer, bufferPos, size).slice();
+        }
+      } else {
+        result = ByteBuffer.wrap(Arrays.copyOfRange(
+                buffer, bufferPos, bufferPos + size));
+      }
       bufferPos += size;
       return result;
     } else if (size == 0) {

--- a/java/src/test/java/com/google/protobuf/CodedInputStreamTest.java
+++ b/java/src/test/java/com/google/protobuf/CodedInputStreamTest.java
@@ -751,6 +751,28 @@ public class CodedInputStreamTest extends TestCase {
     assertEquals((byte) 67, result.get());
     result.position(bytesLength - 1);
     assertEquals((byte) 89, result.get());
+
+    // Enable aliasing when read from ByteString
+    inputStream = ByteString.copyFrom(data).newCodedInput();
+    inputStream.enableAliasing(true);
+    result = inputStream.readByteBuffer();
+    assertEquals(0, result.capacity());
+    result = inputStream.readByteBuffer();
+    // ByteBuffer is readonly, because it shares content with ByteString.
+    // Readonly ByteBuffer does not expose the array.
+    assertFalse(result.hasArray());
+    assertEquals(1, result.capacity());
+    assertEquals((byte) 23, result.get());
+    result = inputStream.readByteBuffer();
+    assertFalse(result.hasArray());
+    assertEquals(1, result.capacity());
+    assertEquals((byte) 45, result.get());
+    result = inputStream.readByteBuffer();
+    assertFalse(result.hasArray());
+    assertEquals(bytesLength, result.capacity());
+    assertEquals((byte) 67, result.get());
+    result.position(bytesLength - 1);
+    assertEquals((byte) 89, result.get());
   }
 
   public void testCompatibleTypes() throws Exception {


### PR DESCRIPTION
With this patch applied `CodedInputStream.readByteBuffer()` returns
`ByteBuffer` wrapping array contained in `LiteralByteString`.  To
ensure that `LiteralByteString` is not modified, returned buffer
is made readonly with `.asReadOnlyBuffer()` operation.
