### PR TITLE
Replace #include <iostream> with #include <ostream> in int128.cc

### DIFF
--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -31,7 +31,7 @@
 #include <google/protobuf/stubs/int128.h>
 
 #include <iomanip>
-#include <iostream>  // NOLINT(readability/streams)
+#include <ostream>  // NOLINT(readability/streams)
 #include <sstream>
 
 namespace google {


### PR DESCRIPTION
iostream is not actually necessary here, and it introduces unnecessary
static initializers.