### PR TITLE
include descriptor.proto in nuget package 

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
@@ -23,6 +23,7 @@
 	<file src="..\..\..\cmake\Release\protoc.exe" target="tools" />
 	<file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
 	<file src="..\..\..\src\google\protobuf\api.proto" target="tools\google\protobuf" />
+	<file src="..\..\..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf" />
 	<file src="..\..\..\src\google\protobuf\duration.proto" target="tools\google\protobuf" />
 	<file src="..\..\..\src\google\protobuf\empty.proto" target="tools\google\protobuf" />
 	<file src="..\..\..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf" />


### PR DESCRIPTION
This is the same change as #738, but this time merging into master.