### PR TITLE
Debug the XCTool timing

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -210,7 +210,10 @@ build_objectivec_ios() {
       -sdk iphonesimulator \
       -destination "${i}" \
       run-tests \
-      -newSimulatorInstance
+      -logicTestBucketSize 1 \
+      -appTestBucketSize 1 \
+      -freshInstall \
+      -resetSimulator
   done
 }
 


### PR DESCRIPTION
This is a temporary PR to test the timing issue that Thomas (@thomasvl) suggested could be causing the iOS builds not to complete successfully.  It slows down the throughput of the `xctool`.  This will initiate a Travis to observe the results.

Paul