### PR TITLE
Updating Xcode Settings to use iOS 9.3

### DIFF
--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -234,6 +234,14 @@ if [[ "${DO_XCODE_IOS_TESTS}" == "yes" ]] ; then
       echo "ERROR: Xcode 6.3/6.4 no longer supported for building, please use 7.0 or higher." 1>&2
       exit 10
       ;;
+    7.1* )
+      XCODEBUILD_TEST_BASE_IOS+=(
+          -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
+          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.0" # 64bit
+          -destination "platform=iOS Simulator,name=iPad 2,OS=8.1" # 32bit
+          -destination "platform=iOS Simulator,name=iPad Air,OS=9.0" # 64bit
+      )
+      ;;
     7.3* )
       XCODEBUILD_TEST_BASE_IOS+=(
           -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
@@ -245,9 +253,9 @@ if [[ "${DO_XCODE_IOS_TESTS}" == "yes" ]] ; then
     7.* )
       XCODEBUILD_TEST_BASE_IOS+=(
           -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.3" # 64bit
+          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.2" # 64bit
           -destination "platform=iOS Simulator,name=iPad 2,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPad Air,OS=9.3" # 64bit
+          -destination "platform=iOS Simulator,name=iPad Air,OS=9.2" # 64bit
       )
       ;;
     * )

--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -245,9 +245,9 @@ if [[ "${DO_XCODE_IOS_TESTS}" == "yes" ]] ; then
     7.* )
       XCODEBUILD_TEST_BASE_IOS+=(
           -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.2" # 64bit
+          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.3" # 64bit
           -destination "platform=iOS Simulator,name=iPad 2,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPad Air,OS=9.2" # 64bit
+          -destination "platform=iOS Simulator,name=iPad Air,OS=9.3" # 64bit
       )
       ;;
     * )

--- a/objectivec/DevTools/full_mac_build.sh
+++ b/objectivec/DevTools/full_mac_build.sh
@@ -234,12 +234,12 @@ if [[ "${DO_XCODE_IOS_TESTS}" == "yes" ]] ; then
       echo "ERROR: Xcode 6.3/6.4 no longer supported for building, please use 7.0 or higher." 1>&2
       exit 10
       ;;
-    7.1* )
+    7.3* )
       XCODEBUILD_TEST_BASE_IOS+=(
           -destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.0" # 64bit
+          -destination "platform=iOS Simulator,name=iPhone 6,OS=9.3" # 64bit
           -destination "platform=iOS Simulator,name=iPad 2,OS=8.1" # 32bit
-          -destination "platform=iOS Simulator,name=iPad Air,OS=9.0" # 64bit
+          -destination "platform=iOS Simulator,name=iPad Air,OS=9.3" # 64bit
       )
       ;;
     7.* )


### PR DESCRIPTION
Xcode 7.3 is released with iOS 9.3 simulator as the default. I'm not sure when you typically update these, and I wasn't sure if it was better to add another entry for Xcode 7.2 w/ iOS 9.2, but there wasn't a similar entry for Xcode 7.1, so I followed the existing pattern.