### PR TITLE
Fixed an issue where packageless protos would generate invalid java code (Fixes issue #891)

### DIFF
--- a/src/google/protobuf/compiler/java/java_shared_code_generator.cc
+++ b/src/google/protobuf/compiler/java/java_shared_code_generator.cc
@@ -1,4 +1,4 @@
-// Protocol Buffers - Google's data interchange format
+﻿// Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
 // https://developers.google.com/protocol-buffers/
 //
@@ -172,8 +172,7 @@ void SharedCodeGenerator::GenerateDescriptors(io::Printer* printer) {
       string classname = name_resolver_->GetDescriptorClassName(file_->dependency(i));
       if (package.empty()) {
         dependencies.push_back(std::make_pair(filename, classname));
-      }
-      else {
+      } else {
         dependencies.push_back(std::make_pair(filename, package + "." + classname));
       }
     }

--- a/src/google/protobuf/compiler/java/java_shared_code_generator.cc
+++ b/src/google/protobuf/compiler/java/java_shared_code_generator.cc
@@ -168,10 +168,14 @@ void SharedCodeGenerator::GenerateDescriptors(io::Printer* printer) {
   for (int i = 0; i < file_->dependency_count(); i++) {
     if (ShouldIncludeDependency(file_->dependency(i))) {
       string filename = file_->dependency(i)->name();
-      string classname = FileJavaPackage(file_->dependency(i)) + "." +
-                         name_resolver_->GetDescriptorClassName(
-                             file_->dependency(i));
-      dependencies.push_back(std::make_pair(filename, classname));
+      string package = FileJavaPackage(file_->dependency(i));
+      string classname = name_resolver_->GetDescriptorClassName(file_->dependency(i));
+      if (package.empty()) {
+        dependencies.push_back(std::make_pair(filename, classname));
+      }
+      else {
+        dependencies.push_back(std::make_pair(filename, package + "." + classname));
+      }
     }
   }
 


### PR DESCRIPTION
The old code always assuemd a dependency would also have a package. If this was not the case it would produce invalid java code in the form of

``` java
 .{dependency}.getDescriptor()
```

The new code checks if the dependency has a package and if not ommits the dot at the beginning
