### PR TITLE
Add ObjC build to travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ language: cpp
 os:
   - linux
   - osx
+# The Objective C build needs Xcode 6.4 or later.
+osx_image: xcode7.1
 script:
   - ./travis.sh $CONFIG
 env:
@@ -46,11 +48,22 @@ matrix:
     # which doesn't work on OS X.
     - os: osx
       env: CONFIG=csharp
+  # Add into the matrix OS X tests of Objective C (needs Xcode, so it won't
+  # work on other platforms). These are split so it doesn't take as long to run.
+  include:
+    - os: osx
+      env: CONFIG=objectivec_ios
+    - os: osx
+      env: CONFIG=objectivec_osx
   allow_failures:
     # These currently do not work on OS X but are being worked on by @haberman.
     - os: osx
       env: CONFIG=ruby22
     - os: osx
       env: CONFIG=jruby
+    # Travis seems be flaky in letting the iOS simulator launch, so keep that
+    # flake from failing builds by marking that build as an allowed failure.
+    - os: osx
+      env: CONFIG=objectivec_ios
 notifications:
   email: false

--- a/travis.sh
+++ b/travis.sh
@@ -112,7 +112,12 @@ build_javanano_oracle7() {
 }
 
 internal_install_python_deps() {
-  sudo pip install tox
+  # Install tox (OS X doesn't have pip).
+  if [ $(uname -s) == "Darwin" ]; then
+    sudo easy_install tox
+  else
+    sudo pip install tox
+  fi
   # Only install Python2.6/3.x on Linux.
   if [ $(uname -s) == "Linux" ]; then
     sudo apt-get install -y python-software-properties # for apt-add-repository
@@ -124,6 +129,19 @@ internal_install_python_deps() {
   fi
 }
 
+build_objectivec_common () {
+  # Reused the build script that takes care of configure and then Xcode
+  # builds/tests.
+  objectivec/DevTools/full_mac_build.sh --core-only "$@"
+}
+
+build_objectivec_ios() {
+  build_objectivec_common --skip-xcode-osx
+}
+
+build_objectivec_osx() {
+  build_objectivec_common --skip-xcode-ios
+}
 
 build_python() {
   internal_build_cpp
@@ -189,6 +207,8 @@ Usage: $0 { cpp |
             javanano_jdk6 |
             javanano_jdk7 |
             javanano_oracle7 |
+            objectivec_ios |
+            objectivec_osx |
             python |
             python_cpp |
             ruby_19 |


### PR DESCRIPTION
- Add objc for iOS and OS X builds to travis configs.
- Update handing of python install to deal with newer OS X versions.