### PR TITLE
A very small fix to silence some warnings.

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google-protobuf (3.0.0.alpha.4)
+    google-protobuf (3.0.0.alpha.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -23,3 +23,6 @@ DEPENDENCIES
   rake-compiler
   rubygems-tasks
   test-unit
+
+BUNDLED WITH
+   1.10.6

--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -35,11 +35,13 @@
 // For more information, see:
 //   https://bugs.ruby-lang.org/issues/11328
 VALUE noleak_rb_str_cat(VALUE rb_str, const char *str, long len) {
+  char *p;
   size_t oldlen = RSTRING_LEN(rb_str);
   rb_str_modify_expand(rb_str, len);
-  char *p = RSTRING_PTR(rb_str);
+  p = RSTRING_PTR(rb_str);
   memcpy(p + oldlen, str, len);
   rb_str_set_len(rb_str, oldlen + len);
+  return rb_str;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Also updated the Gemfile.lock since alpha-4 has been
pushed to RubyGems.

Change-Id: I8ddc5f125f28aa9a33c88dfe48251a75a877e1d3