### PR TITLE
Fix packing of repeated value fields

### DIFF
--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -347,7 +347,7 @@ namespace Google.Protobuf
     public sealed class FieldCodec<T>
     {
         private static readonly T DefaultDefault;
-        private static readonly bool TypeSupportsPacking = typeof(T).IsValueType() && Nullable.GetUnderlyingType(typeof(T)) == null;
+        private static readonly bool TypeSupportsPacking = typeof(T).IsValueType && Nullable.GetUnderlyingType(typeof(T)) == null;
 
         static FieldCodec()
         {


### PR DESCRIPTION
This was called the IsValueType from the Compatibility TypeExtensions, which caused this to ALWAYS return false.

As typeof(T) returns a System.Type, and IsValueType() will turn this into System.Type.GetType().IsValueType. Since a "System.Type" is never a value, this will be false.