### PR TITLE
Use the T() instead of NULL for the default value.

### DIFF
--- a/src/google/protobuf/stubs/statusor.h
+++ b/src/google/protobuf/stubs/statusor.h
@@ -224,7 +224,7 @@ inline StatusOr<T>& StatusOr<T>::operator=(const StatusOr<T>& other) {
 template<typename T>
 template<typename U>
 inline StatusOr<T>::StatusOr(const StatusOr<U>& other)
-    : status_(other.status_), value_(other.status_.ok() ? other.value_ : NULL) {
+    : status_(other.status_), value_(other.status_.ok() ? other.value_ : T()) {
 }
 
 template<typename T>


### PR DESCRIPTION
The template can be specialized on primitives, e.g. double, where
converting NULL will trigger a warning.