### PR TITLE
Changed argument typ to uint32 in set function that sets an uint32 value

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -275,7 +275,7 @@ class LIBPROTOBUF_EXPORT MapValueRef {
                "MapValueRef::SetInt32Value");
     *reinterpret_cast<int32*>(data_) = value;
   }
-  void SetUInt32Value(uint64 value) {
+  void SetUInt32Value(uint32 value) {
     TYPE_CHECK(FieldDescriptor::CPPTYPE_UINT32,
                "MapValueRef::SetUInt32Value");
     *reinterpret_cast<uint32*>(data_) = value;


### PR DESCRIPTION
In visual studio the code yields the following warning: C4244: '=' : conversion from 'google::protobuf::uint64' to 'google::protobuf::uint32', possible loss of data

The function is named SetUInt32Value so I see no reason for it to use a uint64 value as argument.

Please accept my fix for this.