### PR TITLE
Only create the readonlySemaphore on demand.

### DIFF
--- a/objectivec/GPBMessage_PackagePrivate.h
+++ b/objectivec/GPBMessage_PackagePrivate.h
@@ -67,6 +67,10 @@ typedef struct GPBMessage_Storage *GPBMessage_StoragePtr;
   // priority inversion:
   //   http://mjtsai.com/blog/2015/12/16/osspinlock-is-unsafe/
   //   https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000372.html
+  // Use of readOnlySemaphore_ must be prefaced by a call to
+  // GPBPrepareReadOnlySemaphore to ensure it has been created. This allows
+  // readOnlySemaphore_ to be only created when actually needed.
+  dispatch_once_t readOnlySemaphoreCreationOnce_;
   dispatch_semaphore_t readOnlySemaphore_;
 }
 
@@ -102,6 +106,14 @@ typedef struct GPBMessage_Storage *GPBMessage_StoragePtr;
 @end
 
 CF_EXTERN_C_BEGIN
+
+
+// Call this before using the readOnlySemaphore_. This ensures it is created only once.
+NS_INLINE void GPBPrepareReadOnlySemaphore(GPBMessage *self) {
+  dispatch_once(&self->readOnlySemaphoreCreationOnce_, ^{
+    self->readOnlySemaphore_ = dispatch_semaphore_create(1);
+  });
+}
 
 // Returns a new instance that was automatically created by |autocreator| for
 // its field |field|.

--- a/objectivec/GPBUtilities.m
+++ b/objectivec/GPBUtilities.m
@@ -412,6 +412,7 @@ id GPBGetObjectIvarWithField(GPBMessage *self, GPBFieldDescriptor *field) {
     return field.defaultValue.valueMessage;
   }
 
+  GPBPrepareReadOnlySemaphore(self);
   dispatch_semaphore_wait(self->readOnlySemaphore_, DISPATCH_TIME_FOREVER);
   GPBMessage *result = GPBGetObjectIvarWithFieldNoAutocreate(self, field);
   if (!result) {


### PR DESCRIPTION
This will lower the amount of dispatch_semaphores created per Message when the
full object tree isn't walked in a way that would require them to be created.
Uses a dispatch_once_t for one time init of the dispatch_semaphore.