### PR TITLE
Adding visibility parameter to cc_proto_library.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -141,6 +141,7 @@ def cc_proto_library(
         deps=[s + "_genproto" for s in deps],
         includes=includes,
         protoc=protoc,
+        visibility=["//visibility:public"],
     )
     # An empty cc_library to make rule dependency consistent.
     native.cc_library(
@@ -157,6 +158,7 @@ def cc_proto_library(
       protoc=protoc,
       gen_cc=1,
       outs=outs,
+      visibility=["//visibility:public"],
   )
 
   if default_runtime and not default_runtime in cc_libs:
@@ -245,6 +247,7 @@ def py_proto_library(
       protoc=protoc,
       gen_py=1,
       outs=outs,
+      visibility=["//visibility:public"],
   )
 
   if include != None:


### PR DESCRIPTION
The visibility argument is passed in **kargs which is not propagated
into all nested build rules. Adding it explicitly allows for propagating
visibility into all nested rules.

Specifically, the rule depends on <dependency>_genproto for all its
dependencies and such the _genproto rules need to inherit visibility.