### PR TITLE
Fix compiling clang/libc++ builds. (Issue: #1266)

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -548,6 +548,10 @@ class Map {
     !defined(GOOGLE_PROTOBUF_OS_NACL) && !defined(GOOGLE_PROTOBUF_OS_ANDROID)
     template<class NodeType, class... Args>
     void construct(NodeType* p, Args&&... args) {
+      // Clang 3.6 doesn't compile static casting to void* directly. (Issue #1266)
+      // According C++ standard 5.2.9/1: "The static_cast operator shall not cast
+      // away constness". So first the maybe const pointer is casted to const void* and
+      // after the const void* is const casted.
       new (const_cast<void*>(static_cast<const void*>(p))) NodeType(std::forward<Args>(args)...);
     }
 

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -548,7 +548,7 @@ class Map {
     !defined(GOOGLE_PROTOBUF_OS_NACL) && !defined(GOOGLE_PROTOBUF_OS_ANDROID)
     template<class NodeType, class... Args>
     void construct(NodeType* p, Args&&... args) {
-      new (static_cast<void*>(p)) NodeType(std::forward<Args>(args)...);
+      new (const_cast<void*>(static_cast<const void*>(p))) NodeType(std::forward<Args>(args)...);
     }
 
     template<class NodeType>


### PR DESCRIPTION
I got error during building protobuf with clang/libc++. I could solve the problem with the given patch.

I used kubuntu 15.04 with clang 3.6. libc++ version `_LIBCPP_VERSION=1101`
```
./configure CC=clang CXX=clang++ CXXFLAGS="-std=c++11 -stdlib=libc++"
```
All tests ran successful for me.
