### PR TITLE
Fix compilation errors when built internally.

### DIFF
--- a/src/google/protobuf/util/field_comparator_test.cc
+++ b/src/google/protobuf/util/field_comparator_test.cc
@@ -34,8 +34,9 @@
 
 #include <google/protobuf/unittest.pb.h>
 #include <google/protobuf/descriptor.h>
-#include <gtest/gtest.h>
 #include <google/protobuf/stubs/mathutil.h>
+
+#include <gtest/gtest.h>
 
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -602,7 +602,7 @@ void ProtoStreamObjectWriter::ProtoElement::TakeOneofIndex(int32 index) {
 
 bool ProtoStreamObjectWriter::ProtoElement::InsertMapKeyIfNotPresent(
     StringPiece map_key) {
-  return InsertIfNotPresent(&map_keys_, map_key);
+  return InsertIfNotPresent(&map_keys_, map_key.ToString());
 }
 
 inline void ProtoStreamObjectWriter::InvalidName(StringPiece unknown_name,

--- a/src/google/protobuf/util/internal/protostream_objectwriter.h
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.h
@@ -305,7 +305,7 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectWriter : public StructuredObjectWriter
 
     // Set of map keys already seen for the type_. Used to validate incoming
     // messages so no map key appears more than once.
-    hash_set<StringPiece> map_keys_;
+    hash_set<string> map_keys_;
 
     GOOGLE_DISALLOW_IMPLICIT_CONSTRUCTORS(ProtoElement);
   };


### PR DESCRIPTION
  1. mathlimits.h must be included before the inclusion of cmath (which
     gtest/gtest.h seems to include).
  2. hash function for StringPiece doesn't work.

@TeBoring to review