### PR TITLE
Add support for arguments.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,6 +6,18 @@
 
 set -e
 
+if [ ! -z "$@" ]; then
+  for argument in "$@"; do
+    case $argument in
+	  # make curl silent
+      "-s")
+        curlopts="-s"
+        ;;
+    esac
+  done
+fi
+
+
 # Check that we're being run from the right directory.
 if test ! -f src/google/protobuf/stubs/common.h; then
   cat >&2 << __EOF__
@@ -19,7 +31,7 @@ fi
 # directory is set up as an SVN external.
 if test ! -e gmock; then
   echo "Google Mock not present.  Fetching gmock-1.7.0 from the web..."
-  curl -O https://googlemock.googlecode.com/files/gmock-1.7.0.zip
+  curl $curlopts -O https://googlemock.googlecode.com/files/gmock-1.7.0.zip
   unzip -q gmock-1.7.0.zip
   rm gmock-1.7.0.zip
   mv gmock-1.7.0 gmock


### PR DESCRIPTION
Support curl -s argument.

This is a nice-to-have feature when automating and want curl to be quiet.

Signed-off-by: Matthew Valimaki <matthew.valimaki@gmail.com>