### PR TITLE
javanano seems to be exporting wrong package

### DIFF
--- a/javanano/pom.xml
+++ b/javanano/pom.xml
@@ -164,8 +164,8 @@
         <configuration>
           <instructions>
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
-            <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
-            <Export-Package>com.google.protobuf;version=3.0.0-alpha-4</Export-Package>
+            <Bundle-SymbolicName>com.google.protobuf.nano</Bundle-SymbolicName>
+            <Export-Package>com.google.protobuf.nano;version=3.0.0-alpha-4</Export-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
javanano is configured to export package com.google.protobuf, but it probably should be com.google.protobuf.nano
