### PR TITLE
VS2010 compatibility of address initalization

### DIFF
--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -163,7 +163,7 @@ typedef pair<char*, int> Segment;
 class SegmentedZeroCopyOutputStream : public io::ZeroCopyOutputStream {
  public:
   explicit SegmentedZeroCopyOutputStream(list<Segment> segments)
-      : segments_(segments), last_segment_((char*)NULL, 0), byte_count_(0) {}
+      : segments_(segments), last_segment_(static_cast<char*>(NULL), 0), byte_count_(0) {}
 
   virtual bool Next(void** buffer, int* length) {
     if (segments_.empty()) {

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -163,7 +163,7 @@ typedef pair<char*, int> Segment;
 class SegmentedZeroCopyOutputStream : public io::ZeroCopyOutputStream {
  public:
   explicit SegmentedZeroCopyOutputStream(list<Segment> segments)
-      : segments_(segments), last_segment_(NULL, 0), byte_count_(0) {}
+      : segments_(segments), last_segment_((char*)NULL, 0), byte_count_(0) {}
 
   virtual bool Next(void** buffer, int* length) {
     if (segments_.empty()) {


### PR DESCRIPTION
VS2010 cannot compile json_util_test.cc since it assumes NULL as a zero (int), and therefore cannot convert into to char*