### PR TITLE
Remove our own version of MakeTag now that the main one is fixed.

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -59,7 +59,7 @@ void FieldGeneratorBase::SetCommonFieldVariables(
   // repeated fields varies by wire format. The wire format is encoded in the bottom 3 bits, which
   // never effects the tag size.
   int tag_size = internal::WireFormat::TagSize(descriptor_->number(), descriptor_->type());
-  uint tag = FixedMakeTag(descriptor_);
+  uint tag = internal::WireFormat::MakeTag(descriptor_);
   uint8 tag_array[5];
   io::CodedOutputStream::WriteTagToArray(tag, tag_array);
   string tag_bytes = SimpleItoa(tag_array[0]);

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -338,17 +338,6 @@ std::string FileDescriptorToBase64(const FileDescriptor* descriptor) {
   return StringToBase64(fdp_bytes);
 }
 
-// TODO(jonskeet): Remove this when internal::WireFormat::MakeTag works
-// properly...
-// Workaround for issue #493
-uint FixedMakeTag(const FieldDescriptor* field) {
-  internal::WireFormatLite::WireType field_type = field->is_packed()
-      ? internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED
-      : internal::WireFormat::WireTypeForFieldType(field->type());
-
-  return internal::WireFormatLite::MakeTag(field->number(), field_type);
-}
-
 FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor,
                                          int fieldOrdinal) {
   switch (descriptor->type()) {


### PR DESCRIPTION
"Tested" by regenerating code and observing that there are no changes.