### PR TITLE
Build protoc for host platform to enable cross-compilation.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -81,6 +81,7 @@ _proto_gen = rule(
         "deps": attr.label_list(providers = ["proto"]),
         "includes": attr.string_list(),
         "protoc": attr.label(
+            cfg = HOST_CFG,
             executable = True,
             single_file = True,
             mandatory = True,


### PR DESCRIPTION
This is necessary to run protoc on the host as a dependency for Android BUILD targets with Bazel.