### PR TITLE
Delete kNanosPerSecond from time.cc.

### DIFF
--- a/src/google/protobuf/stubs/time.cc
+++ b/src/google/protobuf/stubs/time.cc
@@ -21,7 +21,6 @@ static const int64 kSecondsFromEraToEpoch = 62135596800LL;
 static const int64 kMinTime = -62135596800LL;  // 0001-01-01T00:00:00
 static const int64 kMaxTime = 253402300799LL;  // 9999-12-31T23:59:59
 
-static const int kNanosPerSecond = 1000000000;
 static const int kNanosPerMillisecond = 1000000;
 static const int kNanosPerMicrosecond = 1000;
 


### PR DESCRIPTION
This variable is unused, and thus triggers a build warning on MSVC.