### PR TITLE
Fix compiler warning from repeated_field.h

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -692,7 +692,7 @@ class LIBPROTOBUF_EXPORT StringTypeHandlerBase {
 class StringTypeHandler : public StringTypeHandlerBase {
  public:
   static int SpaceUsed(const string& value)  {
-    return sizeof(value) + StringSpaceUsedExcludingSelf(value);
+    return static_cast<int>(sizeof(value)) + StringSpaceUsedExcludingSelf(value);
   }
 };
 


### PR DESCRIPTION
StringTypeHandler::SpaceUsed implicitly casts a size_t to an int; g++ does not approve.
Fix by using static_cast to make the cast explicit.