### PR TITLE
Add (some) XML documentation to generated code

### DIFF
--- a/csharp/src/AddressBook/Addressbook.cs
+++ b/csharp/src/AddressBook/Addressbook.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.Examples.AddressBook {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from addressbook.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class Addressbook {
 
     #region Descriptor
@@ -214,8 +214,8 @@ namespace Google.Protobuf.Examples.AddressBook {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the Person message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum PhoneType {
         MOBILE = 0,

--- a/csharp/src/AddressBook/Addressbook.cs
+++ b/csharp/src/AddressBook/Addressbook.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.Examples.AddressBook {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from addressbook.proto</summary>
   public static partial class Addressbook {
 
     #region Descriptor
+    /// <summary>File descriptor for addressbook.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -213,6 +215,7 @@ namespace Google.Protobuf.Examples.AddressBook {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the Person message type.</summary>
     public static partial class Types {
       public enum PhoneType {
         MOBILE = 0,

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -227,7 +227,7 @@ namespace Conformance {
     }
 
     private object payload_;
-    /// <summary>Enum of possibly cases for the "payload" oneof.</summary>
+    /// <summary>Enum of possible cases for the "payload" oneof.</summary>
     public enum PayloadOneofCase {
       None = 0,
       ProtobufPayload = 1,
@@ -434,7 +434,7 @@ namespace Conformance {
     }
 
     private object result_;
-    /// <summary>Enum of possibly cases for the "result" oneof.</summary>
+    /// <summary>Enum of possible cases for the "result" oneof.</summary>
     public enum ResultOneofCase {
       None = 0,
       ParseError = 1,
@@ -1244,7 +1244,7 @@ namespace Conformance {
     }
 
     private object oneofField_;
-    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
+    /// <summary>Enum of possible cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       OneofUint32 = 111,

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Conformance {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from conformance.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class Conformance {
 
     #region Descriptor
@@ -2128,8 +2128,8 @@ namespace Conformance {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the TestAllTypes message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum NestedEnum {
         FOO = 0,

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Conformance {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from conformance.proto</summary>
   public static partial class Conformance {
 
     #region Descriptor
+    /// <summary>File descriptor for conformance.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -225,6 +227,7 @@ namespace Conformance {
     }
 
     private object payload_;
+    /// <summary>Enum of possibly cases for the "payload" oneof.</summary>
     public enum PayloadOneofCase {
       None = 0,
       ProtobufPayload = 1,
@@ -431,6 +434,7 @@ namespace Conformance {
     }
 
     private object result_;
+    /// <summary>Enum of possibly cases for the "result" oneof.</summary>
     public enum ResultOneofCase {
       None = 0,
       ParseError = 1,
@@ -1240,6 +1244,7 @@ namespace Conformance {
     }
 
     private object oneofField_;
+    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       OneofUint32 = 111,
@@ -2124,6 +2129,7 @@ namespace Conformance {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the TestAllTypes message type.</summary>
     public static partial class Types {
       public enum NestedEnum {
         FOO = 0,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/map_unittest_proto3.proto</summary>
   public static partial class MapUnittestProto3 {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/map_unittest_proto3.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -1306,6 +1308,7 @@ namespace Google.Protobuf.TestProtos {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the MessageContainingEnumCalledType message type.</summary>
     public static partial class Types {
       public enum Type {
         TYPE_FOO = 0,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/map_unittest_proto3.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class MapUnittestProto3 {
 
     #region Descriptor
@@ -1307,8 +1307,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the MessageContainingEnumCalledType message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum Type {
         TYPE_FOO = 0,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/unittest_import_proto3.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class UnittestImportProto3 {
 
     #region Descriptor

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/unittest_import_proto3.proto</summary>
   public static partial class UnittestImportProto3 {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/unittest_import_proto3.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/unittest_import_public_proto3.proto</summary>
   public static partial class UnittestImportPublicProto3 {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/unittest_import_public_proto3.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/unittest_import_public_proto3.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class UnittestImportPublicProto3 {
 
     #region Descriptor

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace UnitTest.Issues.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from unittest_issues.proto</summary>
   public static partial class UnittestIssues {
 
     #region Descriptor
+    /// <summary>File descriptor for unittest_issues.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -150,6 +152,7 @@ namespace UnitTest.Issues.TestProtos {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the Issue307 message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class NestedOnce : pb::IMessage<NestedOnce> {
@@ -227,6 +230,7 @@ namespace UnitTest.Issues.TestProtos {
 
         #region Nested types
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        /// <summary>Container for nested types declared in the NestedOnce message type.</summary>
         public static partial class Types {
           [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
           public sealed partial class NestedTwice : pb::IMessage<NestedTwice> {
@@ -982,6 +986,7 @@ namespace UnitTest.Issues.TestProtos {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the ReservedNames message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class SomeNestedType : pb::IMessage<SomeNestedType> {
@@ -1165,6 +1170,7 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     private object o1_;
+    /// <summary>Enum of possibly cases for the "o1" oneof.</summary>
     public enum O1OneofCase {
       None = 0,
       O1String = 2,
@@ -1181,6 +1187,7 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     private object o2_;
+    /// <summary>Enum of possibly cases for the "o2" oneof.</summary>
     public enum O2OneofCase {
       None = 0,
       O2Int32 = 6,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
@@ -1170,7 +1170,7 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     private object o1_;
-    /// <summary>Enum of possibly cases for the "o1" oneof.</summary>
+    /// <summary>Enum of possible cases for the "o1" oneof.</summary>
     public enum O1OneofCase {
       None = 0,
       O1String = 2,
@@ -1187,7 +1187,7 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     private object o2_;
-    /// <summary>Enum of possibly cases for the "o2" oneof.</summary>
+    /// <summary>Enum of possible cases for the "o2" oneof.</summary>
     public enum O2OneofCase {
       None = 0,
       O2Int32 = 6,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace UnitTest.Issues.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from unittest_issues.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class UnittestIssues {
 
     #region Descriptor
@@ -151,8 +151,8 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the Issue307 message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class NestedOnce : pb::IMessage<NestedOnce> {
@@ -229,8 +229,8 @@ namespace UnitTest.Issues.TestProtos {
         }
 
         #region Nested types
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         /// <summary>Container for nested types declared in the NestedOnce message type.</summary>
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         public static partial class Types {
           [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
           public sealed partial class NestedTwice : pb::IMessage<NestedTwice> {
@@ -985,8 +985,8 @@ namespace UnitTest.Issues.TestProtos {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the ReservedNames message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class SomeNestedType : pb::IMessage<SomeNestedType> {

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/unittest_proto3.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class UnittestProto3 {
 
     #region Descriptor
@@ -1446,8 +1446,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the TestAllTypes message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum NestedEnum {
         NESTED_ENUM_UNSPECIFIED = 0,
@@ -3060,8 +3060,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the TestFieldOrderings message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class NestedMessage : pb::IMessage<NestedMessage> {

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
@@ -717,7 +717,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object oneofField_;
-    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
+    /// <summary>Enum of possible cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       OneofUint32 = 111,
@@ -4274,7 +4274,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object foo_;
-    /// <summary>Enum of possibly cases for the "foo" oneof.</summary>
+    /// <summary>Enum of possible cases for the "foo" oneof.</summary>
     public enum FooOneofCase {
       None = 0,
       FooInt = 1,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/unittest_proto3.proto</summary>
   public static partial class UnittestProto3 {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/unittest_proto3.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -715,6 +717,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object oneofField_;
+    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       OneofUint32 = 111,
@@ -1444,6 +1447,7 @@ namespace Google.Protobuf.TestProtos {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the TestAllTypes message type.</summary>
     public static partial class Types {
       public enum NestedEnum {
         NESTED_ENUM_UNSPECIFIED = 0,
@@ -3057,6 +3061,7 @@ namespace Google.Protobuf.TestProtos {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the TestFieldOrderings message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       public sealed partial class NestedMessage : pb::IMessage<NestedMessage> {
@@ -4269,6 +4274,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object foo_;
+    /// <summary>Enum of possibly cases for the "foo" oneof.</summary>
     public enum FooOneofCase {
       None = 0,
       FooInt = 1,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/unittest_well_known_types.proto</summary>
   public static partial class UnittestWellKnownTypes {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/unittest_well_known_types.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -1468,6 +1470,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object oneofField_;
+    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       AnyField = 1,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
@@ -1470,7 +1470,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     private object oneofField_;
-    /// <summary>Enum of possibly cases for the "oneof_field" oneof.</summary>
+    /// <summary>Enum of possible cases for the "oneof_field" oneof.</summary>
     public enum OneofFieldOneofCase {
       None = 0,
       AnyField = 1,

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.TestProtos {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/unittest_well_known_types.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class UnittestWellKnownTypes {
 
     #region Descriptor

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -38,7 +38,7 @@ using System.IO;
 namespace Google.Protobuf
 {
     /// <summary>
-    /// Readings and decodes protocol message fields.
+    /// Reads and decodes protocol message fields.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorProtoFile.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorProtoFile.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.Reflection {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/descriptor.proto</summary>
   internal static partial class DescriptorProtoFile {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/descriptor.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }
@@ -878,6 +880,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the DescriptorProto message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class ExtensionRange : pb::IMessage<ExtensionRange> {
@@ -1456,6 +1459,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the FieldDescriptorProto message type.</summary>
     public static partial class Types {
       internal enum Type {
         TYPE_DOUBLE = 1,
@@ -2777,6 +2781,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the FileOptions message type.</summary>
     public static partial class Types {
       internal enum OptimizeMode {
         SPEED = 1,
@@ -3237,6 +3242,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the FieldOptions message type.</summary>
     public static partial class Types {
       internal enum CType {
         STRING = 0,
@@ -4011,6 +4017,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the UninterpretedOption message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class NamePart : pb::IMessage<NamePart> {
@@ -4239,6 +4246,7 @@ namespace Google.Protobuf.Reflection {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the SourceCodeInfo message type.</summary>
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class Location : pb::IMessage<Location> {

--- a/csharp/src/Google.Protobuf/Reflection/DescriptorProtoFile.cs
+++ b/csharp/src/Google.Protobuf/Reflection/DescriptorProtoFile.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.Reflection {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/descriptor.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   internal static partial class DescriptorProtoFile {
 
     #region Descriptor
@@ -879,8 +879,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the DescriptorProto message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class ExtensionRange : pb::IMessage<ExtensionRange> {
@@ -1458,8 +1458,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the FieldDescriptorProto message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       internal enum Type {
         TYPE_DOUBLE = 1,
@@ -2780,8 +2780,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the FileOptions message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       internal enum OptimizeMode {
         SPEED = 1,
@@ -3241,8 +3241,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the FieldOptions message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       internal enum CType {
         STRING = 0,
@@ -4016,8 +4016,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the UninterpretedOption message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class NamePart : pb::IMessage<NamePart> {
@@ -4245,8 +4245,8 @@ namespace Google.Protobuf.Reflection {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the SourceCodeInfo message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
       internal sealed partial class Location : pb::IMessage<Location> {

--- a/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FieldDescriptor.cs
@@ -252,7 +252,7 @@ namespace Google.Protobuf.Reflection
             {
                 if (fieldType != FieldType.Message)
                 {
-                    throw new InvalidOperationException("MessageType is only valid for enum fields.");
+                    throw new InvalidOperationException("MessageType is only valid for message fields.");
                 }
                 return messageType;
             }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/any.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Any {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/any.proto</summary>
     public static partial class Any {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/any.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/api.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Api {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/api.proto</summary>
     public static partial class Api {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/api.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/duration.proto</summary>
     public static partial class Duration {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/duration.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/duration.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Duration {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/empty.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Empty {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/empty.proto</summary>
     public static partial class Empty {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/empty.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/field_mask.proto</summary>
     public static partial class FieldMask {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/field_mask.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/field_mask.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class FieldMask {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/source_context.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class SourceContext {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/source_context.proto</summary>
     public static partial class SourceContext {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/source_context.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
@@ -255,7 +255,7 @@ namespace Google.Protobuf.WellKnownTypes {
     }
 
     private object kind_;
-    /// <summary>Enum of possibly cases for the "kind" oneof.</summary>
+    /// <summary>Enum of possible cases for the "kind" oneof.</summary>
     public enum KindOneofCase {
       None = 0,
       NullValue = 1,

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/struct.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Struct {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/struct.proto</summary>
     public static partial class Struct {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/struct.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }
@@ -253,6 +255,7 @@ namespace Google.Protobuf.WellKnownTypes {
     }
 
     private object kind_;
+    /// <summary>Enum of possibly cases for the "kind" oneof.</summary>
     public enum KindOneofCase {
       None = 0,
       NullValue = 1,

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/timestamp.proto</summary>
     public static partial class Timestamp {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/timestamp.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/timestamp.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Timestamp {
 
       #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
@@ -11,8 +11,8 @@ namespace Google.Protobuf.WellKnownTypes {
 
   namespace Proto {
 
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Holder for reflection information generated from google/protobuf/type.proto</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Type {
 
       #region Descriptor
@@ -597,8 +597,8 @@ namespace Google.Protobuf.WellKnownTypes {
     }
 
     #region Nested types
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     /// <summary>Container for nested types declared in the Field message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     public static partial class Types {
       public enum Kind {
         TYPE_UNKNOWN = 0,

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
@@ -12,9 +12,11 @@ namespace Google.Protobuf.WellKnownTypes {
   namespace Proto {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Holder for reflection information generated from google/protobuf/type.proto</summary>
     public static partial class Type {
 
       #region Descriptor
+      /// <summary>File descriptor for google/protobuf/type.proto</summary>
       public static pbr::FileDescriptor Descriptor {
         get { return descriptor; }
       }
@@ -596,6 +598,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     #region Nested types
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    /// <summary>Container for nested types declared in the Field message type.</summary>
     public static partial class Types {
       public enum Kind {
         TYPE_UNKNOWN = 0,

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
@@ -9,8 +9,8 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.WellKnownTypes {
 
-  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   /// <summary>Holder for reflection information generated from google/protobuf/wrappers.proto</summary>
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
   public static partial class Wrappers {
 
     #region Descriptor

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
@@ -10,9 +10,11 @@ using scg = global::System.Collections.Generic;
 namespace Google.Protobuf.WellKnownTypes {
 
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+  /// <summary>Holder for reflection information generated from google/protobuf/wrappers.proto</summary>
   public static partial class Wrappers {
 
     #region Descriptor
+    /// <summary>File descriptor for google/protobuf/wrappers.proto</summary>
     public static pbr::FileDescriptor Descriptor {
       get { return descriptor; }
     }

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -169,7 +169,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
     printer->Print(
       vars,
       "private object $name$_;\n"
-      "/// <summary>Enum of possibly cases for the \"$original_name$\" oneof.</summary>\n"
+      "/// <summary>Enum of possible cases for the \"$original_name$\" oneof.</summary>\n"
       "public enum $property_name$OneofCase {\n");
     printer->Indent();
     printer->Print("None = 0,\n");

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -200,13 +200,13 @@ void MessageGenerator::Generate(io::Printer* printer) {
 
   // Nested messages and enums
   if (HasNestedGeneratedTypes()) {
-    printer->Print("#region Nested types\n"
-		   "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
-    WriteGeneratedCodeAttributes(printer);
     printer->Print(
-        vars,
-        "/// <summary>Container for nested types declared in the $class_name$ message type.</summary>\n"
-        "public static partial class Types {\n");
+      vars,
+      "#region Nested types\n"
+      "/// <summary>Container for nested types declared in the $class_name$ message type.</summary>\n"
+      "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
+    WriteGeneratedCodeAttributes(printer);
+    printer->Print("public static partial class Types {\n");
     printer->Indent();
     for (int i = 0; i < descriptor_->enum_type_count(); i++) {
       EnumGenerator enumGenerator(descriptor_->enum_type(i));

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -169,6 +169,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
     printer->Print(
       vars,
       "private object $name$_;\n"
+      "/// <summary>Enum of possibly cases for the \"$original_name$\" oneof.</summary>\n"
       "public enum $property_name$OneofCase {\n");
     printer->Indent();
     printer->Print("None = 0,\n");
@@ -202,7 +203,10 @@ void MessageGenerator::Generate(io::Printer* printer) {
     printer->Print("#region Nested types\n"
 		   "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
     WriteGeneratedCodeAttributes(printer);
-    printer->Print("public static partial class Types {\n");
+    printer->Print(
+        vars,
+        "/// <summary>Container for nested types declared in the $class_name$ message type.</summary>\n"
+        "public static partial class Types {\n");
     printer->Indent();
     for (int i = 0; i < descriptor_->enum_type_count(); i++) {
       EnumGenerator enumGenerator(descriptor_->enum_type(i));

--- a/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
@@ -135,13 +135,13 @@ void UmbrellaClassGenerator::WriteIntroduction(io::Printer* printer) {
   }
 
   printer->Print(
-    "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
+    "/// <summary>Holder for reflection information generated from $file_name$</summary>\n"
+    "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n",
+    "file_name", file_->name());
   WriteGeneratedCodeAttributes(printer);
   printer->Print(
-    "/// <summary>Holder for reflection information generated from $file_name$</summary>\n"
     "$access_level$ static partial class $umbrella_class_name$ {\n"
     "\n",
-    "file_name", file_->name(),
     "access_level", class_access_level(),
     "umbrella_class_name", umbrellaClassname_);
   printer->Indent();

--- a/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_umbrella_class.cc
@@ -138,8 +138,10 @@ void UmbrellaClassGenerator::WriteIntroduction(io::Printer* printer) {
     "[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]\n");
   WriteGeneratedCodeAttributes(printer);
   printer->Print(
+    "/// <summary>Holder for reflection information generated from $file_name$</summary>\n"
     "$access_level$ static partial class $umbrella_class_name$ {\n"
     "\n",
+    "file_name", file_->name(),
     "access_level", class_access_level(),
     "umbrella_class_name", umbrellaClassname_);
   printer->Indent();
@@ -148,12 +150,14 @@ void UmbrellaClassGenerator::WriteIntroduction(io::Printer* printer) {
 void UmbrellaClassGenerator::WriteDescriptor(io::Printer* printer) {
   printer->Print(
     "#region Descriptor\n"
+    "/// <summary>File descriptor for $file_name$</summary>\n"
     "public static pbr::FileDescriptor Descriptor {\n"
     "  get { return descriptor; }\n"
     "}\n"
     "private static pbr::FileDescriptor descriptor;\n"
     "\n"
     "static $umbrella_class_name$() {\n",
+    "file_name", file_->name(),
     "umbrella_class_name", umbrellaClassname_);
   printer->Indent();
   printer->Print(


### PR DESCRIPTION
Not the "pulling .proto comments" yet, but just enough on a few common types and properties to make the generated API docs rather more readable.