### PR TITLE
Make cpp generated enum constants constexpr when Options::proto_h is specified

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_enum.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum.cc
@@ -178,12 +178,13 @@ void EnumGenerator::GenerateSymbolImports(io::Printer* printer) {
   map<string, string> vars;
   vars["nested_name"] = descriptor_->name();
   vars["classname"] = classname_;
+  vars["constexpr"] = options_.proto_h ? "constexpr " : "";
   printer->Print(vars, "typedef $classname$ $nested_name$;\n");
 
   for (int j = 0; j < descriptor_->value_count(); j++) {
     vars["tag"] = EnumValueName(descriptor_->value(j));
     printer->Print(vars,
-      "static const $nested_name$ $tag$ = $classname$_$tag$;\n");
+      "static $constexpr$const $nested_name$ $tag$ = $classname$_$tag$;\n");
   }
 
   printer->Print(vars,
@@ -237,6 +238,7 @@ void EnumGenerator::GenerateDescriptorInitializer(
 void EnumGenerator::GenerateMethods(io::Printer* printer) {
   map<string, string> vars;
   vars["classname"] = classname_;
+  vars["constexpr"] = options_.proto_h ? "constexpr " : "";
 
   if (HasDescriptorMethods(descriptor_->file())) {
     printer->Print(vars,
@@ -287,7 +289,7 @@ void EnumGenerator::GenerateMethods(io::Printer* printer) {
     for (int i = 0; i < descriptor_->value_count(); i++) {
       vars["value"] = EnumValueName(descriptor_->value(i));
       printer->Print(vars,
-        "const $classname$ $parent$::$value$;\n");
+        "$constexpr$const $classname$ $parent$::$value$;\n");
     }
     printer->Print(vars,
       "const $classname$ $parent$::$nested_name$_MIN;\n"


### PR DESCRIPTION
This works only for c+11, but it looks like proto_h is already conditionally used to enable c++11 features [1], so I took the liberty of hijacking it for this purpose.

The main advantage of this is that it makes static initialization order well defined. I can develop more if need be.

[1]https://github.com/google/protobuf/blob/a74e912a8be1274fd561db5e8133937d4e9c4a2b/src/google/protobuf/compiler/cpp/cpp_enum.cc#L83