### PR TITLE
Fix conformance test to only report skips in verbose mode.

### DIFF
--- a/conformance/conformance_test.cc
+++ b/conformance/conformance_test.cc
@@ -1967,9 +1967,6 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
                 "These tests succeeded, even though they were listed in "
                 "the failure list.  Remove them from the failure list");
 
-  CheckSetEmpty(skipped_,
-                "These tests were skipped (probably because support for some "
-                "features is not implemented)");
   if (verbose_) {
     CheckSetEmpty(skipped_,
                   "These tests were skipped (probably because support for some "


### PR DESCRIPTION
commit e841bac4fcf47f809e089a70d5f84ac37b3883df seems to have mis-merged the
change to reporting skipped tests.

I didn't check if there were other merge issues.