### PR TITLE
Refine check for unordered_{map|set} availability.

### DIFF
--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -43,8 +43,7 @@
 
 // Use C++11 unordered_{map|set} if available.
 #if ((__cplusplus >= 201103L) &&                            \
-     ((defined(__GLIBCXX__) && (__GLIBCXX__ > 20090421)) || \
-      (defined(_LIBCPP_VERSION) && (_LIBCPP_STD_VER >= 11))))
+     ((__GLIBCXX__ > 20090421) || (_LIBCPP_STD_VER >= 11)))
 # define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 
 // For XCode >= 4.6:  the compiler is clang with libc++.

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -41,10 +41,10 @@
 #define GOOGLE_PROTOBUF_HAVE_HASH_MAP 1
 #define GOOGLE_PROTOBUF_HAVE_HASH_SET 1
 
-// Use C++11 unordered_{map|set} if available. Otherwise, libc++ always support
-// unordered_{map|set}
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X) || \
-    defined(_LIBCPP_VERSION)
+// Use C++11 unordered_{map|set} if available.
+#if ((__cplusplus >= 201103L) &&                            \
+     ((defined(__GLIBCXX__) && (__GLIBCXX__ > 20090421)) || \
+      (defined(_LIBCPP_VERSION) && (_LIBCPP_STD_VER >= 11))))
 # define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 
 // For XCode >= 4.6:  the compiler is clang with libc++.

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -42,8 +42,9 @@
 #define GOOGLE_PROTOBUF_HAVE_HASH_SET 1
 
 // Use C++11 unordered_{map|set} if available.
-#if ((__cplusplus >= 201103L) &&                            \
-     ((__GLIBCXX__ > 20090421) || (_LIBCPP_STD_VER >= 11)))
+#if ((_LIBCPP_STD_VER >= 11) ||
+     (((__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X)) &&
+      (__GLIBCXX__ > 20090421)))
 # define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 
 // For XCode >= 4.6:  the compiler is clang with libc++.

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -42,8 +42,8 @@
 #define GOOGLE_PROTOBUF_HAVE_HASH_SET 1
 
 // Use C++11 unordered_{map|set} if available.
-#if ((_LIBCPP_STD_VER >= 11) ||
-     (((__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X)) &&
+#if ((_LIBCPP_STD_VER >= 11) || \
+     (((__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X)) && \
       (__GLIBCXX__ > 20090421)))
 # define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 


### PR DESCRIPTION
It's not enough to check for C++11 language support, as it's possible for
projects to enable C++11 language and library features independently (e.g.
Chromium currently does this).  Instead, explicitly check the library version to
see if it is recent enough to include unordered_{map|set}.