### PR TITLE
Add region tags for protocol buffers tutorials.

### DIFF
--- a/examples/addressbook.proto
+++ b/examples/addressbook.proto
@@ -1,16 +1,29 @@
 // See README.txt for information and build instructions.
+//
+// Note: START and END tags are used in comments to define sections used in
+// tutorials.  They are not part of the syntax for Protocol Buffers.
+//
+// To get an in-depth walkthrough of this file and the related examples, see:
+// https://developers.google.com/protocol-buffers/docs/tutorials
 
+// [START declaration]
 syntax = "proto3";
-
 package tutorial;
+// [END declaration]
 
+// [START java_declaration]
 option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
-option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
+// [END java_declaration]
 
+// [START csharp_declaration]
+option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
+// [END csharp_declaration]
+
+// [START messages]
 message Person {
   string name = 1;
-  int32 id = 2;        // Unique ID number for this person.
+  int32 id = 2;  // Unique ID number for this person.
   string email = 3;
 
   enum PhoneType {
@@ -31,3 +44,4 @@ message Person {
 message AddressBook {
   repeated Person people = 1;
 }
+// [END messages]


### PR DESCRIPTION
Since these tags might be confusing, added a note that these are not
part of the normal protocol buffers syntax.  I also linked to the main
tutorials page that uses these examples
https://developers.google.com/protocol-buffers/docs/tutorials so that
anyone who arrived here without going through that info first can get
more explanation if they want.