### PR TITLE
add java/util support based on java/util/pom.xml

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -472,6 +472,19 @@ java_library(
     visibility = ["//visibility:public"],
 )
 
+java_library(
+    name = "protobuf_java_util",
+    srcs = glob([
+        "java/util/src/main/java/com/google/protobuf/util/*.java",
+    ]),
+    deps = [
+      "protobuf_java",
+      "//external:gson",
+      "//external:guava",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 ################################################################################
 # Python support
 ################################################################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,3 +31,23 @@ bind(
     name = "six",
     actual = "@six_archive//:six",
 )
+
+maven_jar(
+  name = "guava_maven",
+  artifact = "com.google.guava:guava:18.0",
+)
+
+bind(
+    name = "guava",
+    actual = "@guava_maven//jar",
+)
+
+maven_jar(
+  name = "gson_maven",
+  artifact = "com.google.code.gson:gson:2.3",
+)
+
+bind(
+    name = "gson",
+    actual = "@gson_maven//jar",
+)


### PR DESCRIPTION
The java util package got split off from core and a pom created for it, but the bazel build was never updated: there's no bazel target that creates the util package or includes those classes.

The grpc-java build needs those classes so I added a target.

The target's pretty routine but requires guava and gson, so those got added to WORKSPACE as maven dependences since that pretty much mirrors what the poms do.

Not sure if there are feelings on that?