### PR TITLE
Expose GetOutputFile in csharp_names.h

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -50,41 +50,6 @@ namespace protobuf {
 namespace compiler {
 namespace csharp {
 
-std::string GetOutputFile(
-    const google::protobuf::FileDescriptor* file,
-    const std::string file_extension,
-    const bool generate_directories,
-    const std::string base_namespace,
-    string* error) {
-  string relative_filename = GetUmbrellaClassUnqualifiedName(file) + file_extension;
-  if (!generate_directories) {
-    return relative_filename;
-  }
-  string ns = GetFileNamespace(file);
-  string namespace_suffix = ns;
-  if (!base_namespace.empty()) {
-    // Check that the base_namespace is either equal to or a leading part of
-    // the file namespace. This isn't just a simple prefix; "Foo.B" shouldn't
-    // be regarded as a prefix of "Foo.Bar". The simplest option is to add "."
-    // to both.
-    string extended_ns = ns + ".";
-    if (extended_ns.find(base_namespace + ".") != 0) {
-      *error = "Namespace " + ns + " is not a prefix namespace of base namespace " + base_namespace;
-      return ""; // This will be ignored, because we've set an error.
-    }
-    namespace_suffix = ns.substr(base_namespace.length());
-    if (namespace_suffix.find(".") == 0) {
-      namespace_suffix = namespace_suffix.substr(1);
-    }
-  }
-
-  string namespace_dir = StringReplace(namespace_suffix, ".", "/", true);
-  if (!namespace_dir.empty()) {
-    namespace_dir += "/";
-  }
-  return namespace_dir + relative_filename;
-}
-
 void GenerateFile(const google::protobuf::FileDescriptor* file,
                   io::Printer* printer) {
   UmbrellaClassGenerator umbrellaGenerator(file);
@@ -123,7 +88,7 @@ bool Generator::Generate(
 
   string filename_error = "";
   std::string filename = GetOutputFile(file, file_extension, generate_directories, base_namespace, &filename_error);
-  if (!filename_error.empty()) {
+  if (filename.empty()) {
     *error = filename_error;
     return false;
   }

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -76,8 +76,6 @@ std::string GetUmbrellaClassUnqualifiedName(const FileDescriptor* descriptor);
 // not including the GetFileNamespace part).
 std::string GetUmbrellaClassNestedNamespace(const FileDescriptor* descriptor);
 
-std::string GetClassName(const Descriptor* descriptor);
-
 std::string GetClassName(const EnumDescriptor* descriptor);
 
 std::string GetFieldName(const FieldDescriptor* descriptor);

--- a/src/google/protobuf/compiler/csharp/csharp_names.h
+++ b/src/google/protobuf/compiler/csharp/csharp_names.h
@@ -72,7 +72,28 @@ string GetClassName(const Descriptor* descriptor);
 //   The fully-qualified name of the C# class that provides
 //   access to the file descriptor. Proto compiler generates
 //   such class for each .proto file processed.
-std::string GetUmbrellaClassName(const FileDescriptor* descriptor);
+string GetUmbrellaClassName(const FileDescriptor* descriptor);
+
+// Generates output file name for given file descriptor. If generate_directories
+// is true, the output file will be put under directory corresponding to file's
+// namespace. base_namespace can be used to strip some of the top level
+// directories. E.g. for file with namespace "Bar.Foo" and base_namespace="Bar",
+// the resulting file will be put under directory "Foo" (and not "Bar/Foo").
+//
+// Requires:
+//   descriptor != NULL
+//   error != NULL
+//
+//  Returns:
+//    The file name to use as output file for given file descriptor. In case
+//    of failure, this function will return empty string and error parameter
+//    will contain the error message.
+string GetOutputFile(
+    const google::protobuf::FileDescriptor* descriptor,
+    const string file_extension,
+    const bool generate_directories,
+    const string base_namespace,
+    string* error);
 
 }  // namespace csharp
 }  // namespace compiler


### PR DESCRIPTION
Expose the GetOutputFile function in csharp_names.h so that the file naming logic (including base_namespace logic introduced in #785) can be reused by service stub generators (gRPC).

-- Also a bit of refactoring and remove redundant declaration of GetClassName(const Descriptor* descriptor) in csharp_helpers.h