### PR TITLE
Add a modified patch from craigcitro@ to handle namespace sharing.

### DIFF
--- a/python/google/__init__.py
+++ b/python/google/__init__.py
@@ -1,1 +1,4 @@
-__import__('pkg_resources').declare_namespace(__name__)
+try:
+  __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+  __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/google/protobuf/__init__.py
+++ b/python/google/protobuf/__init__.py
@@ -31,3 +31,9 @@
 # Copyright 2007 Google Inc. All Rights Reserved.
 
 __version__ = '3.0.0b2'
+
+if __name__ != '__main__':
+  try:
+    __import__('pkg_resources').declare_namespace(__name__)
+  except ImportError:
+    __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/google/protobuf/pyext/__init__.py
+++ b/python/google/protobuf/pyext/__init__.py
@@ -1,0 +1,4 @@
+try:
+  __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+  __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/python/setup.py
+++ b/python/setup.py
@@ -210,7 +210,6 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         ],
-      namespace_packages=['google'],
       packages=find_packages(
           exclude=[
               'import_test_package',


### PR DESCRIPTION
ATTN: @haberman, @craigcitro
This is based on a patch from Craig Citro. I will need some hand holding to actually build the protobuf Py lib to do some manual tests. Did not  manage to do a python setup.py build/test/install on a fresh clone.
I know that the __init__.py files will work because I am already doing some namespace sharing in google/ and google/cloud with other packages but still this needs to be manually tested for protobuf.
Thanks,
Silviu 