### PR TITLE
Allow include to be None.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,6 +1,8 @@
 # -*- mode: python; -*- PYTHON-PREPROCESSING-REQUIRED
 
 def _gen_dir(ctx):
+  if ctx.attr.include == None:
+    return ""
   if not ctx.attr.include:
     return ctx.label.package
   if not ctx.label.package:
@@ -70,7 +72,7 @@ def cc_proto_library(
         srcs=[],
         deps=[],
         cc_libs=[],
-        include="",
+        include=None,
         protoc=":protoc",
         internal_bootstrap_hack=False,
         **kargs):
@@ -119,9 +121,13 @@ def cc_proto_library(
       outs=outs,
   )
 
+  includes = []
+  if include != None:
+    includes = [include]
+
   native.cc_library(
       name=name,
       srcs=outs,
       deps=cc_libs + deps,
-      includes=[include],
+      includes=includes,
       **kargs)


### PR DESCRIPTION
This enables the use case where all the paths are relative to the
workspace root, e.g.

foo/bar/BUILD
       /foo.proto -- package foo.bar

would generate the message correctly.