### PR TITLE
Fix copyreg import.

### DIFF
--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -58,7 +58,7 @@ import struct
 import weakref
 
 import six
-import six.moves.copyreg as copyreg
+from six.moves import copyreg
 
 # We use "as" to avoid name collisions with variables.
 from google.protobuf.internal import containers


### PR DESCRIPTION
OSX 10.11 (El Capitan) Python 2.7.10

After installing protobuf 3.0 beta1 I get the following when importing a python proto:

```
>>> import test_pb2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "test_pb2.py", line 6, in <module>
    from google.protobuf import reflection as _reflection
  File "/usr/local/Cellar/google-protobuf/3.0.0-beta-1/libexec/lib/python2.7/site-packages/google/protobuf/reflection.py", line 58, in <module>
    from google.protobuf.internal import python_message as message_impl
  File "/usr/local/Cellar/google-protobuf/3.0.0-beta-1/libexec/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 61, in <module>
    import six.moves.copyreg as copyreg
ImportError: No module named copyreg
```