### PR TITLE
Update the Mac build script to include the conformance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ conformance/conformance-cpp
 conformance/conformance-test-runner
 conformance/conformance.pb.cc
 conformance/conformance.pb.h
+conformance/conformance.rb
 conformance/protoc_middleman

--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -114,7 +114,7 @@ while [[ $# != 0 ]]; do
 done
 
 # Into the proto dir.
-pushd "${ProtoRootDir}"
+cd "${ProtoRootDir}"
 
 # if no Makefile, force the autogen.
 if [[ ! -f Makefile ]] ; then
@@ -160,6 +160,10 @@ header "Building"
 # at random.
 wrapped_make -j "${NUM_MAKE_JOBS}" all
 wrapped_make -j "${NUM_MAKE_JOBS}" check
+# Fire off the conformance tests also.
+cd conformance
+wrapped_make -j "${NUM_MAKE_JOBS}"
+cd ..
 
 header "Ensuring the ObjC descriptors are current."
 # Find the newest input file (protos, compiler, and the generator script).


### PR DESCRIPTION
- Kick off the conformance tests
- Add missing ignore for something generated by a build on the conformance directory.