### PR TITLE
Support specifying the indent level when json dumping protobufs

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -159,8 +159,8 @@ class JsonFormatTest(JsonFormatBase):
       message.string_value += (b'\xe2\x80\xa8\xe2\x80\xa9').decode('utf-8')
     self.assertEqual(
         json_format.MessageToJson(message),
-        '{\n  "stringValue": '
-        '"&\\n<\\\"\\r>\\b\\t\\f\\\\\\u0001/\\u2028\\u2029"\n}')
+        '{"stringValue": '
+        '"&\\n<\\\"\\r>\\b\\t\\f\\\\\\u0001/\\u2028\\u2029"}')
     parsed_message = json_format_proto3_pb2.TestMessage()
     self.CheckParseBack(message, parsed_message)
     text = u'{"int32Value": "\u0031"}'
@@ -233,8 +233,8 @@ class JsonFormatTest(JsonFormatBase):
     message.oneof_int32_value = 0
     self.assertEqual(
         json_format.MessageToJson(message, True),
-        '{\n'
-        '  "oneofInt32Value": 0\n'
+        '{'
+        '"oneofInt32Value": 0'
         '}')
     parsed_message = json_format_proto3_pb2.TestOneof()
     self.CheckParseBack(message, parsed_message)
@@ -311,8 +311,8 @@ class JsonFormatTest(JsonFormatBase):
     message.value.paths.append('bar')
     self.assertEqual(
         json_format.MessageToJson(message, True),
-        '{\n'
-        '  "value": "foo.bar,bar"\n'
+        '{'
+        '"value": "foo.bar,bar"'
         '}')
     parsed_message = json_format_proto3_pb2.TestFieldMask()
     self.CheckParseBack(message, parsed_message)
@@ -327,7 +327,7 @@ class JsonFormatTest(JsonFormatBase):
     message.repeated_bool_value.add().value = False
     self.assertEqual(
         json.loads(json_format.MessageToJson(message, True)),
-        json.loads('{\n'
+        json.loads('{'
                    '  "int32Value": 0,'
                    '  "boolValue": false,'
                    '  "stringValue": "",'
@@ -381,7 +381,7 @@ class JsonFormatTest(JsonFormatBase):
   def testNanFloat(self):
     message = json_format_proto3_pb2.TestMessage()
     message.float_value = float('nan')
-    text = '{\n  "floatValue": "NaN"\n}'
+    text = '{"floatValue": "NaN"}'
     self.assertEqual(json_format.MessageToJson(message), text)
     parsed_message = json_format_proto3_pb2.TestMessage()
     json_format.Parse(text, parsed_message)

--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -239,6 +239,15 @@ class JsonFormatTest(JsonFormatBase):
     parsed_message = json_format_proto3_pb2.TestOneof()
     self.CheckParseBack(message, parsed_message)
 
+  def testJsonFormatIndentation(self):
+    message = json_format_proto3_pb2.TestOneof()
+    message.oneof_int32_value = 0
+    self.assertEqual(
+        json_format.MessageToJson(message, True, indent=2),
+        '{\n'
+        '  "oneofInt32Value": 0'
+        '\n}')
+
   def testTimestampMessage(self):
     message = json_format_proto3_pb2.TestTimestamp()
     message.value.seconds = 0

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -66,7 +66,7 @@ class ParseError(Exception):
   """Thrown in case of parsing error."""
 
 
-def MessageToJson(message, including_default_value_fields=False):
+def MessageToJson(message, including_default_value_fields=False, indent=None):
   """Converts protobuf message to JSON format.
 
   Args:
@@ -80,7 +80,7 @@ def MessageToJson(message, including_default_value_fields=False):
     A string containing the JSON formatted protocol buffer message.
   """
   js = _MessageToJsonObject(message, including_default_value_fields)
-  return json.dumps(js, indent=2)
+  return json.dumps(js, indent=indent)
 
 
 def _MessageToJsonObject(message, including_default_value_fields):


### PR DESCRIPTION
I didn't keep the default of identing by 2 because I don't think its necessary.
