### PR TITLE
Changed return type from int32 to bool in function returning a bool

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -155,7 +155,7 @@ class LIBPROTOBUF_EXPORT MapKey {
                "MapKey::GetUInt32Value");
     return val_.uint32_value_;
   }
-  int32 GetBoolValue() const {
+  bool GetBoolValue() const {
     TYPE_CHECK(FieldDescriptor::CPPTYPE_BOOL,
                "MapKey::GetBoolValue");
     return val_.bool_value_;


### PR DESCRIPTION
In visual studio this the code generates the following warning: warning C4800: 'google::protobuf::int32' : forcing value to bool 'true' or 'false' (performance warning)

And looking in the code a bool is returned from a function with return type int32. Is this just a typo?

If there is no justification for the current code please accept my change.