### PR TITLE
Set the stream limit to the length of the data.

### DIFF
--- a/conformance/failure_list_objc.txt
+++ b/conformance/failure_list_objc.txt
@@ -1,2 +1,1 @@
-ProtobufInput.PrematureEofInDelimitedDataForKnownNonRepeatedValue.MESSAGE
-ProtobufInput.PrematureEofInDelimitedDataForKnownRepeatedValue.MESSAGE
+# No tests currently failing.

--- a/objectivec/GPBCodedInputStream.m
+++ b/objectivec/GPBCodedInputStream.m
@@ -264,10 +264,6 @@ void GPBCodedInputStreamPopLimit(GPBCodedInputStreamState *state,
 }
 
 size_t GPBCodedInputStreamBytesUntilLimit(GPBCodedInputStreamState *state) {
-  if (state->currentLimit == SIZE_T_MAX) {
-    return state->currentLimit;
-  }
-
   return state->currentLimit - state->bufferPos;
 }
 
@@ -299,7 +295,7 @@ void GPBCodedInputStreamCheckLastTagWas(GPBCodedInputStreamState *state,
     buffer_ = [data retain];
     state_.bytes = (const uint8_t *)[data bytes];
     state_.bufferSize = [data length];
-    state_.currentLimit = NSUIntegerMax;
+    state_.currentLimit = state_.bufferSize;
   }
   return self;
 }


### PR DESCRIPTION
Also mark all conformance tests as now passing.