### PR TITLE
Remove "see README" comment from example proto.

### DIFF
--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -1,5 +1,3 @@
-// See README.txt for information and build instructions.
-
 syntax = "proto3";
 
 package tutorial;


### PR DESCRIPTION
This comment is confusing when the code is embedded in documentation
pages, such as:
    https://developers.google.com/protocol-buffers/docs/csharptutorial
Currently this tutorial has copy-pasted this file, but that means it
will get out of sync if the example programs change.