### PR TITLE
Include 'source' attribute in the podspec

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -11,6 +11,9 @@ Pod::Spec.new do |s|
   s.license  = 'New BSD'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
+  s.source = { :git => 'https://github.com/google/protobuf.git',
+               :tag => "v#{s.version}" }
+
   s.source_files = 'objectivec/*.{h,m}',
                    'objectivec/google/protobuf/Any.pbobjc.{h,m}',
                    'objectivec/google/protobuf/Api.pbobjc.{h,m}',


### PR DESCRIPTION
The new version of Cocoapods requires it even when using the podspec locally.