### PR TITLE
Add GOOGLE_ATTRIBUTE_NOINLINE to GetArena() and GetMaybeArenaPointer(…

### DIFF
--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -495,11 +495,19 @@ Message* GenericTypeHandler<Message>::NewFromPrototype(
   return prototype->New(arena);
 }
 template<>
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+// Note: force noinline to workaround MSVC 2015 compiler bug, issue #240
+GOOGLE_ATTRIBUTE_NOINLINE
+#endif
 google::protobuf::Arena* GenericTypeHandler<Message>::GetArena(
     Message* value) {
   return value->GetArena();
 }
 template<>
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+// Note: force noinline to workaround MSVC 2015 compiler bug, issue #240
+GOOGLE_ATTRIBUTE_NOINLINE
+#endif
 void* GenericTypeHandler<Message>::GetMaybeArenaPointer(
     Message* value) {
   return value->GetMaybeArenaPointer();


### PR DESCRIPTION
…) methods. This is to avoid "unresolved link" errors in MSVC 2015 during Release build