### PR TITLE
Fix Release builds with MSVC14 - disable inlining for message.cc

### DIFF
--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -54,7 +54,7 @@ set(libprotobuf_files
 
 # Disable inlining in message.cc to solve link error missing NewFromPrototype
 if(MSVC)
-	set_source_files_properties(${protobuf_source_dir}/src/google/protobuf/message.cc PROPERTIES COMPILE_FLAGS /Ob0)
+  set_source_files_properties(${protobuf_source_dir}/src/google/protobuf/message.cc PROPERTIES COMPILE_FLAGS /Ob0)
 endif()
 
 add_library(libprotobuf ${libprotobuf_lite_files} ${libprotobuf_files})

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -52,6 +52,11 @@ set(libprotobuf_files
   ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.cc
 )
 
+# Disable inlining in message.cc to solve link error missing NewFromPrototype
+if(MSVC)
+	set_source_files_properties(${protobuf_source_dir}/src/google/protobuf/message.cc PROPERTIES COMPILE_FLAGS /Ob0)
+endif()
+
 add_library(libprotobuf ${libprotobuf_lite_files} ${libprotobuf_files})
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
 target_include_directories(libprotobuf PUBLIC ${protobuf_source_dir}/src)


### PR DESCRIPTION
When building protoc with Visual Studio 2015 CMake, I've been getting a linker error:

> Error LNK2019 unresolved external symbol "public: static class google::protobuf::Message * __cdecl google::protobuf::internal::GenericTypeHandler<class google::protobuf::Message>::NewFromPrototype(class google::protobuf::Message const *,class google::protobuf::Arena *)" (?NewFromPrototype@?$GenericTypeHandler@VMessage@protobuf@google@@internal@protobuf@google@SAPEAVMessage@34@PEBV534@PEAVArena@34@Z) referenced in function "private: void __cdecl google::protobuf::internal::RepeatedPtrFieldBase::MergeFromInnerLoop<class google::protobuf::internal::GenericTypeHandler<class google::protobuf::Message> >(void * *,void * *,int,int)" (??$MergeFromInnerLoop@V?$GenericTypeHandler@VMessage@protobuf@google@internal@protobuf@google@RepeatedPtrFieldBase@internal@protobuf@google@AEAAXPEAPEAX0HH@Z) 

I've solved it by disabling inlining in message.cc

(If there's a better solution, I'd love to know!)