### PR TITLE
Fix the no-op definitions of GOOGLE_PREDICT_{TRUE,FALSE}

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -184,7 +184,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 // Provided at least since GCC 3.0.
 #define GOOGLE_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
 #else
-#define GOOGLE_PREDICT_TRUE
+#define GOOGLE_PREDICT_TRUE(x) (x)
 #endif
 #endif
 
@@ -193,7 +193,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 // Provided at least since GCC 3.0.
 #define GOOGLE_PREDICT_FALSE(x) (__builtin_expect(x, 0))
 #else
-#define GOOGLE_PREDICT_FALSE
+#define GOOGLE_PREDICT_FALSE(x) (x)
 #endif
 #endif
 


### PR DESCRIPTION
Updating to the current protobuf version caused the following build errors in
Chromium when using Clang on Windows:

..\..\third_party\protobuf\src\google/protobuf/stubs/fastmem.h(67,43) :  error: equality comparison with extraneous parentheses [-Werror,-Wparentheses-equality]
  if (GOOGLE_PREDICT_FALSE(n_rounded_down == 0)) {  // n <= 7
                           ~~~~~~~~~~~~~~~^~~~

The problem is that on Windows, GOOGLE_PREDICT_FALSE is #defined to nothing, so
the code expands to 'if ((n_rounded_down == 0))', which Clang warns about.

Clang would not have warned if the extra parentheses came from the macro,
but in this case they don't because the macro is just dropped.

Fix this by making the macros behave as an identity function instead of just
getting dropped.

This is closer to what these macros look like in stubs/port.h internally.