### PR TITLE
Arena type traits standardization.

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -511,8 +511,7 @@ class LIBPROTOBUF_EXPORT Arena {
   struct is_arena_constructable :
       public google::protobuf::internal::integral_constant<bool,
           sizeof(InternalIsArenaConstructableHelper::ArenaConstructable<
-                 const T>(static_cast<const T*>(0))) ==
-          sizeof(char)> {
+                 const T>(static_cast<const T*>(0))) == sizeof(char)> {
   };
 
  private:
@@ -574,6 +573,7 @@ class LIBPROTOBUF_EXPORT Arena {
     return google::protobuf::internal::has_trivial_destructor<T>::value;
   }
 
+ private:
   struct InternalIsDestructorSkippableHelper {
     template<typename U>
     static char DestructorSkippable(
@@ -582,6 +582,7 @@ class LIBPROTOBUF_EXPORT Arena {
     static double DestructorSkippable(...);
   };
 
+ public:
   // Helper typetrait that indicates whether the desctructor of type T should be
   // called when arena is destroyed at compile time. This is only to allow
   // construction of higher-level templated utilities.
@@ -778,10 +779,10 @@ class LIBPROTOBUF_EXPORT Arena {
   // which needs to declare google::protobuf::Map as friend of generated message.
   template <typename T>
   static void CreateInArenaStorage(T* ptr, Arena* arena) {
-    CreateInArenaStorageInternal(
-        ptr, arena, typename is_arena_constructable<T>::type());
-    RegisterDestructorInternal(
-        ptr, arena, typename is_destructor_skippable<T>::type());
+    CreateInArenaStorageInternal(ptr, arena,
+                                 typename is_arena_constructable<T>::type());
+    RegisterDestructorInternal(ptr, arena,
+                               typename is_destructor_skippable<T>::type());
   }
 
   template <typename T>


### PR DESCRIPTION
This PR aims to address the incompatibility between arena.h and the NVCC compiler. NVidia has solved the bug for the latest compiler but earlier ones might still be affected by it. @xfxyjwf and I had a chat in September and he had a solution:

https://github.com/xfxyjwf/protobuf/commit/494716a682ef854168e92231a3cdcc89d587d9b9

but it seems to be not yet merged into the repo. Since it is blocking a side project I've been doing, I am wondering if we can have this merged - a few issues on github would be solved by this too: #787 #800 

Tested against nvcc 6.5 and 7.0.