### PR TITLE
Fix compile issues with -std=c++11

### DIFF
--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -2188,7 +2188,7 @@ TEST_F(MapFieldInDynamicMessageTest, MapSpaceUsed) {
 
 TEST_F(MapFieldInDynamicMessageTest, RecursiveMap) {
   TestRecursiveMapMessage from;
-  (*from.mutable_a())[0];
+  (*from.mutable_a())[""];
   string data = from.SerializeAsString();
   google::protobuf::scoped_ptr<Message> to(
       factory_.GetPrototype(recursive_map_descriptor_)->New());

--- a/src/google/protobuf/map_unittest.proto
+++ b/src/google/protobuf/map_unittest.proto
@@ -116,7 +116,7 @@ message MessageContainingEnumCalledType {
   enum Type {
     TYPE_FOO = 0;
   }
-  map<int32, MessageContainingEnumCalledType> type = 1;
+  map<string, MessageContainingEnumCalledType> type = 1;
 }
 
 // Previously, message cannot contain map field called "entry".
@@ -125,5 +125,5 @@ message MessageContainingMapCalledEntry {
 }
 
 message TestRecursiveMapMessage {
-  map<int32, TestRecursiveMapMessage> a = 1;
+  map<string, TestRecursiveMapMessage> a = 1;
 }


### PR DESCRIPTION
This compiles with -std=c++11:
```
message Foo {
  map<string, Foo> value = 1;
}
```

This does not compile:
```
message Foo {
  map<int32, Foo> value = 1;
}
```

Needs to dig more into the underlying issue.