### PR TITLE
Set limit of data size

### DIFF
--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1918,6 +1918,7 @@ static PyObject* MergeFromString(CMessage* self, PyObject* arg) {
   io::CodedInputStream input(
       reinterpret_cast<const uint8*>(data), data_length);
   PyDescriptorPool* pool = GetDescriptorPoolForMessage(self);
+  input.SetTotalBytesLimit(data_length, data_length);
   input.SetExtensionRegistry(pool->pool, pool->message_factory);
   bool success = self->message->MergePartialFromCodedStream(&input);
   if (success) {


### PR DESCRIPTION
C++ implementation of python cannot read large size of data because `total_bytes_limit_` is too small. And users cannot change this member variable as `CodedInputStream` object is a local variable.
I set the limit. With this patch I can read a large size of data.