### PR TITLE
Added deprecated option handling to objective-c

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
@@ -72,8 +72,9 @@ void EnumGenerator::GenerateHeader(io::Printer* printer) {
       "\n",
       "name", name_);
 
-  printer->Print("$comments$typedef GPB_ENUM($name$) {\n",
+  printer->Print("$comments$typedef$deprecated_attribute$ GPB_ENUM($name$) {\n",
                  "comments", enum_comments,
+                 "deprecated_attribute", GetOptionalDeprecatedAttribute(descriptor_),
                  "name", name_);
   printer->Indent();
 
@@ -99,8 +100,9 @@ void EnumGenerator::GenerateHeader(io::Printer* printer) {
     }
 
     printer->Print(
-        "$name$ = $value$,\n",
+        "$name$$deprecated_attribute$ = $value$,\n",
         "name", EnumValueName(all_values_[i]),
+        "deprecated_attribute", GetOptionalDeprecatedAttribute(all_values_[i]),
         "value", SimpleItoa(all_values_[i]->number()));
   }
   printer->Outdent();

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -78,6 +78,7 @@ void SetCommonFieldVariables(const FieldDescriptor* descriptor,
       classname + "_FieldNumber_" + capitalized_name;
   (*variables)["field_number"] = SimpleItoa(descriptor->number());
   (*variables)["field_type"] = GetCapitalizedType(descriptor);
+  (*variables)["deprecated_attribute"] = GetOptionalDeprecatedAttribute(descriptor);
   std::vector<string> field_flags;
   if (descriptor->is_repeated()) field_flags.push_back("GPBFieldRepeated");
   if (descriptor->is_required()) field_flags.push_back("GPBFieldRequired");
@@ -266,12 +267,12 @@ void SingleFieldGenerator::GeneratePropertyDeclaration(
   printer->Print(variables_, "$comments$");
   printer->Print(
       variables_,
-      "@property(nonatomic, readwrite) $property_type$ $name$;\n"
+      "@property(nonatomic, readwrite) $property_type$ $name$$deprecated_attribute$;\n"
       "\n");
   if (WantsHasProperty()) {
     printer->Print(
         variables_,
-        "@property(nonatomic, readwrite) BOOL has$capitalized_name$;\n");
+        "@property(nonatomic, readwrite) BOOL has$capitalized_name$$deprecated_attribute$;\n");
   }
 }
 
@@ -330,18 +331,18 @@ void ObjCObjFieldGenerator::GeneratePropertyDeclaration(
   printer->Print(variables_, "$comments$");
   printer->Print(
       variables_,
-      "@property(nonatomic, readwrite, $property_storage_attribute$, null_resettable) $property_type$ *$name$$storage_attribute$;\n");
+      "@property(nonatomic, readwrite, $property_storage_attribute$, null_resettable) $property_type$ *$name$$storage_attribute$$deprecated_attribute$;\n");
   if (WantsHasProperty()) {
     printer->Print(
         variables_,
         "/// Test to see if @c $name$ has been set.\n"
-        "@property(nonatomic, readwrite) BOOL has$capitalized_name$;\n");
+        "@property(nonatomic, readwrite) BOOL has$capitalized_name$$deprecated_attribute$;\n");
   }
   if (IsInitName(variables_.find("name")->second)) {
     // If property name starts with init we need to annotate it to get past ARC.
     // http://stackoverflow.com/questions/18723226/how-do-i-annotate-an-objective-c-property-with-an-objc-method-family/18723227#18723227
     printer->Print(variables_,
-                   "- ($property_type$ *)$name$ GPB_METHOD_FAMILY_NONE;\n");
+                   "- ($property_type$ *)$name$ GPB_METHOD_FAMILY_NONE$deprecated_attribute$;\n");
   }
   printer->Print("\n");
 }
@@ -385,14 +386,14 @@ void RepeatedFieldGenerator::GeneratePropertyDeclaration(
       variables_,
       "$comments$"
       "$array_comment$"
-      "@property(nonatomic, readwrite, strong, null_resettable) $array_property_type$ *$name$$storage_attribute$;\n"
+      "@property(nonatomic, readwrite, strong, null_resettable) $array_property_type$ *$name$$storage_attribute$$deprecated_attribute$;\n"
       "/// The number of items in @c $name$ without causing the array to be created.\n"
-      "@property(nonatomic, readonly) NSUInteger $name$_Count;\n");
+      "@property(nonatomic, readonly) NSUInteger $name$_Count$deprecated_attribute$;\n");
   if (IsInitName(variables_.find("name")->second)) {
     // If property name starts with init we need to annotate it to get past ARC.
     // http://stackoverflow.com/questions/18723226/how-do-i-annotate-an-objective-c-property-with-an-objc-method-family/18723227#18723227
     printer->Print(variables_,
-                   "- ($array_property_type$ *)$name$ GPB_METHOD_FAMILY_NONE;\n");
+                   "- ($array_property_type$ *)$name$ GPB_METHOD_FAMILY_NONE$deprecated_attribute$;\n");
   }
   printer->Print("\n");
 }

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -115,6 +115,9 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
   printer->Print(
       "// @@protoc_insertion_point(imports)\n"
       "\n"
+      "#pragma clang diagnostic push\n"
+      "#pragma clang diagnostic ignored \"-Wdeprecated-declarations\"\n"
+      "\n"
       "CF_EXTERN_C_BEGIN\n"
       "\n");
 
@@ -189,6 +192,8 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
       "\n"
       "CF_EXTERN_C_END\n"
       "\n"
+      "#pragma clang diagnostic pop\n"
+      "\n"
       "// @@protoc_insertion_point(global_scope)\n");
 }
 
@@ -216,6 +221,9 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
   }
   printer->Print(
       "// @@protoc_insertion_point(imports)\n"
+      "\n"
+      "#pragma clang diagnostic push\n"
+      "#pragma clang diagnostic ignored \"-Wdeprecated-declarations\"\n"
       "\n");
 
   printer->Print(
@@ -342,6 +350,8 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
   }
 
   printer->Print(
+    "\n"
+    "#pragma clang diagnostic pop\n"
     "\n"
     "// @@protoc_insertion_point(global_scope)\n");
 }

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -133,6 +133,22 @@ enum ObjectiveCType {
   OBJECTIVECTYPE_MESSAGE
 };
 
+template<class TDescriptor>
+string GetOptionalDeprecatedAttribute(const TDescriptor* descriptor, bool preSpace = true, bool postNewline = false) {
+  if (descriptor->options().deprecated()) {
+    string result = "DEPRECATED_ATTRIBUTE";
+    if (preSpace) {
+      result.insert(0, " ");
+    }
+    if (postNewline) {
+      result.append("\n");
+    }
+    return result;
+  } else {
+    return "";
+  }
+}
+
 string GetCapitalizedType(const FieldDescriptor* field);
 
 ObjectiveCType GetObjectiveCType(FieldDescriptor::Type field_type);

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -321,8 +321,9 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
   }
 
   printer->Print(
-      "$comments$@interface $classname$ : GPBMessage\n\n",
+      "$comments$$deprecated_attribute$@interface $classname$ : GPBMessage\n\n",
       "classname", class_name_,
+      "deprecated_attribute", GetOptionalDeprecatedAttribute(descriptor_, false, true),
       "comments", message_comments);
 
   vector<char> seen_oneofs(descriptor_->oneof_decl_count(), 0);


### PR DESCRIPTION
Previously generated objective-c code didn't have deprecated attribute for fields marked with deprecated option. This pull requests fixes this problem by adding DEPRECATED_ATTRIBUTE to all generated properties (field property itself, 'has' properties and '_Count' properties).

Example:
For field repeated int32 positions = 2 [deprecated = true]; following code would be generated:
`@property(nonatomic, readwrite) BOOL hasTableInfo DEPRECATED_ATTRIBUTE;`
`@property(nonatomic, readwrite, strong, null_resettable) LV2TableInfo *tableInfo DEPRECATED_ATTRIBUTE;`
instead of:
`@property(nonatomic, readwrite) BOOL hasTableInfo;`
`@property(nonatomic, readwrite, strong, null_resettable) LV2TableInfo *tableInfo;`