### PR TITLE
examples/go: use multiple versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ env:
   - CONFIG=cpp
   - CONFIG=cpp_distcheck
   - CONFIG=csharp
-  - CONFIG=golang
+  - CONFIG=golang_1_4
+  - CONFIG=golang_1_5
+  - CONFIG=golang_1_6
   - CONFIG=java_jdk6
   - CONFIG=java_jdk7
   - CONFIG=java_oracle7
@@ -50,10 +52,6 @@ matrix:
     # which doesn't work on OS X.
     - os: osx
       env: CONFIG=csharp
-    # Requires installing golang, currently travis.sh is doing that with apt-get
-    # which doesn't work on OS X.
-    - os: osx
-      env: CONFIG=golang
   # Add into the matrix OS X tests of Objective C (needs Xcode, so it won't
   # work on other platforms). These are split so it doesn't take as long to run.
   include:

--- a/travis.sh
+++ b/travis.sh
@@ -56,22 +56,52 @@ build_csharp() {
   cd conformance && make test_csharp && cd ..
 }
 
-build_golang() {
+use_golang() {
+  version=$1
+
   # Go build needs `protoc`.
   internal_build_cpp
   # Add protoc to the path so that the examples build finds it.
   export PATH="`pwd`/src:$PATH"
 
-  # Install Go and the Go protobuf compiler plugin.
-  sudo apt-get update -qq
-  sudo apt-get install -qq golang
+  # Install Go.
+  mkdir -p "${HOME}/bin"
+  curl -sL -o "${HOME}/bin/gimme" https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+  chmod +x "${HOME}/bin/gimme"
+  export PATH="${HOME}/bin:${PATH}"
+
+  gimme "${version}"
+  source "${HOME}/.gimme/envs/go${version}.env"
+}
+
+build_golang() {
+  # Install the Go protobuf compiler plugin.
   export GOPATH="$HOME/gocode"
   mkdir -p "$GOPATH/src/github.com/google"
-  ln -s "`pwd`" "$GOPATH/src/github.com/google/protobuf"
+  ln -s "$(pwd)" "$GOPATH/src/github.com/google/protobuf"
   export PATH="$GOPATH/bin:$PATH"
-  go get github.com/golang/protobuf/protoc-gen-go
+  go get -u github.com/golang/protobuf/protoc-gen-go
 
-  cd examples && make gotest && cd ..
+  # Build and run the Go examples.
+  (
+  cd examples
+  make gotest
+  )
+}
+
+build_golang_1_4() {
+  use_golang 1.4.3
+  build_golang
+}
+
+build_golang_1_5() {
+  use_golang 1.5.3
+  build_golang
+}
+
+build_golang_1_6() {
+  use_golang 1.6
+  build_golang
 }
 
 use_java() {
@@ -290,6 +320,9 @@ if [ "$#" -ne 1 ]; then
   echo "
 Usage: $0 { cpp |
             csharp |
+            golang_1_4 |
+            golang_1_5 |
+            golang_1_6 |
             java_jdk6 |
             java_jdk7 |
             java_oracle7 |


### PR DESCRIPTION
The Travis build is breaking for the Go sample. I believe this is due to
the Go generator using 1.6 features, such as `strings.LastIndexByte`.
Here is an example: https://travis-ci.org/google/protobuf/jobs/114293020

To help debug issues like this in the future, use
[gimme](https://github.com/travis-ci/gimme) to test on multiple
different versions of Go.

Fixes #1305.