### PR TITLE
Replace 'port' installation note with 'homebrew'

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ For advanced usage information on configure and make, see INSTALL.txt.
 
     $ sudo xcode-select --install
 
-  To install Unix tools, you can install "port" following the instructions at
-  https://www.macports.org . This will reside in /opt/local/bin/port for most
+  To install Unix tools, you can install "homebrew" following the instructions at
+  http://brew.sh/ . This will reside in /usr/local for most
   Mac installations.
 
-    $ sudo /opt/local/bin/port install autoconf automake libtool
+    $ brew install autoconf automake libtool
 
   Then follow the Unix instructions above.
 


### PR DESCRIPTION
```bash
$ brew info autoconf automake libtool

autoconf: stable 2.69 (bottled)
Automatic configure script builder
https://www.gnu.org/software/autoconf
/usr/local/Cellar/autoconf/2.69 (70 files, 3.1M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/autoconf.rb
==> Caveats
Emacs Lisp files have been installed to:
/usr/local/share/emacs/site-lisp/

Add the following to your init file to have packages installed by
Homebrew added to your load-path:
(let ((default-directory "/usr/local/share/emacs/site-lisp/"))
  (normal-top-level-add-subdirs-to-load-path))

automake: stable 1.15 (bottled)
Tool for generating GNU Standards-compliant Makefiles
https://www.gnu.org/software/automake/
/usr/local/Cellar/automake/1.15 (130 files, 3.2M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/automake.rb
==> Dependencies
Build: xz ✔
Required: autoconf ✔

libtool: stable 2.4.6 (bottled)
Generic library support script
https://www.gnu.org/software/libtool/
/usr/local/Cellar/libtool/2.4.6 (69 files, 3.8M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/libtool.rb
==> Dependencies
Build: xz ✔
==> Options
--universal
        Build a universal binary
==> Caveats
In order to prevent conflicts with Apple's own libtool we have prepended a "g"
so, you have instead: glibtool and glibtoolize.
```

`libtool` reference may need to be changed to `glibtool` following the Caveats mentioned by brew.