### PR TITLE
Fix minor typo in LazyField javadoc

### DIFF
--- a/java/src/main/java/com/google/protobuf/LazyField.java
+++ b/java/src/main/java/com/google/protobuf/LazyField.java
@@ -39,14 +39,14 @@ import java.util.Map.Entry;
  *
  * Most of key methods are implemented in {@link LazyFieldLite} but this class
  * can contain default instance of the message to provide {@code hashCode()},
- * {@code euqals()} and {@code toString()}.
+ * {@code equals()} and {@code toString()}.
  *
  * @author xiangl@google.com (Xiang Li)
  */
 public class LazyField extends LazyFieldLite {
 
   /**
-   * Carry a message's default instance which is used by {@code hashCode()}, {@code euqals()} and
+   * Carry a message's default instance which is used by {@code hashCode()}, {@code equals()} and
    * {@code toString()}.
    */
   private final MessageLite defaultInstance;


### PR DESCRIPTION
Noticed a typo in the generated documentation for Java LazyField.