### PR TITLE
Ignore unused typedef in _GPBCompileAssert macro

### DIFF
--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -58,7 +58,10 @@ static NSString *const kGPBDataCoderKey = @"GPBData";
 #define _GPBCompileAssertSymbolInner(line, msg) _GPBCompileAssert ## line ## __ ## msg
 #define _GPBCompileAssertSymbol(line, msg) _GPBCompileAssertSymbolInner(line, msg)
 #define _GPBCompileAssert(test, msg) \
-    typedef char _GPBCompileAssertSymbol(__LINE__, msg) [ ((test) ? 1 : -1) ]
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wunused-local-typedefs\"") \
+    typedef char _GPBCompileAssertSymbol(__LINE__, msg) [ ((test) ? 1 : -1) ] \
+_Pragma("clang diagnostic pop")
 #endif // _GPBCompileAssert
 
 //


### PR DESCRIPTION
This fixes a warning about an unused typedef:

```
Ignore unused typedef in _GPBCompileAssert macro
```

I got this error when adding the Protobuf code to my project, but I can't figure out how to trigger the warning in the Protobuf project. I'm using Xcode 7.0 in both projects.
#285 is kind of hard to parse, but this may fix the compiler error reported in this.
