### PR TITLE
Adds more information to Objective C error.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -968,7 +968,8 @@ bool ValidateObjCClassPrefix(const FileDescriptor* file,
     } else {
       // ...it didn't match!
       *out_error = "error: Expected 'option objc_class_prefix = \"" +
-                   package_match->second + "\";' in '" + file->name() + "'";
+                   package_match->second + "\";' for package '" + package +
+                   "' in '" + file->name() + "'";
       if (prefix.length()) {
         *out_error += "; but found '" + prefix + "' instead";
       }


### PR DESCRIPTION
Adds the package to the error displayed when the expected objc_class_prefix option is missing.