### PR TITLE
Don't include system headers inside protobuf namespace.

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -269,6 +269,9 @@ inline void GOOGLE_UNALIGNED_STORE64(void *p, uint64 v) {
 #define GOOGLE_THREAD_LOCAL __thread
 #endif
 
+}  // namespace protobuf
+}  // namespace google
+
 // The following guarantees declaration of the byte swap functions, and
 // defines __BYTE_ORDER for MSVC
 #ifdef _MSC_VER
@@ -289,6 +292,13 @@ inline void GOOGLE_UNALIGNED_STORE64(void *p, uint64 v) {
 #include <byteswap.h>  // IWYU pragma: export
 
 #else
+#define PROTOBUF_NEED_BSWAP
+#endif
+
+namespace google {
+namespace protobuf {
+
+#ifdef PROTOBUF_NEED_BSWAP
 
 static inline uint16 bswap_16(uint16 x) {
   return static_cast<uint16>(((x & 0xFF) << 8) | ((x & 0xFF00) >> 8));


### PR DESCRIPTION
port.h includes several system headers inside the protobuf namespace.
As a result, if another header included after a protobuf header
also includes one of those system headers, the header guards will be
defined, but the symbols will be inaccessible inside the protobuf
namespace.