### PR TITLE
Remove static initializers from Status class.

### DIFF
--- a/src/google/protobuf/stubs/status.cc
+++ b/src/google/protobuf/stubs/status.cc
@@ -82,9 +82,9 @@ inline string CodeEnumToString(error::Code code) {
 }
 }  // namespace error.
 
-const Status Status::OK = Status();
-const Status Status::CANCELLED = Status(error::CANCELLED, "");
-const Status Status::UNKNOWN = Status(error::UNKNOWN, "");
+const StatusPod Status::OK = { error::OK, "" };
+const StatusPod Status::CANCELLED = { error::CANCELLED, "" };
+const StatusPod Status::UNKNOWN = { error::UNKNOWN, "" };
 
 Status::Status() : error_code_(error::OK) {
 }
@@ -98,6 +98,11 @@ Status::Status(error::Code error_code, StringPiece error_message)
 
 Status::Status(const Status& other)
     : error_code_(other.error_code_), error_message_(other.error_message_) {
+}
+
+Status::Status(const StatusPod& status_pod)
+    : error_code_(status_pod.error_code),
+      error_message_(status_pod.error_message) {
 }
 
 Status& Status::operator=(const Status& other) {

--- a/src/google/protobuf/stubs/status.h
+++ b/src/google/protobuf/stubs/status.h
@@ -62,6 +62,11 @@ enum Code {
 };
 }  // namespace error
 
+struct StatusPod {
+  error::Code error_code;
+  const char* error_message;
+};
+
 class LIBPROTOBUF_EXPORT Status {
  public:
   // Creates a "successful" status.
@@ -73,13 +78,14 @@ class LIBPROTOBUF_EXPORT Status {
   // constructed.
   Status(error::Code error_code, StringPiece error_message);
   Status(const Status&);
+  Status(const StatusPod&);
   Status& operator=(const Status& x);
   ~Status() {}
 
   // Some pre-defined Status objects
-  static const Status OK;             // Identical to 0-arg constructor
-  static const Status CANCELLED;
-  static const Status UNKNOWN;
+  static const StatusPod OK;  // Identical to 0-arg constructor
+  static const StatusPod CANCELLED;
+  static const StatusPod UNKNOWN;
 
   // Accessor
   bool ok() const {


### PR DESCRIPTION
Statically initialized Status objects are replaced with POD types, and
an implicit conversion constructor is added to create Status instance
from these.

This will result in an extra constructor call when using Status::OK and friends, and I'm not sure if this is desirable. Additionally, I think StatusPod type should be in a separate namespace, as I'm not sure we want to expose it as a part of protobuf interface.
