### PR TITLE
Add stubs\stl_util.h to extract_includes.bat

### DIFF
--- a/vsprojects/extract_includes.bat
+++ b/vsprojects/extract_includes.bat
@@ -12,6 +12,7 @@ copy ..\src\google\protobuf\stubs\atomicops_internals_x86_msvc.h include\google\
 copy ..\src\google\protobuf\stubs\common.h include\google\protobuf\stubs\common.h
 copy ..\src\google\protobuf\stubs\once.h include\google\protobuf\stubs\once.h
 copy ..\src\google\protobuf\stubs\platform_macros.h include\google\protobuf\stubs\platform_macros.h
+copy ..\src\google\protobuf\stubs\stl_util.h include\google\protobuf\stubs\stl_util.h
 copy ..\src\google\protobuf\stubs\template_util.h include\google\protobuf\stubs\template_util.h
 copy ..\src\google\protobuf\stubs\type_traits.h include\google\protobuf\stubs\type_traits.h
 copy ..\src\google\protobuf\descriptor.h include\google\protobuf\descriptor.h


### PR DESCRIPTION
On v2.6.1, extract_includes.bat seems to be missing the stl_util.h file which is included by zero_copy_stream_impl_lite.h.