### PR TITLE
Update coded_stream.h

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -1136,7 +1136,7 @@ inline void CodedOutputStream::WriteVarint32(uint32 value) {
     // this write won't cross the end, so we can skip the checks.
     uint8* target = buffer_;
     uint8* end = WriteVarint32ToArray(value, target);
-    int size = end - target;
+    int size = static_cast<int>(end - target);
     Advance(size);
   } else {
     WriteVarint32SlowPath(value);


### PR DESCRIPTION
fix for warning treated as error prevents building on 64-bit windows