### PR TITLE
Expose a method to list only the extension fields

### DIFF
--- a/src/google/protobuf/generated_message_reflection.cc
+++ b/src/google/protobuf/generated_message_reflection.cc
@@ -1020,6 +1020,17 @@ void GeneratedMessageReflection::ListFields(
   std::sort(output->begin(), output->end(), FieldNumberSorter());
 }
 
+void GeneratedMessageReflection::ListExtensionFields(
+    const Message& message,
+    vector<const FieldDescriptor*>* output) const {
+  output->clear();
+
+  if (extensions_offset_ != -1) {
+    GetExtensionSet(message).AppendToList(descriptor_, descriptor_pool_,
+                                          output);
+  }
+}
+
 // -------------------------------------------------------------------
 
 #undef DEFINE_PRIMITIVE_ACCESSORS

--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -231,6 +231,8 @@ class LIBPROTOBUF_EXPORT GeneratedMessageReflection : public Reflection {
                     int index1, int index2) const;
   void ListFields(const Message& message,
                   vector<const FieldDescriptor*>* output) const;
+  void ListExtensionFields(const Message& message,
+                           vector<const FieldDescriptor*>* output) const;
 
   int32  GetInt32 (const Message& message,
                    const FieldDescriptor* field) const;

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -490,6 +490,13 @@ class LIBPROTOBUF_EXPORT Reflection {
       const Message& message,
       std::vector<const FieldDescriptor*>* output) const = 0;
 
+  // List all the extension fields which are currently set.  Fields
+  // will not be in any particular order.  This is much faster than ListFields
+  // for retrieving just this information.
+  virtual void ListExtensionFields(
+      const Message &message,
+      vector<const FieldDescriptor *> *output) const = 0;
+
   // Singular field getters ------------------------------------------
   // These get the value of a non-repeated field.  They return the default
   // value for fields that aren't set.


### PR DESCRIPTION
This is much faster than ListFields. ListFields was a performance
bottleneck for my code.
