### PR TITLE
POC: Supporting zero-copy for writing

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,6 +32,12 @@
       scm:git:https://github.com/google/protobuf.git
     </connection>
   </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -51,18 +57,31 @@
       <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.11.1</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
         <configuration>
           <includes>
             <include>**/*Test.java</include>
@@ -304,6 +323,7 @@
                 <include>**/UnmodifiableLazyStringList.java</include>
                 <include>**/Utf8.java</include>
                 <include>**/WireFormat.java</include>
+                <include>**/UnsafeByteString.java</include>
               </includes>
               <testIncludes>
                 <testInclude>**/*Lite.java</testInclude>
@@ -316,6 +336,7 @@
                 <testInclude>**/LongArrayListTest.java</testInclude>
                 <testInclude>**/ProtobufArrayListTest.java</testInclude>
                 <testInclude>**/UnknownFieldSetLiteTest.java</testInclude>
+                <testInclude>**/UnsafeByteStringTest.java</testInclude>
               </testIncludes>
             </configuration>
           </plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -291,6 +291,7 @@
                 <include>**/AbstractProtobufList.java</include>
                 <include>**/BoundedByteString.java</include>
                 <include>**/BooleanArrayList.java</include>
+                <include>**/ByteBufferByteString.java</include>
                 <include>**/ByteString.java</include>
                 <include>**/CodedInputStream.java</include>
                 <include>**/CodedOutputStream.java</include>
@@ -314,6 +315,7 @@
                 <include>**/MessageLiteOrBuilder.java</include>
                 <include>**/MutabilityOracle.java</include>
                 <include>**/Parser.java</include>
+                <include>**/PlatformDependent.java</include>
                 <include>**/ProtobufArrayList.java</include>
                 <include>**/ProtocolStringList.java</include>
                 <include>**/RopeByteString.java</include>
@@ -323,20 +325,20 @@
                 <include>**/UnmodifiableLazyStringList.java</include>
                 <include>**/Utf8.java</include>
                 <include>**/WireFormat.java</include>
-                <include>**/UnsafeByteString.java</include>
               </includes>
               <testIncludes>
                 <testInclude>**/*Lite.java</testInclude>
                 <testInclude>**/BooleanArrayListTest.java</testInclude>
+                <testInclude>**/ByteBufferByteStringTest.java</testInclude>
                 <testInclude>**/DoubleArrayListTest.java</testInclude>
                 <testInclude>**/FloatArrayListTest.java</testInclude>
                 <testInclude>**/IntArrayListTest.java</testInclude>
                 <testInclude>**/LazyMessageLiteTest.java</testInclude>
                 <testInclude>**/LiteTest.java</testInclude>
                 <testInclude>**/LongArrayListTest.java</testInclude>
+                <testInclude>**/PlatformDependentTest.java</testInclude>
                 <testInclude>**/ProtobufArrayListTest.java</testInclude>
                 <testInclude>**/UnknownFieldSetLiteTest.java</testInclude>
-                <testInclude>**/UnsafeByteStringTest.java</testInclude>
               </testIncludes>
             </configuration>
           </plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,12 +61,13 @@
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <version>1.11.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
       <version>1.11.1</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/java/src/main/java/com/google/protobuf/AbstractMessage.java
+++ b/java/src/main/java/com/google/protobuf/AbstractMessage.java
@@ -82,7 +82,7 @@ public abstract class AbstractMessage extends AbstractMessageLite
     return TextFormat.printToString(this);
   }
 
-  public void writeTo(final CodedOutputStream output) throws IOException {
+  public void writeTo(final Encoder output) throws IOException {
     MessageReflection.writeMessageTo(this, getAllFields(), output, false);
   }
 

--- a/java/src/main/java/com/google/protobuf/ByteBufferByteString.java
+++ b/java/src/main/java/com/google/protobuf/ByteBufferByteString.java
@@ -61,7 +61,7 @@ final class ByteBufferByteString extends ByteString implements Externalizable {
   private List<ByteBuffer> readOnlyBufferList;
 
   /**
-   * Has is lazy-calculated.
+   * Hash is lazy-calculated.
    */
   private int hash;
 
@@ -241,7 +241,7 @@ final class ByteBufferByteString extends ByteString implements Externalizable {
     int offset;
     if(buffer.hasArray()) {
       bytes = buffer.array();
-      offset = buffer.arrayOffset();
+      offset = buffer.arrayOffset() + buffer.position();
     } else {
       bytes = new byte[buffer.remaining()];
       offset = 0;
@@ -344,7 +344,7 @@ final class ByteBufferByteString extends ByteString implements Externalizable {
       private int mark;
 
       @Override
-      public synchronized void mark(int readlimit) {
+      public void mark(int readlimit) {
         mark = buf.position();
       }
 
@@ -354,7 +354,7 @@ final class ByteBufferByteString extends ByteString implements Externalizable {
       }
 
       @Override
-      public synchronized void reset() throws IOException {
+      public void reset() throws IOException {
         buf.position(mark);
       }
 

--- a/java/src/main/java/com/google/protobuf/ByteBufferByteString.java
+++ b/java/src/main/java/com/google/protobuf/ByteBufferByteString.java
@@ -44,9 +44,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * A {@link ByteString} that wraps around a {@link ByteBuffer} and exposes the underlying buffer.
+ * A {@link ByteString} that wraps around a {@link ByteBuffer}.
  */
-public final class UnsafeByteString extends ByteString implements Externalizable {
+final class ByteBufferByteString extends ByteString implements Externalizable {
   private static final long serialVersionUID = -5543703061195105843L;
 
   /**
@@ -67,10 +67,10 @@ public final class UnsafeByteString extends ByteString implements Externalizable
   /**
    * Public no-arg constructor is needed by {@link Externalizable}. Do not use directly.
    */
-  public UnsafeByteString() {
+  public ByteBufferByteString() {
   }
 
-  UnsafeByteString(ByteBuffer buffer) {
+  ByteBufferByteString(ByteBuffer buffer) {
     if (buffer == null) {
       throw new NullPointerException("buffer");
     }
@@ -170,7 +170,7 @@ public final class UnsafeByteString extends ByteString implements Externalizable
   @Override
   public ByteString substring(int beginIndex, int endIndex) {
     ByteBuffer slice = slice(beginIndex, endIndex);
-    return new UnsafeByteString(slice);
+    return new ByteBufferByteString(slice);
   }
 
   @Override
@@ -287,8 +287,8 @@ public final class UnsafeByteString extends ByteString implements Externalizable
     if (size() == 0) {
       return true;
     }
-    if (other instanceof UnsafeByteString) {
-      return buffer.equals(((UnsafeByteString) other).buffer);
+    if (other instanceof ByteBufferByteString) {
+      return buffer.equals(((ByteBufferByteString) other).buffer);
     }
     if (other instanceof RopeByteString) {
       return other.equals(this);

--- a/java/src/main/java/com/google/protobuf/ByteString.java
+++ b/java/src/main/java/com/google/protobuf/ByteString.java
@@ -247,12 +247,27 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
   }
 
   /**
-   * Unsafe operation that creates a {@link UnsafeByteString} that directly wraps the given
-   * {@link ByteBuffer}. Any changes to the underlying {@link ByteBuffer} will change the content
-   * of the returned {@link UnsafeByteString}. Use at your own risk.
+   * Unsafe operation, allowing zero-copy. Creates a {@link ByteString} backed by the given
+   * array. This should only be used if the given array is guaranteed never to change.
    */
-  public static UnsafeByteString unsafeWrapper(ByteBuffer bytes) {
-    return new UnsafeByteString(bytes);
+  public static ByteString wrap(byte[] bytes) {
+    return new LiteralByteString(bytes);
+  }
+
+  /**
+   * Unsafe operation, allowing zero-copy. Creates a {@link ByteString} backed by the given
+   * array. This should only be used if the given array is guaranteed never to change.
+   */
+  public static ByteString wrap(byte[] bytes, int offset, int length) {
+    return new BoundedByteString(bytes, offset, length);
+  }
+
+  /**
+   * Unsafe operation, allowing zero-copy. Creates a {@link ByteString} backed by the given
+   * buffer. This should only be used if the given buffer is guaranteed never to change.
+   */
+  public static ByteString wrap(ByteBuffer bytes) {
+    return new ByteBufferByteString(bytes);
   }
 
   /**

--- a/java/src/main/java/com/google/protobuf/ByteString.java
+++ b/java/src/main/java/com/google/protobuf/ByteString.java
@@ -551,7 +551,19 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
    * @throws java.nio.BufferOverflowException if the {@code target}'s
    *     remaining() space is not large enough to hold the data.
    */
-  public abstract void copyTo(ByteBuffer target);
+  public void copyTo(ByteBuffer target) {
+    copyTo(target, 0, size());
+  }
+
+  /**
+   * Copies bytes into a ByteBuffer.
+   *
+   * @param target ByteBuffer to copy into.
+   * @throws java.nio.ReadOnlyBufferException if the {@code target} is read-only
+   * @throws java.nio.BufferOverflowException if the {@code target}'s
+   *     remaining() space is not large enough to hold the data.
+   */
+  public abstract void copyTo(ByteBuffer target, int sourceOffset, int numberToCopy);
 
   /**
    * Copies bytes to a {@code byte[]}.

--- a/java/src/main/java/com/google/protobuf/ByteString.java
+++ b/java/src/main/java/com/google/protobuf/ByteString.java
@@ -247,6 +247,15 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
   }
 
   /**
+   * Unsafe operation that creates a {@link UnsafeByteString} that directly wraps the given
+   * {@link ByteBuffer}. Any changes to the underlying {@link ByteBuffer} will change the content
+   * of the returned {@link UnsafeByteString}. Use at your own risk.
+   */
+  public static UnsafeByteString unsafeWrapper(ByteBuffer bytes) {
+    return new UnsafeByteString(bytes);
+  }
+
+  /**
    * Encodes {@code text} into a sequence of bytes using the named charset
    * and returns the result as a {@code ByteString}.
    *
@@ -716,6 +725,17 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
   public abstract boolean equals(Object o);
 
   /**
+   * Check equality of the substring of given length of this object starting at
+   * zero with another {@code ByteString} substring starting at offset.
+   *
+   * @param other  what to compare a substring in
+   * @param offset offset into other
+   * @param length number of bytes to compare
+   * @return true for equality of substrings, else false.
+   */
+  abstract boolean equalsRange(ByteString other, int offset, int length);
+
+  /**
    * Return a non-zero hashCode depending only on the sequence of bytes
    * in this ByteString.
    *
@@ -1004,7 +1024,7 @@ public abstract class ByteString implements Iterable<Byte>, Serializable {
       return new LiteralByteString(buffer);
     }
 
-    public CodedOutputStream getCodedOutput() {
+    public Encoder getCodedOutput() {
       return output;
     }
   }

--- a/java/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -224,29 +224,29 @@ public final class CodedInputStream {
     switch (WireFormat.getTagWireType(tag)) {
       case WireFormat.WIRETYPE_VARINT: {
         long value = readInt64();
-        output.writeRawVarint32(tag);
+        output.writeUInt32NoTag(tag);
         output.writeUInt64NoTag(value);
         return true;
       }
       case WireFormat.WIRETYPE_FIXED64: {
         long value = readRawLittleEndian64();
-        output.writeRawVarint32(tag);
+        output.writeUInt32NoTag(tag);
         output.writeFixed64NoTag(value);
         return true;
       }
       case WireFormat.WIRETYPE_LENGTH_DELIMITED: {
         ByteString value = readBytes();
-        output.writeRawVarint32(tag);
+        output.writeUInt32NoTag(tag);
         output.writeBytesNoTag(value);
         return true;
       }
       case WireFormat.WIRETYPE_START_GROUP: {
-        output.writeRawVarint32(tag);
+        output.writeUInt32NoTag(tag);
         skipMessage(output);
         int endtag = WireFormat.makeTag(WireFormat.getTagFieldNumber(tag),
                                         WireFormat.WIRETYPE_END_GROUP);
         checkLastTagWas(endtag);
-        output.writeRawVarint32(endtag);
+        output.writeUInt32NoTag(endtag);
         return true;
       }
       case WireFormat.WIRETYPE_END_GROUP: {
@@ -254,7 +254,7 @@ public final class CodedInputStream {
       }
       case WireFormat.WIRETYPE_FIXED32: {
         int value = readRawLittleEndian32();
-        output.writeRawVarint32(tag);
+        output.writeUInt32NoTag(tag);
         output.writeFixed32NoTag(value);
         return true;
       }

--- a/java/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -219,7 +219,7 @@ public final class CodedInputStream {
    * @return {@code false} if the tag is an endgroup tag, in which case
    *         nothing is skipped.  Otherwise, returns {@code true}.
    */
-  public boolean skipField(final int tag, final CodedOutputStream output)
+  public boolean skipField(final int tag, final Encoder output)
       throws IOException {
     switch (WireFormat.getTagWireType(tag)) {
       case WireFormat.WIRETYPE_VARINT: {
@@ -281,7 +281,7 @@ public final class CodedInputStream {
    * This will read either until EOF or until an endgroup tag,
    * whichever comes first.
    */
-  public void skipMessage(CodedOutputStream output) throws IOException {
+  public void skipMessage(Encoder output) throws IOException {
     while (true) {
       final int tag = readTag();
       if (tag == 0 || !skipField(tag, output)) {

--- a/java/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -172,6 +172,7 @@ public final class CodedOutputStream implements Encoder {
   // -----------------------------------------------------------------
 
   /** Write a {@code double} field, including tag, to the stream. */
+  @Override
   public void writeDouble(final int fieldNumber, final double value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
@@ -179,6 +180,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code float} field, including tag, to the stream. */
+  @Override
   public void writeFloat(final int fieldNumber, final float value)
                          throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
@@ -186,6 +188,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code uint64} field, including tag, to the stream. */
+  @Override
   public void writeUInt64(final int fieldNumber, final long value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -193,6 +196,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code int64} field, including tag, to the stream. */
+  @Override
   public void writeInt64(final int fieldNumber, final long value)
                          throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -200,6 +204,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code int32} field, including tag, to the stream. */
+  @Override
   public void writeInt32(final int fieldNumber, final int value)
                          throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -207,6 +212,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code fixed64} field, including tag, to the stream. */
+  @Override
   public void writeFixed64(final int fieldNumber, final long value)
                            throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
@@ -214,6 +220,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code fixed32} field, including tag, to the stream. */
+  @Override
   public void writeFixed32(final int fieldNumber, final int value)
                            throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
@@ -221,6 +228,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code bool} field, including tag, to the stream. */
+  @Override
   public void writeBool(final int fieldNumber, final boolean value)
                         throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -228,6 +236,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code string} field, including tag, to the stream. */
+  @Override
   public void writeString(final int fieldNumber, final String value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
@@ -235,6 +244,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code group} field, including tag, to the stream. */
+  @Override
   public void writeGroup(final int fieldNumber, final MessageLite value)
                          throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_START_GROUP);
@@ -257,6 +267,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an embedded message field, including tag, to the stream. */
+  @Override
   public void writeMessage(final int fieldNumber, final MessageLite value)
                            throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
@@ -265,6 +276,7 @@ public final class CodedOutputStream implements Encoder {
 
 
   /** Write a {@code bytes} field, including tag, to the stream. */
+  @Override
   public void writeBytes(final int fieldNumber, final ByteString value)
                          throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
@@ -279,6 +291,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code bytes} field, including tag, to the stream. */
+  @Override
   public void writeByteArray(final int fieldNumber,
                              final byte[] value,
                              final int offset,
@@ -305,6 +318,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code uint32} field, including tag, to the stream. */
+  @Override
   public void writeUInt32(final int fieldNumber, final int value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -315,6 +329,7 @@ public final class CodedOutputStream implements Encoder {
    * Write an enum field, including tag, to the stream.  Caller is responsible
    * for converting the enum value to its numeric value.
    */
+  @Override
   public void writeEnum(final int fieldNumber, final int value)
                         throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -322,6 +337,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code sfixed32} field, including tag, to the stream. */
+  @Override
   public void writeSFixed32(final int fieldNumber, final int value)
                             throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
@@ -329,6 +345,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code sfixed64} field, including tag, to the stream. */
+  @Override
   public void writeSFixed64(final int fieldNumber, final long value)
                             throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
@@ -336,6 +353,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code sint32} field, including tag, to the stream. */
+  @Override
   public void writeSInt32(final int fieldNumber, final int value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -343,6 +361,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an {@code sint64} field, including tag, to the stream. */
+  @Override
   public void writeSInt64(final int fieldNumber, final long value)
                           throws IOException {
     writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -353,6 +372,7 @@ public final class CodedOutputStream implements Encoder {
    * Write a MessageSet extension field to the stream.  For historical reasons,
    * the wire format differs from normal fields.
    */
+  @Override
   public void writeMessageSetExtension(final int fieldNumber,
                                        final MessageLite value)
                                        throws IOException {
@@ -366,6 +386,7 @@ public final class CodedOutputStream implements Encoder {
    * Write an unparsed MessageSet extension field to the stream.  For
    * historical reasons, the wire format differs from normal fields.
    */
+  @Override
   public void writeRawMessageSetExtension(final int fieldNumber,
                                           final ByteString value)
                                           throws IOException {
@@ -378,26 +399,31 @@ public final class CodedOutputStream implements Encoder {
   // -----------------------------------------------------------------
 
   /** Write a {@code double} field to the stream. */
+  @Override
   public void writeDoubleNoTag(final double value) throws IOException {
     writeRawLittleEndian64(Double.doubleToRawLongBits(value));
   }
 
   /** Write a {@code float} field to the stream. */
+  @Override
   public void writeFloatNoTag(final float value) throws IOException {
     writeRawLittleEndian32(Float.floatToRawIntBits(value));
   }
 
   /** Write a {@code uint64} field to the stream. */
+  @Override
   public void writeUInt64NoTag(final long value) throws IOException {
     writeRawVarint64(value);
   }
 
   /** Write an {@code int64} field to the stream. */
+  @Override
   public void writeInt64NoTag(final long value) throws IOException {
     writeRawVarint64(value);
   }
 
   /** Write an {@code int32} field to the stream. */
+  @Override
   public void writeInt32NoTag(final int value) throws IOException {
     if (value >= 0) {
       writeRawVarint32(value);
@@ -408,22 +434,26 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code fixed64} field to the stream. */
+  @Override
   public void writeFixed64NoTag(final long value) throws IOException {
     writeRawLittleEndian64(value);
   }
 
   /** Write a {@code fixed32} field to the stream. */
+  @Override
   public void writeFixed32NoTag(final int value) throws IOException {
     writeRawLittleEndian32(value);
   }
 
   /** Write a {@code bool} field to the stream. */
+  @Override
   public void writeBoolNoTag(final boolean value) throws IOException {
     writeRawByte(value ? 1 : 0);
   }
 
   /** Write a {@code string} field to the stream. */
   // TODO(dweis): Document behavior on ill-formed UTF-16 input.
+  @Override
   public void writeStringNoTag(final String value) throws IOException {
     try {
       efficientWriteStringNoTag(value);
@@ -458,7 +488,7 @@ public final class CodedOutputStream implements Encoder {
     // UTF-8 byte length of the string is at least its UTF-16 code unit length (value.length()),
     // and at most 3 times of it. We take advantage of this in both branches below.
     final int maxLength = value.length() * Utf8.MAX_BYTES_PER_CHAR;
-    final int maxLengthVarIntSize = computeRawVarint32Size(maxLength);
+    final int maxLengthVarIntSize = WireFormat.computeRawVarint32Size(maxLength);
 
     // If we are streaming and the potential length is too big to fit in our buffer, we take the
     // slower path. Otherwise, we're good to try the fast path.
@@ -474,7 +504,7 @@ public final class CodedOutputStream implements Encoder {
     } else {
       // Optimize for the case where we know this length results in a constant varint length as this
       // saves a pass for measuring the length of the string.
-      final int minLengthVarIntSize = computeRawVarint32Size(value.length());
+      final int minLengthVarIntSize = WireFormat.computeRawVarint32Size(value.length());
       int oldPosition = position;
       final int length;
       try {
@@ -505,6 +535,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code group} field to the stream. */
+  @Override
   public void writeGroupNoTag(final MessageLite value) throws IOException {
     value.writeTo(this);
   }
@@ -523,6 +554,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write an embedded message field to the stream. */
+  @Override
   public void writeMessageNoTag(final MessageLite value) throws IOException {
     writeRawVarint32(value.getSerializedSize());
     value.writeTo(this);
@@ -530,6 +562,7 @@ public final class CodedOutputStream implements Encoder {
 
 
   /** Write a {@code bytes} field to the stream. */
+  @Override
   public void writeBytesNoTag(final ByteString value) throws IOException {
     writeRawVarint32(value.size());
     writeRawBytes(value);
@@ -542,6 +575,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code bytes} field to the stream. */
+  @Override
   public void writeByteArrayNoTag(final byte[] value,
                                   final int offset,
                                   final int length) throws IOException {
@@ -564,6 +598,7 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Write a {@code uint32} field to the stream. */
+  @Override
   public void writeUInt32NoTag(final int value) throws IOException {
     writeRawVarint32(value);
   }
@@ -572,28 +607,33 @@ public final class CodedOutputStream implements Encoder {
    * Write an enum field to the stream.  Caller is responsible
    * for converting the enum value to its numeric value.
    */
+  @Override
   public void writeEnumNoTag(final int value) throws IOException {
     writeInt32NoTag(value);
   }
 
   /** Write an {@code sfixed32} field to the stream. */
+  @Override
   public void writeSFixed32NoTag(final int value) throws IOException {
     writeRawLittleEndian32(value);
   }
 
   /** Write an {@code sfixed64} field to the stream. */
+  @Override
   public void writeSFixed64NoTag(final long value) throws IOException {
     writeRawLittleEndian64(value);
   }
 
   /** Write an {@code sint32} field to the stream. */
+  @Override
   public void writeSInt32NoTag(final int value) throws IOException {
-    writeRawVarint32(encodeZigZag32(value));
+    writeRawVarint32(WireFormat.encodeZigZag32(value));
   }
 
   /** Write an {@code sint64} field to the stream. */
+  @Override
   public void writeSInt64NoTag(final long value) throws IOException {
-    writeRawVarint64(encodeZigZag64(value));
+    writeRawVarint64(WireFormat.encodeZigZag64(value));
   }
 
   // =================================================================
@@ -601,87 +641,107 @@ public final class CodedOutputStream implements Encoder {
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code double} field, including tag.
+   * @deprecated Use {@link WireFormat#computeDoubleSize(int, double)} instead.
    */
+  @Deprecated
   public static int computeDoubleSize(final int fieldNumber,
                                       final double value) {
-    return computeTagSize(fieldNumber) + computeDoubleSizeNoTag(value);
+    return WireFormat.computeDoubleSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code float} field, including tag.
+   * @deprecated Use {@link WireFormat#computeFloatSize(int, float)} instead.
    */
+  @Deprecated
   public static int computeFloatSize(final int fieldNumber, final float value) {
-    return computeTagSize(fieldNumber) + computeFloatSizeNoTag(value);
+    return WireFormat.computeFloatSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code uint64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeUInt64Size(int, long)} instead.
    */
+  @Deprecated
   public static int computeUInt64Size(final int fieldNumber, final long value) {
-    return computeTagSize(fieldNumber) + computeUInt64SizeNoTag(value);
+    return WireFormat.computeUInt64Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code int64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeInt64Size(int, long)} instead.
    */
+  @Deprecated
   public static int computeInt64Size(final int fieldNumber, final long value) {
-    return computeTagSize(fieldNumber) + computeInt64SizeNoTag(value);
+    return WireFormat.computeInt64Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code int32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeInt32Size(int, int)} instead.
    */
+  @Deprecated
   public static int computeInt32Size(final int fieldNumber, final int value) {
-    return computeTagSize(fieldNumber) + computeInt32SizeNoTag(value);
+    return WireFormat.computeInt32Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code fixed64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeFixed64Size(int, long)} instead.
    */
+  @Deprecated
   public static int computeFixed64Size(final int fieldNumber,
                                        final long value) {
-    return computeTagSize(fieldNumber) + computeFixed64SizeNoTag(value);
+    return WireFormat.computeFixed64Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code fixed32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeFixed32Size(int, int)} instead.
    */
+  @Deprecated
   public static int computeFixed32Size(final int fieldNumber,
                                        final int value) {
-    return computeTagSize(fieldNumber) + computeFixed32SizeNoTag(value);
+    return WireFormat.computeFixed32Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bool} field, including tag.
+   * @deprecated Use {@link WireFormat#computeBoolSize(int, boolean)} instead.
    */
+  @Deprecated
   public static int computeBoolSize(final int fieldNumber,
                                     final boolean value) {
-    return computeTagSize(fieldNumber) + computeBoolSizeNoTag(value);
+    return WireFormat.computeBoolSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code string} field, including tag.
+   * @deprecated Use {@link WireFormat#computeStringSize(int, String)} instead.
    */
+  @Deprecated
   public static int computeStringSize(final int fieldNumber,
                                       final String value) {
-    return computeTagSize(fieldNumber) + computeStringSizeNoTag(value);
+    return WireFormat.computeStringSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code group} field, including tag.
+   * @deprecated Use {@link WireFormat#computeGroupSize(int, MessageLite)} instead.
    */
+  @Deprecated
   public static int computeGroupSize(final int fieldNumber,
                                      final MessageLite value) {
-    return computeTagSize(fieldNumber) * 2 + computeGroupSizeNoTag(value);
+    return WireFormat.computeGroupSize(fieldNumber, value);
   }
 
   /**
@@ -695,34 +755,40 @@ public final class CodedOutputStream implements Encoder {
   @Deprecated
   public static int computeUnknownGroupSize(final int fieldNumber,
                                             final MessageLite value) {
-    return computeGroupSize(fieldNumber, value);
+    return WireFormat.computeGroupSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * embedded message field, including tag.
+   * @deprecated Use {@link WireFormat#computeMessageSize(int, MessageLite)} instead.
    */
+  @Deprecated
   public static int computeMessageSize(final int fieldNumber,
                                        final MessageLite value) {
-    return computeTagSize(fieldNumber) + computeMessageSizeNoTag(value);
+    return WireFormat.computeMessageSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bytes} field, including tag.
+   * @deprecated Use {@link WireFormat#computeBytesSize(int, ByteString)} instead.
    */
+  @Deprecated
   public static int computeBytesSize(final int fieldNumber,
                                      final ByteString value) {
-    return computeTagSize(fieldNumber) + computeBytesSizeNoTag(value);
+    return WireFormat.computeBytesSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bytes} field, including tag.
+   * @deprecated Use {@link WireFormat#computeByteArraySize(int, byte[])} instead.
    */
+  @Deprecated
   public static int computeByteArraySize(final int fieldNumber,
                                          final byte[] value) {
-    return computeTagSize(fieldNumber) + computeByteArraySizeNoTag(value);
+    return WireFormat.computeTagSize(fieldNumber) + computeByteArraySizeNoTag(value);
   }
 
   /**
@@ -731,103 +797,118 @@ public final class CodedOutputStream implements Encoder {
    */
   public static int computeByteBufferSize(final int fieldNumber,
                                          final ByteBuffer value) {
-    return computeTagSize(fieldNumber) + computeByteBufferSizeNoTag(value);
+    return WireFormat.computeTagSize(fieldNumber) + computeByteBufferSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * embedded message in lazy field, including tag.
+   * @deprecated Use {@link WireFormat#computeLazyFieldSize(int, LazyFieldLite)} instead.
    */
+  @Deprecated
   public static int computeLazyFieldSize(final int fieldNumber,
                                          final LazyFieldLite value) {
-    return computeTagSize(fieldNumber) + computeLazyFieldSizeNoTag(value);
+    return WireFormat.computeLazyFieldSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code uint32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeUInt32Size(int, int)} instead.
    */
+  @Deprecated
   public static int computeUInt32Size(final int fieldNumber, final int value) {
-    return computeTagSize(fieldNumber) + computeUInt32SizeNoTag(value);
+    return WireFormat.computeUInt32Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * enum field, including tag.  Caller is responsible for converting the
    * enum value to its numeric value.
+   * @deprecated Use {@link WireFormat#computeEnumSize(int, int)} instead.
    */
+  @Deprecated
   public static int computeEnumSize(final int fieldNumber, final int value) {
-    return computeTagSize(fieldNumber) + computeEnumSizeNoTag(value);
+    return WireFormat.computeEnumSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sfixed32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeSFixed32Size(int, int)} instead.
    */
+  @Deprecated
   public static int computeSFixed32Size(final int fieldNumber,
                                         final int value) {
-    return computeTagSize(fieldNumber) + computeSFixed32SizeNoTag(value);
+    return WireFormat.computeSFixed32Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sfixed64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeSFixed64Size(int, long)} instead.
    */
+  @Deprecated
   public static int computeSFixed64Size(final int fieldNumber,
                                         final long value) {
-    return computeTagSize(fieldNumber) + computeSFixed64SizeNoTag(value);
+    return WireFormat.computeSFixed64Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sint32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeSInt32Size(int, int)} instead.
    */
+  @Deprecated
   public static int computeSInt32Size(final int fieldNumber, final int value) {
-    return computeTagSize(fieldNumber) + computeSInt32SizeNoTag(value);
+    return WireFormat.computeSInt32Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sint64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeSInt64Size(int, long)} instead.
    */
+  @Deprecated
   public static int computeSInt64Size(final int fieldNumber, final long value) {
-    return computeTagSize(fieldNumber) + computeSInt64SizeNoTag(value);
+    return WireFormat.computeSInt64Size(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * MessageSet extension to the stream.  For historical reasons,
    * the wire format differs from normal fields.
+   * @deprecated Use {@link WireFormat#computeMessageSetExtensionSize(int, MessageLite)} instead.
    */
+  @Deprecated
   public static int computeMessageSetExtensionSize(
       final int fieldNumber, final MessageLite value) {
-    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
-           computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
-           computeMessageSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+    return WireFormat.computeMessageSetExtensionSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * unparsed MessageSet extension field to the stream.  For
    * historical reasons, the wire format differs from normal fields.
+   * @deprecated Use {@link WireFormat#computeRawMessageSetExtensionSize(int, ByteString)} instead.
    */
+  @Deprecated
   public static int computeRawMessageSetExtensionSize(
       final int fieldNumber, final ByteString value) {
-    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
-           computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
-           computeBytesSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+    return WireFormat.computeRawMessageSetExtensionSize(fieldNumber, value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * lazily parsed MessageSet extension field to the stream.  For
    * historical reasons, the wire format differs from normal fields.
+   * @deprecated Use {@link WireFormat#computeLazyFieldMessageSetExtensionSize(int, LazyFieldLite)}
+   * instead.
    */
+  @Deprecated
   public static int computeLazyFieldMessageSetExtensionSize(
       final int fieldNumber, final LazyFieldLite value) {
-    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
-           computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
-           computeLazyFieldSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+    return WireFormat.computeLazyFieldMessageSetExtensionSize(fieldNumber, value);
   }
 
   // -----------------------------------------------------------------
@@ -835,95 +916,101 @@ public final class CodedOutputStream implements Encoder {
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code double} field, including tag.
+   * @deprecated Use {@link WireFormat#computeDoubleSizeNoTag(double)} instead.
    */
+  @Deprecated
   public static int computeDoubleSizeNoTag(final double value) {
-    return LITTLE_ENDIAN_64_SIZE;
+    return WireFormat.LITTLE_ENDIAN_64_SIZE;
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code float} field, including tag.
+   * @deprecated Use {@link WireFormat#computeFloatSizeNoTag(float)} instead.
    */
-  public static int computeFloatSizeNoTag(final float value) {
-    return LITTLE_ENDIAN_32_SIZE;
+  @Deprecated
+  public static int computeFloatSizeNoTag(@SuppressWarnings("unused") final float value) {
+    return WireFormat.LITTLE_ENDIAN_32_SIZE;
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code uint64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeUInt64SizeNoTag(long)} instead.
    */
+  @Deprecated
   public static int computeUInt64SizeNoTag(final long value) {
-    return computeRawVarint64Size(value);
+    return WireFormat.computeUInt64SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code int64} field, including tag.
+   * @deprecated Use {@link WireFormat#computeInt64SizeNoTag(long)} instead.
    */
+  @Deprecated
   public static int computeInt64SizeNoTag(final long value) {
-    return computeRawVarint64Size(value);
+    return WireFormat.computeInt64SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code int32} field, including tag.
+   * @deprecated Use {@link WireFormat#computeInt32SizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeInt32SizeNoTag(final int value) {
-    if (value >= 0) {
-      return computeRawVarint32Size(value);
-    } else {
-      // Must sign-extend.
-      return 10;
-    }
+    return WireFormat.computeInt32SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code fixed64} field.
+   * @deprecated Use {@link WireFormat#computeFixed64SizeNoTag(long)} instead.
    */
+  @Deprecated
   public static int computeFixed64SizeNoTag(final long value) {
-    return LITTLE_ENDIAN_64_SIZE;
+    return WireFormat.computeFixed64SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code fixed32} field.
+   * @deprecated Use {@link WireFormat#computeFixed32SizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeFixed32SizeNoTag(final int value) {
-    return LITTLE_ENDIAN_32_SIZE;
+    return WireFormat.computeFixed32SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bool} field.
+   * @deprecated Use {@link WireFormat#computeBoolSizeNoTag(boolean)} instead.
    */
+  @Deprecated
   public static int computeBoolSizeNoTag(final boolean value) {
-    return 1;
+    return WireFormat.computeBoolSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code string} field.
+   * @deprecated Use {@link WireFormat#computeStringSizeNoTag(String)} instead.
    */
+  @Deprecated
   public static int computeStringSizeNoTag(final String value) {
-    int length;
-    try {
-      length = Utf8.encodedLength(value);
-    } catch (UnpairedSurrogateException e) {
-      // TODO(dweis): Consider using nio Charset methods instead.
-      final byte[] bytes = value.getBytes(Internal.UTF_8);
-      length = bytes.length;
-    }
-
-    return computeRawVarint32Size(length) + length;
+    return WireFormat.computeStringSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code group} field.
+   * @deprecated Use {@link WireFormat#computeGroupSizeNoTag(MessageLite)} instead.
    */
+  @Deprecated
   public static int computeGroupSizeNoTag(final MessageLite value) {
-    return value.getSerializedSize();
+    return WireFormat.computeGroupSizeNoTag(value);
   }
 
   /**
@@ -932,46 +1019,51 @@ public final class CodedOutputStream implements Encoder {
    * tag.
    *
    * @deprecated UnknownFieldSet now implements MessageLite, so you can just
-   *             call {@link #computeUnknownGroupSizeNoTag}.
+   *             call {@link WireFormat#computeGroupSizeNoTag}.
    */
   @Deprecated
   public static int computeUnknownGroupSizeNoTag(final MessageLite value) {
-    return computeGroupSizeNoTag(value);
+    return WireFormat.computeGroupSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an embedded
    * message field.
+   * @deprecated Use {@link WireFormat#computeMessageSizeNoTag(MessageLite)} instead.
    */
+  @Deprecated
   public static int computeMessageSizeNoTag(final MessageLite value) {
-    final int size = value.getSerializedSize();
-    return computeRawVarint32Size(size) + size;
+    return WireFormat.computeMessageSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an embedded
    * message stored in lazy field.
+   * @deprecated Use {@link WireFormat#computeLazyFieldSizeNoTag(LazyFieldLite)} instead.
    */
+  @Deprecated
   public static int computeLazyFieldSizeNoTag(final LazyFieldLite value) {
-    final int size = value.getSerializedSize();
-    return computeRawVarint32Size(size) + size;
+    return WireFormat.computeLazyFieldSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bytes} field.
+   * @deprecated Use {@link WireFormat#computeBytesSizeNoTag(ByteString)} instead.
    */
+  @Deprecated
   public static int computeBytesSizeNoTag(final ByteString value) {
-    return computeRawVarint32Size(value.size()) +
-           value.size();
+    return WireFormat.computeBytesSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code bytes} field.
+   * @deprecated Use {@link WireFormat#computeByteArraySizeNoTag(byte[])} instead.
    */
+  @Deprecated
   public static int computeByteArraySizeNoTag(final byte[] value) {
-    return computeRawVarint32Size(value.length) + value.length;
+    return WireFormat.computeRawVarint32Size(value.length) + value.length;
   }
 
   /**
@@ -979,55 +1071,67 @@ public final class CodedOutputStream implements Encoder {
    * {@code bytes} field.
    */
   public static int computeByteBufferSizeNoTag(final ByteBuffer value) {
-    return computeRawVarint32Size(value.capacity()) + value.capacity();
+    return WireFormat.computeRawVarint32Size(value.capacity()) + value.capacity();
   }
 
   /**
    * Compute the number of bytes that would be needed to encode a
    * {@code uint32} field.
+   * @deprecated Use {@link WireFormat#computeUInt32SizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeUInt32SizeNoTag(final int value) {
-    return computeRawVarint32Size(value);
+    return WireFormat.computeUInt32SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an enum field.
    * Caller is responsible for converting the enum value to its numeric value.
+   * @deprecated Use {@link WireFormat#computeEnumSizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeEnumSizeNoTag(final int value) {
-    return computeInt32SizeNoTag(value);
+    return WireFormat.computeEnumSizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sfixed32} field.
+   * @deprecated Use {@link WireFormat#computeSFixed32SizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeSFixed32SizeNoTag(final int value) {
-    return LITTLE_ENDIAN_32_SIZE;
+    return WireFormat.computeSFixed32SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sfixed64} field.
+   * @deprecated Use {@link WireFormat#computeSFixed64SizeNoTag(long)} instead.
    */
+  @Deprecated
   public static int computeSFixed64SizeNoTag(final long value) {
-    return LITTLE_ENDIAN_64_SIZE;
+    return WireFormat.computeSFixed64SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sint32} field.
+   * @deprecated Use {@link WireFormat#computeSInt32SizeNoTag(int)} instead.
    */
+  @Deprecated
   public static int computeSInt32SizeNoTag(final int value) {
-    return computeRawVarint32Size(encodeZigZag32(value));
+    return WireFormat.computeSInt32SizeNoTag(value);
   }
 
   /**
    * Compute the number of bytes that would be needed to encode an
    * {@code sint64} field.
+   * @deprecated Use {@link WireFormat#computeSInt64SizeNoTag(long)} instead.
    */
+  @Deprecated
   public static int computeSInt64SizeNoTag(final long value) {
-    return computeRawVarint64Size(encodeZigZag64(value));
+    return WireFormat.computeSInt64SizeNoTag(value);
   }
 
   // =================================================================
@@ -1052,6 +1156,7 @@ public final class CodedOutputStream implements Encoder {
    * Flushes the stream and forces any buffered bytes to be written.  This
    * does not flush the underlying OutputStream.
    */
+  @Override
   public void flush() throws IOException {
     if (output != null) {
       refreshBuffer();
@@ -1263,14 +1368,19 @@ public final class CodedOutputStream implements Encoder {
   }
 
   /** Encode and write a tag. */
+  @Override
   public void writeTag(final int fieldNumber, final int wireType)
                        throws IOException {
     writeRawVarint32(WireFormat.makeTag(fieldNumber, wireType));
   }
 
-  /** Compute the number of bytes that would be needed to encode a tag. */
+  /**
+   * Compute the number of bytes that would be needed to encode a tag.
+   * @deprecated Use {@link WireFormat#computeTagSize(int)} instead.
+   */
+  @Deprecated
   public static int computeTagSize(final int fieldNumber) {
-    return computeRawVarint32Size(WireFormat.makeTag(fieldNumber, 0));
+    return WireFormat.computeTagSize(fieldNumber);
   }
 
   /**
@@ -1293,13 +1403,11 @@ public final class CodedOutputStream implements Encoder {
    * Compute the number of bytes that would be needed to encode a varint.
    * {@code value} is treated as unsigned, so it won't be sign-extended if
    * negative.
+   * @deprecated Use {@link WireFormat#computeRawVarint32Size(int)} instead.
    */
+  @Deprecated
   public static int computeRawVarint32Size(final int value) {
-    if ((value & (0xffffffff <<  7)) == 0) return 1;
-    if ((value & (0xffffffff << 14)) == 0) return 2;
-    if ((value & (0xffffffff << 21)) == 0) return 3;
-    if ((value & (0xffffffff << 28)) == 0) return 4;
-    return 5;
+    return WireFormat.computeRawVarint32Size(value);
   }
 
   /** Encode and write a varint. */
@@ -1315,18 +1423,13 @@ public final class CodedOutputStream implements Encoder {
     }
   }
 
-  /** Compute the number of bytes that would be needed to encode a varint. */
+  /**
+   * Compute the number of bytes that would be needed to encode a varint.
+   * @deprecated Use {@link WireFormat#computeRawVarint64Size(long)} instead.
+   */
+  @Deprecated
   public static int computeRawVarint64Size(final long value) {
-    if ((value & (0xffffffffffffffffL <<  7)) == 0) return 1;
-    if ((value & (0xffffffffffffffffL << 14)) == 0) return 2;
-    if ((value & (0xffffffffffffffffL << 21)) == 0) return 3;
-    if ((value & (0xffffffffffffffffL << 28)) == 0) return 4;
-    if ((value & (0xffffffffffffffffL << 35)) == 0) return 5;
-    if ((value & (0xffffffffffffffffL << 42)) == 0) return 6;
-    if ((value & (0xffffffffffffffffL << 49)) == 0) return 7;
-    if ((value & (0xffffffffffffffffL << 56)) == 0) return 8;
-    if ((value & (0xffffffffffffffffL << 63)) == 0) return 9;
-    return 10;
+    return WireFormat.computeRawVarint64Size(value);
   }
 
   /** Write a little-endian 32-bit integer. */
@@ -1337,7 +1440,11 @@ public final class CodedOutputStream implements Encoder {
     writeRawByte((value >> 24) & 0xFF);
   }
 
-  public static final int LITTLE_ENDIAN_32_SIZE = 4;
+  /**
+   * @deprecated Use {@link WireFormat#LITTLE_ENDIAN_32_SIZE} instead.
+   */
+  @Deprecated
+  public static final int LITTLE_ENDIAN_32_SIZE = WireFormat.LITTLE_ENDIAN_32_SIZE;
 
   /** Write a little-endian 64-bit integer. */
   public void writeRawLittleEndian64(final long value) throws IOException {
@@ -1351,7 +1458,11 @@ public final class CodedOutputStream implements Encoder {
     writeRawByte((int)(value >> 56) & 0xFF);
   }
 
-  public static final int LITTLE_ENDIAN_64_SIZE = 8;
+  /**
+   * @deprecated Use {@link WireFormat#LITTLE_ENDIAN_64_SIZE} instead.
+   */
+  @Deprecated
+  public static final int LITTLE_ENDIAN_64_SIZE = WireFormat.LITTLE_ENDIAN_64_SIZE;
 
   /**
    * Encode a ZigZag-encoded 32-bit value.  ZigZag encodes signed integers
@@ -1362,10 +1473,11 @@ public final class CodedOutputStream implements Encoder {
    * @param n A signed 32-bit integer.
    * @return An unsigned 32-bit integer, stored in a signed int because
    *         Java has no explicit unsigned support.
+   * @deprecated Use {@link WireFormat#encodeZigZag32(int)} instead.
    */
+  @Deprecated
   public static int encodeZigZag32(final int n) {
-    // Note:  the right-shift must be arithmetic
-    return (n << 1) ^ (n >> 31);
+    return WireFormat.encodeZigZag32(n);
   }
 
   /**
@@ -1377,9 +1489,10 @@ public final class CodedOutputStream implements Encoder {
    * @param n A signed 64-bit integer.
    * @return An unsigned 64-bit integer, stored in a signed int because
    *         Java has no explicit unsigned support.
+   * @deprecated Use {@link WireFormat#encodeZigZag64(long)} instead.
    */
+  @Deprecated
   public static long encodeZigZag64(final long n) {
-    // Note:  the right-shift must be arithmetic
-    return (n << 1) ^ (n >> 63);
+    return WireFormat.encodeZigZag64(n);
   }
 }

--- a/java/src/main/java/com/google/protobuf/CodedOutputStream.java
+++ b/java/src/main/java/com/google/protobuf/CodedOutputStream.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
  *
  * @author kneton@google.com Kenton Varda
  */
-public final class CodedOutputStream {
+public final class CodedOutputStream implements Encoder {
   
   private static final Logger logger = Logger.getLogger(CodedOutputStream.class.getName());
 

--- a/java/src/main/java/com/google/protobuf/DynamicMessage.java
+++ b/java/src/main/java/com/google/protobuf/DynamicMessage.java
@@ -237,7 +237,7 @@ public final class DynamicMessage extends AbstractMessage {
   }
 
   @Override
-  public void writeTo(CodedOutputStream output) throws IOException {
+  public void writeTo(Encoder output) throws IOException {
     if (type.getOptions().getMessageSetWireFormat()) {
       fields.writeMessageSetTo(output);
       unknownFields.writeAsMessageSetTo(output);

--- a/java/src/main/java/com/google/protobuf/Encoder.java
+++ b/java/src/main/java/com/google/protobuf/Encoder.java
@@ -1,0 +1,247 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * An encoder for protobuf fields.
+ */
+public interface Encoder {
+  /** Write a {@code double} field, including tag, to the stream. */
+  void writeDouble(final int fieldNumber, final double value) throws IOException;
+
+  /** Write a {@code float} field, including tag, to the stream. */
+  void writeFloat(final int fieldNumber, final float value) throws IOException;
+
+  /** Write a {@code uint64} field, including tag, to the stream. */
+  void writeUInt64(final int fieldNumber, final long value) throws IOException;
+
+  /** Write an {@code int64} field, including tag, to the stream. */
+  void writeInt64(final int fieldNumber, final long value) throws IOException;
+
+  /** Write an {@code int32} field, including tag, to the stream. */
+  void writeInt32(final int fieldNumber, final int value) throws IOException;
+
+  /** Write a {@code fixed64} field, including tag, to the stream. */
+  void writeFixed64(final int fieldNumber, final long value) throws IOException;
+
+  /** Write a {@code fixed32} field, including tag, to the stream. */
+  void writeFixed32(final int fieldNumber, final int value) throws IOException;
+
+  /** Write a {@code bool} field, including tag, to the stream. */
+  void writeBool(final int fieldNumber, final boolean value) throws IOException;
+
+  /** Write a {@code string} field, including tag, to the stream. */
+  void writeString(final int fieldNumber, final String value) throws IOException;
+
+  /** Write a {@code group} field, including tag, to the stream. */
+  void writeGroup(final int fieldNumber, final MessageLite value) throws IOException;
+
+  /** Write an embedded message field, including tag, to the stream. */
+  void writeMessage(final int fieldNumber, final MessageLite value) throws IOException;
+
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  void writeBytes(final int fieldNumber, final ByteString value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  void writeByteArray(final int fieldNumber, final byte[] value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  void writeByteArray(final int fieldNumber,
+                             final byte[] value,
+                             final int offset,
+                             final int length) throws IOException;
+
+  /** Write a {@code uint32} field, including tag, to the stream. */
+  void writeUInt32(final int fieldNumber, final int value) throws IOException;
+
+  /**
+   * Write an enum field, including tag, to the stream.  Caller is responsible
+   * for converting the enum value to its numeric value.
+   */
+  void writeEnum(final int fieldNumber, final int value) throws IOException;
+
+  /** Write an {@code sfixed32} field, including tag, to the stream. */
+  void writeSFixed32(final int fieldNumber, final int value) throws IOException;
+
+  /** Write an {@code sfixed64} field, including tag, to the stream. */
+  void writeSFixed64(final int fieldNumber, final long value) throws IOException;
+
+  /** Write an {@code sint32} field, including tag, to the stream. */
+  void writeSInt32(final int fieldNumber, final int value) throws IOException;
+
+  /** Write an {@code sint64} field, including tag, to the stream. */
+  void writeSInt64(final int fieldNumber, final long value) throws IOException;
+
+  /**
+   * Write a MessageSet extension field to the stream.  For historical reasons,
+   * the wire format differs from normal fields.
+   */
+  void writeMessageSetExtension(final int fieldNumber,
+                                       final MessageLite value)
+      throws IOException;
+
+  /**
+   * Write an unparsed MessageSet extension field to the stream.  For
+   * historical reasons, the wire format differs from normal fields.
+   */
+  void writeRawMessageSetExtension(final int fieldNumber,
+                                          final ByteString value)
+      throws IOException;
+
+  // -----------------------------------------------------------------
+
+  /** Write a {@code double} field to the stream. */
+  void writeDoubleNoTag(final double value) throws IOException;
+
+  /** Write a {@code float} field to the stream. */
+  void writeFloatNoTag(final float value) throws IOException;
+
+  /** Write a {@code uint64} field to the stream. */
+  void writeUInt64NoTag(final long value) throws IOException;
+
+  /** Write an {@code int64} field to the stream. */
+  void writeInt64NoTag(final long value) throws IOException;
+
+  /** Write an {@code int32} field to the stream. */
+  void writeInt32NoTag(final int value) throws IOException;
+
+  /** Write a {@code fixed64} field to the stream. */
+  void writeFixed64NoTag(final long value) throws IOException;
+
+  /** Write a {@code fixed32} field to the stream. */
+  void writeFixed32NoTag(final int value) throws IOException;
+
+  /** Write a {@code bool} field to the stream. */
+  void writeBoolNoTag(final boolean value) throws IOException;
+
+  /** Write a {@code string} field to the stream. */
+  // TODO(dweis): Document behavior on ill-formed UTF-16 input.
+  void writeStringNoTag(final String value) throws IOException;
+
+  /** Write a {@code group} field to the stream. */
+  void writeGroupNoTag(final MessageLite value) throws IOException;
+
+  /** Write an embedded message field to the stream. */
+  void writeMessageNoTag(final MessageLite value) throws IOException;
+
+
+  /** Write a {@code bytes} field to the stream. */
+  void writeBytesNoTag(final ByteString value) throws IOException;
+
+  /** Write a {@code bytes} field to the stream. */
+  void writeByteArrayNoTag(final byte[] value) throws IOException;
+
+  /** Write a {@code bytes} field to the stream. */
+  void writeByteArrayNoTag(final byte[] value,
+                                  final int offset,
+                                  final int length) throws IOException;
+
+  /** Write a {@code uint32} field to the stream. */
+  void writeUInt32NoTag(final int value) throws IOException;
+
+  /**
+   * Write an enum field to the stream.  Caller is responsible
+   * for converting the enum value to its numeric value.
+   */
+  void writeEnumNoTag(final int value) throws IOException;
+
+  /** Write an {@code sfixed32} field to the stream. */
+  void writeSFixed32NoTag(final int value) throws IOException;
+
+  /** Write an {@code sfixed64} field to the stream. */
+  void writeSFixed64NoTag(final long value) throws IOException;
+
+  /** Write an {@code sint32} field to the stream. */
+  void writeSInt32NoTag(final int value) throws IOException;
+
+  /** Write an {@code sint64} field to the stream. */
+  void writeSInt64NoTag(final long value) throws IOException;
+
+  /**
+   * Flushes the stream and forces any buffered bytes to be written.  This
+   * does not flush the underlying OutputStream.
+   */
+  void flush() throws IOException;
+
+  /** Write a single byte. */
+  void writeRawByte(final byte value) throws IOException;
+
+  /** Write a single byte, represented by an integer value. */
+  void writeRawByte(final int value) throws IOException;
+
+  /** Write a byte string. */
+  void writeRawBytes(final ByteString value) throws IOException;
+
+  /** Write an array of bytes. */
+  void writeRawBytes(final byte[] value) throws IOException;
+
+  /**
+   * Write a ByteBuffer. This method will onDataEncoded all content of the ByteBuffer
+   * regardless of the current position and limit (i.e., the number of bytes
+   * to be written is value.capacity(), not value.remaining()). Furthermore,
+   * this method doesn't alter the state of the passed-in ByteBuffer. Its
+   * position, limit, mark, etc. will remain unchanged. If you only want to
+   * onDataEncoded the remaining bytes of a ByteBuffer, you can call
+   * {@code writeRawBytes(byteBuffer.slice())}.
+   */
+  void writeRawBytes(final ByteBuffer value) throws IOException;
+
+  /** Write part of an array of bytes. */
+  void writeRawBytes(final byte[] value, int offset, int length)
+      throws IOException;
+
+  /** Write part of a byte string. */
+  void writeRawBytes(final ByteString value, int offset, int length)
+      throws IOException;
+
+  /** Encode and onDataEncoded a tag. */
+  void writeTag(final int fieldNumber, final int wireType)
+      throws IOException;
+
+  /**
+   * Encode and onDataEncoded a varint.  {@code value} is treated as
+   * unsigned, so it won't be sign-extended if negative.
+   */
+  void writeRawVarint32(int value) throws IOException;
+
+  /** Encode and onDataEncoded a varint. */
+  void writeRawVarint64(long value) throws IOException;
+
+  /** Write a little-endian 32-bit integer. */
+  void writeRawLittleEndian32(final int value) throws IOException;
+
+  /** Write a little-endian 64-bit integer. */
+  void writeRawLittleEndian64(final long value) throws IOException;
+}

--- a/java/src/main/java/com/google/protobuf/Encoder.java
+++ b/java/src/main/java/com/google/protobuf/Encoder.java
@@ -31,11 +31,40 @@
 package com.google.protobuf;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * An encoder for protobuf fields.
  */
 public interface Encoder {
+
+  /**
+   * A handler for the output of an {@link Encoder}.
+   */
+  interface Handler {
+    /**
+     * Handler for encoded data.
+     *
+     * @param b        a byte array containing the encoded data.
+     * @param offset   the offset in the array where the encoded data begins.
+     * @param length   the length of the encoded data.
+     * @param mustCopy if {@code true}, the handler must make a defensive copy of the encoded data
+     *                 as the content of the array may change after the method returns. If {@code
+     *                 false}, the handler may safely assume that the content of the array will
+     *                 never change.
+     */
+    void onDataEncoded(byte[] b, int offset, int length, boolean mustCopy) throws IOException;
+
+    /**
+     * Handler for encoded data.
+     *
+     * @param data     the encoded data.
+     * @param mustCopy if {@code true}, the handler must make a defensive copy of the encoded data
+     *                 as the content may change after the method returns. If {@code false}, the
+     *                 handler may safely assume that the content of the buffer will never change.
+     */
+    void onDataEncoded(ByteBuffer data, boolean mustCopy) throws IOException;
+  }
 
   /** Encode and onDataEncoded a tag. */
   void writeTag(int fieldNumber, int wireType) throws IOException;

--- a/java/src/main/java/com/google/protobuf/Encoder.java
+++ b/java/src/main/java/com/google/protobuf/Encoder.java
@@ -31,217 +31,153 @@
 package com.google.protobuf;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * An encoder for protobuf fields.
  */
 public interface Encoder {
-  /** Write a {@code double} field, including tag, to the stream. */
-  void writeDouble(final int fieldNumber, final double value) throws IOException;
 
-  /** Write a {@code float} field, including tag, to the stream. */
-  void writeFloat(final int fieldNumber, final float value) throws IOException;
-
-  /** Write a {@code uint64} field, including tag, to the stream. */
-  void writeUInt64(final int fieldNumber, final long value) throws IOException;
-
-  /** Write an {@code int64} field, including tag, to the stream. */
-  void writeInt64(final int fieldNumber, final long value) throws IOException;
+  /** Encode and onDataEncoded a tag. */
+  void writeTag(int fieldNumber, int wireType) throws IOException;
 
   /** Write an {@code int32} field, including tag, to the stream. */
-  void writeInt32(final int fieldNumber, final int value) throws IOException;
-
-  /** Write a {@code fixed64} field, including tag, to the stream. */
-  void writeFixed64(final int fieldNumber, final long value) throws IOException;
-
-  /** Write a {@code fixed32} field, including tag, to the stream. */
-  void writeFixed32(final int fieldNumber, final int value) throws IOException;
-
-  /** Write a {@code bool} field, including tag, to the stream. */
-  void writeBool(final int fieldNumber, final boolean value) throws IOException;
-
-  /** Write a {@code string} field, including tag, to the stream. */
-  void writeString(final int fieldNumber, final String value) throws IOException;
-
-  /** Write a {@code group} field, including tag, to the stream. */
-  void writeGroup(final int fieldNumber, final MessageLite value) throws IOException;
-
-  /** Write an embedded message field, including tag, to the stream. */
-  void writeMessage(final int fieldNumber, final MessageLite value) throws IOException;
-
-
-  /** Write a {@code bytes} field, including tag, to the stream. */
-  void writeBytes(final int fieldNumber, final ByteString value) throws IOException;
-
-  /** Write a {@code bytes} field, including tag, to the stream. */
-  void writeByteArray(final int fieldNumber, final byte[] value) throws IOException;
-
-  /** Write a {@code bytes} field, including tag, to the stream. */
-  void writeByteArray(final int fieldNumber,
-                             final byte[] value,
-                             final int offset,
-                             final int length) throws IOException;
+  void writeInt32(int fieldNumber, int value) throws IOException;
 
   /** Write a {@code uint32} field, including tag, to the stream. */
-  void writeUInt32(final int fieldNumber, final int value) throws IOException;
+  void writeUInt32(int fieldNumber, int value) throws IOException;
+
+  /** Write an {@code sint32} field, including tag, to the stream. */
+  void writeSInt32(int fieldNumber, int value) throws IOException;
+
+  /** Write a {@code fixed32} field, including tag, to the stream. */
+  void writeFixed32(int fieldNumber, int value) throws IOException;
+
+  /** Write an {@code sfixed32} field, including tag, to the stream. */
+  void writeSFixed32(int fieldNumber, int value) throws IOException;
+
+  /** Write an {@code int64} field, including tag, to the stream. */
+  void writeInt64(int fieldNumber, long value) throws IOException;
+
+  /** Write a {@code uint64} field, including tag, to the stream. */
+  void writeUInt64(int fieldNumber, long value) throws IOException;
+
+  /** Write an {@code sint64} field, including tag, to the stream. */
+  void writeSInt64(int fieldNumber, long value) throws IOException;
+
+  /** Write a {@code fixed64} field, including tag, to the stream. */
+  void writeFixed64(int fieldNumber, long value) throws IOException;
+
+  /** Write an {@code sfixed64} field, including tag, to the stream. */
+  void writeSFixed64(int fieldNumber, long value) throws IOException;
+
+  /** Write a {@code float} field, including tag, to the stream. */
+  void writeFloat(int fieldNumber, float value) throws IOException;
+
+  /** Write a {@code double} field, including tag, to the stream. */
+  void writeDouble(int fieldNumber, double value) throws IOException;
+
+  /** Write a {@code bool} field, including tag, to the stream. */
+  void writeBool(int fieldNumber, boolean value) throws IOException;
+
+  /** Write a {@code string} field, including tag, to the stream. */
+  void writeString(int fieldNumber, String value) throws IOException;
+
+  /** Write a {@code group} field, including tag, to the stream. */
+  void writeGroup(int fieldNumber, MessageLite value) throws IOException;
+
+  /** Write an embedded message field, including tag, to the stream. */
+  void writeMessage(int fieldNumber, MessageLite value) throws IOException;
 
   /**
    * Write an enum field, including tag, to the stream.  Caller is responsible
    * for converting the enum value to its numeric value.
    */
-  void writeEnum(final int fieldNumber, final int value) throws IOException;
-
-  /** Write an {@code sfixed32} field, including tag, to the stream. */
-  void writeSFixed32(final int fieldNumber, final int value) throws IOException;
-
-  /** Write an {@code sfixed64} field, including tag, to the stream. */
-  void writeSFixed64(final int fieldNumber, final long value) throws IOException;
-
-  /** Write an {@code sint32} field, including tag, to the stream. */
-  void writeSInt32(final int fieldNumber, final int value) throws IOException;
-
-  /** Write an {@code sint64} field, including tag, to the stream. */
-  void writeSInt64(final int fieldNumber, final long value) throws IOException;
+  void writeEnum(int fieldNumber, int value) throws IOException;
 
   /**
    * Write a MessageSet extension field to the stream.  For historical reasons,
    * the wire format differs from normal fields.
    */
-  void writeMessageSetExtension(final int fieldNumber,
-                                       final MessageLite value)
-      throws IOException;
+  void writeMessageSetExtension(int fieldNumber, MessageLite value) throws IOException;
 
   /**
    * Write an unparsed MessageSet extension field to the stream.  For
    * historical reasons, the wire format differs from normal fields.
    */
-  void writeRawMessageSetExtension(final int fieldNumber,
-                                          final ByteString value)
-      throws IOException;
+  void writeRawMessageSetExtension(int fieldNumber, ByteString value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  void writeBytes(int fieldNumber, ByteString value) throws IOException;
+
+  /** Write a {@code bytes} field, including tag, to the stream. */
+  void writeByteArray(int fieldNumber, byte[] value, int offset, int length) throws IOException;
 
   // -----------------------------------------------------------------
 
-  /** Write a {@code double} field to the stream. */
-  void writeDoubleNoTag(final double value) throws IOException;
-
-  /** Write a {@code float} field to the stream. */
-  void writeFloatNoTag(final float value) throws IOException;
-
-  /** Write a {@code uint64} field to the stream. */
-  void writeUInt64NoTag(final long value) throws IOException;
-
-  /** Write an {@code int64} field to the stream. */
-  void writeInt64NoTag(final long value) throws IOException;
-
   /** Write an {@code int32} field to the stream. */
-  void writeInt32NoTag(final int value) throws IOException;
+  void writeInt32NoTag(int value) throws IOException;
 
-  /** Write a {@code fixed64} field to the stream. */
-  void writeFixed64NoTag(final long value) throws IOException;
+  /** Write a {@code uint32} field to the stream. */
+  void writeUInt32NoTag(int value) throws IOException;
+
+  /** Write an {@code sint32} field to the stream. */
+  void writeSInt32NoTag(int value) throws IOException;
 
   /** Write a {@code fixed32} field to the stream. */
-  void writeFixed32NoTag(final int value) throws IOException;
+  void writeFixed32NoTag(int value) throws IOException;
+
+  /** Write an {@code sfixed32} field to the stream. */
+  void writeSFixed32NoTag(int value) throws IOException;
+
+  /** Write an {@code int64} field to the stream. */
+  void writeInt64NoTag(long value) throws IOException;
+
+  /** Write a {@code uint64} field to the stream. */
+  void writeUInt64NoTag(long value) throws IOException;
+
+  /** Write an {@code sint64} field to the stream. */
+  void writeSInt64NoTag(long value) throws IOException;
+
+  /** Write a {@code fixed64} field to the stream. */
+  void writeFixed64NoTag(long value) throws IOException;
+
+  /** Write an {@code sfixed64} field to the stream. */
+  void writeSFixed64NoTag(long value) throws IOException;
+
+  /** Write a {@code float} field to the stream. */
+  void writeFloatNoTag(float value) throws IOException;
+
+  /** Write a {@code double} field to the stream. */
+  void writeDoubleNoTag(double value) throws IOException;
 
   /** Write a {@code bool} field to the stream. */
-  void writeBoolNoTag(final boolean value) throws IOException;
+  void writeBoolNoTag(boolean value) throws IOException;
 
   /** Write a {@code string} field to the stream. */
   // TODO(dweis): Document behavior on ill-formed UTF-16 input.
-  void writeStringNoTag(final String value) throws IOException;
+  void writeStringNoTag(String value) throws IOException;
 
   /** Write a {@code group} field to the stream. */
-  void writeGroupNoTag(final MessageLite value) throws IOException;
+  void writeGroupNoTag(MessageLite value) throws IOException;
 
   /** Write an embedded message field to the stream. */
-  void writeMessageNoTag(final MessageLite value) throws IOException;
-
-
-  /** Write a {@code bytes} field to the stream. */
-  void writeBytesNoTag(final ByteString value) throws IOException;
-
-  /** Write a {@code bytes} field to the stream. */
-  void writeByteArrayNoTag(final byte[] value) throws IOException;
-
-  /** Write a {@code bytes} field to the stream. */
-  void writeByteArrayNoTag(final byte[] value,
-                                  final int offset,
-                                  final int length) throws IOException;
-
-  /** Write a {@code uint32} field to the stream. */
-  void writeUInt32NoTag(final int value) throws IOException;
+  void writeMessageNoTag(MessageLite value) throws IOException;
 
   /**
    * Write an enum field to the stream.  Caller is responsible
    * for converting the enum value to its numeric value.
    */
-  void writeEnumNoTag(final int value) throws IOException;
+  void writeEnumNoTag(int value) throws IOException;
 
-  /** Write an {@code sfixed32} field to the stream. */
-  void writeSFixed32NoTag(final int value) throws IOException;
+  /** Write a {@code bytes} field to the stream. */
+  void writeBytesNoTag(ByteString value) throws IOException;
 
-  /** Write an {@code sfixed64} field to the stream. */
-  void writeSFixed64NoTag(final long value) throws IOException;
-
-  /** Write an {@code sint32} field to the stream. */
-  void writeSInt32NoTag(final int value) throws IOException;
-
-  /** Write an {@code sint64} field to the stream. */
-  void writeSInt64NoTag(final long value) throws IOException;
+  /** Write a {@code bytes} field to the stream. */
+  void writeByteArrayNoTag(byte[] value, int offset, int length) throws IOException;
 
   /**
    * Flushes the stream and forces any buffered bytes to be written.  This
    * does not flush the underlying OutputStream.
    */
   void flush() throws IOException;
-
-  /** Write a single byte. */
-  void writeRawByte(final byte value) throws IOException;
-
-  /** Write a single byte, represented by an integer value. */
-  void writeRawByte(final int value) throws IOException;
-
-  /** Write a byte string. */
-  void writeRawBytes(final ByteString value) throws IOException;
-
-  /** Write an array of bytes. */
-  void writeRawBytes(final byte[] value) throws IOException;
-
-  /**
-   * Write a ByteBuffer. This method will onDataEncoded all content of the ByteBuffer
-   * regardless of the current position and limit (i.e., the number of bytes
-   * to be written is value.capacity(), not value.remaining()). Furthermore,
-   * this method doesn't alter the state of the passed-in ByteBuffer. Its
-   * position, limit, mark, etc. will remain unchanged. If you only want to
-   * onDataEncoded the remaining bytes of a ByteBuffer, you can call
-   * {@code writeRawBytes(byteBuffer.slice())}.
-   */
-  void writeRawBytes(final ByteBuffer value) throws IOException;
-
-  /** Write part of an array of bytes. */
-  void writeRawBytes(final byte[] value, int offset, int length)
-      throws IOException;
-
-  /** Write part of a byte string. */
-  void writeRawBytes(final ByteString value, int offset, int length)
-      throws IOException;
-
-  /** Encode and onDataEncoded a tag. */
-  void writeTag(final int fieldNumber, final int wireType)
-      throws IOException;
-
-  /**
-   * Encode and onDataEncoded a varint.  {@code value} is treated as
-   * unsigned, so it won't be sign-extended if negative.
-   */
-  void writeRawVarint32(int value) throws IOException;
-
-  /** Encode and onDataEncoded a varint. */
-  void writeRawVarint64(long value) throws IOException;
-
-  /** Write a little-endian 32-bit integer. */
-  void writeRawLittleEndian32(final int value) throws IOException;
-
-  /** Write a little-endian 64-bit integer. */
-  void writeRawLittleEndian64(final long value) throws IOException;
 }

--- a/java/src/main/java/com/google/protobuf/FieldSet.java
+++ b/java/src/main/java/com/google/protobuf/FieldSet.java
@@ -461,7 +461,7 @@ final class FieldSet<FieldDescriptorType extends
   /**
    * Given a field type, return the wire type.
    *
-   * @returns One of the {@code WIRETYPE_} constants defined in
+   * @return One of the {@code WIRETYPE_} constants defined in
    *          {@link WireFormat}.
    */
   static int getWireFormatForFieldType(final WireFormat.FieldType type,
@@ -669,7 +669,8 @@ final class FieldSet<FieldDescriptorType extends
         if (value instanceof ByteString) {
           output.writeBytesNoTag((ByteString) value);
         } else {
-          output.writeByteArrayNoTag((byte[]) value);
+          byte[] bytes = (byte[]) value;
+          output.writeByteArrayNoTag(bytes, 0, bytes.length);
         }
         break;
       case UINT32  : output.writeUInt32NoTag  ((Integer    ) value); break;
@@ -704,7 +705,7 @@ final class FieldSet<FieldDescriptorType extends
         for (final Object element : valueList) {
           dataSize += computeElementSizeNoTag(type, element);
         }
-        output.writeRawVarint32(dataSize);
+        output.writeUInt32NoTag(dataSize);
         // Write the data itself, without any tags.
         for (final Object element : valueList) {
           writeElementNoTag(output, type, element);
@@ -763,10 +764,10 @@ final class FieldSet<FieldDescriptorType extends
     if (descriptor.getLiteJavaType() == WireFormat.JavaType.MESSAGE
         && !descriptor.isRepeated() && !descriptor.isPacked()) {
       if (value instanceof LazyField) {
-        return CodedOutputStream.computeLazyFieldMessageSetExtensionSize(
+        return WireFormat.computeLazyFieldMessageSetExtensionSize(
             entry.getKey().getNumber(), (LazyField) value);
       } else {
-        return CodedOutputStream.computeMessageSetExtensionSize(
+        return WireFormat.computeMessageSetExtensionSize(
             entry.getKey().getNumber(), (MessageLite) value);
       }
     } else {
@@ -788,7 +789,7 @@ final class FieldSet<FieldDescriptorType extends
   private static int computeElementSize(
       final WireFormat.FieldType type,
       final int number, final Object value) {
-    int tagSize = CodedOutputStream.computeTagSize(number);
+    int tagSize = WireFormat.computeTagSize(number);
     if (type == WireFormat.FieldType.GROUP) {
       // Only count the end group tag for proto2 messages as for proto1 the end
       // group tag will be counted as a part of getSerializedSize().
@@ -812,46 +813,46 @@ final class FieldSet<FieldDescriptorType extends
     switch (type) {
       // Note:  Minor violation of 80-char limit rule here because this would
       //   actually be harder to read if we wrapped the lines.
-      case DOUBLE  : return CodedOutputStream.computeDoubleSizeNoTag  ((Double     )value);
-      case FLOAT   : return CodedOutputStream.computeFloatSizeNoTag   ((Float      )value);
-      case INT64   : return CodedOutputStream.computeInt64SizeNoTag   ((Long       )value);
-      case UINT64  : return CodedOutputStream.computeUInt64SizeNoTag  ((Long       )value);
-      case INT32   : return CodedOutputStream.computeInt32SizeNoTag   ((Integer    )value);
-      case FIXED64 : return CodedOutputStream.computeFixed64SizeNoTag ((Long       )value);
-      case FIXED32 : return CodedOutputStream.computeFixed32SizeNoTag ((Integer    )value);
-      case BOOL    : return CodedOutputStream.computeBoolSizeNoTag    ((Boolean    )value);
-      case GROUP   : return CodedOutputStream.computeGroupSizeNoTag   ((MessageLite)value);
+      case DOUBLE  : return WireFormat.computeDoubleSizeNoTag  ((Double     )value);
+      case FLOAT   : return WireFormat.computeFloatSizeNoTag   ((Float      )value);
+      case INT64   : return WireFormat.computeInt64SizeNoTag   ((Long       )value);
+      case UINT64  : return WireFormat.computeUInt64SizeNoTag  ((Long       )value);
+      case INT32   : return WireFormat.computeInt32SizeNoTag   ((Integer    )value);
+      case FIXED64 : return WireFormat.computeFixed64SizeNoTag ((Long       )value);
+      case FIXED32 : return WireFormat.computeFixed32SizeNoTag ((Integer    )value);
+      case BOOL    : return WireFormat.computeBoolSizeNoTag    ((Boolean    )value);
+      case GROUP   : return WireFormat.computeGroupSizeNoTag   ((MessageLite)value);
       case BYTES   :
         if (value instanceof ByteString) {
-          return CodedOutputStream.computeBytesSizeNoTag((ByteString) value);
+          return WireFormat.computeBytesSizeNoTag((ByteString) value);
         } else {
-          return CodedOutputStream.computeByteArraySizeNoTag((byte[]) value);
+          return WireFormat.computeByteArraySizeNoTag((byte[]) value);
         }
       case STRING  :
         if (value instanceof ByteString) {
-          return CodedOutputStream.computeBytesSizeNoTag((ByteString) value);
+          return WireFormat.computeBytesSizeNoTag((ByteString) value);
         } else {
-          return CodedOutputStream.computeStringSizeNoTag((String) value);
+          return WireFormat.computeStringSizeNoTag((String) value);
         }
-      case UINT32  : return CodedOutputStream.computeUInt32SizeNoTag  ((Integer    )value);
-      case SFIXED32: return CodedOutputStream.computeSFixed32SizeNoTag((Integer    )value);
-      case SFIXED64: return CodedOutputStream.computeSFixed64SizeNoTag((Long       )value);
-      case SINT32  : return CodedOutputStream.computeSInt32SizeNoTag  ((Integer    )value);
-      case SINT64  : return CodedOutputStream.computeSInt64SizeNoTag  ((Long       )value);
+      case UINT32  : return WireFormat.computeUInt32SizeNoTag  ((Integer    )value);
+      case SFIXED32: return WireFormat.computeSFixed32SizeNoTag((Integer    )value);
+      case SFIXED64: return WireFormat.computeSFixed64SizeNoTag((Long       )value);
+      case SINT32  : return WireFormat.computeSInt32SizeNoTag  ((Integer    )value);
+      case SINT64  : return WireFormat.computeSInt64SizeNoTag  ((Long       )value);
 
       case MESSAGE:
         if (value instanceof LazyField) {
-          return CodedOutputStream.computeLazyFieldSizeNoTag((LazyField) value);
+          return WireFormat.computeLazyFieldSizeNoTag((LazyField) value);
         } else {
-          return CodedOutputStream.computeMessageSizeNoTag((MessageLite) value);
+          return WireFormat.computeMessageSizeNoTag((MessageLite) value);
         }
 
       case ENUM:
         if (value instanceof Internal.EnumLite) {
-          return CodedOutputStream.computeEnumSizeNoTag(
+          return WireFormat.computeEnumSizeNoTag(
               ((Internal.EnumLite) value).getNumber());
         } else {
-          return CodedOutputStream.computeEnumSizeNoTag((Integer) value);
+          return WireFormat.computeEnumSizeNoTag((Integer) value);
         }
     }
 
@@ -872,9 +873,8 @@ final class FieldSet<FieldDescriptorType extends
         for (final Object element : (List<?>)value) {
           dataSize += computeElementSizeNoTag(type, element);
         }
-        return dataSize +
-            CodedOutputStream.computeTagSize(number) +
-            CodedOutputStream.computeRawVarint32Size(dataSize);
+        return dataSize + WireFormat.computeTagSize(number) +
+                WireFormat.computeRawVarint32Size(dataSize);
       } else {
         int size = 0;
         for (final Object element : (List<?>)value) {

--- a/java/src/main/java/com/google/protobuf/FieldSet.java
+++ b/java/src/main/java/com/google/protobuf/FieldSet.java
@@ -563,8 +563,8 @@ final class FieldSet<FieldDescriptorType extends
   }
 
 
-  /** See {@link Message#writeTo(CodedOutputStream)}. */
-  public void writeTo(final CodedOutputStream output)
+  /** See {@link Message#writeTo(Encoder)}. */
+  public void writeTo(final Encoder output)
                       throws IOException {
     for (int i = 0; i < fields.getNumArrayEntries(); i++) {
       final Map.Entry<FieldDescriptorType, Object> entry =
@@ -580,7 +580,7 @@ final class FieldSet<FieldDescriptorType extends
   /**
    * Like {@link #writeTo} but uses MessageSet wire format.
    */
-  public void writeMessageSetTo(final CodedOutputStream output)
+  public void writeMessageSetTo(final Encoder output)
                                 throws IOException {
     for (int i = 0; i < fields.getNumArrayEntries(); i++) {
       writeMessageSetTo(fields.getArrayEntryAt(i), output);
@@ -593,7 +593,7 @@ final class FieldSet<FieldDescriptorType extends
 
   private void writeMessageSetTo(
       final Map.Entry<FieldDescriptorType, Object> entry,
-      final CodedOutputStream output) throws IOException {
+      final Encoder output) throws IOException {
     final FieldDescriptorType descriptor = entry.getKey();
     if (descriptor.getLiteJavaType() == WireFormat.JavaType.MESSAGE &&
         !descriptor.isRepeated() && !descriptor.isPacked()) {
@@ -619,7 +619,7 @@ final class FieldSet<FieldDescriptorType extends
    *               {@link Message#getField(Descriptors.FieldDescriptor)} for
    *               this field.
    */
-  private static void writeElement(final CodedOutputStream output,
+  private static void writeElement(final Encoder output,
                                    final WireFormat.FieldType type,
                                    final int number,
                                    final Object value) throws IOException {
@@ -644,7 +644,7 @@ final class FieldSet<FieldDescriptorType extends
    *               this field.
    */
   static void writeElementNoTag(
-      final CodedOutputStream output,
+      final Encoder output,
       final WireFormat.FieldType type,
       final Object value) throws IOException {
     switch (type) {
@@ -691,7 +691,7 @@ final class FieldSet<FieldDescriptorType extends
   /** Write a single field. */
   public static void writeField(final FieldDescriptorLite<?> descriptor,
                                 final Object value,
-                                final CodedOutputStream output)
+                                final Encoder output)
                                 throws IOException {
     WireFormat.FieldType type = descriptor.getLiteType();
     int number = descriptor.getNumber();

--- a/java/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -36,15 +36,12 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
-import com.google.protobuf.GeneratedMessageLite.ExtendableMessage;
-import com.google.protobuf.GeneratedMessageLite.GeneratedExtension;
 
 import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -277,7 +274,7 @@ public abstract class GeneratedMessage extends AbstractMessage
   }
 
   @Override
-  public void writeTo(final CodedOutputStream output) throws IOException {
+  public void writeTo(final Encoder output) throws IOException {
     MessageReflection.writeMessageTo(this, getAllFieldsRaw(), output, false);
   }
 
@@ -880,7 +877,7 @@ public abstract class GeneratedMessage extends AbstractMessage
         this.messageSetWireFormat = messageSetWireFormat;
       }
 
-      public void writeUntil(final int end, final CodedOutputStream output)
+      public void writeUntil(final int end, final Encoder output)
                              throws IOException {
         while (next != null && next.getKey().getNumber() < end) {
           FieldDescriptor descriptor = next.getKey();
@@ -2759,7 +2756,7 @@ public abstract class GeneratedMessage extends AbstractMessage
   }
   
   protected static void writeString(
-      CodedOutputStream output, final int fieldNumber, final Object value) throws IOException {
+      Encoder output, final int fieldNumber, final Object value) throws IOException {
     if (value instanceof String) {
       output.writeString(fieldNumber, (String) value);
     } else {
@@ -2768,7 +2765,7 @@ public abstract class GeneratedMessage extends AbstractMessage
   }
   
   protected static void writeStringNoTag(
-      CodedOutputStream output, final Object value) throws IOException {
+      Encoder output, final Object value) throws IOException {
     if (value instanceof String) {
       output.writeStringNoTag((String) value);
     } else {

--- a/java/src/main/java/com/google/protobuf/GeneratedMessageLite.java
+++ b/java/src/main/java/com/google/protobuf/GeneratedMessageLite.java
@@ -434,7 +434,7 @@ public abstract class GeneratedMessageLite<
         this.messageSetWireFormat = messageSetWireFormat;
       }
 
-      public void writeUntil(final int end, final CodedOutputStream output)
+      public void writeUntil(final int end, final Encoder output)
                              throws IOException {
         while (next != null && next.getKey().getNumber() < end) {
           ExtensionDescriptor extension = next.getKey();

--- a/java/src/main/java/com/google/protobuf/LiteralByteString.java
+++ b/java/src/main/java/com/google/protobuf/LiteralByteString.java
@@ -30,8 +30,6 @@
 
 package com.google.protobuf;
 
-import sun.misc.Unsafe;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/java/src/main/java/com/google/protobuf/LiteralByteString.java
+++ b/java/src/main/java/com/google/protobuf/LiteralByteString.java
@@ -120,8 +120,8 @@ class LiteralByteString extends ByteString {
   }
 
   @Override
-  public void copyTo(ByteBuffer target) {
-    target.put(bytes, getOffsetIntoBytes(), size());  // Copies bytes
+  public void copyTo(ByteBuffer target, int sourceOffset, int numberToCopy) {
+    target.put(bytes, getOffsetIntoBytes() + sourceOffset, numberToCopy);  // Copies bytes
   }
 
   @Override

--- a/java/src/main/java/com/google/protobuf/LiteralByteString.java
+++ b/java/src/main/java/com/google/protobuf/LiteralByteString.java
@@ -30,6 +30,8 @@
 
 package com.google.protobuf;
 
+import sun.misc.Unsafe;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -219,7 +221,7 @@ class LiteralByteString extends ByteString {
    * @param length number of bytes to compare
    * @return true for equality of substrings, else false.
    */
-  boolean equalsRange(LiteralByteString other, int offset, int length) {
+  boolean equalsRange(ByteString other, int offset, int length) {
     if (length > other.size()) {
       throw new IllegalArgumentException(
           "Length too large: " + length + size());
@@ -230,17 +232,22 @@ class LiteralByteString extends ByteString {
               other.size());
     }
 
-    byte[] thisBytes = bytes;
-    byte[] otherBytes = other.bytes;
-    int thisLimit = getOffsetIntoBytes() + length;
-    for (int thisIndex = getOffsetIntoBytes(), otherIndex =
-        other.getOffsetIntoBytes() + offset;
-        (thisIndex < thisLimit); ++thisIndex, ++otherIndex) {
-      if (thisBytes[thisIndex] != otherBytes[otherIndex]) {
-        return false;
+    if (other instanceof LiteralByteString) {
+      LiteralByteString lbsOther = (LiteralByteString) other;
+      byte[] thisBytes = bytes;
+      byte[] otherBytes = lbsOther.bytes;
+      int thisLimit = getOffsetIntoBytes() + length;
+      for (int thisIndex = getOffsetIntoBytes(), otherIndex =
+           lbsOther.getOffsetIntoBytes() + offset;
+           (thisIndex < thisLimit); ++thisIndex, ++otherIndex) {
+        if (thisBytes[thisIndex] != otherBytes[otherIndex]) {
+          return false;
+        }
       }
+      return true;
     }
-    return true;
+
+    return other.substring(offset, offset + length).equals(substring(0, length));
   }
 
   /**

--- a/java/src/main/java/com/google/protobuf/MapEntry.java
+++ b/java/src/main/java/com/google/protobuf/MapEntry.java
@@ -121,7 +121,7 @@ public final class MapEntry<K, V> extends AbstractMessage {
   }
   
   @Override
-  public void writeTo(CodedOutputStream output) throws IOException {
+  public void writeTo(Encoder output) throws IOException {
     data.writeTo(output);
   }
   

--- a/java/src/main/java/com/google/protobuf/MapEntryLite.java
+++ b/java/src/main/java/com/google/protobuf/MapEntryLite.java
@@ -113,14 +113,14 @@ public class MapEntryLite<K, V> extends AbstractMessageLite {
   }
   
   @Override
-  public void writeTo(CodedOutputStream output) throws IOException {
+  public void writeTo(Encoder output) throws IOException {
     writeField(KEY_FIELD_NUMBER, metadata.keyType, key, output);
     writeField(VALUE_FIELD_NUMBER, metadata.valueType, value, output);
   }
 
   private void writeField(
       int number, WireFormat.FieldType type, Object value,
-      CodedOutputStream output) throws IOException {
+      Encoder output) throws IOException {
     output.writeTag(number, type.getWireType());
     FieldSet.writeElementNoTag(output, type, value);
   }

--- a/java/src/main/java/com/google/protobuf/MessageLite.java
+++ b/java/src/main/java/com/google/protobuf/MessageLite.java
@@ -71,7 +71,7 @@ public interface MessageLite extends MessageLiteOrBuilder {
    * Serializes the message and writes it to {@code output}.  This does not
    * flush or close the stream.
    */
-  void writeTo(CodedOutputStream output) throws IOException;
+  void writeTo(Encoder output) throws IOException;
 
   /**
    * Get the number of bytes required to encode this message.  The result
@@ -91,20 +91,20 @@ public interface MessageLite extends MessageLiteOrBuilder {
   /**
    * Serializes the message to a {@code ByteString} and returns it. This is
    * just a trivial wrapper around
-   * {@link #writeTo(CodedOutputStream)}.
+   * {@link #writeTo(Encoder)}.
    */
   ByteString toByteString();
 
   /**
    * Serializes the message to a {@code byte} array and returns it.  This is
    * just a trivial wrapper around
-   * {@link #writeTo(CodedOutputStream)}.
+   * {@link #writeTo(Encoder)}.
    */
   byte[] toByteArray();
 
   /**
    * Serializes the message and writes it to {@code output}.  This is just a
-   * trivial wrapper around {@link #writeTo(CodedOutputStream)}.  This does
+   * trivial wrapper around {@link #writeTo(Encoder)}.  This does
    * not flush or close the stream.
    * <p>
    * NOTE:  Protocol Buffers are not self-delimiting.  Therefore, if you write

--- a/java/src/main/java/com/google/protobuf/MessageReflection.java
+++ b/java/src/main/java/com/google/protobuf/MessageReflection.java
@@ -48,7 +48,7 @@ class MessageReflection {
   static void writeMessageTo(
       Message message,
       Map<FieldDescriptor, Object> fields,
-      CodedOutputStream output,
+      Encoder output,
       boolean alwaysWriteRequiredFields)
       throws IOException {
     final boolean isMessageSet =

--- a/java/src/main/java/com/google/protobuf/PlatformDependent.java
+++ b/java/src/main/java/com/google/protobuf/PlatformDependent.java
@@ -1,0 +1,315 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import sun.misc.Unsafe;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.charset.CoderResult;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Optimized platform-specific utilities.
+ */
+class PlatformDependent {
+  private static final Logger logger = Logger.getLogger(PlatformDependent.class.getName());
+  private static final Unsafe UNSAFE;
+
+  static {
+    UNSAFE = getUnsafe();
+  }
+
+  private static Unsafe getUnsafe() {
+    Unsafe unsafe = null;
+    try {
+      java.lang.reflect.Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+      unsafeField.setAccessible(true);
+      unsafe = (Unsafe) unsafeField.get(null);
+    } catch (Throwable cause) {
+      // Do nothing.
+    }
+
+    log("sun.misc.Unsafe.theUnsafe: {}", unsafe != null ? "available" : "unavailable");
+    return unsafe;
+  }
+
+  private static java.lang.reflect.Field field(Class clazz, String fieldName) {
+    java.lang.reflect.Field field;
+    try {
+      field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+    } catch (Throwable t) {
+      // Failed to access the fields.
+      field = null;
+    }
+    log("{0}.{1}: {2}", clazz.getName(), fieldName, field != null? "available" : "unavailable");
+    return field;
+  }
+
+  private static long objectFieldOffset(java.lang.reflect.Field field) {
+    return field == null || UNSAFE == null ? -1 : UNSAFE.objectFieldOffset(field);
+  }
+
+  private static void log(String format, Object... params) {
+    logger.log(Level.FINEST, format, params);
+  }
+
+  /**
+   * Encodes a {@code UTF-8} {@link String} to the given {@link ByteBuffer}. Implements the
+   * same algorithm given by {@link Utf8#encode(CharSequence, byte[], int, int)}. Uses
+   * optimizations provided by {@link Unsafe} where possible.
+   */
+  static CoderResult encode(String src, ByteBuffer target) {
+    if (target.hasArray()) {
+      return encodeToHeap(src, target);
+    }
+    if (UnsafeDirectByteBuffer.isAvailable()) {
+      return unsafeEncodeToDirect(src, target);
+    }
+    return encodeToDirect(src, target);
+  }
+
+  /**
+   * Uses {@link Unsafe} to write to the direct buffer's underlying address space.
+   */
+  private static CoderResult unsafeEncodeToDirect(String src, ByteBuffer targetBuffer) {
+    long targetOffset = UnsafeDirectByteBuffer.getAddress(targetBuffer);
+    long targetLimit = targetOffset + targetBuffer.remaining();
+
+    long targetIx = targetOffset;
+    int srcIx = 0;
+    int srcLimit = src.length();
+
+    // Designed to take advantage of
+    // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
+    for (char c;
+         srcIx < srcLimit && targetIx < targetLimit&& (c = src.charAt(srcIx)) < 0x80;
+         srcIx++) {
+      UnsafeDirectByteBuffer.putByte(targetIx++, (byte) c);
+    }
+    if (srcIx == srcLimit) {
+      targetBuffer.position(targetBuffer.position() + (int) (targetIx - targetOffset));
+      return CoderResult.UNDERFLOW;
+    }
+
+    for (char c; srcIx < srcLimit; srcIx++) {
+      c = src.charAt(srcIx);
+      if (c < 0x80 && targetIx < targetLimit) {
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) c);
+      } else if (c < 0x800 && targetIx <= targetLimit - 2) { // 11 bits, two UTF-8 bytes
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) ((0xF << 6) | (c >>> 6)));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & c)));
+      } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)
+              && targetIx <= targetLimit - 3) {
+        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) ((0xF << 5) | (c >>> 12)));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & (c >>> 6))));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & c)));
+      } else if (targetIx <= targetLimit - 4) {
+        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+        final char low;
+        if (srcIx + 1 == srcLimit
+                || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
+          return CoderResult.malformedForLength(srcIx - 1);
+        }
+        int codePoint = Character.toCodePoint(c, low);
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) ((0xF << 4) | (codePoint >>> 18)));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 12))));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 6))));
+        UnsafeDirectByteBuffer.putByte(targetIx++, (byte) (0x80 | (0x3F & codePoint)));
+      } else {
+        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
+                && (srcIx + 1 == srcLimit
+                || !Character.isSurrogatePair(c, src.charAt(srcIx + 1)))) {
+          // We are surrogates and we're not a surrogate pair.
+          return CoderResult.malformedForLength(srcIx);
+        }
+        // Not enough space in the output buffer.
+        return CoderResult.OVERFLOW;
+      }
+    }
+    // All bytes have been encoded.
+    targetBuffer.position(targetBuffer.position() + (int) (targetIx - targetOffset));
+    return CoderResult.UNDERFLOW;
+  }
+
+  /**
+   * Encodes the {@link String} to the heap buffer's underlying array.
+   */
+  private static CoderResult encodeToHeap(String src, ByteBuffer target) {
+    byte[] bytes = target.array();
+    int targetOffset = target.arrayOffset() + target.position();
+
+    int srcLength = src.length();
+    int targetIx = targetOffset;
+    int srcIx = 0;
+    int targetLimit = targetOffset + target.remaining();
+
+    // Designed to take advantage of
+    // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
+    for (char c;
+         srcIx < srcLength && targetIx < targetLimit && (c = src.charAt(srcIx)) < 0x80;
+         srcIx++) {
+      bytes[targetIx++] = (byte) c;
+    }
+    if (srcIx == srcLength) {
+      // The entire source buffer has been consumed.
+      target.position(targetIx - target.arrayOffset());
+      return CoderResult.UNDERFLOW;
+    }
+
+    for (char c; srcIx < srcLength; srcIx++) {
+      c = src.charAt(srcIx);
+      if (c < 0x80 && targetIx < targetLimit) {
+        bytes[targetIx++] = (byte) c;
+      } else if (c < 0x800 && targetIx <= targetLimit - 2) { // 11 bits, two UTF-8 bytes
+        bytes[targetIx++] = (byte) ((0xF << 6) | (c >>> 6));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & c));
+      } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)
+              && targetIx <= targetLimit - 3) {
+        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+        bytes[targetIx++] = (byte) ((0xF << 5) | (c >>> 12));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & c));
+      } else if (targetIx <= targetLimit - 4) {
+        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+        final char low;
+        if (srcIx + 1 == srcLength
+                || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
+          return CoderResult.malformedForLength(srcIx - 1);
+        }
+        int codePoint = Character.toCodePoint(c, low);
+        bytes[targetIx++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+        bytes[targetIx++] = (byte) (0x80 | (0x3F & codePoint));
+      } else {
+        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
+                && (srcIx + 1 == srcLength
+                || !Character.isSurrogatePair(c, src.charAt(srcIx + 1)))) {
+          // We are surrogates and we're not a surrogate pair.
+          return CoderResult.malformedForLength(srcIx);
+        }
+        // Not enough space in the output buffer.
+        return CoderResult.OVERFLOW;
+      }
+    }
+    // All bytes have been encoded.
+    target.position(targetIx - target.arrayOffset());
+    return CoderResult.UNDERFLOW;
+  }
+
+  /**
+   * Encodes the {@link String} to the direct buffer using the standard {@link ByteBuffer} API.
+   */
+  private static CoderResult encodeToDirect(String src, ByteBuffer target) {
+    int srcLength = src.length();
+    int targetOffset = target.position();
+    int targetIx = targetOffset;
+    int srcIx = 0;
+    int targetLimit = targetOffset + target.remaining();
+
+    // Designed to take advantage of
+    // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
+    for (char c;
+         srcIx < srcLength && targetIx < targetLimit && (c = src.charAt(srcIx)) < 0x80;
+         srcIx++) {
+      target.put(targetIx++, (byte) c);
+    }
+    if (srcIx == srcLength) {
+      // The entire source buffer has been consumed.
+      target.position(targetIx);
+      return CoderResult.UNDERFLOW;
+    }
+
+    for (char c; srcIx < srcLength; srcIx++) {
+      c = src.charAt(srcIx);
+      if (c < 0x80 && targetIx < targetLimit) {
+        target.put(targetIx++, (byte) c);
+      } else if (c < 0x800 && targetIx <= targetLimit - 2) { // 11 bits, two UTF-8 bytes
+        target.put(targetIx++, (byte) ((0xF << 6) | (c >>> 6)));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & c)));
+      } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)
+              && targetIx <= targetLimit - 3) {
+        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+        target.put(targetIx++, (byte) ((0xF << 5) | (c >>> 12)));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & (c >>> 6))));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & c)));
+      } else if (targetIx <= targetLimit - 4) {
+        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+        final char low;
+        if (srcIx + 1 == srcLength
+                || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
+          return CoderResult.malformedForLength(srcIx - 1);
+        }
+        int codePoint = Character.toCodePoint(c, low);
+        target.put(targetIx++, (byte) ((0xF << 4) | (codePoint >>> 18)));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 12))));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 6))));
+        target.put(targetIx++, (byte) (0x80 | (0x3F & codePoint)));
+      } else {
+        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
+                && (srcIx + 1 == srcLength
+                || !Character.isSurrogatePair(c, src.charAt(srcIx + 1)))) {
+          // We are surrogates and we're not a surrogate pair.
+          return CoderResult.malformedForLength(srcIx);
+        }
+        // Not enough space in the output buffer.
+        return CoderResult.OVERFLOW;
+      }
+    }
+    // All bytes have been encoded.
+    target.position(targetIx);
+    return CoderResult.UNDERFLOW;
+  }
+
+  private static class UnsafeDirectByteBuffer {
+    private static final long ADDRESS_OFFSET;
+
+    static {
+      ADDRESS_OFFSET = objectFieldOffset(field(Buffer.class, "address"));
+    }
+
+    static boolean isAvailable() {
+      return ADDRESS_OFFSET != -1;
+    }
+
+    private static long getAddress(ByteBuffer buffer) {
+      return UNSAFE.getLong(buffer, ADDRESS_OFFSET);
+    }
+
+    public static void putByte(long address, byte b) {
+      UNSAFE.putByte(address, b);
+    }
+  }
+}

--- a/java/src/main/java/com/google/protobuf/PlatformDependent.java
+++ b/java/src/main/java/com/google/protobuf/PlatformDependent.java
@@ -92,36 +92,159 @@ class PlatformDependent {
   static CoderResult encode(String src, ByteBuffer target) {
     if (target.hasArray()) {
       return encodeToHeap(src, target);
-    }
-    if (UnsafeDirectByteBuffer.isAvailable()) {
+    } else if (UnsafeDirectByteBuffer.isAvailable()) {
       return unsafeEncodeToDirect(src, target);
+    } else {
+      return encodeToDirect(src, target);
     }
-    return encodeToDirect(src, target);
+  }
+
+  /**
+   * Encodes the {@link String} to the heap buffer's underlying array.
+   */
+  static CoderResult encodeToHeap(final String src, final ByteBuffer target) {
+    // Since Java array access already checks boundaries for us, no need to explicitly check
+    // the target array access. Assume the array is big enough and handle the
+    // out of bounds exception if it happens.
+    try {
+      final byte[] bytes = target.array();
+      final int arrayOffset = target.arrayOffset();
+      final int startOffset = arrayOffset + target.position();
+      final int srcLength = src.length();
+      int i = 0;
+      //final int limit = arrayOffset + target.limit();
+      // Designed to take advantage of
+      // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
+      for (char c; i < srcLength && (c = src.charAt(i)) < 0x80; ++i) {
+        bytes[startOffset + i] = (byte) c;
+      }
+      if (i == srcLength) {
+        // Successfully encoded the entire string.
+        target.position(target.position() + i);
+        return CoderResult.UNDERFLOW;
+      }
+      int j = startOffset + i;
+      for (char c; i < srcLength; ++i) {
+        c = src.charAt(i);
+        if (c < 0x80) {
+          bytes[j++] = (byte) c;
+        } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
+          bytes[j++] = (byte) ((0xF << 6) | (c >>> 6));
+          bytes[j++] = (byte) (0x80 | (0x3F & c));
+        } else if (c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c) {
+          // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+          bytes[j++] = (byte) ((0xF << 5) | (c >>> 12));
+          bytes[j++] = (byte) (0x80 | (0x3F & (c >>> 6)));
+          bytes[j++] = (byte) (0x80 | (0x3F & c));
+        } else {
+          // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+          final char low;
+          if (i + 1 == srcLength
+                  || !Character.isSurrogatePair(c, (low = src.charAt(++i)))) {
+            return CoderResult.malformedForLength(i - 1);
+          }
+          int codePoint = Character.toCodePoint(c, low);
+          bytes[j++] = (byte) ((0xF << 4) | (codePoint >>> 18));
+          bytes[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
+          bytes[j++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
+          bytes[j++] = (byte) (0x80 | (0x3F & codePoint));
+        }
+      }
+
+      // Successfully encoded the entire string.
+      target.position(j - arrayOffset);
+      return CoderResult.UNDERFLOW;
+    } catch (ArrayIndexOutOfBoundsException e){
+      return CoderResult.OVERFLOW;
+    }
+  }
+
+  /**
+   * Encodes the {@link String} to the direct buffer using the standard {@link ByteBuffer} API.
+   */
+  static CoderResult encodeToDirect(final String src, final ByteBuffer target) {
+    // Since ByteBuffer.putXXX() already checks boundaries for us, no need to explicitly check
+    // the target array access. Assume the array is big enough and handle the
+    // out of bounds exception if it happens.
+    try {
+      final int srcLength = src.length();
+      int pos = target.position();
+      int srcIx = 0;
+
+      // Designed to take advantage of
+      // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
+      for (char c; srcIx < srcLength && (c = src.charAt(srcIx)) < 0x80; ++srcIx) {
+        target.put(pos + srcIx, (byte) c);
+      }
+      if (srcIx == srcLength) {
+        // Successfully encoded the entire string.
+        target.position(pos + srcIx);
+        return CoderResult.UNDERFLOW;
+      }
+
+      // Ensure that we're using BIG_ENDIAN byte order.
+
+      pos += srcIx;
+      for (char c; srcIx < srcLength; ++srcIx) {
+        c = src.charAt(srcIx);
+        if (c < 0x80) {
+          target.put(pos++, (byte) c);
+        } else if (c < 0x800) { // 11 bits, two UTF-8 bytes
+          target.put(pos++, (byte) ((0xF << 6) | (c >>> 6)));
+          target.put(pos++, (byte) (0x80 | (0x3F & c)));
+        } else if (c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c) {
+          // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
+          target.put(pos++, (byte) ((0xF << 5) | (c >>> 12)));
+          target.put(pos++, (byte) (0x80 | (0x3F & (c >>> 6))));
+          target.put(pos++, (byte) (0x80 | (0x3F & c)));
+        } else {
+          // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
+          final char low;
+          if (srcIx + 1 == srcLength
+                  || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
+            return CoderResult.malformedForLength(srcIx - 1);
+          }
+          int codePoint = Character.toCodePoint(c, low);
+          target.put(pos++, (byte) ((0xF << 4) | (codePoint >>> 18)));
+          target.put(pos++, (byte) (0x80 | (0x3F & (codePoint >>> 12))));
+          target.put(pos++, (byte) (0x80 | (0x3F & (codePoint >>> 6))));
+          target.put(pos++, (byte) (0x80 | (0x3F & codePoint)));
+        }
+      }
+      // Successfully encoded the entire string.
+      target.position(pos);
+      return CoderResult.UNDERFLOW;
+    } catch (ArrayIndexOutOfBoundsException e) {
+      return CoderResult.OVERFLOW;
+    }
   }
 
   /**
    * Uses {@link Unsafe} to write to the direct buffer's underlying address space.
    */
-  private static CoderResult unsafeEncodeToDirect(String src, ByteBuffer targetBuffer) {
-    long targetOffset = UnsafeDirectByteBuffer.getAddress(targetBuffer);
-    long targetLimit = targetOffset + targetBuffer.remaining();
+  static CoderResult unsafeEncodeToDirect(final String src, final ByteBuffer targetBuffer) {
+    final long targetOffset = UnsafeDirectByteBuffer.getAddress(targetBuffer);
+    final long targetLimit = targetOffset + targetBuffer.limit();
+    final int srcLimit = src.length();
 
-    long targetIx = targetOffset;
-    int srcIx = 0;
-    int srcLimit = src.length();
+    if (srcLimit > targetLimit - targetOffset) {
+      // Not even enough room for an ASCII-encoded string.
+      return CoderResult.OVERFLOW;
+    }
 
     // Designed to take advantage of
     // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
-    for (char c;
-         srcIx < srcLimit && targetIx < targetLimit&& (c = src.charAt(srcIx)) < 0x80;
-         srcIx++) {
-      UnsafeDirectByteBuffer.putByte(targetIx++, (byte) c);
+    int srcIx = 0;
+    for (char c; srcIx < srcLimit && (c = src.charAt(srcIx)) < 0x80; srcIx++) {
+      UnsafeDirectByteBuffer.putByte(targetOffset + srcIx, (byte) c);
     }
     if (srcIx == srcLimit) {
-      targetBuffer.position(targetBuffer.position() + (int) (targetIx - targetOffset));
+      // We're done, it was ASCII encoded.
+      targetBuffer.position(srcIx);
       return CoderResult.UNDERFLOW;
     }
 
+    long targetIx = targetOffset + targetBuffer.position();
     for (char c; srcIx < srcLimit; srcIx++) {
       c = src.charAt(srcIx);
       if (c < 0x80 && targetIx < targetLimit) {
@@ -159,156 +282,28 @@ class PlatformDependent {
       }
     }
     // All bytes have been encoded.
-    targetBuffer.position(targetBuffer.position() + (int) (targetIx - targetOffset));
+    targetBuffer.position((int) (targetIx - targetOffset));
     return CoderResult.UNDERFLOW;
   }
 
-  /**
-   * Encodes the {@link String} to the heap buffer's underlying array.
-   */
-  private static CoderResult encodeToHeap(String src, ByteBuffer target) {
-    byte[] bytes = target.array();
-    int targetOffset = target.arrayOffset() + target.position();
-
-    int srcLength = src.length();
-    int targetIx = targetOffset;
-    int srcIx = 0;
-    int targetLimit = targetOffset + target.remaining();
-
-    // Designed to take advantage of
-    // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
-    for (char c;
-         srcIx < srcLength && targetIx < targetLimit && (c = src.charAt(srcIx)) < 0x80;
-         srcIx++) {
-      bytes[targetIx++] = (byte) c;
-    }
-    if (srcIx == srcLength) {
-      // The entire source buffer has been consumed.
-      target.position(targetIx - target.arrayOffset());
-      return CoderResult.UNDERFLOW;
-    }
-
-    for (char c; srcIx < srcLength; srcIx++) {
-      c = src.charAt(srcIx);
-      if (c < 0x80 && targetIx < targetLimit) {
-        bytes[targetIx++] = (byte) c;
-      } else if (c < 0x800 && targetIx <= targetLimit - 2) { // 11 bits, two UTF-8 bytes
-        bytes[targetIx++] = (byte) ((0xF << 6) | (c >>> 6));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & c));
-      } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)
-              && targetIx <= targetLimit - 3) {
-        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
-        bytes[targetIx++] = (byte) ((0xF << 5) | (c >>> 12));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & (c >>> 6)));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & c));
-      } else if (targetIx <= targetLimit - 4) {
-        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
-        final char low;
-        if (srcIx + 1 == srcLength
-                || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
-          return CoderResult.malformedForLength(srcIx - 1);
-        }
-        int codePoint = Character.toCodePoint(c, low);
-        bytes[targetIx++] = (byte) ((0xF << 4) | (codePoint >>> 18));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & (codePoint >>> 12)));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & (codePoint >>> 6)));
-        bytes[targetIx++] = (byte) (0x80 | (0x3F & codePoint));
-      } else {
-        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
-                && (srcIx + 1 == srcLength
-                || !Character.isSurrogatePair(c, src.charAt(srcIx + 1)))) {
-          // We are surrogates and we're not a surrogate pair.
-          return CoderResult.malformedForLength(srcIx);
-        }
-        // Not enough space in the output buffer.
-        return CoderResult.OVERFLOW;
-      }
-    }
-    // All bytes have been encoded.
-    target.position(targetIx - target.arrayOffset());
-    return CoderResult.UNDERFLOW;
-  }
-
-  /**
-   * Encodes the {@link String} to the direct buffer using the standard {@link ByteBuffer} API.
-   */
-  private static CoderResult encodeToDirect(String src, ByteBuffer target) {
-    int srcLength = src.length();
-    int targetOffset = target.position();
-    int targetIx = targetOffset;
-    int srcIx = 0;
-    int targetLimit = targetOffset + target.remaining();
-
-    // Designed to take advantage of
-    // https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination
-    for (char c;
-         srcIx < srcLength && targetIx < targetLimit && (c = src.charAt(srcIx)) < 0x80;
-         srcIx++) {
-      target.put(targetIx++, (byte) c);
-    }
-    if (srcIx == srcLength) {
-      // The entire source buffer has been consumed.
-      target.position(targetIx);
-      return CoderResult.UNDERFLOW;
-    }
-
-    for (char c; srcIx < srcLength; srcIx++) {
-      c = src.charAt(srcIx);
-      if (c < 0x80 && targetIx < targetLimit) {
-        target.put(targetIx++, (byte) c);
-      } else if (c < 0x800 && targetIx <= targetLimit - 2) { // 11 bits, two UTF-8 bytes
-        target.put(targetIx++, (byte) ((0xF << 6) | (c >>> 6)));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & c)));
-      } else if ((c < Character.MIN_SURROGATE || Character.MAX_SURROGATE < c)
-              && targetIx <= targetLimit - 3) {
-        // Maximum single-char code point is 0xFFFF, 16 bits, three UTF-8 bytes
-        target.put(targetIx++, (byte) ((0xF << 5) | (c >>> 12)));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & (c >>> 6))));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & c)));
-      } else if (targetIx <= targetLimit - 4) {
-        // Minimum code point represented by a surrogate pair is 0x10000, 17 bits, four UTF-8 bytes
-        final char low;
-        if (srcIx + 1 == srcLength
-                || !Character.isSurrogatePair(c, (low = src.charAt(++srcIx)))) {
-          return CoderResult.malformedForLength(srcIx - 1);
-        }
-        int codePoint = Character.toCodePoint(c, low);
-        target.put(targetIx++, (byte) ((0xF << 4) | (codePoint >>> 18)));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 12))));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & (codePoint >>> 6))));
-        target.put(targetIx++, (byte) (0x80 | (0x3F & codePoint)));
-      } else {
-        if ((Character.MIN_SURROGATE <= c && c <= Character.MAX_SURROGATE)
-                && (srcIx + 1 == srcLength
-                || !Character.isSurrogatePair(c, src.charAt(srcIx + 1)))) {
-          // We are surrogates and we're not a surrogate pair.
-          return CoderResult.malformedForLength(srcIx);
-        }
-        // Not enough space in the output buffer.
-        return CoderResult.OVERFLOW;
-      }
-    }
-    // All bytes have been encoded.
-    target.position(targetIx);
-    return CoderResult.UNDERFLOW;
-  }
-
-  private static class UnsafeDirectByteBuffer {
+  static class UnsafeDirectByteBuffer {
     private static final long ADDRESS_OFFSET;
+    private static final boolean AVAILABLE;
 
     static {
       ADDRESS_OFFSET = objectFieldOffset(field(Buffer.class, "address"));
+      AVAILABLE = ADDRESS_OFFSET != -1;
     }
 
     static boolean isAvailable() {
-      return ADDRESS_OFFSET != -1;
+      return AVAILABLE;
     }
 
     private static long getAddress(ByteBuffer buffer) {
       return UNSAFE.getLong(buffer, ADDRESS_OFFSET);
     }
 
-    public static void putByte(long address, byte b) {
+    private static void putByte(long address, byte b) {
       UNSAFE.putByte(address, b);
     }
   }

--- a/java/src/main/java/com/google/protobuf/RopeByteString.java
+++ b/java/src/main/java/com/google/protobuf/RopeByteString.java
@@ -373,9 +373,14 @@ class RopeByteString extends ByteString {
   }
 
   @Override
-  public void copyTo(ByteBuffer target) {
-    left.copyTo(target);
-    right.copyTo(target);
+  public void copyTo(ByteBuffer target, int sourceOffset, int numberToCopy) {
+    if (sourceOffset == 0 && numberToCopy == size()) {
+      // Copy everything.
+      left.copyTo(target);
+      right.copyTo(target);
+    } else {
+      substring(sourceOffset, sourceOffset + numberToCopy).copyTo(target);
+    }
   }
 
   @Override

--- a/java/src/main/java/com/google/protobuf/RopeByteString.java
+++ b/java/src/main/java/com/google/protobuf/RopeByteString.java
@@ -391,7 +391,7 @@ class RopeByteString extends ByteString {
     List<ByteBuffer> result = new ArrayList<ByteBuffer>();
     PieceIterator pieces = new PieceIterator(this);
     while (pieces.hasNext()) {
-      LiteralByteString byteString = pieces.next();
+      ByteString byteString = pieces.next();
       result.add(byteString.asReadOnlyByteBuffer());
     }
     return result;
@@ -481,6 +481,11 @@ class RopeByteString extends ByteString {
     return equalsFragments(otherByteString);
   }
 
+  @Override
+  boolean equalsRange(ByteString other, int offset, int length) {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Determines if this string is equal to another of the same length by
    * iterating over the leaf nodes. On each step of the iteration, the
@@ -492,12 +497,12 @@ class RopeByteString extends ByteString {
    */
   private boolean equalsFragments(ByteString other) {
     int thisOffset = 0;
-    Iterator<LiteralByteString> thisIter = new PieceIterator(this);
-    LiteralByteString thisString = thisIter.next();
+    Iterator<ByteString> thisIter = new PieceIterator(this);
+    ByteString thisString = thisIter.next();
 
     int thatOffset = 0;
-    Iterator<LiteralByteString> thatIter = new PieceIterator(other);
-    LiteralByteString thatString = thatIter.next();
+    Iterator<ByteString> thatIter = new PieceIterator(other);
+    ByteString thatString = thatIter.next();
 
     int pos = 0;
     while (true) {
@@ -714,34 +719,34 @@ class RopeByteString extends ByteString {
    * <p>This iterator is used to implement
    * {@link RopeByteString#equalsFragments(ByteString)}.
    */
-  private static class PieceIterator implements Iterator<LiteralByteString> {
+  private static class PieceIterator implements Iterator<ByteString> {
 
     private final Stack<RopeByteString> breadCrumbs =
         new Stack<RopeByteString>();
-    private LiteralByteString next;
+    private ByteString next;
 
     private PieceIterator(ByteString root) {
       next = getLeafByLeft(root);
     }
 
-    private LiteralByteString getLeafByLeft(ByteString root) {
+    private ByteString getLeafByLeft(ByteString root) {
       ByteString pos = root;
       while (pos instanceof RopeByteString) {
         RopeByteString rbs = (RopeByteString) pos;
         breadCrumbs.push(rbs);
         pos = rbs.left;
       }
-      return (LiteralByteString) pos;
+      return pos;
     }
 
-    private LiteralByteString getNextNonEmptyLeaf() {
+    private ByteString getNextNonEmptyLeaf() {
       while (true) {
         // Almost always, we go through this loop exactly once.  However, if
         // we discover an empty string in the rope, we toss it and try again.
         if (breadCrumbs.isEmpty()) {
           return null;
         } else {
-          LiteralByteString result = getLeafByLeft(breadCrumbs.pop().right);
+          ByteString result = getLeafByLeft(breadCrumbs.pop().right);
           if (!result.isEmpty()) {
             return result;
           }
@@ -758,11 +763,11 @@ class RopeByteString extends ByteString {
      *
      * @return next non-empty LiteralByteString or {@code null}
      */
-    public LiteralByteString next() {
+    public ByteString next() {
       if (next == null) {
         throw new NoSuchElementException();
       }
-      LiteralByteString result = next;
+      ByteString result = next;
       next = getNextNonEmptyLeaf();
       return result;
     }
@@ -835,7 +840,7 @@ class RopeByteString extends ByteString {
     // Iterates through the pieces of the rope
     private PieceIterator pieceIterator;
     // The current piece
-    private LiteralByteString currentPiece;
+    private ByteString currentPiece;
     // The size of the current piece
     private int currentPieceSize;
     // The index of the next byte to read in the current piece

--- a/java/src/main/java/com/google/protobuf/UnknownFieldSet.java
+++ b/java/src/main/java/com/google/protobuf/UnknownFieldSet.java
@@ -126,7 +126,7 @@ public final class UnknownFieldSet implements MessageLite {
   }
 
   /** Serializes the set and writes it to {@code output}. */
-  public void writeTo(final CodedOutputStream output) throws IOException {
+  public void writeTo(final Encoder output) throws IOException {
     for (final Map.Entry<Integer, Field> entry : fields.entrySet()) {
       entry.getValue().writeTo(entry.getKey(), output);
     }
@@ -144,7 +144,7 @@ public final class UnknownFieldSet implements MessageLite {
 
   /**
    * Serializes the message to a {@code ByteString} and returns it. This is
-   * just a trivial wrapper around {@link #writeTo(CodedOutputStream)}.
+   * just a trivial wrapper around {@link #writeTo(Encoder)}.
    */
   public ByteString toByteString() {
     try {
@@ -161,7 +161,7 @@ public final class UnknownFieldSet implements MessageLite {
 
   /**
    * Serializes the message to a {@code byte} array and returns it.  This is
-   * just a trivial wrapper around {@link #writeTo(CodedOutputStream)}.
+   * just a trivial wrapper around {@link #writeTo(Encoder)}.
    */
   public byte[] toByteArray() {
     try {
@@ -179,7 +179,7 @@ public final class UnknownFieldSet implements MessageLite {
 
   /**
    * Serializes the message and writes it to {@code output}.  This is just a
-   * trivial wrapper around {@link #writeTo(CodedOutputStream)}.
+   * trivial wrapper around {@link #writeTo(Encoder)}.
    */
   public void writeTo(final OutputStream output) throws IOException {
     final CodedOutputStream codedOutput = CodedOutputStream.newInstance(output);
@@ -207,7 +207,7 @@ public final class UnknownFieldSet implements MessageLite {
    * Serializes the set and writes it to {@code output} using
    * {@code MessageSet} wire format.
    */
-  public void writeAsMessageSetTo(final CodedOutputStream output)
+  public void writeAsMessageSetTo(final Encoder output)
       throws IOException {
     for (final Map.Entry<Integer, Field> entry : fields.entrySet()) {
       entry.getValue().writeAsMessageSetExtensionTo(
@@ -760,7 +760,7 @@ public final class UnknownFieldSet implements MessageLite {
      * Serializes the field, including field number, and writes it to
      * {@code output}.
      */
-    public void writeTo(final int fieldNumber, final CodedOutputStream output)
+    public void writeTo(final int fieldNumber, final Encoder output)
                         throws IOException {
       for (final long value : varint) {
         output.writeUInt64(fieldNumber, value);
@@ -809,7 +809,7 @@ public final class UnknownFieldSet implements MessageLite {
      */
     public void writeAsMessageSetExtensionTo(
         final int fieldNumber,
-        final CodedOutputStream output)
+        final Encoder output)
         throws IOException {
       for (final ByteString value : lengthDelimited) {
         output.writeRawMessageSetExtension(fieldNumber, value);

--- a/java/src/main/java/com/google/protobuf/UnknownFieldSetLite.java
+++ b/java/src/main/java/com/google/protobuf/UnknownFieldSetLite.java
@@ -117,7 +117,7 @@ public final class UnknownFieldSetLite {
    *
    * <p>For use by generated code only.
    */
-  public void writeTo(CodedOutputStream output) throws IOException {
+  public void writeTo(Encoder output) throws IOException {
     for (int i = 0; i < count; i++) {
       int tag = tags[i];
       int fieldNumber = WireFormat.getTagFieldNumber(tag);

--- a/java/src/main/java/com/google/protobuf/UnsafeByteString.java
+++ b/java/src/main/java/com/google/protobuf/UnsafeByteString.java
@@ -1,0 +1,409 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * A {@link ByteString} that wraps around a {@link ByteBuffer} and exposes the underlying buffer.
+ */
+public final class UnsafeByteString extends ByteString implements Externalizable {
+  private static final long serialVersionUID = -5543703061195105843L;
+
+  /**
+   * The underlying buffer. This is generally final, but is non-final to support serialization.
+   */
+  private ByteBuffer buffer;
+
+  /**
+   * This is an optimization to support quick access to a read-only version of the buffer.
+   */
+  private List<ByteBuffer> readOnlyBufferList;
+
+  /**
+   * Has is lazy-calculated.
+   */
+  private int hash;
+
+  /**
+   * Public no-arg constructor is needed by {@link Externalizable}. Do not use directly.
+   */
+  public UnsafeByteString() {
+  }
+
+  UnsafeByteString(ByteBuffer buffer) {
+    if (buffer == null) {
+      throw new NullPointerException("buffer");
+    }
+
+    setBuffer(buffer);
+  }
+
+  private void setBuffer(ByteBuffer buffer) {
+    this.buffer = buffer;
+    this.readOnlyBufferList = Collections.singletonList(buffer.asReadOnlyBuffer());
+  }
+
+  /**
+   * Provides direct access to the underlying {@code ByteBuffer}. Use at your own risk.
+   */
+  public ByteBuffer buffer() {
+    return buffer;
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    byte[] bytes;
+    int offset;
+    int length;
+
+    if (buffer.hasArray()) {
+      bytes = buffer.array();
+      offset = buffer.arrayOffset() + buffer.position();
+      length = buffer.remaining();
+    } else {
+      bytes = new byte[buffer.remaining()];
+      offset = buffer.position();
+      length = buffer.remaining();
+
+      int pos = buffer.position();
+      try {
+        buffer.get(bytes);
+      } finally {
+        buffer.position(pos);
+      }
+    }
+
+    out.writeInt(length);
+    out.write(bytes, offset, length);
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    int length = in.readInt();
+    byte[] bytes = new byte[length];
+    in.readFully(bytes);
+
+    setBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  @Override
+  public byte byteAt(int index) {
+    return buffer.get(index);
+  }
+
+  @Override
+  public ByteIterator iterator() {
+    return new ByteIterator() {
+      private final ByteBuffer slice = buffer.slice();
+
+      @Override
+      public boolean hasNext() {
+        return slice.hasRemaining();
+      }
+
+      @Override
+      public Byte next() {
+        return nextByte();
+      }
+
+      @Override
+      public byte nextByte() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+
+        return slice.get();
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @Override
+  public int size() {
+    return buffer.remaining();
+  }
+
+  @Override
+  public ByteString substring(int beginIndex, int endIndex) {
+    ByteBuffer slice = slice(beginIndex, endIndex);
+    return new UnsafeByteString(slice);
+  }
+
+  @Override
+  protected void copyToInternal(byte[] target, int sourceOffset, int targetOffset, int numberToCopy) {
+    int oldPos = buffer.position();
+    try {
+      buffer.position(sourceOffset);
+      buffer.get(target, targetOffset, numberToCopy);
+    } finally {
+      buffer.position(oldPos);
+    }
+  }
+
+  @Override
+  public void copyTo(ByteBuffer target) {
+    int oldPos = buffer.position();
+    try {
+      target.put(buffer);
+    } finally {
+      buffer.position(oldPos);
+    }
+  }
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    writeBufferTo(buffer, out);
+  }
+
+  @Override
+  boolean equalsRange(ByteString other, int offset, int length) {
+    return substring(0, length).equals(other.substring(offset, offset + length));
+  }
+
+  @Override
+  void writeToInternal(OutputStream out, int sourceOffset, int numberToWrite) throws IOException {
+    ByteBuffer slice = slice(sourceOffset, sourceOffset + numberToWrite);
+    writeBufferTo(slice, out);
+  }
+
+  @Override
+  public ByteBuffer asReadOnlyByteBuffer() {
+    return readOnlyBufferList.get(0);
+  }
+
+  @Override
+  public List<ByteBuffer> asReadOnlyByteBufferList() {
+    return readOnlyBufferList;
+  }
+
+  @Override
+  protected String toStringInternal(Charset charset) {
+    byte[] bytes;
+    int offset;
+    if(buffer.hasArray()) {
+      bytes = buffer.array();
+      offset = buffer.arrayOffset();
+    } else {
+      bytes = new byte[buffer.remaining()];
+      offset = 0;
+      copyToInternal(bytes, buffer.position(), offset, size());
+    }
+    return new String(bytes, offset, size(), charset);
+  }
+
+  @Override
+  public boolean isValidUtf8() {
+    byte[] bytes;
+    int startIndex;
+    if (buffer.hasArray()) {
+      bytes = buffer.array();
+      startIndex = buffer.arrayOffset() + buffer.position();
+    } else {
+      bytes = new byte[buffer.remaining()];
+      startIndex = 0;
+      copyToInternal(bytes, 0, 0, size());
+    }
+    return Utf8.isValidUtf8(bytes, startIndex, startIndex + size());
+  }
+
+  @Override
+  protected int partialIsValidUtf8(int state, int offset, int length) {
+    byte[] bytes;
+    int startIndex;
+    if (buffer.hasArray()) {
+      bytes = buffer.array();
+      startIndex = buffer.arrayOffset() + buffer.position();
+    } else {
+      bytes = new byte[buffer.remaining()];
+      startIndex = 0;
+      copyToInternal(bytes, 0, 0, size());
+    }
+    return Utf8.partialIsValidUtf8(state, bytes, startIndex, startIndex + size());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof ByteString)) {
+      return false;
+    }
+    ByteString otherString = ((ByteString) other);
+    if (size() != otherString.size()) {
+      return false;
+    }
+    if (size() == 0) {
+      return true;
+    }
+    if (other instanceof UnsafeByteString) {
+      return buffer.equals(((UnsafeByteString) other).buffer);
+    }
+    if (other instanceof RopeByteString) {
+      return other.equals(this);
+    }
+    if (other instanceof LiteralByteString) {
+      LiteralByteString lbs = (LiteralByteString) other;
+      ByteBuffer otherByteBuffer = ByteBuffer.wrap(lbs.bytes, lbs.getOffsetIntoBytes(), lbs.size());
+      return buffer.equals(otherByteBuffer);
+    }
+    for(int index=0; index < size(); ++index) {
+      if (byteAt(index) != otherString.byteAt(index)) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = hash;
+
+    if (h == 0) {
+      int size = size();
+      h = partialHash(size, 0, size);
+      if (h == 0) {
+        h = 1;
+      }
+      hash = h;
+    }
+    return h;
+  }
+
+  @Override
+  protected int partialHash(int h, int offset, int length) {
+    for (int i = offset; i < offset + length; i++) {
+      h = h * 31 + buffer.get(i);
+    }
+    return h;
+  }
+
+  @Override
+  public InputStream newInput() {
+    return new InputStream() {
+      private final ByteBuffer buf = buffer.slice();
+      private int mark;
+
+      @Override
+      public synchronized void mark(int readlimit) {
+        mark = buf.position();
+      }
+
+      @Override
+      public boolean markSupported() {
+        return true;
+      }
+
+      @Override
+      public synchronized void reset() throws IOException {
+        buf.position(mark);
+      }
+
+      @Override
+      public int available() throws IOException {
+        return buf.remaining();
+      }
+
+      public int read() throws IOException {
+        if (!buf.hasRemaining()) {
+          return -1;
+        }
+        return buf.get() & 0xFF;
+      }
+
+      public int read(byte[] bytes, int off, int len)
+          throws IOException {
+        if (!buf.hasRemaining()) {
+          return -1;
+        }
+
+        len = Math.min(len, buf.remaining());
+        buf.get(bytes, off, len);
+        return len;
+      }
+    };
+  }
+
+  @Override
+  public CodedInputStream newCodedInput() {
+    // TODO(nmittler): Do we care about this? It does a copy.
+    return CodedInputStream.newInstance(buffer);
+  }
+
+  @Override
+  protected int getTreeDepth() {
+    return 0;
+  }
+
+  @Override
+  protected boolean isBalanced() {
+    return true;
+  }
+
+  @Override
+  protected int peekCachedHashCode() {
+    return hash;
+  }
+
+  private void writeBufferTo(ByteBuffer source, OutputStream out) throws IOException {
+    WritableByteChannel channel = Channels.newChannel(out);
+    channel.write(source.slice());
+  }
+
+  private ByteBuffer slice(int beginIndex, int endIndex) {
+    if (beginIndex < buffer.position() || endIndex > buffer.limit() || beginIndex > endIndex) {
+      throw new IllegalArgumentException(
+          String.format("Invalid indices [%d, %d]", beginIndex, endIndex));
+    }
+
+    ByteBuffer slice = buffer.slice();
+    slice.position(beginIndex - buffer.position());
+    slice.limit(endIndex - buffer.position());
+    return slice;
+  }
+}

--- a/java/src/main/java/com/google/protobuf/WireFormat.java
+++ b/java/src/main/java/com/google/protobuf/WireFormat.java
@@ -163,6 +163,455 @@ public final class WireFormat {
   static final int MESSAGE_SET_MESSAGE_TAG =
     makeTag(MESSAGE_SET_MESSAGE, WIRETYPE_LENGTH_DELIMITED);
 
+  public static final int LITTLE_ENDIAN_32_SIZE = 4;
+  public static final int LITTLE_ENDIAN_64_SIZE = 8;
+
+  /** Compute the number of bytes that would be needed to encode a tag. */
+  public static int computeTagSize(final int fieldNumber) {
+    return computeRawVarint32Size(WireFormat.makeTag(fieldNumber, 0));
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code double} field, including tag.
+   */
+  public static int computeDoubleSize(final int fieldNumber,
+                                      final double value) {
+    return computeTagSize(fieldNumber) + computeDoubleSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code float} field, including tag.
+   */
+  public static int computeFloatSize(final int fieldNumber, final float value) {
+    return computeTagSize(fieldNumber) + computeFloatSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code uint64} field, including tag.
+   */
+  public static int computeUInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeUInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code int64} field, including tag.
+   */
+  public static int computeInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code int32} field, including tag.
+   */
+  public static int computeInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code fixed64} field, including tag.
+   */
+  public static int computeFixed64Size(final int fieldNumber,
+                                       final long value) {
+    return computeTagSize(fieldNumber) + computeFixed64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code fixed32} field, including tag.
+   */
+  public static int computeFixed32Size(final int fieldNumber,
+                                       final int value) {
+    return computeTagSize(fieldNumber) + computeFixed32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bool} field, including tag.
+   */
+  public static int computeBoolSize(final int fieldNumber,
+                                    final boolean value) {
+    return computeTagSize(fieldNumber) + computeBoolSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code string} field, including tag.
+   */
+  public static int computeStringSize(final int fieldNumber,
+                                      final String value) {
+    return computeTagSize(fieldNumber) + computeStringSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code group} field, including tag.
+   */
+  public static int computeGroupSize(final int fieldNumber,
+                                     final MessageLite value) {
+    return computeTagSize(fieldNumber) * 2 + computeGroupSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * embedded message field, including tag.
+   */
+  public static int computeMessageSize(final int fieldNumber,
+                                       final MessageLite value) {
+    return computeTagSize(fieldNumber) + computeMessageSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bytes} field, including tag.
+   */
+  public static int computeBytesSize(final int fieldNumber,
+                                     final ByteString value) {
+    return computeTagSize(fieldNumber) + computeBytesSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bytes} field, including tag.
+   */
+  public static int computeByteArraySize(final int fieldNumber,
+                                         final byte[] value) {
+    return WireFormat.computeTagSize(fieldNumber) + computeByteArraySizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * embedded message in lazy field, including tag.
+   */
+  public static int computeLazyFieldSize(final int fieldNumber,
+                                         final LazyFieldLite value) {
+    return computeTagSize(fieldNumber) + computeLazyFieldSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code uint32} field, including tag.
+   */
+  public static int computeUInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeUInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * enum field, including tag.  Caller is responsible for converting the
+   * enum value to its numeric value.
+   */
+  public static int computeEnumSize(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeEnumSizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sfixed32} field, including tag.
+   */
+  public static int computeSFixed32Size(final int fieldNumber,
+                                        final int value) {
+    return computeTagSize(fieldNumber) + computeSFixed32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sfixed64} field, including tag.
+   */
+  public static int computeSFixed64Size(final int fieldNumber,
+                                        final long value) {
+    return computeTagSize(fieldNumber) + computeSFixed64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sint32} field, including tag.
+   */
+  public static int computeSInt32Size(final int fieldNumber, final int value) {
+    return computeTagSize(fieldNumber) + computeSInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sint64} field, including tag.
+   */
+  public static int computeSInt64Size(final int fieldNumber, final long value) {
+    return computeTagSize(fieldNumber) + computeSInt64SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * MessageSet extension to the stream.  For historical reasons,
+   * the wire format differs from normal fields.
+   */
+  public static int computeMessageSetExtensionSize(
+          final int fieldNumber, final MessageLite value) {
+    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
+            computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
+            computeMessageSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * unparsed MessageSet extension field to the stream.  For
+   * historical reasons, the wire format differs from normal fields.
+   */
+  public static int computeRawMessageSetExtensionSize(
+          final int fieldNumber, final ByteString value) {
+    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
+            computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
+            computeBytesSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * lazily parsed MessageSet extension field to the stream.  For
+   * historical reasons, the wire format differs from normal fields.
+   */
+  public static int computeLazyFieldMessageSetExtensionSize(
+          final int fieldNumber, final LazyFieldLite value) {
+    return computeTagSize(WireFormat.MESSAGE_SET_ITEM) * 2 +
+            computeUInt32Size(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber) +
+            computeLazyFieldSize(WireFormat.MESSAGE_SET_MESSAGE, value);
+  }
+
+  // -----------------------------------------------------------------
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code double} field, including tag.
+   */
+  public static int computeDoubleSizeNoTag(@SuppressWarnings("unused") final double value) {
+    return LITTLE_ENDIAN_64_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code float} field, including tag.
+   */
+  public static int computeFloatSizeNoTag(@SuppressWarnings("unused") final float value) {
+    return LITTLE_ENDIAN_32_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code uint64} field, including tag.
+   */
+  public static int computeUInt64SizeNoTag(final long value) {
+    return computeRawVarint64Size(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code int64} field, including tag.
+   */
+  public static int computeInt64SizeNoTag(final long value) {
+    return computeRawVarint64Size(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code int32} field, including tag.
+   */
+  public static int computeInt32SizeNoTag(final int value) {
+    if (value >= 0) {
+      return computeRawVarint32Size(value);
+    } else {
+      // Must sign-extend.
+      return 10;
+    }
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code fixed64} field.
+   */
+  public static int computeFixed64SizeNoTag(@SuppressWarnings("unused") final long value) {
+    return LITTLE_ENDIAN_64_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code fixed32} field.
+   */
+  public static int computeFixed32SizeNoTag(@SuppressWarnings("unused") final int value) {
+    return LITTLE_ENDIAN_32_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bool} field.
+   */
+  public static int computeBoolSizeNoTag(@SuppressWarnings("unused") final boolean value) {
+    return 1;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code string} field.
+   */
+  public static int computeStringSizeNoTag(final String value) {
+    int length;
+    try {
+      length = Utf8.encodedLength(value);
+    } catch (Utf8.UnpairedSurrogateException e) {
+      // TODO(dweis): Consider using nio Charset methods instead.
+      final byte[] bytes = value.getBytes(Internal.UTF_8);
+      length = bytes.length;
+    }
+
+    return computeRawVarint32Size(length) + length;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code group} field.
+   */
+  public static int computeGroupSizeNoTag(final MessageLite value) {
+    return value.getSerializedSize();
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an embedded
+   * message field.
+   */
+  public static int computeMessageSizeNoTag(final MessageLite value) {
+    final int size = value.getSerializedSize();
+    return computeRawVarint32Size(size) + size;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an embedded
+   * message stored in lazy field.
+   */
+  public static int computeLazyFieldSizeNoTag(final LazyFieldLite value) {
+    final int size = value.getSerializedSize();
+    return computeRawVarint32Size(size) + size;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bytes} field.
+   */
+  public static int computeBytesSizeNoTag(final ByteString value) {
+    return computeRawVarint32Size(value.size()) +
+            value.size();
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code bytes} field.
+   */
+  public static int computeByteArraySizeNoTag(final byte[] value) {
+    return WireFormat.computeRawVarint32Size(value.length) + value.length;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a
+   * {@code uint32} field.
+   */
+  public static int computeUInt32SizeNoTag(final int value) {
+    return computeRawVarint32Size(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an enum field.
+   * Caller is responsible for converting the enum value to its numeric value.
+   */
+  public static int computeEnumSizeNoTag(final int value) {
+    return computeInt32SizeNoTag(value);
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sfixed32} field.
+   */
+  public static int computeSFixed32SizeNoTag(@SuppressWarnings("unused") final int value) {
+    return LITTLE_ENDIAN_32_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sfixed64} field.
+   */
+  public static int computeSFixed64SizeNoTag(@SuppressWarnings("unused") final long value) {
+    return LITTLE_ENDIAN_64_SIZE;
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sint32} field.
+   */
+  public static int computeSInt32SizeNoTag(final int value) {
+    return computeRawVarint32Size(encodeZigZag32(value));
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode an
+   * {@code sint64} field.
+   */
+  public static int computeSInt64SizeNoTag(final long value) {
+    return computeRawVarint64Size(encodeZigZag64(value));
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a varint. {@code value} is treated
+   * as unsigned, so it won't be sign-extended if negative.
+   */
+  public static int computeRawVarint32Size(final int value) {
+    if ((value & (0xffffffff << 7)) == 0) return 1;
+    if ((value & (0xffffffff << 14)) == 0) return 2;
+    if ((value & (0xffffffff << 21)) == 0) return 3;
+    if ((value & (0xffffffff << 28)) == 0) return 4;
+    return 5;
+  }
+
+  public static int computeRawVarint64Size(final long value) {
+    if ((value & (0xffffffffffffffffL <<  7)) == 0) return 1;
+    if ((value & (0xffffffffffffffffL << 14)) == 0) return 2;
+    if ((value & (0xffffffffffffffffL << 21)) == 0) return 3;
+    if ((value & (0xffffffffffffffffL << 28)) == 0) return 4;
+    if ((value & (0xffffffffffffffffL << 35)) == 0) return 5;
+    if ((value & (0xffffffffffffffffL << 42)) == 0) return 6;
+    if ((value & (0xffffffffffffffffL << 49)) == 0) return 7;
+    if ((value & (0xffffffffffffffffL << 56)) == 0) return 8;
+    if ((value & (0xffffffffffffffffL << 63)) == 0) return 9;
+    return 10;
+  }
+
+  /**
+   * Encode a ZigZag-encoded 32-bit value.  ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint.  (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 32-bit integer.
+   * @return An unsigned 32-bit integer, stored in a signed int because Java has no explicit
+   * unsigned support.
+   */
+  public static int encodeZigZag32(final int n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 31);
+  }
+
+  /**
+   * Encode a ZigZag-encoded 64-bit value.  ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint.  (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 64-bit integer.
+   * @return An unsigned 64-bit integer, stored in a signed int because Java has no explicit
+   * unsigned support.
+   */
+  public static long encodeZigZag64(final long n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 63);
+  }
+
   /**
    * Validation level for handling incoming string field data which potentially
    * contain non-UTF8 bytes.

--- a/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
+++ b/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
@@ -65,34 +65,6 @@ public final class ZeroCopyEncoder implements Encoder {
    */
   private final ByteBuffer buffer;
 
-  /**
-   * A handler for the output of this encoder.
-   */
-  public interface Handler {
-    /**
-     * Handler for encoded data.
-     *
-     * @param b        a byte array containing the encoded data.
-     * @param offset   the offset in the array where the encoded data begins.
-     * @param length   the length of the encoded data.
-     * @param mustCopy if {@code true}, the handler must make a defensive copy of the encoded data
-     *                 as the content of the array may change after the method returns. If {@code
-     *                 false}, the handler may safely assume that the content of the array will
-     *                 never change.
-     */
-    void onDataEncoded(byte[] b, int offset, int length, boolean mustCopy) throws IOException;
-
-    /**
-     * Handler for encoded data.
-     *
-     * @param data     the encoded data.
-     * @param mustCopy if {@code true}, the handler must make a defensive copy of the encoded data
-     *                 as the content may change after the method returns. If {@code false}, the
-     *                 handler may safely assume that the content of the buffer will never change.
-     */
-    void onDataEncoded(ByteBuffer data, boolean mustCopy) throws IOException;
-  }
-
   public ZeroCopyEncoder(Handler handler) {
     this(handler, DEFAULT_BUFFER_SIZE);
   }

--- a/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
+++ b/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
@@ -1,0 +1,647 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A protobuf {@link Encoder} that does little to no buffering for fields. It's not fully
+ * zero-copy in that it does maintain an internal buffer for small operations. Large fields,
+ * however, are written directly through.
+ */
+public final class ZeroCopyEncoder implements Encoder {
+  // TODO(nmittler): Consider using an allocator for buffers to allow pooling.
+  // TODO(nmittler): Need experimentation with good values.
+  private static final int SMALL_BUFFER = 1024;
+  private static final double COPY_THRESHOLD = 0.75;
+
+  /**
+   * Java 1.8 defines Integer.BYTES, but we need this for older versions.
+   */
+  private static final int INTEGER_BYTES = Integer.SIZE / 8;
+  private static final int LONG_BYTES = Long.SIZE / 8;
+
+  private final Handler handler;
+  private final int bufferSize;
+
+  /**
+   * Internal buffer used to avoid writing small chunks of data. This is guaranteed to be
+   * backed by an array.
+   */
+  private ByteBuffer buffer;
+
+  /**
+   * A target to receive individual writes from this marshaller.
+   */
+  public interface Handler {
+    /**
+     * Handler for encoded data. It is assumed that this data will not change.
+     */
+    void onDataEncoded(byte[] b, int offset, int length) throws IOException;
+
+    /**
+     * Handler for an encoded, read-only {@link ByteBuffer}. It is assumed that this data
+     * will not change.
+     */
+    void onDataEncoded(ByteBuffer data) throws IOException;
+  }
+
+  public ZeroCopyEncoder(Handler handler) {
+    this(handler, SMALL_BUFFER);
+  }
+
+  public ZeroCopyEncoder(Handler handler, int bufferSize) {
+    if (handler == null) {
+      throw new NullPointerException("writer");
+    }
+
+    this.handler = handler;
+    this.bufferSize = Math.max(bufferSize, SMALL_BUFFER);
+  }
+
+  @Override
+  public void writeDouble(int fieldNumber, double value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
+    writeDoubleNoTag(value);
+  }
+
+  @Override
+  public void writeFloat(int fieldNumber, float value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
+    writeFloatNoTag(value);
+  }
+
+  @Override
+  public void writeUInt64(int fieldNumber, long value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeUInt64NoTag(value);
+  }
+
+  @Override
+  public void writeInt64(int fieldNumber, long value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeInt64NoTag(value);
+  }
+
+  @Override
+  public void writeInt32(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeInt32NoTag(value);
+  }
+
+  @Override
+  public void writeFixed64(int fieldNumber, long value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
+    writeFixed64NoTag(value);
+  }
+
+  @Override
+  public void writeFixed32(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
+    writeFixed32NoTag(value);
+  }
+
+  @Override
+  public void writeBool(int fieldNumber, boolean value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeBoolNoTag(value);
+  }
+
+  @Override
+  public void writeString(int fieldNumber, String value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+    writeStringNoTag(value);
+  }
+
+  @Override
+  public void writeGroup(int fieldNumber, MessageLite value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_START_GROUP);
+    writeGroupNoTag(value);
+    writeTag(fieldNumber, WireFormat.WIRETYPE_END_GROUP);
+  }
+
+  @Override
+  public void writeMessage(int fieldNumber, MessageLite value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+    writeMessageNoTag(value);
+  }
+
+  @Override
+  public void writeBytes(int fieldNumber, ByteString value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+    writeBytesNoTag(value);
+  }
+
+  @Override
+  public void writeByteArray(int fieldNumber, byte[] value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+    writeByteArrayNoTag(value);
+  }
+
+  @Override
+  public void writeByteArray(int fieldNumber, byte[] value, int offset, int length) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+    writeByteArrayNoTag(value, offset, length);
+  }
+
+  @Override
+  public void writeUInt32(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeUInt32NoTag(value);
+  }
+
+  @Override
+  public void writeEnum(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeEnumNoTag(value);
+  }
+
+  @Override
+  public void writeSFixed32(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED32);
+    writeSFixed32NoTag(value);
+  }
+
+  @Override
+  public void writeSFixed64(int fieldNumber, long value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_FIXED64);
+    writeSFixed64NoTag(value);
+  }
+
+  @Override
+  public void writeSInt32(int fieldNumber, int value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeSInt32NoTag(value);
+  }
+
+  @Override
+  public void writeSInt64(int fieldNumber, long value) throws IOException {
+    writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+    writeSInt64NoTag(value);
+  }
+
+  @Override
+  public void writeMessageSetExtension(int fieldNumber, MessageLite value) throws IOException {
+    writeTag(WireFormat.MESSAGE_SET_ITEM, WireFormat.WIRETYPE_START_GROUP);
+    writeUInt32(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber);
+    writeMessage(WireFormat.MESSAGE_SET_MESSAGE, value);
+    writeTag(WireFormat.MESSAGE_SET_ITEM, WireFormat.WIRETYPE_END_GROUP);
+  }
+
+  @Override
+  public void writeRawMessageSetExtension(int fieldNumber, ByteString value) throws IOException {
+    writeTag(WireFormat.MESSAGE_SET_ITEM, WireFormat.WIRETYPE_START_GROUP);
+    writeUInt32(WireFormat.MESSAGE_SET_TYPE_ID, fieldNumber);
+    writeBytes(WireFormat.MESSAGE_SET_MESSAGE, value);
+    writeTag(WireFormat.MESSAGE_SET_ITEM, WireFormat.WIRETYPE_END_GROUP);
+  }
+
+  @Override
+  public void writeDoubleNoTag(double value) throws IOException {
+    writeRawLittleEndian64(Double.doubleToRawLongBits(value));
+  }
+
+  @Override
+  public void writeFloatNoTag(float value) throws IOException {
+    writeRawLittleEndian32(Float.floatToRawIntBits(value));
+  }
+
+  @Override
+  public void writeUInt64NoTag(long value) throws IOException {
+    writeRawVarint64(value);
+  }
+
+  @Override
+  public void writeInt64NoTag(long value) throws IOException {
+    writeRawVarint64(value);
+  }
+
+  @Override
+  public void writeInt32NoTag(int value) throws IOException {
+    if (value >= 0) {
+      writeRawVarint32(value);
+    } else {
+      // Must sign-extend.
+      writeRawVarint64(value);
+    }
+  }
+
+  @Override
+  public void writeFixed64NoTag(long value) throws IOException {
+    writeRawLittleEndian64(value);
+  }
+
+  @Override
+  public void writeFixed32NoTag(int value) throws IOException {
+    writeRawLittleEndian32(value);
+  }
+
+  @Override
+  public void writeBoolNoTag(boolean value) throws IOException {
+    writeRawByte(value ? 1 : 0);
+  }
+
+  @Override
+  public void writeStringNoTag(String value) throws IOException {
+    //byte[] bytes = value.getBytes("UTF-8");
+    //writeRawBytes(bytes);
+    // UTF-8 byte length of the string is at least its UTF-16 code unit length (value.length()),
+    // and at most 3 times of it. We take advantage of this in both branches below.
+    final int maxEncodedSize = value.length() * Utf8.MAX_BYTES_PER_CHAR;
+    final int maxLengthVarIntSize = computeRawVarint32Size(maxEncodedSize);
+    final int maxRequiredSize = maxEncodedSize + maxLengthVarIntSize;
+
+    int capacity = capacity();
+    if (capacity >= maxRequiredSize) {
+      // Optimize for the case where we know this length results in a constant varint length as this
+      // saves a pass for measuring the length of the string.
+      final int minLengthVarIntSize = computeRawVarint32Size(value.length());
+
+      getOrCreateBuffer();
+      int oldPosition = buffer.position();
+      if (minLengthVarIntSize == maxLengthVarIntSize) {
+        int position = oldPosition + minLengthVarIntSize;
+        int newPosition = Utf8.encode(value, getOrCreateBuffer().array(),
+                buffer.arrayOffset() + position,
+                capacity - position);
+        // Since this class is stateful and tracks the position, we rewind and store the state,
+        // prepend the length, then reset it back to the end of the string.
+        buffer.position(oldPosition);
+        int length = newPosition - oldPosition - minLengthVarIntSize;
+        writeRawVarint32(length);
+        buffer.position(newPosition);
+      } else {
+        int length = Utf8.encodedLength(value);
+        writeRawVarint32(length);
+        int position = Utf8.encode(value, getOrCreateBuffer().array(),
+                buffer.arrayOffset() + buffer.position(),
+                capacity - buffer.position());
+        buffer.position(position);
+      }
+    } else {
+      // There is not enough space to onDataEncoded the entire string to the buffer.
+
+      // Calculate the encoded length of the string and onDataEncoded it to the buffer.
+      int encodedLength = Utf8.encodedLength(value);
+      writeRawVarint32(encodedLength);
+
+      // Write encoded chunks and flush as needed until the entire encoded string is written.
+      int charPos = 0;
+      while (charPos < value.length()) {
+        capacity = capacity();
+        int charsToWrite = Math.min(value.length() - charPos, capacity / Utf8.MAX_BYTES_PER_CHAR);
+        if (charsToWrite == 0) {
+          // The buffer is full, flush it and try again.
+          flush();
+          continue;
+        }
+
+        getOrCreateBuffer();
+
+        // Write a chunk of the string to buffer.
+        String chunk = value.substring(charPos, charPos + charsToWrite);
+        int position = Utf8.encode(chunk, buffer.array(),
+                buffer.arrayOffset() + buffer.position(),
+                bufferSize - buffer.position());
+        buffer.position(position);
+        charPos += charsToWrite;
+      }
+    }
+  }
+
+  /**
+   * Compute the number of bytes that would be needed to encode a varint. {@code value} is treated
+   * as unsigned, so it won't be sign-extended if negative.
+   */
+  private static int computeRawVarint32Size(final int value) {
+    if ((value & (0xffffffff << 7)) == 0) return 1;
+    if ((value & (0xffffffff << 14)) == 0) return 2;
+    if ((value & (0xffffffff << 21)) == 0) return 3;
+    if ((value & (0xffffffff << 28)) == 0) return 4;
+    return 5;
+  }
+
+  @Override
+  public void writeGroupNoTag(MessageLite value) throws IOException {
+    value.writeTo(this);
+  }
+
+  @Override
+  public void writeMessageNoTag(MessageLite value) throws IOException {
+    writeRawVarint32(value.getSerializedSize());
+    value.writeTo(this);
+  }
+
+  @Override
+  public void writeBytesNoTag(ByteString value) throws IOException {
+    writeRawVarint32(value.size());
+    writeRawBytes(value);
+  }
+
+  @Override
+  public void writeByteArrayNoTag(byte[] value) throws IOException {
+    writeRawVarint32(value.length);
+    writeRawBytes(value);
+  }
+
+  @Override
+  public void writeByteArrayNoTag(byte[] value, int offset, int length) throws IOException {
+    writeRawVarint32(length);
+    writeRawBytes(value, offset, length);
+  }
+
+  @Override
+  public void writeUInt32NoTag(int value) throws IOException {
+    writeRawVarint32(value);
+  }
+
+  @Override
+  public void writeEnumNoTag(int value) throws IOException {
+    writeInt32NoTag(value);
+  }
+
+  @Override
+  public void writeSFixed32NoTag(int value) throws IOException {
+    writeRawLittleEndian32(value);
+  }
+
+  @Override
+  public void writeSFixed64NoTag(long value) throws IOException {
+    writeRawLittleEndian64(value);
+  }
+
+  @Override
+  public void writeSInt32NoTag(int value) throws IOException {
+    writeRawVarint32(encodeZigZag32(value));
+  }
+
+  @Override
+  public void writeSInt64NoTag(long value) throws IOException {
+    writeRawVarint64(encodeZigZag64(value));
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (position() == 0) {
+      // Nothing to flush.
+      return;
+    }
+
+    buffer.flip();
+    int limit = buffer.limit();
+    if (limit < SMALL_BUFFER || (bufferSize / limit) < COPY_THRESHOLD) {
+      // Either not much data to onDataEncoded or the buffer is not very full ... copy the buffer.
+      byte[] bytes = new byte[limit];
+      buffer.get(bytes);
+      buffer.position(0);
+      handler.onDataEncoded(bytes, 0, limit);
+    } else {
+      // Use the current buffer and create a new buffer on the next onDataEncoded.
+      ByteBuffer buf = buffer;
+      buffer = null;
+      handler.onDataEncoded(buf);
+    }
+  }
+
+  @Override
+  public void writeRawByte(byte value) throws IOException {
+    if (capacity() == 0) {
+      flush();
+    }
+
+    getOrCreateBuffer().put(value);
+  }
+
+  @Override
+  public void writeRawByte(int value) throws IOException {
+    writeRawByte((byte) value);
+  }
+
+  @Override
+  public void writeRawBytes(ByteString value) throws IOException {
+    writeRawBytes(value, 0, value.size());
+  }
+
+  @Override
+  public void writeRawBytes(byte[] value) throws IOException {
+    writeRawBytes(value, 0, value.length);
+  }
+
+  @Override
+  public void writeRawBytes(ByteBuffer value) throws IOException {
+    if (!value.hasRemaining()) {
+      // Nothing to onDataEncoded.
+      return;
+    }
+
+    if (value.remaining() > SMALL_BUFFER) {
+      // It's a large buffer, just flush any previous data and onDataEncoded the buffer directly.
+      flush();
+
+      // Write a read-only view of this buffer. The new buffer has its own position and limit.
+      handler.onDataEncoded(value.asReadOnlyBuffer());
+
+      // Indicate that the buffer has been fully read.
+      value.position(value.limit());
+      return;
+    }
+
+    // Copy the value to the internal buffer, flushing as necessary.
+    while (value.hasRemaining()) {
+      int capacity = capacity();
+      if (capacity == 0) {
+        // The buffer is full, flush it and try again.
+        flush();
+        continue;
+      }
+
+      // Limit the value buffer by the number of bytes that can be written now.
+      int bytesToWrite = Math.min(value.remaining(), capacity);
+      int valueLimit = value.limit();
+      value.limit(value.position() + bytesToWrite);
+
+      getOrCreateBuffer().put(value);
+
+      // Restore the actual limit to the input value.
+      value.limit(valueLimit);
+    }
+  }
+
+  @Override
+  public void writeRawBytes(byte[] value, int offset, int length) throws IOException {
+    if (length == 0) {
+      return;
+    }
+
+    if (length > SMALL_BUFFER) {
+      // It's a large buffer, just flush any previous data and onDataEncoded the buffer directly.
+      flush();
+
+      // Write a read-only view of this buffer. The new buffer has its own position and limit.
+      handler.onDataEncoded(value, offset, length);
+      return;
+    }
+
+    while(offset < length) {
+      int capacity = capacity();
+      if (capacity == 0) {
+        // The buffer is full, flush it and try again.
+        flush();
+        continue;
+      }
+
+      // Determine the number of bytes that can be written before another flush is required.
+      int remaining = length - offset;
+      int bytesToWrite = Math.min(remaining, capacity);
+
+      getOrCreateBuffer().put(value, offset, bytesToWrite);
+      offset += bytesToWrite;
+    }
+  }
+
+  @Override
+  public void writeRawBytes(ByteString value, int offset, int length) throws IOException {
+    if (length == 0) {
+      return;
+    }
+
+    if (value instanceof LiteralByteString) {
+      LiteralByteString lbs = (LiteralByteString) value;
+      writeRawBytes(lbs.bytes, lbs.getOffsetIntoBytes(), lbs.size());
+    } else if (value instanceof UnsafeByteString) {
+      writeRawBytes(value.asReadOnlyByteBuffer());
+    } else {
+      for(ByteBuffer buf : value.asReadOnlyByteBufferList()) {
+        writeRawBytes(buf);
+      }
+    }
+  }
+
+  @Override
+  public void writeTag(int fieldNumber, int wireType) throws IOException {
+    writeRawVarint32(WireFormat.makeTag(fieldNumber, wireType));
+  }
+
+  @Override
+  public void writeRawVarint32(int value) throws IOException {
+    while (true) {
+      if ((value & ~0x7F) == 0) {
+        writeRawByte(value);
+        return;
+      } else {
+        writeRawByte((value & 0x7F) | 0x80);
+        value >>>= 7;
+      }
+    }
+  }
+
+  @Override
+  public void writeRawVarint64(long value) throws IOException {
+    while (true) {
+      if ((value & ~0x7FL) == 0) {
+        writeRawByte((int) value);
+        return;
+      } else {
+        writeRawByte(((int) value & 0x7F) | 0x80);
+        value >>>= 7;
+      }
+    }
+  }
+
+  @Override
+  public void writeRawLittleEndian32(int value) throws IOException {
+    if(capacity() < INTEGER_BYTES) {
+      flush();
+    }
+    getOrCreateBuffer();
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putInt(value);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  @Override
+  public void writeRawLittleEndian64(long value) throws IOException {
+    if(capacity() < LONG_BYTES) {
+      flush();
+    }
+    getOrCreateBuffer();
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putLong(value);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private int position() {
+    return buffer == null ? 0 : buffer.position();
+  }
+
+  private int capacity() {
+    return bufferSize - position();
+  }
+
+  private ByteBuffer getOrCreateBuffer() {
+    if (buffer == null) {
+      // Guarantee that it has a backing array.
+      buffer = ByteBuffer.wrap(new byte[bufferSize]);
+      buffer.order(ByteOrder.BIG_ENDIAN);
+    }
+    return buffer;
+  }
+
+  /**
+   * Encode a ZigZag-encoded 32-bit value.  ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint.  (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 32-bit integer.
+   * @return An unsigned 32-bit integer, stored in a signed int because Java has no explicit
+   * unsigned support.
+   */
+  private static int encodeZigZag32(final int n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 31);
+  }
+
+  /**
+   * Encode a ZigZag-encoded 64-bit value.  ZigZag encodes signed integers into values that can be
+   * efficiently encoded with varint.  (Otherwise, negative values must be sign-extended to 64 bits
+   * to be varint encoded, thus always taking 10 bytes on the wire.)
+   *
+   * @param n A signed 64-bit integer.
+   * @return An unsigned 64-bit integer, stored in a signed int because Java has no explicit
+   * unsigned support.
+   */
+  public static long encodeZigZag64(final long n) {
+    // Note:  the right-shift must be arithmetic
+    return (n << 1) ^ (n >> 63);
+  }
+}

--- a/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
+++ b/java/src/main/java/com/google/protobuf/ZeroCopyEncoder.java
@@ -65,6 +65,7 @@ public final class ZeroCopyEncoder implements Encoder {
    */
   private final ByteBuffer buffer;
 
+
   public ZeroCopyEncoder(Handler handler) {
     this(handler, DEFAULT_BUFFER_SIZE);
   }
@@ -522,7 +523,7 @@ public final class ZeroCopyEncoder implements Encoder {
     }
   }
 
-  private void writeRawVarint64(long value) throws IOException {
+  private void writeRawVarint64(long value) {
     while (true) {
       if ((value & ~0x7FL) == 0) {
         buffer.put((byte) value);

--- a/java/src/test/java/com/google/protobuf/ByteBufferByteStringTest.java
+++ b/java/src/test/java/com/google/protobuf/ByteBufferByteStringTest.java
@@ -47,9 +47,9 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * Tests for {@link UnsafeByteString}.
+ * Tests for {@link ByteBufferByteString}.
  */
-public class UnsafeByteStringTest extends TestCase {
+public class ByteBufferByteStringTest extends TestCase {
   protected static final String UTF_8 = "UTF-8";
 
   protected String classUnderTest;
@@ -59,9 +59,9 @@ public class UnsafeByteStringTest extends TestCase {
 
   @Override
   protected void setUp() throws Exception {
-    classUnderTest = UnsafeByteString.class.getSimpleName();
+    classUnderTest = ByteBufferByteString.class.getSimpleName();
     referenceBytes = ByteStringTest.getTestBytes(1234, 11337766L);
-    stringUnderTest = ByteString.unsafeWrapper(ByteBuffer.wrap(referenceBytes));
+    stringUnderTest = ByteString.wrap(ByteBuffer.wrap(referenceBytes));
     expectedHashCode = 331161852;
   }
 

--- a/java/src/test/java/com/google/protobuf/ByteStringTest.java
+++ b/java/src/test/java/com/google/protobuf/ByteStringTest.java
@@ -517,7 +517,7 @@ public class ByteStringTest extends TestCase {
   public void testNewCodedBuilder() throws IOException {
     byte[] bytes = getTestBytes();
     ByteString.CodedBuilder builder = ByteString.newCodedBuilder(bytes.length);
-    builder.getCodedOutput().writeRawBytes(bytes);
+    ((CodedOutputStream) builder.getCodedOutput()).writeRawBytes(bytes, 0, bytes.length);
     ByteString byteString = builder.build();
     assertTrue("String built from newCodedBuilder() must contain the expected bytes",
         isArrayRange(bytes, byteString.toByteArray(), 0, bytes.length));

--- a/java/src/test/java/com/google/protobuf/EncoderBenchmark.java
+++ b/java/src/test/java/com/google/protobuf/EncoderBenchmark.java
@@ -1,0 +1,118 @@
+package com.google.protobuf;
+
+import com.google.protobuf.FieldPresenceTestProto.TestAllTypes;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.util.Random;
+
+/**
+ * Microbenchmarks for writing out protobufs.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+public class EncoderBenchmark {
+
+  public enum DataSize {
+    SMALL(10),
+    MEDIUM(1024),
+    LARGE(1024 * 100),
+    JUMBO(1024 * 10000);
+
+    final int size;
+
+    DataSize(int size) {
+      this.size = size;
+    }
+  }
+
+  public enum BufferSize {
+    SMALL(1024),
+    MEDIUM(1024 * 4),
+    LARGE(1024 * 8);
+
+    final int size;
+
+    BufferSize(int size) {
+      this.size = size;
+    }
+  }
+
+  public enum Type {
+    OLD,
+    NEW
+  }
+
+  @Param
+  private DataSize dataSize;
+
+  @Param
+  private BufferSize bufferSize;
+
+  @Param
+  private Type type;
+
+  private Encoder outputter;
+
+  private ByteArrayOutputStream stream = new ByteArrayOutputStream(BufferSize.LARGE.size * 2);
+
+  private MessageLite msg;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    switch (type) {
+      case OLD:
+        outputter = CodedOutputStream.newInstance(stream, bufferSize.size);
+        break;
+      case NEW:
+        outputter = new ZeroCopyEncoder(new ZeroCopyEncoder.Handler() {
+          private final WritableByteChannel channel = Channels.newChannel(stream);
+          @Override
+          public void onDataEncoded(byte[] b, int offset, int length) {
+            stream.write(b, offset, length);
+          }
+
+          @Override
+          public void onDataEncoded(ByteBuffer data) throws IOException {
+            channel.write(data);
+          }
+        }, bufferSize.size);
+        break;
+    }
+
+    // Create a builder for the test message and put a few simple fields in it.
+    TestAllTypes.Builder msgBuilder = TestAllTypes.newBuilder();
+    ByteString smallBytes = ByteString.unsafeWrapper(
+            ByteBuffer.wrap("This is a test string!".getBytes(Charset.forName("UTF-8"))));
+    for (int ix=0; ix < 10; ++ix) {
+      msgBuilder.addRepeatedInt32(ix);
+      msgBuilder.addRepeatedBytes(smallBytes);
+      msgBuilder.addRepeatedString("This is a test string!");
+    }
+
+    // Create a random buffer for the data size and add it to the message.
+    byte[] bytes = new byte[dataSize.size];
+    new Random().nextBytes(bytes);
+    msgBuilder.addRepeatedBytes(ByteString.unsafeWrapper(ByteBuffer.wrap(bytes)));
+    msg = msgBuilder.build();
+  }
+
+  @Benchmark
+  public void doOutput() throws IOException {
+    stream.reset();
+    msg.writeTo(outputter);
+    outputter.flush();
+  }
+}

--- a/java/src/test/java/com/google/protobuf/EncoderBenchmark.java
+++ b/java/src/test/java/com/google/protobuf/EncoderBenchmark.java
@@ -139,7 +139,7 @@ public class EncoderBenchmark {
 
   private OutputManager outputManager;
 
-  private ZeroCopyEncoder.Handler handler = new ZeroCopyEncoder.Handler() {
+  private Encoder.Handler handler = new Encoder.Handler() {
     @Override
     public void onDataEncoded(byte[] b, int offset, int length, boolean copy) throws IOException {
       outputManager.add(b, offset, length, copy);

--- a/java/src/test/java/com/google/protobuf/PlatformDependentTest.java
+++ b/java/src/test/java/com/google/protobuf/PlatformDependentTest.java
@@ -1,0 +1,115 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import junit.framework.TestCase;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Tests for {@link PlatformDependent}.
+ */
+public class PlatformDependentTest  extends TestCase {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  public void testUtfEncoding() {
+    testUtf8Encoding(0x80);
+    testUtf8Encoding(0x90);
+    testUtf8Encoding(0x800);
+    testUtf8Encoding(0x10000);
+    testUtf8Encoding(0x10ffff);
+  }
+
+  private void testUtf8Encoding(int maxCodePoint) {
+    String input = randomString(maxCodePoint);
+    byte[] expected = input.getBytes(UTF_8);
+
+    byte[] actualToHeap = bytes(encodeHeapByteBuf(input));
+    assertTrue(Arrays.equals(expected, actualToHeap));
+
+    byte[] actualToDirect = bytes(encodeDirectByteBuf(input));
+    assertTrue(Arrays.equals(expected, actualToDirect));
+
+    if (PlatformDependent.UnsafeDirectByteBuffer.isAvailable()) {
+      byte[] actualToUnsafeDirect = bytes(encodeUnsafeDirectByteBuf(input));
+      assertTrue(Arrays.equals(expected, actualToUnsafeDirect));
+    }
+  }
+
+  private ByteBuffer encodeHeapByteBuf(String input) {
+    ByteBuffer buffer = ByteBuffer.allocate(input.length() * Utf8.MAX_BYTES_PER_CHAR);
+    PlatformDependent.encodeToHeap(input, buffer);
+    buffer.flip();
+    return buffer;
+  }
+
+  private ByteBuffer encodeDirectByteBuf(String input) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(input.length() * Utf8.MAX_BYTES_PER_CHAR);
+    PlatformDependent.encodeToDirect(input, buffer);
+    buffer.flip();
+    return buffer;
+  }
+
+  private ByteBuffer encodeUnsafeDirectByteBuf(String input) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(input.length() * Utf8.MAX_BYTES_PER_CHAR);
+    PlatformDependent.unsafeEncodeToDirect(input, buffer);
+    buffer.flip();
+    return buffer;
+  }
+
+  private byte[] bytes(ByteBuffer buffer) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+    return bytes;
+  }
+
+  private String randomString(int maxCodePoint) {
+    final long seed = 99;
+    final Random rnd = new Random(seed);
+    StringBuilder sb = new StringBuilder();
+    for (int j = 0; j < 100; j++) {
+      int codePoint;
+      do {
+        codePoint = rnd.nextInt(maxCodePoint);
+      } while (isSurrogate(codePoint));
+      sb.appendCodePoint(codePoint);
+    }
+    return sb.toString();
+  }
+
+  /** Character.isSurrogate was added in Java SE 7. */
+  private static boolean isSurrogate(int c) {
+    return Character.MIN_HIGH_SURROGATE <= c && c <= Character.MAX_LOW_SURROGATE;
+  }
+}

--- a/java/src/test/java/com/google/protobuf/UnsafeByteStringTest.java
+++ b/java/src/test/java/com/google/protobuf/UnsafeByteStringTest.java
@@ -1,0 +1,493 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Tests for {@link UnsafeByteString}.
+ */
+public class UnsafeByteStringTest extends TestCase {
+  protected static final String UTF_8 = "UTF-8";
+
+  protected String classUnderTest;
+  protected byte[] referenceBytes;
+  protected ByteString stringUnderTest;
+  protected int expectedHashCode;
+
+  @Override
+  protected void setUp() throws Exception {
+    classUnderTest = UnsafeByteString.class.getSimpleName();
+    referenceBytes = ByteStringTest.getTestBytes(1234, 11337766L);
+    stringUnderTest = ByteString.unsafeWrapper(ByteBuffer.wrap(referenceBytes));
+    expectedHashCode = 331161852;
+  }
+
+  public void testExpectedType() {
+    String actualClassName = getActualClassName(stringUnderTest);
+    assertEquals(classUnderTest + " should match type exactly", classUnderTest, actualClassName);
+  }
+
+  protected String getActualClassName(Object object) {
+    String actualClassName = object.getClass().getName();
+    actualClassName = actualClassName.substring(actualClassName.lastIndexOf('.') + 1);
+    return actualClassName;
+  }
+
+  public void testByteAt() {
+    boolean stillEqual = true;
+    for (int i = 0; stillEqual && i < referenceBytes.length; ++i) {
+      stillEqual = (referenceBytes[i] == stringUnderTest.byteAt(i));
+    }
+    assertTrue(classUnderTest + " must capture the right bytes", stillEqual);
+  }
+
+  public void testByteIterator() {
+    boolean stillEqual = true;
+    ByteString.ByteIterator iter = stringUnderTest.iterator();
+    for (int i = 0; stillEqual && i < referenceBytes.length; ++i) {
+      stillEqual = (iter.hasNext() && referenceBytes[i] == iter.nextByte());
+    }
+    assertTrue(classUnderTest + " must capture the right bytes", stillEqual);
+    assertFalse(classUnderTest + " must have exhausted the itertor", iter.hasNext());
+
+    try {
+      iter.nextByte();
+      fail("Should have thrown an exception.");
+    } catch (NoSuchElementException e) {
+      // This is success
+    }
+  }
+
+  public void testByteIterable() {
+    boolean stillEqual = true;
+    int j = 0;
+    for (byte quantum : stringUnderTest) {
+      stillEqual = (referenceBytes[j] == quantum);
+      ++j;
+    }
+    assertTrue(classUnderTest + " must capture the right bytes as Bytes", stillEqual);
+    assertEquals(classUnderTest + " iterable character count", referenceBytes.length, j);
+  }
+
+  public void testSize() {
+    assertEquals(classUnderTest + " must have the expected size", referenceBytes.length,
+        stringUnderTest.size());
+  }
+
+  public void testGetTreeDepth() {
+    assertEquals(classUnderTest + " must have depth 0", 0, stringUnderTest.getTreeDepth());
+  }
+
+  public void testIsBalanced() {
+    assertTrue(classUnderTest + " is technically balanced", stringUnderTest.isBalanced());
+  }
+
+  public void testCopyTo_ByteArrayOffsetLength() {
+    int destinationOffset = 50;
+    int length = 100;
+    byte[] destination = new byte[destinationOffset + length];
+    int sourceOffset = 213;
+    stringUnderTest.copyTo(destination, sourceOffset, destinationOffset, length);
+    boolean stillEqual = true;
+    for (int i = 0; stillEqual && i < length; ++i) {
+      stillEqual = referenceBytes[i + sourceOffset] == destination[i + destinationOffset];
+    }
+    assertTrue(classUnderTest + ".copyTo(4 arg) must give the expected bytes", stillEqual);
+  }
+
+  public void testCopyTo_ByteArrayOffsetLengthErrors() {
+    int destinationOffset = 50;
+    int length = 100;
+    byte[] destination = new byte[destinationOffset + length];
+
+    try {
+      // Copy one too many bytes
+      stringUnderTest.copyTo(destination, stringUnderTest.size() + 1 - length,
+          destinationOffset, length);
+      fail("Should have thrown an exception when copying too many bytes of a "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+
+    try {
+      // Copy with illegal negative sourceOffset
+      stringUnderTest.copyTo(destination, -1, destinationOffset, length);
+      fail("Should have thrown an exception when given a negative sourceOffset in "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+
+    try {
+      // Copy with illegal negative destinationOffset
+      stringUnderTest.copyTo(destination, 0, -1, length);
+      fail("Should have thrown an exception when given a negative destinationOffset in "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+
+    try {
+      // Copy with illegal negative size
+      stringUnderTest.copyTo(destination, 0, 0, -1);
+      fail("Should have thrown an exception when given a negative size in "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+
+    try {
+      // Copy with illegal too-large sourceOffset
+      stringUnderTest.copyTo(destination, 2 * stringUnderTest.size(), 0, length);
+      fail("Should have thrown an exception when the destinationOffset is too large in "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+
+    try {
+      // Copy with illegal too-large destinationOffset
+      stringUnderTest.copyTo(destination, 0, 2 * destination.length, length);
+      fail("Should have thrown an exception when the destinationOffset is too large in "
+          + classUnderTest);
+    } catch (IndexOutOfBoundsException expected) {
+      // This is success
+    }
+  }
+
+  public void testCopyTo_ByteBuffer() {
+    ByteBuffer myBuffer = ByteBuffer.allocate(referenceBytes.length);
+    stringUnderTest.copyTo(myBuffer);
+    assertTrue(classUnderTest + ".copyTo(ByteBuffer) must give back the same bytes",
+        Arrays.equals(referenceBytes, myBuffer.array()));
+  }
+
+  public void testMarkSupported() {
+    InputStream stream = stringUnderTest.newInput();
+    assertTrue(classUnderTest + ".newInput() must support marking", stream.markSupported());
+  }
+
+  public void testMarkAndReset() throws IOException {
+    int fraction = stringUnderTest.size() / 3;
+
+    InputStream stream = stringUnderTest.newInput();
+    stream.mark(stringUnderTest.size()); // First, mark() the end.
+
+    skipFully(stream, fraction); // Skip a large fraction, but not all.
+    int available = stream.available();
+    assertTrue(
+        classUnderTest + ": after skipping to the 'middle', half the bytes are available",
+        (stringUnderTest.size() - fraction) == available);
+    stream.reset();
+
+    skipFully(stream, stringUnderTest.size()); // Skip to the end.
+    available = stream.available();
+    assertTrue(
+        classUnderTest + ": after skipping to the end, no more bytes are available",
+        0 == available);
+  }
+
+  /**
+   * Discards {@code n} bytes of data from the input stream. This method
+   * will block until the full amount has been skipped. Does not close the
+   * stream.
+   * <p>Copied from com.google.common.io.ByteStreams to avoid adding dependency.
+   *
+   * @param in the input stream to read from
+   * @param n the number of bytes to skip
+   * @throws EOFException if this stream reaches the end before skipping all
+   *     the bytes
+   * @throws IOException if an I/O error occurs, or the stream does not
+   *     support skipping
+   */
+  static void skipFully(InputStream in, long n) throws IOException {
+    long toSkip = n;
+    while (n > 0) {
+      long amt = in.skip(n);
+      if (amt == 0) {
+        // Force a blocking read to avoid infinite loop
+        if (in.read() == -1) {
+          long skipped = toSkip - n;
+          throw new EOFException("reached end of stream after skipping "
+              + skipped + " bytes; " + toSkip + " bytes expected");
+        }
+        n--;
+      } else {
+        n -= amt;
+      }
+    }
+  }
+
+  public void testAsReadOnlyByteBuffer() {
+    ByteBuffer byteBuffer = stringUnderTest.asReadOnlyByteBuffer();
+    byte[] roundTripBytes = new byte[referenceBytes.length];
+    assertTrue(byteBuffer.remaining() == referenceBytes.length);
+    assertTrue(byteBuffer.isReadOnly());
+    byteBuffer.get(roundTripBytes);
+    assertTrue(classUnderTest + ".asReadOnlyByteBuffer() must give back the same bytes",
+        Arrays.equals(referenceBytes, roundTripBytes));
+  }
+
+  public void testAsReadOnlyByteBufferList() {
+    List<ByteBuffer> byteBuffers = stringUnderTest.asReadOnlyByteBufferList();
+    int bytesSeen = 0;
+    byte[] roundTripBytes = new byte[referenceBytes.length];
+    for (ByteBuffer byteBuffer : byteBuffers) {
+      int thisLength = byteBuffer.remaining();
+      assertTrue(byteBuffer.isReadOnly());
+      assertTrue(bytesSeen + thisLength <= referenceBytes.length);
+      byteBuffer.get(roundTripBytes, bytesSeen, thisLength);
+      bytesSeen += thisLength;
+    }
+    assertTrue(bytesSeen == referenceBytes.length);
+    assertTrue(classUnderTest + ".asReadOnlyByteBufferTest() must give back the same bytes",
+        Arrays.equals(referenceBytes, roundTripBytes));
+  }
+
+  public void testToByteArray() {
+    byte[] roundTripBytes = stringUnderTest.toByteArray();
+    assertTrue(classUnderTest + ".toByteArray() must give back the same bytes",
+        Arrays.equals(referenceBytes, roundTripBytes));
+  }
+
+  public void testWriteTo() throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    stringUnderTest.writeTo(bos);
+    byte[] roundTripBytes = bos.toByteArray();
+    assertTrue(classUnderTest + ".writeTo() must give back the same bytes",
+        Arrays.equals(referenceBytes, roundTripBytes));
+  }
+
+  public void testWriteTo_mutating() throws IOException {
+    OutputStream os = new OutputStream() {
+      @Override
+      public void write(byte[] b, int off, int len) {
+        for (int x = 0; x < len; ++x) {
+          b[off + x] = (byte) 0;
+        }
+      }
+
+      @Override
+      public void write(int b) {
+        // Purposefully left blank.
+      }
+    };
+
+    stringUnderTest.writeTo(os);
+    byte[] newBytes = stringUnderTest.toByteArray();
+    assertTrue(classUnderTest + ".writeTo() must not grant access to underlying array",
+        Arrays.equals(referenceBytes, newBytes));
+  }
+
+  public void testNewOutput() throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ByteString.Output output = ByteString.newOutput();
+    stringUnderTest.writeTo(output);
+    assertEquals("Output Size returns correct result",
+        output.size(), stringUnderTest.size());
+    output.writeTo(bos);
+    assertTrue("Output.writeTo() must give back the same bytes",
+        Arrays.equals(referenceBytes, bos.toByteArray()));
+
+    // write the output stream to itself! This should cause it to double
+    output.writeTo(output);
+    assertEquals("Writing an output stream to itself is successful",
+        stringUnderTest.concat(stringUnderTest), output.toByteString());
+
+    output.reset();
+    assertEquals("Output.reset() resets the output", 0, output.size());
+    assertEquals("Output.reset() resets the output",
+        ByteString.EMPTY, output.toByteString());
+  }
+
+  public void testToString() throws UnsupportedEncodingException {
+    String testString = "I love unicode \u1234\u5678 characters";
+    LiteralByteString unicode = new LiteralByteString(testString.getBytes(Internal.UTF_8));
+    String roundTripString = unicode.toString(UTF_8);
+    assertEquals(classUnderTest + " unicode must match", testString, roundTripString);
+  }
+
+  public void testCharsetToString() throws UnsupportedEncodingException {
+    String testString = "I love unicode \u1234\u5678 characters";
+    LiteralByteString unicode = new LiteralByteString(testString.getBytes(Internal.UTF_8));
+    String roundTripString = unicode.toString(Internal.UTF_8);
+    assertEquals(classUnderTest + " unicode must match", testString, roundTripString);
+  }
+
+  public void testToString_returnsCanonicalEmptyString() {
+    assertSame(classUnderTest + " must be the same string references",
+        ByteString.EMPTY.toString(Internal.UTF_8),
+        new LiteralByteString(new byte[]{}).toString(Internal.UTF_8));
+  }
+
+  public void testToString_raisesException() {
+    try {
+      ByteString.EMPTY.toString("invalid");
+      fail("Should have thrown an exception.");
+    } catch (UnsupportedEncodingException expected) {
+      // This is success
+    }
+
+    try {
+      new LiteralByteString(referenceBytes).toString("invalid");
+      fail("Should have thrown an exception.");
+    } catch (UnsupportedEncodingException expected) {
+      // This is success
+    }
+  }
+
+  public void testEquals() {
+    assertEquals(classUnderTest + " must not equal null", false, stringUnderTest.equals(null));
+    assertEquals(classUnderTest + " must equal self", stringUnderTest, stringUnderTest);
+    assertFalse(classUnderTest + " must not equal the empty string",
+        stringUnderTest.equals(ByteString.EMPTY));
+    assertEquals(classUnderTest + " empty strings must be equal",
+        new LiteralByteString(new byte[]{}), stringUnderTest.substring(55, 55));
+    assertEquals(classUnderTest + " must equal another string with the same value",
+        stringUnderTest, new LiteralByteString(referenceBytes));
+
+    byte[] mungedBytes = new byte[referenceBytes.length];
+    System.arraycopy(referenceBytes, 0, mungedBytes, 0, referenceBytes.length);
+    mungedBytes[mungedBytes.length - 5] = (byte) (mungedBytes[mungedBytes.length - 5] ^ 0xFF);
+    assertFalse(classUnderTest + " must not equal every string with the same length",
+        stringUnderTest.equals(new LiteralByteString(mungedBytes)));
+  }
+
+  public void testHashCode() {
+    int hash = stringUnderTest.hashCode();
+    assertEquals(classUnderTest + " must have expected hashCode", expectedHashCode, hash);
+  }
+
+  public void testPeekCachedHashCode() {
+    assertEquals(classUnderTest + ".peekCachedHashCode() should return zero at first", 0,
+        stringUnderTest.peekCachedHashCode());
+    stringUnderTest.hashCode();
+    assertEquals(classUnderTest + ".peekCachedHashCode should return zero at first",
+        expectedHashCode, stringUnderTest.peekCachedHashCode());
+  }
+
+  public void testPartialHash() {
+    // partialHash() is more strenuously tested elsewhere by testing hashes of substrings.
+    // This test would fail if the expected hash were 1.  It's not.
+    int hash = stringUnderTest.partialHash(stringUnderTest.size(), 0, stringUnderTest.size());
+    assertEquals(classUnderTest + ".partialHash() must yield expected hashCode",
+        expectedHashCode, hash);
+  }
+
+  public void testNewInput() throws IOException {
+    InputStream input = stringUnderTest.newInput();
+    assertEquals("InputStream.available() returns correct value",
+        stringUnderTest.size(), input.available());
+    boolean stillEqual = true;
+    for (byte referenceByte : referenceBytes) {
+      int expectedInt = (referenceByte & 0xFF);
+      stillEqual = (expectedInt == input.read());
+    }
+    assertEquals("InputStream.available() returns correct value",
+        0, input.available());
+    assertTrue(classUnderTest + " must give the same bytes from the InputStream", stillEqual);
+    assertEquals(classUnderTest + " InputStream must now be exhausted", -1, input.read());
+  }
+
+  public void testNewInput_skip() throws IOException {
+    InputStream input = stringUnderTest.newInput();
+    int stringSize = stringUnderTest.size();
+    int nearEndIndex = stringSize * 2 / 3;
+    long skipped1 = input.skip(nearEndIndex);
+    assertEquals("InputStream.skip()", skipped1, nearEndIndex);
+    assertEquals("InputStream.available()",
+        stringSize - skipped1, input.available());
+    assertTrue("InputStream.mark() is available", input.markSupported());
+    input.mark(0);
+    assertEquals("InputStream.skip(), read()",
+        stringUnderTest.byteAt(nearEndIndex) & 0xFF, input.read());
+    assertEquals("InputStream.available()",
+        stringSize - skipped1 - 1, input.available());
+    long skipped2 = input.skip(stringSize);
+    assertEquals("InputStream.skip() incomplete",
+        skipped2, stringSize - skipped1 - 1);
+    assertEquals("InputStream.skip(), no more input", 0, input.available());
+    assertEquals("InputStream.skip(), no more input", -1, input.read());
+    input.reset();
+    assertEquals("InputStream.reset() succeded",
+        stringSize - skipped1, input.available());
+    assertEquals("InputStream.reset(), read()",
+        stringUnderTest.byteAt(nearEndIndex) & 0xFF, input.read());
+  }
+
+  public void testNewCodedInput() throws IOException {
+    CodedInputStream cis = stringUnderTest.newCodedInput();
+    byte[] roundTripBytes = cis.readRawBytes(referenceBytes.length);
+    assertTrue(classUnderTest + " must give the same bytes back from the CodedInputStream",
+        Arrays.equals(referenceBytes, roundTripBytes));
+    assertTrue(classUnderTest + " CodedInputStream must now be exhausted", cis.isAtEnd());
+  }
+
+  /**
+   * Make sure we keep things simple when concatenating with empty. See also
+   * {@link ByteStringTest#testConcat_empty()}.
+   */
+  public void testConcat_empty() {
+    assertSame(classUnderTest + " concatenated with empty must give " + classUnderTest,
+        stringUnderTest.concat(ByteString.EMPTY), stringUnderTest);
+    assertSame("empty concatenated with " + classUnderTest + " must give " + classUnderTest,
+        ByteString.EMPTY.concat(stringUnderTest), stringUnderTest);
+  }
+
+  public void testJavaSerialization() throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(out);
+    oos.writeObject(stringUnderTest);
+    oos.close();
+    byte[] pickled = out.toByteArray();
+    InputStream in = new ByteArrayInputStream(pickled);
+    ObjectInputStream ois = new ObjectInputStream(in);
+    Object o = ois.readObject();
+    assertTrue("Didn't get a ByteString back", o instanceof ByteString);
+    assertEquals("Should get an equal ByteString back", stringUnderTest, o);
+  }
+}

--- a/java/src/test/java/com/google/protobuf/Utf8EncodingBenchmark.java
+++ b/java/src/test/java/com/google/protobuf/Utf8EncodingBenchmark.java
@@ -1,0 +1,190 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package com.google.protobuf;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Microbenchmarks for UTF-8 encoding.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+public class Utf8EncodingBenchmark {
+
+  public enum EncoderType {
+    ORIGINAL,
+    NEW_HEAP,
+    NEW_DIRECT,
+    NEW_DIRECT_UNSAFE,
+  }
+
+  public enum CharSize {
+    ONE_BYTE(0x80),
+    ONE_OR_TWO_BYTE(0x90),
+    TWO_BYTE(0x800),
+    THREE_BYTE(0x10000),
+    FOUR_BYTE(0x10FFFF);
+
+    final int maxCodePoint;
+
+    CharSize(int maxCodePoint) {
+      this.maxCodePoint = maxCodePoint;
+    }
+  }
+
+
+  @Param
+  private CharSize charSize = CharSize.ONE_BYTE;
+
+  @Param({"1024" /*, "16384"*/})
+  private int length = 1024;
+
+  @Param
+  private EncoderType encoderType = EncoderType.NEW_HEAP;
+
+  private String input;
+
+  private Encoder encoder;
+
+  private interface Encoder {
+    void encode(String input);
+  }
+
+  private final class OldEncoder implements Encoder {
+    private final byte[] buffer;
+
+    OldEncoder() {
+      buffer = new byte[length * Utf8.MAX_BYTES_PER_CHAR];
+    }
+
+    @Override
+    public void encode(String input) {
+      Utf8.encode(input, buffer, 0, buffer.length);
+    }
+  }
+
+  private final class NewHeapEncoder implements Encoder {
+    private final ByteBuffer buffer;
+
+    NewHeapEncoder() {
+      buffer = ByteBuffer.allocate(length * Utf8.MAX_BYTES_PER_CHAR);
+    }
+
+    @Override
+    public void encode(String input) {
+      buffer.clear();
+      PlatformDependent.encodeToHeap(input, buffer);
+    }
+  }
+
+  private final class NewDirectEncoder implements Encoder {
+    private final ByteBuffer buffer;
+
+    NewDirectEncoder() {
+      buffer = ByteBuffer.allocateDirect(length * Utf8.MAX_BYTES_PER_CHAR);
+    }
+
+    @Override
+    public void encode(String input) {
+      buffer.clear();
+      PlatformDependent.encodeToDirect(input, buffer);
+    }
+  }
+
+  private final class NewUnsafeDirectEncoder implements Encoder {
+    private final ByteBuffer buffer;
+
+    NewUnsafeDirectEncoder() {
+      buffer = ByteBuffer.allocateDirect(length * Utf8.MAX_BYTES_PER_CHAR);
+    }
+
+    @Override
+    public void encode(String input) {
+      buffer.clear();
+      PlatformDependent.unsafeEncodeToDirect(input, buffer);
+    }
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    StringBuilder sb = new StringBuilder();
+
+    // Evenly distribute the string across the range of characters.
+    int codePointIncrement = Math.max(charSize.maxCodePoint / length, 1);
+    for (int j = 0; j < length; j++) {
+      int codePoint;
+      do {
+        codePoint = (codePointIncrement * j) % length;
+      } while (isSurrogate(codePoint));
+      sb.appendCodePoint(codePoint);
+    }
+    input = sb.toString();
+
+    switch(encoderType) {
+      case ORIGINAL:
+        encoder = new OldEncoder();
+        break;
+      case NEW_HEAP:
+        encoder = new NewHeapEncoder();
+        break;
+      case NEW_DIRECT:
+        encoder = new NewDirectEncoder();
+        break;
+      case NEW_DIRECT_UNSAFE:
+        encoder = new NewUnsafeDirectEncoder();
+        break;
+    }
+  }
+
+  @Benchmark
+  public void encodeUtf8() {
+    encoder.encode(input);
+  }
+
+  /** Character.isSurrogate was added in Java SE 7. */
+  private static boolean isSurrogate(int c) {
+    return Character.MIN_HIGH_SURROGATE <= c && c <= Character.MAX_LOW_SURROGATE;
+  }
+
+  public static void main(String[] args) {
+    Utf8EncodingBenchmark bm = new Utf8EncodingBenchmark();
+    bm.setUp();
+    bm.encodeUtf8();
+  }
+}

--- a/java/src/test/java/com/google/protobuf/WellKnownTypesTest.java
+++ b/java/src/test/java/com/google/protobuf/WellKnownTypesTest.java
@@ -30,18 +30,9 @@
 
 package com.google.protobuf;
 
-import com.google.protobuf.Descriptors.Descriptor;
-import com.google.protobuf.Descriptors.EnumDescriptor;
-import com.google.protobuf.Descriptors.EnumValueDescriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.test.TestWellKnownTypes;
 
 import junit.framework.TestCase;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This test ensures that well-known types are included in protobuf Java

--- a/java/src/test/java/com/google/protobuf/WireFormatTest.java
+++ b/java/src/test/java/com/google/protobuf/WireFormatTest.java
@@ -562,7 +562,7 @@ public class WireFormatTest extends TestCase {
     // Serialize RawMessageSet unnormally (message value before type id)
     ByteString.CodedBuilder out = ByteString.newCodedBuilder(
         raw.getSerializedSize());
-    CodedOutputStream output = out.getCodedOutput();
+    Encoder output = out.getCodedOutput();
     List<RawMessageSet.Item> items = raw.getItemList();
     for (int i = 0; i < items.size(); i++) {
       RawMessageSet.Item item = items.get(i);

--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -342,7 +342,7 @@ void ImmutableEnumFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($is_field_present_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeEnumSize($number$, $name$_);\n"
     "}\n");
 }
@@ -526,7 +526,7 @@ void ImmutableEnumOneofFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeEnumSize($number$, ((java.lang.Integer) $oneof_name$_));\n"
     "}\n");
 }
@@ -894,8 +894,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->is_packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.writeEnumNoTag($name$_.get(i));\n"
@@ -917,7 +917,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
 
   printer->Print(variables_,
     "for (int i = 0; i < $name$_.size(); i++) {\n"
-    "  dataSize += com.google.protobuf.CodedOutputStream\n"
+    "  dataSize += com.google.protobuf.WireFormat\n"
     "    .computeEnumSizeNoTag($name$_.get(i));\n"
     "}\n");
   printer->Print(
@@ -926,7 +926,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "    .computeRawVarint32Size(dataSize);\n"
       "}");
   } else {

--- a/src/google/protobuf/compiler/java/java_enum_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field_lite.cc
@@ -326,7 +326,7 @@ void ImmutableEnumFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($is_field_present_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeEnumSize($number$, $name$_);\n"
     "}\n");
 }
@@ -514,7 +514,7 @@ void ImmutableEnumOneofFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeEnumSize($number$, ((java.lang.Integer) $oneof_name$_));\n"
     "}\n");
 }
@@ -893,8 +893,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->options().packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.writeEnumNoTag($name$_.get(i));\n"
@@ -916,7 +916,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
 
   printer->Print(variables_,
     "for (int i = 0; i < $name$_.size(); i++) {\n"
-    "  dataSize += com.google.protobuf.CodedOutputStream\n"
+    "  dataSize += com.google.protobuf.WireFormat\n"
     "    .computeEnumSizeNoTag($name$_.get(i));\n"
     "}\n");
   printer->Print(
@@ -925,7 +925,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "    .computeRawVarint32Size(dataSize);\n"
       "}");
   } else {

--- a/src/google/protobuf/compiler/java/java_lazy_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_lazy_message_field.cc
@@ -262,7 +262,7 @@ void ImmutableLazyMessageFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($get_has_field_bit_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, $name$_);\n"
     "}\n");
 }
@@ -449,7 +449,7 @@ void ImmutableLazyMessageOneofFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, ($lazy_type$) $oneof_name$_);\n"
     "}\n");
 }
@@ -803,7 +803,7 @@ void RepeatedImmutableLazyMessageFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "for (int i = 0; i < $name$_.size(); i++) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, $name$_.get(i));\n"
     "}\n");
 }

--- a/src/google/protobuf/compiler/java/java_lazy_message_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_lazy_message_field_lite.cc
@@ -211,7 +211,7 @@ void ImmutableLazyMessageFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($get_has_field_bit_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, $name$_);\n"
     "}\n");
 }
@@ -397,7 +397,7 @@ void ImmutableLazyMessageOneofFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, ($lazy_type$) $oneof_name$_);\n"
     "}\n");
 }
@@ -697,7 +697,7 @@ void RepeatedImmutableLazyMessageFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "for (int i = 0; i < $name$_.size(); i++) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeLazyFieldSize($number$, $name$_.get(i));\n"
     "}\n");
 }

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -534,11 +534,11 @@ GenerateMessageSerializationMethods(io::Printer* printer) {
             ExtensionRangeOrdering());
 
   printer->Print(
-    "public void writeTo(com.google.protobuf.CodedOutputStream output)\n"
+    "public void writeTo(com.google.protobuf.Encoder output)\n"
     "                    throws java.io.IOException {\n");
   printer->Indent();
   if (HasPackedFields(descriptor_)) {
-    // writeTo(CodedOutputStream output) might be invoked without
+    // writeTo(Encoder output) might be invoked without
     // getSerializedSize() ever being called, but we need the memoized
     // sizes in case this message has packed fields. Rather than emit checks for
     // each packed field, just call getSerializedSize() up front.

--- a/src/google/protobuf/compiler/java/java_message_lite.cc
+++ b/src/google/protobuf/compiler/java/java_message_lite.cc
@@ -469,11 +469,11 @@ GenerateMessageSerializationMethods(io::Printer* printer) {
             ExtensionRangeOrdering());
 
   printer->Print(
-    "public void writeTo(com.google.protobuf.CodedOutputStream output)\n"
+    "public void writeTo(com.google.protobuf.Encoder output)\n"
     "                    throws java.io.IOException {\n");
   printer->Indent();
   if (HasPackedFields(descriptor_)) {
-    // writeTo(CodedOutputStream output) might be invoked without
+    // writeTo(Encoder output) might be invoked without
     // getSerializedSize() ever being called, but we need the memoized
     // sizes in case this message has packed fields. Rather than emit checks for
     // each packed field, just call getSerializedSize() up front.

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -324,7 +324,7 @@ void ImmutablePrimitiveFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($is_field_present_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .compute$capitalized_type$Size($number$, $name$_);\n"
     "}\n");
 }
@@ -537,7 +537,7 @@ void ImmutablePrimitiveOneofFieldGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .compute$capitalized_type$Size(\n"
     "        $number$, ($type$)(($boxed_type$) $oneof_name$_));\n"
     "}\n");
@@ -783,8 +783,8 @@ GenerateSerializationCode(io::Printer* printer) const {
     // That makes it safe to rely on the memoized size here.
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.write$capitalized_type$NoTag($name$_.get(i));\n"
@@ -807,7 +807,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
   if (FixedSize(GetType(descriptor_)) == -1) {
     printer->Print(variables_,
       "for (int i = 0; i < $name$_.size(); i++) {\n"
-      "  dataSize += com.google.protobuf.CodedOutputStream\n"
+      "  dataSize += com.google.protobuf.WireFormat\n"
       "    .compute$capitalized_type$SizeNoTag($name$_.get(i));\n"
       "}\n");
   } else {
@@ -822,7 +822,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {\n"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "      .computeInt32SizeNoTag(dataSize);\n"
       "}\n");
   } else {

--- a/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
@@ -345,7 +345,7 @@ void ImmutablePrimitiveFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($is_field_present_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .compute$capitalized_type$Size($number$, $name$_);\n"
     "}\n");
 }
@@ -564,7 +564,7 @@ void ImmutablePrimitiveOneofFieldLiteGenerator::
 GenerateSerializedSizeCode(io::Printer* printer) const {
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .compute$capitalized_type$Size(\n"
     "        $number$, ($type$)(($boxed_type$) $oneof_name$_));\n"
     "}\n");
@@ -810,8 +810,8 @@ GenerateSerializationCode(io::Printer* printer) const {
     // That makes it safe to rely on the memoized size here.
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.write$capitalized_type$NoTag($name$_.get(i));\n"
@@ -834,7 +834,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
   if (FixedSize(GetType(descriptor_)) == -1) {
     printer->Print(variables_,
       "for (int i = 0; i < $name$_.size(); i++) {\n"
-      "  dataSize += com.google.protobuf.CodedOutputStream\n"
+      "  dataSize += com.google.protobuf.WireFormat\n"
       "    .compute$capitalized_type$SizeNoTag($name$_.get(i));\n"
       "}\n");
   } else {
@@ -849,7 +849,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {\n"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "      .computeInt32SizeNoTag(dataSize);\n"
       "}\n");
   } else {

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -1002,8 +1002,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->options().packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  writeStringNoTag(output, $name$_.getRaw(i));\n"
@@ -1035,7 +1035,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {\n"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "      .computeInt32SizeNoTag(dataSize);\n"
       "}\n");
   } else {

--- a/src/google/protobuf/compiler/java/java_string_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_string_field_lite.cc
@@ -367,7 +367,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
   // allocations in half.
   printer->Print(variables_,
     "if ($is_field_present_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeStringSize($number$, get$capitalized_name$());\n"
     "}\n");
 }
@@ -569,7 +569,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
   // allocations in half.
   printer->Print(variables_,
     "if ($has_oneof_case_message$) {\n"
-    "  size += com.google.protobuf.CodedOutputStream\n"
+    "  size += com.google.protobuf.WireFormat\n"
     "    .computeStringSize($number$, get$capitalized_name$());\n"
     "}\n");
 }
@@ -873,8 +873,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->options().packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.writeStringNoTag($name$_.get(i));\n"
@@ -899,7 +899,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
 
   printer->Print(variables_,
     "for (int i = 0; i < $name$_.size(); i++) {\n"
-    "  dataSize += com.google.protobuf.CodedOutputStream\n"
+    "  dataSize += com.google.protobuf.WireFormat\n"
     "    .computeStringSizeNoTag($name$_.get(i));\n"
     "}\n");
 
@@ -910,7 +910,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "if (!get$capitalized_name$List().isEmpty()) {\n"
       "  size += $tag_size$;\n"
-      "  size += com.google.protobuf.CodedOutputStream\n"
+      "  size += com.google.protobuf.WireFormat\n"
       "      .computeInt32SizeNoTag(dataSize);\n"
       "}\n");
   } else {


### PR DESCRIPTION
Added an Encoder interface implemented by CodedOutputStream and the
new ZeroCopyEncoder. Added an UnsafeByteString that wraps around a
ByteBuffer and allows access to the underlying buffer.

Created a JMH EncoderBenchmark that creates a simple protobuf initialized
with 10 ints, 10 small strings, and 10 small ByteStrings, as well as one
ByteString that varies in size between tests (SMALL=10, MEDIUM=1KB,
LARGE=100KB, JUMBO=10MB). I also vary the internal buffer size used by
both encoders (SMALL=1KB, MEDIUM=4KB, LARGE=8KB).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/protobuf/868)

<!-- Reviewable:end -->
