### PR TITLE
Fixing compile errors on Solaris in 64-bit mode

### DIFF
--- a/m4/acx_check_suncc.m4
+++ b/m4/acx_check_suncc.m4
@@ -42,7 +42,6 @@ AC_DEFUN([ACX_CHECK_SUNCC],[
 
         AS_IF([test "x$ac_enable_64bit" = "xyes"],[
 
-          AC_DEFINE([SOLARIS_64BIT_ENABLED], [1], [64bit enabled])
           AS_IF([test "x$libdir" = "x\${exec_prefix}/lib"],[
            dnl The user hasn't overridden the default libdir, so we'll
            dnl the dir suffix to match solaris 32/64-bit policy
@@ -52,17 +51,13 @@ AC_DEFUN([ACX_CHECK_SUNCC],[
           dnl This should just be set in CPPFLAGS and in LDFLAGS, but libtool
           dnl does the wrong thing if you don't put it into CXXFLAGS. sigh.
           dnl (It also needs it in CFLAGS, or it does a different wrong thing!)
-          AS_IF([test "x${ac_cv_env_CXXFLAGS_set}" = "x"],[
-            CXXFLAGS="${CXXFLAGS} -m64"
-            ac_cv_env_CXXFLAGS_set=set
-            ac_cv_env_CXXFLAGS_value='-m64'
-          ])
+          CXXFLAGS="${CXXFLAGS} -m64"
+          ac_cv_env_CXXFLAGS_set=set
+          ac_cv_env_CXXFLAGS_value='-m64'
 
-          AS_IF([test "x${ac_cv_env_CFLAGS_set}" = "x"],[
-            CFLAGS="${CFLAGS} -m64"
-            ac_cv_env_CFLAGS_set=set
-            ac_cv_env_CFLAGS_value='-m64'
-          ])
+          CFLAGS="${CFLAGS} -m64"
+          ac_cv_env_CFLAGS_set=set
+          ac_cv_env_CFLAGS_value='-m64'
 
           AS_IF([test "$target_cpu" = "sparc" -a "x$SUNCC" = "xyes" ],[
             CXXFLAGS="-xmemalign=8s ${CXXFLAGS}"

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -33,6 +33,7 @@
 //  Sanjay Ghemawat, Jeff Dean, and others.
 
 #include <google/protobuf/compiler/command_line_interface.h>
+#include <google/protobuf/stubs/platform_macros.h>
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -47,6 +48,10 @@
 #include <errno.h>
 #include <iostream>
 #include <ctype.h>
+
+#ifdef GOOGLE_PROTOBUF_ARCH_SPARC 
+#include <limits.h> //For PATH_MAX
+#endif
 
 #include <memory>
 #ifndef _SHARED_PTR_H

--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -76,7 +76,7 @@ typedef int32 Atomic32;
 #ifdef GOOGLE_PROTOBUF_ARCH_64_BIT
 // We need to be able to go between Atomic64 and AtomicWord implicitly.  This
 // means Atomic64 and AtomicWord should be the same type on 64-bit.
-#if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL) || defined(GOOGLE_PROTOBUF_ARCH_SPARC)
+#if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL)
 // NaCl's intptr_t is not actually 64-bits on 64-bit!
 // http://code.google.com/p/nativeclient/issues/detail?id=1162
 // sparcv9's pointer type is 32bits

--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -65,7 +65,7 @@
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
 #elif defined(sparc)
 #define GOOGLE_PROTOBUF_ARCH_SPARC 1
-#ifdef SOLARIS_64BIT_ENABLED
+#if defined(__sparc_v9__) || defined(__sparcv9) || defined(__arch64__)
 #define GOOGLE_PROTOBUF_ARCH_64_BIT 1
 #else
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1


### PR DESCRIPTION
# Fixes #585.

#### 1. m4/acx_check_suncc.m4
We should always append -m64 to the CFLAGS and CXXFLAGS even if the user provided them. It's quiet common to provide CFLAGS and CXXFLAGS and not adding -m64 to them while the --64bit-solaris flag is enabled creates confusion.
#### 2. src/google/protobuf/compiler/command_line_interface.cc
PATH_MAX on Solaris is defined in limits.h
#### 3. src/google/protobuf/stubs/atomicops.h
intptr_t is 8 bytes on Solaris in 64-bit mode. There's no need to treat it specially as this creates a compile error where the compiler complains about converting a long int* (intptr_t) to a long long int* (int64) even though both are 8 bytes in 64-bit mode.
#### 4. src/google/protobuf/stubs/platform_macros.h
There is no need for SOLARIS_64BIT_ENABLED as the proper way is to check for compiler defined macros just like all the other architectures. Keep in mind that SOLARIS_64BIT_ENABLED is defined in config.h and to check for it here you'll need to include config.h. config.h can't be included here as platform_macros.h is an external header and including config.h will create include conflicts with code using platform_macros.h.