### PR TITLE
Have the tests rely on the autocreator behaviors.

### DIFF
--- a/objectivec/Tests/GPBMessageTests+Merge.m
+++ b/objectivec/Tests/GPBMessageTests+Merge.m
@@ -675,14 +675,12 @@
 
   TestAllTypes *subMsg = [TestAllTypes message];
   subMsg.repeatedInt32Array = [GPBInt32Array arrayWithValue:100];
-  msg1.mapInt32Message = [GPBInt32ObjectDictionary dictionary];
   [msg1.mapInt32Message setObject:subMsg forKey:0];
   subMsg = nil;
 
   subMsg = [TestAllTypes message];
   subMsg.repeatedInt32Array = [GPBInt32Array arrayWithValue:101];
-  msg2.mapInt32Message = [GPBInt32ObjectDictionary dictionary];
-  
+
   [msg2.mapInt32Message setObject:subMsg forKey:0];
   subMsg = nil;
 

--- a/objectivec/Tests/GPBMessageTests+Runtime.m
+++ b/objectivec/Tests/GPBMessageTests+Runtime.m
@@ -2074,7 +2074,6 @@
 
   // Add an uninitialized message.
   TestRequired *subMsg = [[TestRequired alloc] init];
-  msg.mapField = [GPBInt32ObjectDictionary dictionary];
   [msg.mapField setObject:subMsg forKey:0];
   XCTAssertFalse(msg.initialized);
 

--- a/objectivec/Tests/GPBMessageTests.m
+++ b/objectivec/Tests/GPBMessageTests.m
@@ -55,7 +55,6 @@
   [message setOptionalInt32:1];
   [message setOptionalString:@"foo"];
   [message setOptionalForeignMessage:[ForeignMessage message]];
-  message.repeatedStringArray = [NSMutableArray array];
   [message.repeatedStringArray addObject:@"bar"];
   return message;
 }
@@ -67,7 +66,6 @@
   ForeignMessage *foreignMessage = [ForeignMessage message];
   [foreignMessage setC:3];
   [message setOptionalForeignMessage:foreignMessage];
-  message.repeatedStringArray = [NSMutableArray array];
   [message.repeatedStringArray addObject:@"qux"];
   return message;
 }
@@ -76,7 +74,6 @@
   TestAllTypes *message = [TestAllTypes message];
   [message setOptionalInt64:2];
   [message setOptionalString:@"baz"];
-  message.repeatedStringArray = [NSMutableArray array];
   [message.repeatedStringArray addObject:@"qux"];
   return message;
 }
@@ -89,7 +86,6 @@
   ForeignMessage *foreignMessage = [ForeignMessage message];
   [foreignMessage setC:3];
   [message setOptionalForeignMessage:foreignMessage];
-  message.repeatedStringArray = [NSMutableArray array];
   [message.repeatedStringArray addObject:@"qux"];
   [message.repeatedStringArray addObject:@"bar"];
   return message;
@@ -102,7 +98,6 @@
   [message setOptionalString:@"foo"];
   ForeignMessage *foreignMessage = [ForeignMessage message];
   [message setOptionalForeignMessage:foreignMessage];
-  message.repeatedStringArray = [NSMutableArray array];
   [message.repeatedStringArray addObject:@"qux"];
   [message.repeatedStringArray addObject:@"bar"];
   return message;
@@ -248,7 +243,6 @@
   [message setOptionalMessage:self.testRequiredInitialized];
   XCTAssertTrue(message.initialized);
 
-  message.repeatedMessageArray = [NSMutableArray array];
   [message.repeatedMessageArray addObject:[TestRequired message]];
   XCTAssertFalse(message.initialized);
 
@@ -300,7 +294,6 @@
 - (void)testDataFromNestedUninitialized {
   TestRequiredForeign *message = [TestRequiredForeign message];
   [message setOptionalMessage:[TestRequired message]];
-  message.repeatedMessageArray = [NSMutableArray array];
   [message.repeatedMessageArray addObject:[TestRequired message]];
   [message.repeatedMessageArray addObject:[TestRequired message]];
   NSData *data = [message data];
@@ -319,7 +312,6 @@
 
   TestRequiredForeign *message = [TestRequiredForeign message];
   [message setOptionalMessage:[TestRequired message]];
-  message.repeatedMessageArray = [NSMutableArray array];
   [message.repeatedMessageArray addObject:[TestRequired message]];
   [message.repeatedMessageArray addObject:[TestRequired message]];
 

--- a/objectivec/Tests/GPBWireFormatTests.m
+++ b/objectivec/Tests/GPBWireFormatTests.m
@@ -190,7 +190,6 @@ const int kUnknownTypeId = 1550055;
     TestMessageSetExtension1* message = [TestMessageSetExtension1 message];
     message.i = 123;
     item.message = [message data];
-    raw.itemArray = [NSMutableArray array];
     [raw.itemArray addObject:item];
   }
 


### PR DESCRIPTION
Incase developers look at the tests for examples, have them rely on the
autocreators also.