### PR TITLE
Add back the namespace_packages arg in setup.py.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -210,6 +210,7 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         ],
+      namespace_packages=['google'],
       packages=find_packages(
           exclude=[
               'import_test_package',


### PR DESCRIPTION
Improves #1296.

The problem: in the previous patch, we tweaked the `__init__.py` files to use namespaces, but no longer declared ourselves as a namespace package. The second half was unwise.

Note that this only comes up when installing `protobuf` alongside another package that also installs into the google namespace; as of right now, the only PyPI package that does is `googleapis-common-protos`, though the GAE SDK also uses `google.appengine`. However, this package is in fact a *dependency* of `googleapis-common-protos`, so that's an extremely likely combination. :wink:

With this PR, installing either or both of those alongside this package now works.

The case that still remains is the upgrade path, which is also what worried me in #713. It seems that if protobuf 2.6.1 is installed, there's no way to safely upgrade that to work with a newer protobuf. However, `pip uninstall` && `pip install` does the trick.

PTAL @haberman -- in particular, if we *really* want this issue to go away forever, we should also make sure to add a tests that (1) deal with the upgrade cases and (2) also install another package that uses the google namespace, eg googleapis-common-protos.

/cc @jonparrott @tseaver and @dhermes for some Python wisdom. @jonparrott, with this change, the cases in your gist now pass (since we've fixed the protobuf vs. googleapis conflict). However, I'm worried that we can't seem to upgrade from 2.6.1; is there any hope there? Have other python packages dealt with this?

I'd also be curious about an easy way to trigger the gcloud tests with this PR; could I just switch [this line](https://github.com/GoogleCloudPlatform/gcloud-python/blob/40332e17391369106aa4380eec780cd5c5deccf7/setup.py#L17) to point directly to the commit in my repo and send a PR, thereby letting Travis do its thing?