### PR TITLE
configure.ac: check if libatomic is needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,8 @@ AM_CONDITIONAL([HAVE_PTHREAD], [test "x$acx_pthread_ok" = "xyes"])
 # We still keep this for improving pbconfig.h for unsupported platforms.
 AC_CXX_STL_HASH
 
+AC_SEARCH_LIBS([__atomic_load_4], [atomic])
+
 case "$target_os" in
   mingw* | cygwin* | win*)
     ;;


### PR DESCRIPTION
Compilation of protobuf for PowerPC and SPARC may fail due to missing
references to __atomic_fetch_add_4 and __atomic_compare_exchange_4.

The __atomic_*() intrinsics for all sizes are provided by libatomic when
gcc is >= 4.8. This can be achieved by adding this to configure.ac:

    AC_SEARCH_LIBS([__atomic_fetch_add_4], [atomic])

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>