### PR TITLE
include plugin.proto and generated code in protobuf-java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -92,6 +92,7 @@
                   <arg value="../src/google/protobuf/timestamp.proto" />
                   <arg value="../src/google/protobuf/type.proto" />
                   <arg value="../src/google/protobuf/wrappers.proto" />
+                  <arg value="../src/google/protobuf/compiler/plugin.proto" />
                 </exec>
               </tasks>
               <sourceRoot>target/generated-sources</sourceRoot>
@@ -186,6 +187,7 @@
           <include>google/protobuf/timestamp.proto</include>
           <include>google/protobuf/type.proto</include>
           <include>google/protobuf/wrappers.proto</include>
+          <include>google/protobuf/compiler/plugin.proto</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
@pherl @xfxyjwf: How about this as an alternative to #895?

This enables a separate project to provide the API in that other pull request, and access the necessary messages needed to implement the plugin protocol, by just linking to the main `protobuf-java` module.