### PR TITLE
Manually down-integrate python JSON struct support from internal code base.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ python/.eggs/
 python/.tox
 python/build/
 python/google/protobuf/compiler/
+python/google/protobuf/util/
 
 src/protoc
 src/unittest_proto_middleman


### PR DESCRIPTION
**NOTE:** Includes some manual reverts from the internal code base to avoid interfering with more recent GitHub commits.

Ignores new generated subdirectory: `python/google/protobuf/util/`