### PR TITLE
fix json_format for python2.6:

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -410,6 +410,9 @@ class JsonFormatTest(JsonFormatBase):
                     '"unknownName".')
 
   def testDuplicateField(self):
+    # Duplicate key check is not supported for python2.6
+    if sys.version_info < (2, 7):
+      return
     self.CheckError('{"int32Value": 1,\n"int32Value":2}',
                     'Failed to load JSON: duplicate key int32Value')
 
@@ -468,15 +471,17 @@ class JsonFormatTest(JsonFormatBase):
         (r'Failed to load JSON: Expecting property name'
          r'( enclosed in double quotes)?: line 1'),
         json_format.Parse, text, message)
-    text = r'{"stringMap": {"a": 3, "\u0061": 2}}'
-    self.assertRaisesRegexp(
-        json_format.ParseError,
-        'Failed to load JSON: duplicate key a',
-        json_format.Parse, text, message)
     text = '{"boolMap": {"null": 1}}'
     self.assertRaisesRegexp(
         json_format.ParseError,
         'Failed to parse boolMap field: Expect "true" or "false", not null.',
+        json_format.Parse, text, message)
+    if sys.version_info < (2, 7):
+      return
+    text = r'{"stringMap": {"a": 3, "\u0061": 2}}'
+    self.assertRaisesRegexp(
+        json_format.ParseError,
+        'Failed to load JSON: duplicate key a',
         json_format.Parse, text, message)
 
   def testInvalidTimestamp(self):

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     # cpp implementation on py34 is currently broken due to
     # changes introduced by http://bugs.python.org/issue22079.
-    # py26 is currently broken due to the json_format
-    py{27,33,34}-{cpp,python}
+    py{26,27,33,34}-{cpp,python}
 
 [testenv]
 usedevelop=true

--- a/travis.sh
+++ b/travis.sh
@@ -131,8 +131,7 @@ build_python() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    # py26 is currently disabled due to json_format
-    envlist=py\{27,33,34\}-python
+    envlist=py\{26,27,33,34\}-python
   else
     envlist=py27-python
   fi


### PR DESCRIPTION
1, objcect_pair_hook is not supported in python2.6, so duplicated key check is removed in 2.6
2, total_seconds is not suppoted in python2.6, changed to compute seconds directly