### PR TITLE
Add srcs_version = "PY2AND3" in BUILD files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -512,6 +512,7 @@ internal_copied_filegroup(
 py_proto_library(
     name = "protobuf_python",
     srcs = WELL_KNOWN_PROTOS,
+    srcs_version = "PY2AND3",
     include = "src",
     protoc = ":protoc",
     py_extra_srcs = [":python_srcs"],
@@ -555,6 +556,7 @@ py_proto_library(
 py_library(
     name = "python_tests",
     srcs = [":python_test_srcs"],
+    srcs_version = "PY2AND3",
     deps = [
         ":protobuf_python",
         ":python_common_test_protos",

--- a/six.BUILD
+++ b/six.BUILD
@@ -8,5 +8,6 @@ genrule(
 py_library(
   name = "six",
   srcs = ["six.py"],
+  srcs_version = "PY2AND3",
   visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The sources themselves appear to already be Python 3 clean.

This was the only protobuf change required to get tensorflow working with Python 3.