### PR TITLE
Remove const from AttachComments

### DIFF
--- a/src/google/protobuf/compiler/parser.cc
+++ b/src/google/protobuf/compiler/parser.cc
@@ -404,7 +404,7 @@ void Parser::LocationRecorder::RecordLegacyLocation(const Message* descriptor,
 
 void Parser::LocationRecorder::AttachComments(
     string* leading, string* trailing,
-    vector<string>* detached_comments) const {
+    vector<string>* detached_comments) {
   GOOGLE_CHECK(!location_->has_leading_comments());
   GOOGLE_CHECK(!location_->has_trailing_comments());
 


### PR DESCRIPTION
AttachComments transitively modifies the location_ field. The location_ pointed to is used in the class and represents modified state in a const method, which may cause surprising results to callers.
