### PR TITLE
export well known protos

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -194,6 +194,12 @@ RELATIVE_WELL_KNOWN_PROTOS = [
 
 WELL_KNOWN_PROTOS = ["src/" + s for s in RELATIVE_WELL_KNOWN_PROTOS]
 
+filegroup(
+    name = "well_known_protos",
+    srcs = WELL_KNOWN_PROTOS,
+    visibility = ["//visibility:public"],
+)
+
 cc_proto_library(
     name = "cc_wkt_protos",
     srcs = WELL_KNOWN_PROTOS,


### PR DESCRIPTION
When we run protoc from within bazel, we need access to the well known protos, e.g., `Any`, so that protoc can include them.