### PR TITLE
Introduce a new nuget package, Google.Protobuf.Tools, basically to contain protoc on multiple platforms.

### DIFF
--- a/csharp/Google.Protobuf.Tools.nuspec
+++ b/csharp/Google.Protobuf.Tools.nuspec
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>Google.Protobuf.Tools</id>
+    <title>Google Protocol Buffers tools</title>
+    <summary>Tools for Protocol Buffers - Google's data interchange format.</summary>
+    <description>See project site for more info.</description>
+    <version>3.0.0-beta2</version>
+    <authors>Google Inc.</authors>
+    <owners>protobuf-packages</owners>
+    <licenseUrl>https://github.com/google/protobuf/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/google/protobuf</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>Tools for Protocol Buffers</releaseNotes>
+    <copyright>Copyright 2015, Google Inc.</copyright>
+    <tags>Protocol Buffers Binary Serialization Format Google proto proto3</tags>
+  </metadata>
+  <files>
+    <file src="protoc\windows_x86\protoc.exe" target="tools\windows_x86\protoc.exe" />
+    <file src="protoc\windows_x64\protoc.exe" target="tools\windows_x64\protoc.exe" />
+    <file src="protoc\linux_x86\protoc" target="tools\linux_x86\protoc" />
+    <file src="protoc\linux_x64\protoc" target="tools\linux_x64\protoc" />
+    <file src="protoc\macosx_x86\protoc" target="tools\macosx_x86\protoc" />
+    <file src="protoc\macosx_x64\protoc" target="tools\macosx_x64\protoc" />
+    <file src="..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\api.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\duration.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\empty.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\source_context.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\struct.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
+    <file src="..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
+  </files>
+</package>

--- a/csharp/Google.Protobuf.Tools.nuspec
+++ b/csharp/Google.Protobuf.Tools.nuspec
@@ -31,7 +31,6 @@
     <file src="..\src\google\protobuf\source_context.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\struct.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
-    <file src="..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
   </files>

--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
@@ -23,7 +23,6 @@
       <group targetFramework="xamarin.ios" />
       <group targetFramework="monotouch" />
       <group targetFramework="monoandroid" />
-
       <!-- Dependencies for newer, more granular platforms (.NET Core etc) -->
       <group targetFramework="dotnet">
         <dependency id="System.Collections" version="4.0.0" />
@@ -49,18 +48,5 @@
     <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/dotnet" />
     <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/dotnet" />
     <file src="**\*.cs" target="src" />
-    <file src="..\..\..\cmake\Release\protoc.exe" target="tools" />
-    <file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\api.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\descriptor.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\duration.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\empty.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\field_mask.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\source_context.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\struct.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\any.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
-    <file src="..\..\..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
   </files>
 </package>


### PR DESCRIPTION
I've moved both protoc.exe and the proto files out of Google.Protobuf.
The .proto files aren't a slam-dunk, but it feels like they belong with protoc as you'd *use* them with protoc.
It's not clear to me whether we really need both an x86 and x64 version of protoc.exe, as x86 would work on 64-bit Windows anyway. Discuss :)