### PR TITLE
Use && for internal_copied_filegroup.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -180,9 +180,9 @@ def internal_copied_filegroup(
       name=name+"_genrule",
       srcs=srcs,
       outs=outs,
-      cmd=";".join(["cp $(location %s) $(location %s)" % \
-                    (s, _RelativeOutputPath(s, include)) \
-                    for s in srcs]))
+      cmd=" && ".join(["cp $(location %s) $(location %s)" %
+                       (s, _RelativeOutputPath(s, include))
+                       for s in srcs]))
 
   native.filegroup(
       name=name,


### PR DESCRIPTION
So that the rule fails if one or more files cannot be copied.

@xfxyjwf  for review