### PR TITLE
Do not link in pthread library for Android builds.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,7 +24,7 @@ config_setting(
 
 # Android builds do not need to link in a separate pthread library.
 LINK_OPTS = select({
-    "//tensorflow:android": [],
+    ":android": [],
     "//conditions:default": ["-lpthread"],
 })
 

--- a/BUILD
+++ b/BUILD
@@ -15,8 +15,18 @@ COPTS = [
     "-Wno-error=unused-function",
 ]
 
-# Bazel should provide portable link_opts for pthread.
-LINK_OPTS = ["-lpthread"]
+config_setting(
+    name = "android",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+    },
+)
+
+# Android builds do not need to link in a separate pthread library.
+LINK_OPTS = select({
+    "//tensorflow:android": [],
+    "//conditions:default": ["-lpthread"],
+})
 
 load(
     "protobuf",


### PR DESCRIPTION
This is required to allow Tensorflow to build on Android without hacks. Currently we create a dummy pthread library just to satisfy this dependency for a library that does not exist on Android. See https://github.com/google/protobuf/issues/1373 for more context.