### PR TITLE
Adding missing generic gcc 64-bit atomicops.

### DIFF
--- a/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+++ b/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
@@ -128,6 +128,24 @@ inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
   return old_value;
 }
 
+inline Atomic64 NoBarrier_AtomicIncrement(volatile Atomic64* ptr,
+                                          Atomic64 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_RELAXED);
+}
+
+inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_AtomicExchange(volatile Atomic64* ptr,
+                                         Atomic64 new_value) {
+  return __atomic_exchange_n(ptr, new_value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
 #endif // defined(__LP64__)
 
 }  // namespace internal


### PR DESCRIPTION
When building for 64-bit big endian MIPS I was getting undefined
references to the following four functions during linking.

NoBarrier_AtomicIncrement
NoBarrier_Store
NoBarrier_AtomicExchange
NoBarrier_Load

Adding 64-bit versions of them to atomicops_internals_generic_gcc.h
fixed the compilation issues.