### PR TITLE
Fixed a bug in CSharp SampleUsage.

### DIFF
--- a/csharp/src/AddressBook/SampleUsage.cs
+++ b/csharp/src/AddressBook/SampleUsage.cs
@@ -57,7 +57,11 @@ namespace Google.Protobuf.Examples.AddressBook
             Person copy = Person.Parser.ParseFrom(bytes);
 
             // A more streamlined approach might look like this:
-            bytes = copy.ToByteArray();
+            AddressBook book = new AddressBook
+            {
+                People = { copy }
+            };
+            bytes = book.ToByteArray();
             // And read the address book back again
             AddressBook restored = AddressBook.Parser.ParseFrom(bytes);
             // The message performs a deep-comparison on equality:

--- a/csharp/src/AddressBook/SampleUsage.cs
+++ b/csharp/src/AddressBook/SampleUsage.cs
@@ -56,7 +56,6 @@ namespace Google.Protobuf.Examples.AddressBook
             }
             Person copy = Person.Parser.ParseFrom(bytes);
 
-            // A more streamlined approach might look like this:
             AddressBook book = new AddressBook
             {
                 People = { copy }


### PR DESCRIPTION
SampleUsage in CSharp had a bug: it used to create `AddressBook` from a person (from byte[] of a `Person`).
As a result the example also used to fail with `ApplicationException("There is a bad person in here!");`
