### PR TITLE
Fix headers for gmock.BUILD

### DIFF
--- a/gmock.BUILD
+++ b/gmock.BUILD
@@ -4,6 +4,11 @@ cc_library(
         "gmock-1.7.0/gtest/src/gtest-all.cc",
         "gmock-1.7.0/src/gmock-all.cc",
     ],
+    hdrs = glob([
+        "gmock-1.7.0/**/*.h",
+        "gmock-1.7.0/gtest/src/*.cc",
+        "gmock-1.7.0/src/*.cc",
+    ]),
     includes = [
         "gmock-1.7.0",
         "gmock-1.7.0/gtest",


### PR DESCRIPTION
Bazel 0.1.2 fix strict header checks and sandboxing for C++
rules. This change add the necessary headers for gmock so
the headers get shipped in the sandbox.