### PR TITLE
Make nuget package support coreCLR

### DIFF
--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
     <id>Google.Protobuf</id>
     <title>Google Protocol Buffers C#</title>
     <summary>C# runtime library for Protocol Buffers - Google's data interchange format.</summary>
     <description>See project site for more info.</description>
-    <version>3.0.0-alpha4</version>
+    <version>3.0.0-beta2</version>
     <authors>Google Inc.</authors>
     <owners>protobuf-packages</owners>
     <licenseUrl>https://github.com/google/protobuf/blob/master/LICENSE</licenseUrl>
@@ -14,24 +14,43 @@
     <releaseNotes>C# proto3 support</releaseNotes>
     <copyright>Copyright 2015, Google Inc.</copyright>
     <tags>Protocol Buffers Binary Serialization Format Google proto proto3</tags>
+    <dependencies>
+      <group targetFramework="dotnet">
+        <dependency id="System.Collections" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.0" />
+        <dependency id="System.IO" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Linq.Expressions" version="4.0.0" />
+        <dependency id="System.ObjectModel" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.0.0" />
+        <dependency id="System.Runtime.Extensions" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.0" />
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="bin/ReleaseSigned/Google.Protobuf.dll" target="lib/portable-net45+netcore45+wpa81+wp8" />
-	<file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/portable-net45+netcore45+wpa81+wp8" />
-	<file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />
-	<file src="**\*.cs" target="src" />
-	<file src="..\..\..\cmake\Release\protoc.exe" target="tools" />
-	<file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\api.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\duration.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\empty.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\source_context.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\struct.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
-	<file src="..\..\..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/portable-net45+netcore45+wpa81+wp8" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.dll" target="lib/dotnet" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/dotnet" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/dotnet" />
+    <file src="**\*.cs" target="src" />
+    <file src="..\..\..\cmake\Release\protoc.exe" target="tools" />
+    <file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\api.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\duration.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\empty.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\source_context.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\struct.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
+    <file src="..\..\..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
   </files>
 </package>


### PR DESCRIPTION
See:
https://oren.codes/2015/07/29/targeting-net-core/
https://stackoverflow.com/questions/34136228/unable-to-resolve-assembly-reference-issue-without-frameworkassemblies

Also bumping nuget package version to beta2.