### PR TITLE
Created a new exception for JSON failures.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,6 +119,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/Google.Protobuf.nuspec                          \
   csharp/src/Google.Protobuf/IDeepCloneable.cs                               \
   csharp/src/Google.Protobuf/IMessage.cs                                     \
+  csharp/src/Google.Protobuf/InvalidJsonException.cs                         \
   csharp/src/Google.Protobuf/InvalidProtocolBufferException.cs               \
   csharp/src/Google.Protobuf/JsonFormatter.cs                                \
   csharp/src/Google.Protobuf/JsonParser.cs                                   \

--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -370,19 +370,19 @@ namespace Google.Protobuf
         }
 
         [Test]
-        [TestCase("+0")]
-        [TestCase("00")]
-        [TestCase("-00")]
-        [TestCase("--1")]
-        [TestCase("+1")]
-        [TestCase("1.5", Ignore = true, Reason = "Desired behaviour unclear")]
-        [TestCase("1e10")]
-        [TestCase("2147483648")]
-        [TestCase("-2147483649")]
-        public void NumberToInt32_Invalid(string jsonValue)
+        [TestCase("+0", typeof(InvalidJsonException))]
+        [TestCase("00", typeof(InvalidJsonException))]
+        [TestCase("-00", typeof(InvalidJsonException))]
+        [TestCase("--1", typeof(InvalidJsonException))]
+        [TestCase("+1", typeof(InvalidJsonException))]
+        [TestCase("1.5", typeof(InvalidProtocolBufferException), Ignore = true, Reason = "Desired behaviour unclear")]
+        [TestCase("1e10", typeof(InvalidProtocolBufferException))]
+        [TestCase("2147483648", typeof(InvalidProtocolBufferException))]
+        [TestCase("-2147483649", typeof(InvalidProtocolBufferException))]
+        public void NumberToInt32_Invalid(string jsonValue, System.Type expectedExceptionType)
         {
             string json = "{ \"singleInt32\": " + jsonValue + "}";
-            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+            Assert.Throws(expectedExceptionType, () => TestAllTypes.Parser.ParseJson(json));
         }
 
         [Test]
@@ -486,7 +486,7 @@ namespace Google.Protobuf
         public void NumberToDouble_Invalid(string jsonValue)
         {
             string json = "{ \"singleDouble\": " + jsonValue + "}";
-            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+            Assert.Throws<InvalidJsonException>(() => TestAllTypes.Parser.ParseJson(json));
         }
 
         [Test]
@@ -506,17 +506,17 @@ namespace Google.Protobuf
         }
 
         [Test]
-        [TestCase("3.402824e38")]
-        [TestCase("-3.402824e38")]
-        [TestCase("1,0")]
-        [TestCase("1.0.0")]
-        [TestCase("+1")]
-        [TestCase("00")]
-        [TestCase("--1")]
-        public void NumberToFloat_Invalid(string jsonValue)
+        [TestCase("3.402824e38", typeof(InvalidProtocolBufferException))]
+        [TestCase("-3.402824e38", typeof(InvalidProtocolBufferException))]
+        [TestCase("1,0", typeof(InvalidJsonException))]
+        [TestCase("1.0.0", typeof(InvalidJsonException))]
+        [TestCase("+1", typeof(InvalidJsonException))]
+        [TestCase("00", typeof(InvalidJsonException))]
+        [TestCase("--1", typeof(InvalidJsonException))]
+        public void NumberToFloat_Invalid(string jsonValue, System.Type expectedExceptionType)
         {
             string json = "{ \"singleFloat\": " + jsonValue + "}";
-            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+            Assert.Throws(expectedExceptionType, () => TestAllTypes.Parser.ParseJson(json));
         }
 
         // The simplest way of testing that the value has parsed correctly is to reformat it,
@@ -721,7 +721,7 @@ namespace Google.Protobuf
         public void DataAfterObject()
         {
             string json = "{} 10";
-            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+            Assert.Throws<InvalidJsonException>(() => TestAllTypes.Parser.ParseJson(json));
         }
     }
 }

--- a/csharp/src/Google.Protobuf.Test/JsonTokenizerTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonTokenizerTest.cs
@@ -223,7 +223,7 @@ namespace Google.Protobuf
             {
                 Assert.IsNotNull(tokenizer.Next());
             }
-            Assert.Throws<InvalidProtocolBufferException>(() => tokenizer.Next());
+            Assert.Throws<InvalidJsonException>(() => tokenizer.Next());
         }
 
         [Test]
@@ -346,7 +346,7 @@ namespace Google.Protobuf
                 }
                 Assert.AreEqual(expectedTokens[i], actualToken);
             }
-            Assert.Throws<InvalidProtocolBufferException>(() => tokenizer.Next());
+            Assert.Throws<InvalidJsonException>(() => tokenizer.Next());
         }
     }
 }

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -84,6 +84,7 @@
     <Compile Include="FieldCodec.cs" />
     <Compile Include="FrameworkPortability.cs" />
     <Compile Include="IDeepCloneable.cs" />
+    <Compile Include="InvalidJsonException.cs" />
     <Compile Include="JsonFormatter.cs" />
     <Compile Include="JsonParser.cs" />
     <Compile Include="JsonToken.cs" />

--- a/csharp/src/Google.Protobuf/InvalidJsonException.cs
+++ b/csharp/src/Google.Protobuf/InvalidJsonException.cs
@@ -1,0 +1,53 @@
+#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using System.IO;
+
+namespace Google.Protobuf
+{
+    /// <summary>
+    /// Thrown when an attempt is made to parse invalid JSON, e.g. using
+    /// a non-string property key, or including a redundant comma. Parsing a protocol buffer
+    /// message represented in JSON using <see cref="JsonParser"/> can throw both this
+    /// exception and <see cref="InvalidProtocolBufferException"/> depending on the situation. This
+    /// exception is only thrown for "pure JSON" errors, whereas <c>InvalidProtocolBufferException</c>
+    /// is thrown when the JSON may be valid in and of itself, but cannot be parsed as a protocol buffer
+    /// message.
+    /// </summary>
+    public sealed class InvalidJsonException : IOException
+    {
+        internal InvalidJsonException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -337,6 +337,8 @@ namespace Google.Protobuf
         /// </summary>
         /// <typeparam name="T">The type of message to create.</typeparam>
         /// <param name="json">The JSON to parse.</param>
+        /// <exception cref="InvalidJsonException">The JSON does not comply with RFC 7159</exception>
+        /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public T Parse<T>(string json) where T : IMessage, new()
         {
             return Parse<T>(new StringReader(json));
@@ -347,6 +349,8 @@ namespace Google.Protobuf
         /// </summary>
         /// <typeparam name="T">The type of message to create.</typeparam>
         /// <param name="jsonReader">Reader providing the JSON to parse.</param>
+        /// <exception cref="InvalidJsonException">The JSON does not comply with RFC 7159</exception>
+        /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public T Parse<T>(TextReader jsonReader) where T : IMessage, new()
         {
             T message = new T();

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -148,6 +148,8 @@ namespace Google.Protobuf
         /// </summary>
         /// <param name="json">The JSON to parse.</param>
         /// <returns>The parsed message.</returns>
+        /// <exception cref="InvalidJsonException">The JSON does not comply with RFC 7159</exception>
+        /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public T ParseJson(string json)
         {
             T message = factory();


### PR DESCRIPTION
This is only thrown directly by JsonTokenizer, but surfaces from JsonParser as well. I've added doc comments to hopefully make everything clear.

The exception is actually thrown by the reader within JsonTokenizer, in anticipation of keeping track of the location within the document, but that change is not within this PR.