### PR TITLE
Avoid #including system headers from inside a namespace.

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -79,6 +79,15 @@
   #define LIBPROTOC_EXPORT
 #endif
 
+// These #includes are for the byte swap functions declared later on.
+#ifdef _MSC_VER
+#include <stdlib.h>  // NOLINT(build/include)
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#elif defined(__GLIBC__) || defined(__CYGWIN__)
+#include <byteswap.h>  // IWYU pragma: export
+#endif
+
 // ===================================================================
 // from google3/base/port.h
 namespace google {
@@ -275,7 +284,6 @@ inline void GOOGLE_UNALIGNED_STORE64(void *p, uint64 v) {
 // The following guarantees declaration of the byte swap functions, and
 // defines __BYTE_ORDER for MSVC
 #ifdef _MSC_VER
-#include <stdlib.h>  // NOLINT(build/include)
 #define __BYTE_ORDER __LITTLE_ENDIAN
 #define bswap_16(x) _byteswap_ushort(x)
 #define bswap_32(x) _byteswap_ulong(x)
@@ -283,15 +291,11 @@ inline void GOOGLE_UNALIGNED_STORE64(void *p, uint64 v) {
 
 #elif defined(__APPLE__)
 // Mac OS X / Darwin features
-#include <libkern/OSByteOrder.h>
 #define bswap_16(x) OSSwapInt16(x)
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
-#elif defined(__GLIBC__) || defined(__CYGWIN__)
-#include <byteswap.h>  // IWYU pragma: export
-
-#else
+#elif !defined(__GLIBC__) && !defined(__CYGWIN__)
 
 static inline uint16 bswap_16(uint16 x) {
   return static_cast<uint16>(((x & 0xFF) << 8) | ((x & 0xFF00) >> 8));


### PR DESCRIPTION
port.h #includes various headers in order to define byteswap functions, but it
currently does so from inside the google::protobuf namespace.  This can cause
bizarre symbol conflicts and other build errors as these headers' contents are
then included inside this namespace.

Instead, #include the relevant headers above the namespace declarations.