### PR TITLE
Generate C# code whenever descriptor.proto changes

### DIFF
--- a/csharp/generate_protos.sh
+++ b/csharp/generate_protos.sh
@@ -6,7 +6,7 @@
 set -ex
 
 # cd to repository root
-cd $(dirname $0)/..
+pushd $(dirname $0)/..
 
 # Protocol buffer compiler to use. If the PROTOC variable is set,
 # use that. Otherwise, probe for expected locations under both

--- a/generate_descriptor_proto.sh
+++ b/generate_descriptor_proto.sh
@@ -96,3 +96,8 @@ if test -x objectivec/generate_descriptors_proto.sh; then
   echo "Generating messages for objc."
   objectivec/generate_descriptors_proto.sh $@
 fi
+
+if test -x csharp/generate_protos.sh; then
+  echo "Generating messages for C#."
+  csharp/generate_protos.sh $@
+fi


### PR DESCRIPTION
This is a start to fixing issue #1212. It won't help for test protos,
conformance etc, but it will definitely be better than nothing, and
would have highlighted a change in descriptor.proto which broken C#
earlier.