### PR TITLE
Avoid upcasting uninitialized pointers

### DIFF
--- a/src/google/protobuf/stubs/statusor.h
+++ b/src/google/protobuf/stubs/statusor.h
@@ -224,14 +224,14 @@ inline StatusOr<T>& StatusOr<T>::operator=(const StatusOr<T>& other) {
 template<typename T>
 template<typename U>
 inline StatusOr<T>::StatusOr(const StatusOr<U>& other)
-    : status_(other.status_), value_(other.value_) {
+    : status_(other.status_), value_(other.status_.ok() ? other.value_ : NULL) {
 }
 
 template<typename T>
 template<typename U>
 inline StatusOr<T>& StatusOr<T>::operator=(const StatusOr<U>& other) {
   status_ = other.status_;
-  value_ = other.value_;
+  if (status_.ok()) value_ = other.value_;
   return *this;
 }
 


### PR DESCRIPTION
Fixes google/protobuf#693

msan flags this as being undefined behavior. I think it's triggering
because the compiler has to insert a branch to avoid changing the
pointer's value if it starts out NULL. I can't figure out if this is
actually undefined behavior or not, but it definitely seems to be a gray
area of the standard which is best avoided.