### PR TITLE
add warning notes for cc|py_proto_library rules.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -105,6 +105,10 @@ def cc_proto_library(
         **kargs):
   """Bazel rule to create a C++ protobuf library from proto source files
 
+  NOTE: the rule is only an internal workaround to generate protos. The
+  interface may change and the rule may be removed when bazel has introduced
+  the native rule.
+
   Args:
     name: the name of the cc_proto_library.
     srcs: the .proto files of the cc_proto_library.
@@ -206,6 +210,10 @@ def py_proto_library(
         protoc="//google/protobuf:protoc",
         **kargs):
   """Bazel rule to create a Python protobuf library from proto source files
+
+  NOTE: the rule is only an internal workaround to generate protos. The
+  interface may change and the rule may be removed when bazel has introduced
+  the native rule.
 
   Args:
     name: the name of the py_proto_library.


### PR DESCRIPTION
To mention that the interface may change or be removed when bazel has
support it natively.