### PR TITLE
Remove hack for building Python support with Bazel.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,6 @@ load(
     "protobuf",
     "cc_proto_library",
     "py_proto_library",
-    "internal_copied_filegroup",
     "internal_protobuf_py_tests",
 )
 
@@ -484,25 +483,7 @@ java_library(
 # Python support
 ################################################################################
 
-# Hack:
-# protoc generated files contain imports like:
-#   "from google.protobuf.xxx import yyy"
-# However, the sources files of the python runtime are not directly under
-# "google/protobuf" (they are under python/google/protobuf).  We workaround
-# this by copying runtime source files into the desired location to workaround
-# the import issue. Ideally py_library should support something similiar to the
-# "include" attribute in cc_library to inject the PYTHON_PATH for all libraries
-# that depend on the target.
-#
-# If you use python protobuf as a third_party library in your bazel managed
-# project:
-# 1) Please import the whole package to //google/protobuf in your
-# project. Otherwise, bazel disallows generated files out of the current
-# package, thus we won't be able to copy protobuf runtime files into
-# //google/protobuf/.
-# 2) The runtime also requires "six" for Python2/3 compatibility, please see the
-# WORKSPACE file and bind "six" to your workspace as well.
-internal_copied_filegroup(
+py_library(
     name = "python_srcs",
     srcs = glob(
         [
@@ -514,7 +495,7 @@ internal_copied_filegroup(
             "python/google/protobuf/internal/test_util.py",
         ],
     ),
-    include = "python",
+    imports = ["python"],
 )
 
 cc_binary(
@@ -527,7 +508,7 @@ cc_binary(
     linkstatic = 1,
     deps = select({
         "//conditions:default": [],
-        ":use_fast_cpp_protos": ["//util/python:python_headers"],
+        ":use_fast_cpp_protos": ["//external:python_headers"],
     }),
 )
 
@@ -553,7 +534,7 @@ cc_binary(
         ":protobuf",
     ] + select({
         "//conditions:default": [],
-        ":use_fast_cpp_protos": ["//util/python:python_headers"],
+        ":use_fast_cpp_protos": ["//external:python_headers"],
     }),
 )
 
@@ -584,21 +565,12 @@ py_proto_library(
     }),
     default_runtime = "",
     protoc = ":protoc",
-    py_extra_srcs = [":python_srcs"],
-    py_libs = ["//external:six"],
+    py_libs = [
+        ":python_srcs",
+        "//external:six"
+    ],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-)
-
-internal_copied_filegroup(
-    name = "python_test_srcs",
-    srcs = glob(
-        [
-            "python/google/protobuf/internal/*_test.py",
-            "python/google/protobuf/internal/test_util.py",
-        ],
-    ),
-    include = "python",
 )
 
 py_proto_library(
@@ -624,7 +596,13 @@ py_proto_library(
 
 py_library(
     name = "python_tests",
-    srcs = [":python_test_srcs"],
+    srcs = glob(
+        [
+            "python/google/protobuf/internal/*_test.py",
+            "python/google/protobuf/internal/test_util.py",
+        ],
+    ),
+    imports = ["python"],
     srcs_version = "PY2AND3",
     deps = [
         ":protobuf_python",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,28 +1,33 @@
 new_http_archive(
-  name = "gmock_archive",
-  url = "https://googlemock.googlecode.com/files/gmock-1.7.0.zip",
-  sha256 = "26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b",
-  build_file = "gmock.BUILD",
+    name = "gmock_archive",
+    url = "https://googlemock.googlecode.com/files/gmock-1.7.0.zip",
+    sha256 = "26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b",
+    build_file = "gmock.BUILD",
 )
 
 new_http_archive(
-  name = "six_archive",
-  url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
-  sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-  build_file = "six.BUILD",
+    name = "six_archive",
+    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
+    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+    build_file = "six.BUILD",
 )
 
 bind(
-  name = "gtest",
-  actual = "@gmock_archive//:gtest",
+    name = "python_headers",
+    actual = "//util/python:python_headers",
 )
 
 bind(
-  name = "gtest_main",
-  actual = "@gmock_archive//:gtest_main",
+    name = "gtest",
+    actual = "@gmock_archive//:gtest",
 )
 
 bind(
-  name = "six",
-  actual = "@six_archive//:six",
+    name = "gtest_main",
+    actual = "@gmock_archive//:gtest_main",
+)
+
+bind(
+    name = "six",
+    actual = "@six_archive//:six",
 )

--- a/util/python/BUILD
+++ b/util/python/BUILD
@@ -1,7 +1,17 @@
 # This is a placeholder for python headers. Projects needing to use
 # fast cpp protos in protobuf's python interface should build with
 # --define=use_fast_cpp_protos=true, and in addition, provide
-# //util/python:python_headers dependency that in turn provides Python.h.
+# //external:python_headers dependency that in turn provides Python.h.
+#
+# Projects that include protobuf using a Bazel external repository will need to
+# add a workspace rule to their WORKSPACE files to add an external workspace
+# that includes the Python headers. For example, the protobuf WORKSPACE file
+# includes the following local_repository rule that points to this directory:
+#
+# new_local_repository(
+#   name = "python",
+#   path = __workspace_dir__ + "/util/python",
+# )
 cc_library(
     name = "python_headers",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This change makes use of new imports attribute for Bazel's Python rules, which
enable adding directories to the PYTHONPATH. This allows us to remove
the hack for building protobuf's Python support with Bazel and now
allows projects to include protobuf using a Bazel external repository
rather than requiring it to be imported directly into the source tree as
//google/protobuf.

This change also updates the protobuf BUILD file to use a named
repository, @python//, for including Python headers rather than
//util/python. This allows projects to specify their own package for
Python headers when including protobuf with an external repository.

Fixes #1230