### PR TITLE
Rename Preconditions to ProtoPreconditions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,7 +133,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/LimitedInputStream.cs                           \
   csharp/src/Google.Protobuf/MessageExtensions.cs                            \
   csharp/src/Google.Protobuf/MessageParser.cs                                \
-  csharp/src/Google.Protobuf/Preconditions.cs                                \
+  csharp/src/Google.Protobuf/ProtoPreconditions.cs                           \
   csharp/src/Google.Protobuf/Properties/AssemblyInfo.cs                      \
   csharp/src/Google.Protobuf/Reflection/Descriptor.cs                        \
   csharp/src/Google.Protobuf/Reflection/DescriptorBase.cs                    \

--- a/csharp/src/AddressBook/Addressbook.cs
+++ b/csharp/src/AddressBook/Addressbook.cs
@@ -82,7 +82,7 @@ namespace Google.Protobuf.Examples.AddressBook {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -105,7 +105,7 @@ namespace Google.Protobuf.Examples.AddressBook {
     public string Email {
       get { return email_; }
       set {
-        email_ = pb::Preconditions.CheckNotNull(value, "value");
+        email_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -267,7 +267,7 @@ namespace Google.Protobuf.Examples.AddressBook {
         public string Number {
           get { return number_; }
           set {
-            number_ = pb::Preconditions.CheckNotNull(value, "value");
+            number_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -261,7 +261,7 @@ namespace Conformance {
     public pb::ByteString ProtobufPayload {
       get { return payloadCase_ == PayloadOneofCase.ProtobufPayload ? (pb::ByteString) payload_ : pb::ByteString.Empty; }
       set {
-        payload_ = pb::Preconditions.CheckNotNull(value, "value");
+        payload_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         payloadCase_ = PayloadOneofCase.ProtobufPayload;
       }
     }
@@ -271,7 +271,7 @@ namespace Conformance {
     public string JsonPayload {
       get { return payloadCase_ == PayloadOneofCase.JsonPayload ? (string) payload_ : ""; }
       set {
-        payload_ = pb::Preconditions.CheckNotNull(value, "value");
+        payload_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         payloadCase_ = PayloadOneofCase.JsonPayload;
       }
     }
@@ -471,7 +471,7 @@ namespace Conformance {
     public string ParseError {
       get { return resultCase_ == ResultOneofCase.ParseError ? (string) result_ : ""; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.ParseError;
       }
     }
@@ -486,7 +486,7 @@ namespace Conformance {
     public string SerializeError {
       get { return resultCase_ == ResultOneofCase.SerializeError ? (string) result_ : ""; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.SerializeError;
       }
     }
@@ -501,7 +501,7 @@ namespace Conformance {
     public string RuntimeError {
       get { return resultCase_ == ResultOneofCase.RuntimeError ? (string) result_ : ""; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.RuntimeError;
       }
     }
@@ -515,7 +515,7 @@ namespace Conformance {
     public pb::ByteString ProtobufPayload {
       get { return resultCase_ == ResultOneofCase.ProtobufPayload ? (pb::ByteString) result_ : pb::ByteString.Empty; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.ProtobufPayload;
       }
     }
@@ -529,7 +529,7 @@ namespace Conformance {
     public string JsonPayload {
       get { return resultCase_ == ResultOneofCase.JsonPayload ? (string) result_ : ""; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.JsonPayload;
       }
     }
@@ -543,7 +543,7 @@ namespace Conformance {
     public string Skipped {
       get { return resultCase_ == ResultOneofCase.Skipped ? (string) result_ : ""; }
       set {
-        result_ = pb::Preconditions.CheckNotNull(value, "value");
+        result_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         resultCase_ = ResultOneofCase.Skipped;
       }
     }
@@ -1008,7 +1008,7 @@ namespace Conformance {
     public string OptionalString {
       get { return optionalString_; }
       set {
-        optionalString_ = pb::Preconditions.CheckNotNull(value, "value");
+        optionalString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1018,7 +1018,7 @@ namespace Conformance {
     public pb::ByteString OptionalBytes {
       get { return optionalBytes_; }
       set {
-        optionalBytes_ = pb::Preconditions.CheckNotNull(value, "value");
+        optionalBytes_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1068,7 +1068,7 @@ namespace Conformance {
     public string OptionalStringPiece {
       get { return optionalStringPiece_; }
       set {
-        optionalStringPiece_ = pb::Preconditions.CheckNotNull(value, "value");
+        optionalStringPiece_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1078,7 +1078,7 @@ namespace Conformance {
     public string OptionalCord {
       get { return optionalCord_; }
       set {
-        optionalCord_ = pb::Preconditions.CheckNotNull(value, "value");
+        optionalCord_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1483,7 +1483,7 @@ namespace Conformance {
     public string OneofString {
       get { return oneofFieldCase_ == OneofFieldOneofCase.OneofString ? (string) oneofField_ : ""; }
       set {
-        oneofField_ = pb::Preconditions.CheckNotNull(value, "value");
+        oneofField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         oneofFieldCase_ = OneofFieldOneofCase.OneofString;
       }
     }
@@ -1493,7 +1493,7 @@ namespace Conformance {
     public pb::ByteString OneofBytes {
       get { return oneofFieldCase_ == OneofFieldOneofCase.OneofBytes ? (pb::ByteString) oneofField_ : pb::ByteString.Empty; }
       set {
-        oneofField_ = pb::Preconditions.CheckNotNull(value, "value");
+        oneofField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         oneofFieldCase_ = OneofFieldOneofCase.OneofBytes;
       }
     }

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
@@ -1164,7 +1164,7 @@ namespace UnitTest.Issues.TestProtos {
     public string O1String {
       get { return o1Case_ == O1OneofCase.O1String ? (string) o1_ : ""; }
       set {
-        o1_ = pb::Preconditions.CheckNotNull(value, "value");
+        o1_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         o1Case_ = O1OneofCase.O1String;
       }
     }
@@ -1185,7 +1185,7 @@ namespace UnitTest.Issues.TestProtos {
     public string PlainString {
       get { return plainString_; }
       set {
-        plainString_ = pb::Preconditions.CheckNotNull(value, "value");
+        plainString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1204,7 +1204,7 @@ namespace UnitTest.Issues.TestProtos {
     public string O2String {
       get { return o2Case_ == O2OneofCase.O2String ? (string) o2_ : ""; }
       set {
-        o2_ = pb::Preconditions.CheckNotNull(value, "value");
+        o2_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         o2Case_ = O2OneofCase.O2String;
       }
     }

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
@@ -459,7 +459,7 @@ namespace Google.Protobuf.TestProtos {
     public string SingleString {
       get { return singleString_; }
       set {
-        singleString_ = pb::Preconditions.CheckNotNull(value, "value");
+        singleString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -469,7 +469,7 @@ namespace Google.Protobuf.TestProtos {
     public pb::ByteString SingleBytes {
       get { return singleBytes_; }
       set {
-        singleBytes_ = pb::Preconditions.CheckNotNull(value, "value");
+        singleBytes_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -775,7 +775,7 @@ namespace Google.Protobuf.TestProtos {
     public string OneofString {
       get { return oneofFieldCase_ == OneofFieldOneofCase.OneofString ? (string) oneofField_ : ""; }
       set {
-        oneofField_ = pb::Preconditions.CheckNotNull(value, "value");
+        oneofField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         oneofFieldCase_ = OneofFieldOneofCase.OneofString;
       }
     }
@@ -785,7 +785,7 @@ namespace Google.Protobuf.TestProtos {
     public pb::ByteString OneofBytes {
       get { return oneofFieldCase_ == OneofFieldOneofCase.OneofBytes ? (pb::ByteString) oneofField_ : pb::ByteString.Empty; }
       set {
-        oneofField_ = pb::Preconditions.CheckNotNull(value, "value");
+        oneofField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         oneofFieldCase_ = OneofFieldOneofCase.OneofBytes;
       }
     }
@@ -2787,7 +2787,7 @@ namespace Google.Protobuf.TestProtos {
     public string StringField {
       get { return stringField_; }
       set {
-        stringField_ = pb::Preconditions.CheckNotNull(value, "value");
+        stringField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3045,7 +3045,7 @@ namespace Google.Protobuf.TestProtos {
     public string MyString {
       get { return myString_; }
       set {
-        myString_ = pb::Preconditions.CheckNotNull(value, "value");
+        myString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3480,7 +3480,7 @@ namespace Google.Protobuf.TestProtos {
     public string Data {
       get { return data_; }
       set {
-        data_ = pb::Preconditions.CheckNotNull(value, "value");
+        data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3678,7 +3678,7 @@ namespace Google.Protobuf.TestProtos {
     public pb::ByteString Data {
       get { return data_; }
       set {
-        data_ = pb::Preconditions.CheckNotNull(value, "value");
+        data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3781,7 +3781,7 @@ namespace Google.Protobuf.TestProtos {
     public pb::ByteString Data {
       get { return data_; }
       set {
-        data_ = pb::Preconditions.CheckNotNull(value, "value");
+        data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -4425,7 +4425,7 @@ namespace Google.Protobuf.TestProtos {
     public string FooString {
       get { return fooCase_ == FooOneofCase.FooString ? (string) foo_ : ""; }
       set {
-        foo_ = pb::Preconditions.CheckNotNull(value, "value");
+        foo_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         fooCase_ = FooOneofCase.FooString;
       }
     }
@@ -5528,7 +5528,7 @@ namespace Google.Protobuf.TestProtos {
     public string A {
       get { return a_; }
       set {
-        a_ = pb::Preconditions.CheckNotNull(value, "value");
+        a_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -115,7 +115,7 @@ namespace Google.Protobuf
         /// <summary>
         /// Creates a new CodedInputStream reading data from the given byte array.
         /// </summary>
-        public CodedInputStream(byte[] buffer) : this(null, Preconditions.CheckNotNull(buffer, "buffer"), 0, buffer.Length)
+        public CodedInputStream(byte[] buffer) : this(null, ProtoPreconditions.CheckNotNull(buffer, "buffer"), 0, buffer.Length)
         {            
         }
 
@@ -123,7 +123,7 @@ namespace Google.Protobuf
         /// Creates a new CodedInputStream that reads from the given byte array slice.
         /// </summary>
         public CodedInputStream(byte[] buffer, int offset, int length)
-            : this(null, Preconditions.CheckNotNull(buffer, "buffer"), offset, offset + length)
+            : this(null, ProtoPreconditions.CheckNotNull(buffer, "buffer"), offset, offset + length)
         {            
             if (offset < 0 || offset > buffer.Length)
             {
@@ -140,7 +140,7 @@ namespace Google.Protobuf
         /// </summary>
         public CodedInputStream(Stream input) : this(input, new byte[BufferSize], 0, 0)
         {
-            Preconditions.CheckNotNull(input, "input");
+            ProtoPreconditions.CheckNotNull(input, "input");
         }
 
         /// <summary>

--- a/csharp/src/Google.Protobuf/Collections/MapField.cs
+++ b/csharp/src/Google.Protobuf/Collections/MapField.cs
@@ -123,7 +123,7 @@ namespace Google.Protobuf.Collections
         /// <returns><c>true</c> if the map contains the given key; <c>false</c> otherwise.</returns>
         public bool ContainsKey(TKey key)
         {
-            Preconditions.CheckNotNullUnconstrained(key, "key");
+            ProtoPreconditions.CheckNotNullUnconstrained(key, "key");
             return map.ContainsKey(key);
         }
 
@@ -140,7 +140,7 @@ namespace Google.Protobuf.Collections
         /// <returns><c>true</c> if the map contained the given key before the entry was removed; <c>false</c> otherwise.</returns>
         public bool Remove(TKey key)
         {
-            Preconditions.CheckNotNullUnconstrained(key, "key");
+            ProtoPreconditions.CheckNotNullUnconstrained(key, "key");
             LinkedListNode<KeyValuePair<TKey, TValue>> node;
             if (map.TryGetValue(key, out node))
             {
@@ -188,7 +188,7 @@ namespace Google.Protobuf.Collections
         {
             get
             {
-                Preconditions.CheckNotNullUnconstrained(key, "key");
+                ProtoPreconditions.CheckNotNullUnconstrained(key, "key");
                 TValue value;
                 if (TryGetValue(key, out value))
                 {
@@ -198,11 +198,11 @@ namespace Google.Protobuf.Collections
             }
             set
             {
-                Preconditions.CheckNotNullUnconstrained(key, "key");
+                ProtoPreconditions.CheckNotNullUnconstrained(key, "key");
                 // value == null check here is redundant, but avoids boxing.
                 if (value == null)
                 {
-                    Preconditions.CheckNotNullUnconstrained(value, "value");
+                    ProtoPreconditions.CheckNotNullUnconstrained(value, "value");
                 }
                 LinkedListNode<KeyValuePair<TKey, TValue>> node;
                 var pair = new KeyValuePair<TKey, TValue>(key, value);
@@ -234,7 +234,7 @@ namespace Google.Protobuf.Collections
         /// <param name="entries">The entries to add to the map.</param>
         public void Add(IDictionary<TKey, TValue> entries)
         {
-            Preconditions.CheckNotNull(entries, "entries");
+            ProtoPreconditions.CheckNotNull(entries, "entries");
             foreach (var pair in entries)
             {
                 Add(pair.Key, pair.Value);
@@ -501,7 +501,7 @@ namespace Google.Protobuf.Collections
 
         void IDictionary.Remove(object key)
         {
-            Preconditions.CheckNotNull(key, "key");
+            ProtoPreconditions.CheckNotNull(key, "key");
             if (!(key is TKey))
             {
                 return;
@@ -530,7 +530,7 @@ namespace Google.Protobuf.Collections
         {
             get
             {
-                Preconditions.CheckNotNull(key, "key");
+                ProtoPreconditions.CheckNotNull(key, "key");
                 if (!(key is TKey))
                 {
                     return null;

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -123,7 +123,7 @@
     <Compile Include="Reflection\RepeatedFieldAccessor.cs" />
     <Compile Include="Reflection\ServiceDescriptor.cs" />
     <Compile Include="Reflection\SingleFieldAccessor.cs" />
-    <Compile Include="Preconditions.cs" />
+    <Compile Include="ProtoPreconditions.cs" />
     <Compile Include="Reflection\TypeRegistry.cs" />
     <Compile Include="WellKnownTypes\Any.cs" />
     <Compile Include="WellKnownTypes\AnyPartial.cs" />

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -141,7 +141,7 @@ namespace Google.Protobuf
         /// <returns>The formatted message.</returns>
         public string Format(IMessage message)
         {
-            Preconditions.CheckNotNull(message, nameof(message));
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
             StringBuilder builder = new StringBuilder();
             if (message.Descriptor.IsWellKnownType)
             {
@@ -173,7 +173,7 @@ namespace Google.Protobuf
         /// <returns>The diagnostic-only JSON representation of the message</returns>
         public static string ToDiagnosticString(IMessage message)
         {
-            Preconditions.CheckNotNull(message, nameof(message));
+            ProtoPreconditions.CheckNotNull(message, nameof(message));
             return diagnosticFormatter.Format(message);
         }
 
@@ -858,7 +858,7 @@ namespace Google.Protobuf
             public Settings(bool formatDefaultValues, TypeRegistry typeRegistry)
             {
                 FormatDefaultValues = formatDefaultValues;
-                TypeRegistry = Preconditions.CheckNotNull(typeRegistry, nameof(typeRegistry));
+                TypeRegistry = ProtoPreconditions.CheckNotNull(typeRegistry, nameof(typeRegistry));
             }
         }
     }

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -374,7 +374,7 @@ namespace Google.Protobuf
         /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public T Parse<T>(string json) where T : IMessage, new()
         {
-            Preconditions.CheckNotNull(json, nameof(json));
+            ProtoPreconditions.CheckNotNull(json, nameof(json));
             return Parse<T>(new StringReader(json));
         }
 
@@ -387,7 +387,7 @@ namespace Google.Protobuf
         /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public T Parse<T>(TextReader jsonReader) where T : IMessage, new()
         {
-            Preconditions.CheckNotNull(jsonReader, nameof(jsonReader));
+            ProtoPreconditions.CheckNotNull(jsonReader, nameof(jsonReader));
             T message = new T();
             Merge(message, jsonReader);
             return message;
@@ -402,8 +402,8 @@ namespace Google.Protobuf
         /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public IMessage Parse(string json, MessageDescriptor descriptor)
         {
-            Preconditions.CheckNotNull(json, nameof(json));
-            Preconditions.CheckNotNull(descriptor, nameof(descriptor));
+            ProtoPreconditions.CheckNotNull(json, nameof(json));
+            ProtoPreconditions.CheckNotNull(descriptor, nameof(descriptor));
             return Parse(new StringReader(json), descriptor);
         }
 
@@ -416,8 +416,8 @@ namespace Google.Protobuf
         /// <exception cref="InvalidProtocolBufferException">The JSON does not represent a Protocol Buffers message correctly</exception>
         public IMessage Parse(TextReader jsonReader, MessageDescriptor descriptor)
         {
-            Preconditions.CheckNotNull(jsonReader, nameof(jsonReader));
-            Preconditions.CheckNotNull(descriptor, nameof(descriptor));
+            ProtoPreconditions.CheckNotNull(jsonReader, nameof(jsonReader));
+            ProtoPreconditions.CheckNotNull(descriptor, nameof(descriptor));
             IMessage message = descriptor.Parser.CreateTemplate();
             Merge(message, jsonReader);
             return message;
@@ -1011,7 +1011,7 @@ namespace Google.Protobuf
             public Settings(int recursionLimit, TypeRegistry typeRegistry)
             {
                 RecursionLimit = recursionLimit;
-                TypeRegistry = Preconditions.CheckNotNull(typeRegistry, nameof(typeRegistry));
+                TypeRegistry = ProtoPreconditions.CheckNotNull(typeRegistry, nameof(typeRegistry));
             }
         }
     }

--- a/csharp/src/Google.Protobuf/MessageExtensions.cs
+++ b/csharp/src/Google.Protobuf/MessageExtensions.cs
@@ -46,8 +46,8 @@ namespace Google.Protobuf
         /// <param name="data">The data to merge, which must be protobuf-encoded binary data.</param>
         public static void MergeFrom(this IMessage message, byte[] data)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(data, "data");
             CodedInputStream input = new CodedInputStream(data);
             message.MergeFrom(input);
             input.CheckReadEndOfStreamTag();
@@ -60,8 +60,8 @@ namespace Google.Protobuf
         /// <param name="data">The data to merge, which must be protobuf-encoded binary data.</param>
         public static void MergeFrom(this IMessage message, ByteString data)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(data, "data");
             CodedInputStream input = data.CreateCodedInput();
             message.MergeFrom(input);
             input.CheckReadEndOfStreamTag();
@@ -74,8 +74,8 @@ namespace Google.Protobuf
         /// <param name="input">Stream containing the data to merge, which must be protobuf-encoded binary data.</param>
         public static void MergeFrom(this IMessage message, Stream input)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(input, "input");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(input, "input");
             CodedInputStream codedInput = new CodedInputStream(input);
             message.MergeFrom(codedInput);
             codedInput.CheckReadEndOfStreamTag();
@@ -92,8 +92,8 @@ namespace Google.Protobuf
         /// <param name="input">Stream containing the data to merge, which must be protobuf-encoded binary data.</param>
         public static void MergeDelimitedFrom(this IMessage message, Stream input)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(input, "input");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(input, "input");
             int size = (int) CodedInputStream.ReadRawVarint32(input);
             Stream limitedStream = new LimitedInputStream(input, size);
             message.MergeFrom(limitedStream);
@@ -106,7 +106,7 @@ namespace Google.Protobuf
         /// <returns>The message data as a byte array.</returns>
         public static byte[] ToByteArray(this IMessage message)
         {
-            Preconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(message, "message");
             byte[] result = new byte[message.CalculateSize()];
             CodedOutputStream output = new CodedOutputStream(result);
             message.WriteTo(output);
@@ -121,8 +121,8 @@ namespace Google.Protobuf
         /// <param name="output">The stream to write to.</param>
         public static void WriteTo(this IMessage message, Stream output)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(output, "output");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(output, "output");
             CodedOutputStream codedOutput = new CodedOutputStream(output);
             message.WriteTo(codedOutput);
             codedOutput.Flush();
@@ -135,8 +135,8 @@ namespace Google.Protobuf
         /// <param name="output">The output stream to write to.</param>
         public static void WriteDelimitedTo(this IMessage message, Stream output)
         {
-            Preconditions.CheckNotNull(message, "message");
-            Preconditions.CheckNotNull(output, "output");
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(output, "output");
             CodedOutputStream codedOutput = new CodedOutputStream(output);
             codedOutput.WriteRawVarint32((uint)message.CalculateSize());
             message.WriteTo(codedOutput);
@@ -150,7 +150,7 @@ namespace Google.Protobuf
         /// <returns>The message data as a byte string.</returns>
         public static ByteString ToByteString(this IMessage message)
         {
-            Preconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(message, "message");
             return ByteString.AttachBytes(message.ToByteArray());
         }        
     }

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -64,7 +64,7 @@ namespace Google.Protobuf
         /// <returns>The newly parsed message.</returns>
         public IMessage ParseFrom(byte[] data)
         {
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(data, "data");
             IMessage message = factory();
             message.MergeFrom(data);
             return message;
@@ -77,7 +77,7 @@ namespace Google.Protobuf
         /// <returns>The parsed message.</returns>
         public IMessage ParseFrom(ByteString data)
         {
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(data, "data");
             IMessage message = factory();
             message.MergeFrom(data);
             return message;
@@ -191,7 +191,7 @@ namespace Google.Protobuf
         /// <returns>The newly parsed message.</returns>
         public new T ParseFrom(byte[] data)
         {
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(data, "data");
             T message = factory();
             message.MergeFrom(data);
             return message;
@@ -204,7 +204,7 @@ namespace Google.Protobuf
         /// <returns>The parsed message.</returns>
         public new T ParseFrom(ByteString data)
         {
-            Preconditions.CheckNotNull(data, "data");
+            ProtoPreconditions.CheckNotNull(data, "data");
             T message = factory();
             message.MergeFrom(data);
             return message;

--- a/csharp/src/Google.Protobuf/ProtoPreconditions.cs
+++ b/csharp/src/Google.Protobuf/ProtoPreconditions.cs
@@ -35,9 +35,14 @@ using System;
 namespace Google.Protobuf
 {
     /// <summary>
-    /// Helper methods for throwing exceptions
+    /// Helper methods for throwing exceptions when preconditions are not met.
     /// </summary>
-    public static class Preconditions
+    /// <remarks>
+    /// This class is used internally and by generated code; it is not particularly
+    /// expected to be used from application code, although nothing prevents it
+    /// from being used that way.
+    /// </remarks>
+    public static class ProtoPreconditions
     {
         /// <summary>
         /// Throws an ArgumentNullException if the given value is null, otherwise

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -317,7 +317,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -330,7 +330,7 @@ namespace Google.Protobuf.Reflection {
     public string Package {
       get { return package_; }
       set {
-        package_ = pb::Preconditions.CheckNotNull(value, "value");
+        package_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -446,7 +446,7 @@ namespace Google.Protobuf.Reflection {
     public string Syntax {
       get { return syntax_; }
       set {
-        syntax_ = pb::Preconditions.CheckNotNull(value, "value");
+        syntax_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -702,7 +702,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1275,7 +1275,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1326,7 +1326,7 @@ namespace Google.Protobuf.Reflection {
     public string TypeName {
       get { return typeName_; }
       set {
-        typeName_ = pb::Preconditions.CheckNotNull(value, "value");
+        typeName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1340,7 +1340,7 @@ namespace Google.Protobuf.Reflection {
     public string Extendee {
       get { return extendee_; }
       set {
-        extendee_ = pb::Preconditions.CheckNotNull(value, "value");
+        extendee_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1357,7 +1357,7 @@ namespace Google.Protobuf.Reflection {
     public string DefaultValue {
       get { return defaultValue_; }
       set {
-        defaultValue_ = pb::Preconditions.CheckNotNull(value, "value");
+        defaultValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1387,7 +1387,7 @@ namespace Google.Protobuf.Reflection {
     public string JsonName {
       get { return jsonName_; }
       set {
-        jsonName_ = pb::Preconditions.CheckNotNull(value, "value");
+        jsonName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1720,7 +1720,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1828,7 +1828,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1986,7 +1986,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2152,7 +2152,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2313,7 +2313,7 @@ namespace Google.Protobuf.Reflection {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2327,7 +2327,7 @@ namespace Google.Protobuf.Reflection {
     public string InputType {
       get { return inputType_; }
       set {
-        inputType_ = pb::Preconditions.CheckNotNull(value, "value");
+        inputType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2337,7 +2337,7 @@ namespace Google.Protobuf.Reflection {
     public string OutputType {
       get { return outputType_; }
       set {
-        outputType_ = pb::Preconditions.CheckNotNull(value, "value");
+        outputType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2583,7 +2583,7 @@ namespace Google.Protobuf.Reflection {
     public string JavaPackage {
       get { return javaPackage_; }
       set {
-        javaPackage_ = pb::Preconditions.CheckNotNull(value, "value");
+        javaPackage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2600,7 +2600,7 @@ namespace Google.Protobuf.Reflection {
     public string JavaOuterClassname {
       get { return javaOuterClassname_; }
       set {
-        javaOuterClassname_ = pb::Preconditions.CheckNotNull(value, "value");
+        javaOuterClassname_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2687,7 +2687,7 @@ namespace Google.Protobuf.Reflection {
     public string GoPackage {
       get { return goPackage_; }
       set {
-        goPackage_ = pb::Preconditions.CheckNotNull(value, "value");
+        goPackage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2773,7 +2773,7 @@ namespace Google.Protobuf.Reflection {
     public string ObjcClassPrefix {
       get { return objcClassPrefix_; }
       set {
-        objcClassPrefix_ = pb::Preconditions.CheckNotNull(value, "value");
+        objcClassPrefix_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2786,7 +2786,7 @@ namespace Google.Protobuf.Reflection {
     public string CsharpNamespace {
       get { return csharpNamespace_; }
       set {
-        csharpNamespace_ = pb::Preconditions.CheckNotNull(value, "value");
+        csharpNamespace_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -4369,7 +4369,7 @@ namespace Google.Protobuf.Reflection {
     public string IdentifierValue {
       get { return identifierValue_; }
       set {
-        identifierValue_ = pb::Preconditions.CheckNotNull(value, "value");
+        identifierValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -4409,7 +4409,7 @@ namespace Google.Protobuf.Reflection {
     public pb::ByteString StringValue {
       get { return stringValue_; }
       set {
-        stringValue_ = pb::Preconditions.CheckNotNull(value, "value");
+        stringValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -4419,7 +4419,7 @@ namespace Google.Protobuf.Reflection {
     public string AggregateValue {
       get { return aggregateValue_; }
       set {
-        aggregateValue_ = pb::Preconditions.CheckNotNull(value, "value");
+        aggregateValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -4621,7 +4621,7 @@ namespace Google.Protobuf.Reflection {
         public string NamePart_ {
           get { return namePart_; }
           set {
-            namePart_ = pb::Preconditions.CheckNotNull(value, "value");
+            namePart_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 
@@ -5004,7 +5004,7 @@ namespace Google.Protobuf.Reflection {
         public string LeadingComments {
           get { return leadingComments_; }
           set {
-            leadingComments_ = pb::Preconditions.CheckNotNull(value, "value");
+            leadingComments_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 
@@ -5014,7 +5014,7 @@ namespace Google.Protobuf.Reflection {
         public string TrailingComments {
           get { return trailingComments_; }
           set {
-            trailingComments_ = pb::Preconditions.CheckNotNull(value, "value");
+            trailingComments_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -5301,7 +5301,7 @@ namespace Google.Protobuf.Reflection {
         public string SourceFile {
           get { return sourceFile_; }
           set {
-            sourceFile_ = pb::Preconditions.CheckNotNull(value, "value");
+            sourceFile_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
           }
         }
 

--- a/csharp/src/Google.Protobuf/Reflection/TypeRegistry.cs
+++ b/csharp/src/Google.Protobuf/Reflection/TypeRegistry.cs
@@ -91,7 +91,7 @@ namespace Google.Protobuf.Reflection
         /// <returns>A type registry for the given files.</returns>
         public static TypeRegistry FromFiles(IEnumerable<FileDescriptor> fileDescriptors)
         {
-            Preconditions.CheckNotNull(fileDescriptors, nameof(fileDescriptors));
+            ProtoPreconditions.CheckNotNull(fileDescriptors, nameof(fileDescriptors));
             var builder = new Builder();
             foreach (var file in fileDescriptors)
             {
@@ -128,7 +128,7 @@ namespace Google.Protobuf.Reflection
         /// <returns>A type registry for the given files.</returns>
         public static TypeRegistry FromMessages(IEnumerable<MessageDescriptor> messageDescriptors)
         {
-            Preconditions.CheckNotNull(messageDescriptors, nameof(messageDescriptors));
+            ProtoPreconditions.CheckNotNull(messageDescriptors, nameof(messageDescriptors));
             return FromFiles(messageDescriptors.Select(md => md.File));
         }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
@@ -124,7 +124,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string TypeUrl {
       get { return typeUrl_; }
       set {
-        typeUrl_ = pb::Preconditions.CheckNotNull(value, "value");
+        typeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -137,7 +137,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public pb::ByteString Value {
       get { return value_; }
       set {
-        value_ = pb::Preconditions.CheckNotNull(value, "value");
+        value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/AnyPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/AnyPartial.cs
@@ -72,7 +72,7 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>An Any message with the content and type URL of <paramref name="message"/>.</returns>
         public static Any Pack(IMessage message)
         {
-            Preconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(message, "message");
             return new Any { TypeUrl = GetTypeUrl(message.Descriptor), Value = message.ToByteString() };
         }
     }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
@@ -97,7 +97,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -153,7 +153,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Version {
       get { return version_; }
       set {
-        version_ = pb::Preconditions.CheckNotNull(value, "value");
+        version_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -388,7 +388,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -401,7 +401,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string RequestTypeUrl {
       get { return requestTypeUrl_; }
       set {
-        requestTypeUrl_ = pb::Preconditions.CheckNotNull(value, "value");
+        requestTypeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -427,7 +427,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string ResponseTypeUrl {
       get { return responseTypeUrl_; }
       set {
-        responseTypeUrl_ = pb::Preconditions.CheckNotNull(value, "value");
+        responseTypeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -740,7 +740,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -754,7 +754,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Root {
       get { return root_; }
       set {
-        root_ = pb::Preconditions.CheckNotNull(value, "value");
+        root_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/DurationPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/DurationPartial.cs
@@ -118,7 +118,7 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>The negated value of this duration.</returns>
         public static Duration operator -(Duration value)
         {
-            Preconditions.CheckNotNull(value, "value");
+            ProtoPreconditions.CheckNotNull(value, "value");
             checked
             {
                 return Normalize(-value.Seconds, -value.Nanos);
@@ -133,8 +133,8 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns></returns>
         public static Duration operator +(Duration lhs, Duration rhs)
         {
-            Preconditions.CheckNotNull(lhs, "lhs");
-            Preconditions.CheckNotNull(rhs, "rhs");
+            ProtoPreconditions.CheckNotNull(lhs, "lhs");
+            ProtoPreconditions.CheckNotNull(rhs, "rhs");
             checked
             {
                 return Normalize(lhs.Seconds + rhs.Seconds, lhs.Nanos + rhs.Nanos);
@@ -149,8 +149,8 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>The difference between the two specified durations.</returns>
         public static Duration operator -(Duration lhs, Duration rhs)
         {
-            Preconditions.CheckNotNull(lhs, "lhs");
-            Preconditions.CheckNotNull(rhs, "rhs");
+            ProtoPreconditions.CheckNotNull(lhs, "lhs");
+            ProtoPreconditions.CheckNotNull(rhs, "rhs");
             checked
             {
                 return Normalize(lhs.Seconds - rhs.Seconds, lhs.Nanos - rhs.Nanos);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
@@ -79,7 +79,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string FileName {
       get { return fileName_; }
       set {
-        fileName_ = pb::Preconditions.CheckNotNull(value, "value");
+        fileName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
@@ -262,7 +262,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string StringValue {
       get { return kindCase_ == KindOneofCase.StringValue ? (string) kind_ : ""; }
       set {
-        kind_ = pb::Preconditions.CheckNotNull(value, "value");
+        kind_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         kindCase_ = KindOneofCase.StringValue;
       }
     }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/TimestampPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/TimestampPartial.cs
@@ -59,8 +59,8 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>The difference between the two specified timestamps.</returns>
         public static Duration operator -(Timestamp lhs, Timestamp rhs)
         {
-            Preconditions.CheckNotNull(lhs, "lhs");
-            Preconditions.CheckNotNull(rhs, "rhs");
+            ProtoPreconditions.CheckNotNull(lhs, "lhs");
+            ProtoPreconditions.CheckNotNull(rhs, "rhs");
             checked
             {
                 return Duration.Normalize(lhs.Seconds - rhs.Seconds, lhs.Nanos - rhs.Nanos);
@@ -75,8 +75,8 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>The result of adding the duration to the timestamp.</returns>
         public static Timestamp operator +(Timestamp lhs, Duration rhs)
         {
-            Preconditions.CheckNotNull(lhs, "lhs");
-            Preconditions.CheckNotNull(rhs, "rhs");
+            ProtoPreconditions.CheckNotNull(lhs, "lhs");
+            ProtoPreconditions.CheckNotNull(rhs, "rhs");
             checked
             {
                 return Normalize(lhs.Seconds + rhs.Seconds, lhs.Nanos + rhs.Nanos);
@@ -91,8 +91,8 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>The result of subtracting the duration from the timestamp.</returns>
         public static Timestamp operator -(Timestamp lhs, Duration rhs)
         {
-            Preconditions.CheckNotNull(lhs, "lhs");
-            Preconditions.CheckNotNull(rhs, "rhs");
+            ProtoPreconditions.CheckNotNull(lhs, "lhs");
+            ProtoPreconditions.CheckNotNull(rhs, "rhs");
             checked
             {
                 return Normalize(lhs.Seconds - rhs.Seconds, lhs.Nanos - rhs.Nanos);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
@@ -133,7 +133,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -417,7 +417,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -431,7 +431,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string TypeUrl {
       get { return typeUrl_; }
       set {
-        typeUrl_ = pb::Preconditions.CheckNotNull(value, "value");
+        typeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -483,7 +483,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string JsonName {
       get { return jsonName_; }
       set {
-        jsonName_ = pb::Preconditions.CheckNotNull(value, "value");
+        jsonName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -496,7 +496,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string DefaultValue {
       get { return defaultValue_; }
       set {
-        defaultValue_ = pb::Preconditions.CheckNotNull(value, "value");
+        defaultValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -857,7 +857,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1074,7 +1074,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -1235,7 +1235,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Name {
       get { return name_; }
       set {
-        name_ = pb::Preconditions.CheckNotNull(value, "value");
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/ValuePartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/ValuePartial.cs
@@ -41,7 +41,7 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>A newly-created Value message with the given value.</returns>
         public static Value ForString(string value)
         {
-            Preconditions.CheckNotNull(value, "value");
+            ProtoPreconditions.CheckNotNull(value, "value");
             return new Value { StringValue = value };
         }
 
@@ -81,7 +81,7 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>A newly-created Value message an initial list value.</returns>
         public static Value ForList(params Value[] values)
         {
-            Preconditions.CheckNotNull(values, "values");
+            ProtoPreconditions.CheckNotNull(values, "values");
             return new Value { ListValue = new ListValue { Values = { values } } };
         }
 
@@ -92,7 +92,7 @@ namespace Google.Protobuf.WellKnownTypes
         /// <returns>A newly-created Value message an initial struct value.</returns>
         public static Value ForStruct(Struct value)
         {
-            Preconditions.CheckNotNull(value, "value");
+            ProtoPreconditions.CheckNotNull(value, "value");
             return new Value { StructValue = value };
         }
     }

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
@@ -869,7 +869,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public string Value {
       get { return value_; }
       set {
-        value_ = pb::Preconditions.CheckNotNull(value, "value");
+        value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -980,7 +980,7 @@ namespace Google.Protobuf.WellKnownTypes {
     public pb::ByteString Value {
       get { return value_; }
       set {
-        value_ = pb::Preconditions.CheckNotNull(value, "value");
+        value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
@@ -83,7 +83,7 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer) {
   } else {
     printer->Print(
       variables_,
-      "    $name$_ = pb::Preconditions.CheckNotNull(value, \"value\");\n");
+      "    $name$_ = pb::ProtoPreconditions.CheckNotNull(value, \"value\");\n");
   }
   printer->Print(
     "  }\n"
@@ -186,7 +186,7 @@ void PrimitiveOneofFieldGenerator::GenerateMembers(io::Printer* printer) {
     } else {
       printer->Print(
         variables_,
-        "    $oneof_name$_ = pb::Preconditions.CheckNotNull(value, \"value\");\n");
+        "    $oneof_name$_ = pb::ProtoPreconditions.CheckNotNull(value, \"value\");\n");
     }
     printer->Print(
       variables_,


### PR DESCRIPTION
(This avoids a possible naming collision in the future, in a possible Google.Common project or similar.)

Only internal code and generated code is likely to be affected - we're not expecting clients to write code against this manually.