### PR TITLE
Add go_package statements for the Go-supported WKTs.

### DIFF
--- a/src/google/protobuf/any.proto
+++ b/src/google/protobuf/any.proto
@@ -33,6 +33,7 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/any";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "AnyProto";
 option java_multiple_files = true;

--- a/src/google/protobuf/duration.proto
+++ b/src/google/protobuf/duration.proto
@@ -33,6 +33,7 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/duration";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DurationProto";
 option java_multiple_files = true;

--- a/src/google/protobuf/empty.proto
+++ b/src/google/protobuf/empty.proto
@@ -33,6 +33,7 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/empty";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "EmptyProto";
 option java_multiple_files = true;

--- a/src/google/protobuf/struct.proto
+++ b/src/google/protobuf/struct.proto
@@ -33,6 +33,7 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/struct;structpb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "StructProto";
 option java_multiple_files = true;

--- a/src/google/protobuf/timestamp.proto
+++ b/src/google/protobuf/timestamp.proto
@@ -34,6 +34,7 @@ package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/timestamp";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "TimestampProto";
 option java_multiple_files = true;

--- a/src/google/protobuf/wrappers.proto
+++ b/src/google/protobuf/wrappers.proto
@@ -39,6 +39,7 @@ package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/wrappers";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "WrappersProto";
 option java_multiple_files = true;


### PR DESCRIPTION
This instructs the Go protobuf code generator how to generate code in the right
place and generate correct import statements. The design for this feature is
described in https://github.com/golang/protobuf/issues/139.

This is an integration of a Google-internal change.