### PR TITLE
Port Java's parseDelimitedFrom() to C++.

### DIFF
--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -188,6 +188,19 @@ bool Message::SerializePartialToOstream(ostream* output) const {
   return SerializePartialToZeroCopyStream(&zero_copy_output);
 }
 
+bool Message::SerializeDelimitedToFileDescriptor(int file_descriptor) const {
+  io::FileOutputStream output(file_descriptor);
+  return SerializeDelimitedToZeroCopyStream(&output);
+}
+
+bool Message::SerializeDelimitedToOstream(ostream* output) const {
+  {
+    io::OstreamOutputStream zero_copy_output(output);
+    if (!SerializeDelimitedToZeroCopyStream(&zero_copy_output)) return false;
+  }
+  return output->good();
+}
+
 
 // =============================================================================
 // Reflection and associated Template Specializations

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -287,6 +287,25 @@ class LIBPROTOBUF_EXPORT Message : public MessageLite {
   // Like SerializeToOstream(), but allows missing required fields.
   bool SerializePartialToOstream(ostream* output) const;
 
+  // Write a single size-delimited message from the given stream. Delimited
+  // format allows a single file or stream to contain multiple messages,
+  // whereas normally writing multiple non-delimited messages to the same
+  // stream would cause them to be merged. A delimited message is a varint
+  // encoding the message size followed by a message of exactly that size.
+  //
+  // Note that if you want to *read* a delimited message from a file descriptor
+  // or istream, you will need to construct an io::FileInputStream or
+  // io::OstreamInputStream (implementations of io::ZeroCopyStream) and use the
+  // MessageLite method ParseDelimitedFromZeroCopyStream(). You must then
+  // continue to use the same ZeroCopyInputStream to read all further data from
+  // the stream until EOF. This is because these ZeroCopyInputStream
+  // implementations are buffered: they read a big chunk of data at a time,
+  // then parse it. As a result, they may read past the end of the delimited
+  // message. There is no way for them to push the extra data back into the
+  // underlying source, so instead you must keep using the same stream object.
+  bool SerializeDelimitedToFileDescriptor(int file_descriptor) const;
+  bool SerializeDelimitedToOstream(ostream* output) const;
+
 
   // Reflection-based methods ----------------------------------------
   // These methods are pure-virtual in MessageLite, but Message provides

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -171,6 +171,23 @@ class LIBPROTOBUF_EXPORT MessageLite {
   // required fields.
   bool ParsePartialFromArray(const void* data, int size);
 
+  // Read a single size-delimited message from the given stream. Delimited
+  // format allows a single file or stream to contain multiple messages,
+  // whereas normally parsing consumes the entire input. A delimited message
+  // is a varint encoding the message size followed by a message of exactly
+  // that size.
+  //
+  // If |clean_eof| is not NULL, then it will be set to indicate whether the
+  // stream ended cleanly. That is, if the stream ends without this method
+  // having read any data at all from it, then *clean_eof will be set true,
+  // otherwise it will be set false. Note that these methods return false
+  // on EOF, but they also return false on other errors, so |clean_eof| is
+  // needed to distinguish a clean end from errors.
+  bool ParseDelimitedFromZeroCopyStream(io::ZeroCopyInputStream* input,
+                                        bool* clean_eof);
+  bool ParseDelimitedFromCodedStream(io::CodedInputStream* input,
+                                     bool* clean_eof);
+
 
   // Reads a protocol buffer from the stream and merges it into this
   // Message.  Singular fields read from the input overwrite what is
@@ -234,6 +251,15 @@ class LIBPROTOBUF_EXPORT MessageLite {
   bool AppendToString(string* output) const;
   // Like AppendToString(), but allows missing required fields.
   bool AppendPartialToString(string* output) const;
+
+  // Write a single size-delimited message from the given stream. Delimited
+  // format allows a single file or stream to contain multiple messages,
+  // whereas normally writing multiple non-delimited messages to the same
+  // stream would cause them to be merged. A delimited message is a varint
+  // encoding the message size followed by a message of exactly that size.
+  bool SerializeDelimitedToZeroCopyStream(
+      io::ZeroCopyOutputStream* output) const;
+  bool SerializeDelimitedToCodedStream(io::CodedOutputStream* output) const;
 
   // Computes the serialized size of the message.  This recursively calls
   // ByteSize() on all embedded messages.  If a subclass does not override

--- a/src/google/protobuf/message_unittest.cc
+++ b/src/google/protobuf/message_unittest.cc
@@ -179,6 +179,44 @@ TEST(MessageTest, ParseHelpers) {
   }
 }
 
+TEST(MessageTest, DelimitedMessages) {
+  stringstream stream;
+
+  {
+    protobuf_unittest::TestAllTypes message1;
+    TestUtil::SetAllFields(&message1);
+    EXPECT_TRUE(message1.SerializeDelimitedToOstream(&stream));
+
+    protobuf_unittest::TestPackedTypes message2;
+    TestUtil::SetPackedFields(&message2);
+    EXPECT_TRUE(message2.SerializeDelimitedToOstream(&stream));
+  }
+
+  {
+    bool clean_eof;
+    io::IstreamInputStream zstream(&stream);
+
+    protobuf_unittest::TestAllTypes message1;
+    clean_eof = true;
+    EXPECT_TRUE(message1.ParseDelimitedFromZeroCopyStream(
+        &zstream, &clean_eof));
+    EXPECT_FALSE(clean_eof);
+    TestUtil::ExpectAllFieldsSet(message1);
+
+    protobuf_unittest::TestPackedTypes message2;
+    clean_eof = true;
+    EXPECT_TRUE(message2.ParseDelimitedFromZeroCopyStream(
+        &zstream, &clean_eof));
+    EXPECT_FALSE(clean_eof);
+    TestUtil::ExpectPackedFieldsSet(message2);
+
+    clean_eof = false;
+    EXPECT_FALSE(message2.ParseDelimitedFromZeroCopyStream(
+        &zstream, &clean_eof));
+    EXPECT_TRUE(clean_eof);
+  }
+}
+
 TEST(MessageTest, ParseFailsIfNotInitialized) {
   unittest::TestRequired message;
   vector<string> errors;


### PR DESCRIPTION
I've been following/answering Protobuf questions on Stack Overflow for a while. It seems that a lot of people really want C++ equivalents of Protobuf-Java's `parseDelimitedFrom()` and `writeDelimitedTo()`. Some examples:

http://stackoverflow.com/q/2340730/2686899
http://stackoverflow.com/q/31953201/2686899

(There are many more.)

So, this change implements them.

(Note that inside of Google, engineers would normally use RecordIO for this purpose. However, outside Google, RecordIO hasn't been released as a stand-alone library (though it seems to be present in various Google open source repositories), and in general it's more cumbersome for people to add additional library dependencies.)
