### PR TITLE
Mark iOS tests as able to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,14 @@ matrix:
     # we moved to an OS X image that is 10.11.
     - os: osx
       env: CONFIG=python_cpp
+    # xctool 0.2.8 seems to have a bug where it randomly kills tests saying
+    # they failed.
+    #   https://github.com/facebook/xctool/issues/619
+    #   https://github.com/google/protobuf/issues/1232
+    # travis updated their images to include 0.2.8:
+    #   https://blog.travis-ci.com/2016-03-23-xcode-image-updates
+    # Mark the iOS test as flakey so these failures don't turn things red.
+    - os: osx
+      env: CONFIG=objectivec_ios
 notifications:
   email: false

--- a/travis.sh
+++ b/travis.sh
@@ -171,13 +171,7 @@ internal_objectivec_common () {
   #  http://docs.travis-ci.com/user/osx-ci-environment/
   # We don't use a before_install because we test multiple OSes.
   brew update
-  # xctool 0.2.8 seems to have a bug where it randomly kills tests saying
-  # they failed. Disabling the updates, but letting it report about being
-  # updates as a hint that this needs to eventually get re-enabled.
-  #   https://github.com/facebook/xctool/issues/619
-  #   https://github.com/google/protobuf/issues/1232
-  brew outdated xctool || true
-  #brew outdated xctool || brew upgrade xctool
+  brew outdated xctool || brew upgrade xctool
   # Reused the build script that takes care of configuring and ensuring things
   # are up to date. Xcode and conformance tests will be directly invoked.
   objectivec/DevTools/full_mac_build.sh \


### PR DESCRIPTION
Travis updated their images to include an xctool that can randomly kill
tests, so mark them as flaky to avoid turning things red.