### PR TITLE
Tidy up for C# codegen

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
@@ -81,8 +81,8 @@ void EnumFieldGenerator::GenerateCodecCode(io::Printer* printer) {
         "pb::FieldCodec.ForEnum($tag$, x => (int) x, x => ($type_name$) x)");
 }
 
-EnumOneofFieldGenerator::EnumOneofFieldGenerator(const FieldDescriptor* descriptor,
-						 int fieldOrdinal, const Options *options)
+EnumOneofFieldGenerator::EnumOneofFieldGenerator(
+    const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options)
   : PrimitiveOneofFieldGenerator(descriptor, fieldOrdinal, options) {
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_enum_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_enum_field.h
@@ -43,7 +43,9 @@ namespace csharp {
 
 class EnumFieldGenerator : public PrimitiveFieldGenerator {
  public:
-  EnumFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  EnumFieldGenerator(const FieldDescriptor* descriptor,
+                     int fieldOrdinal,
+                     const Options *options);
   ~EnumFieldGenerator();
 
   virtual void GenerateCodecCode(io::Printer* printer);
@@ -57,7 +59,9 @@ class EnumFieldGenerator : public PrimitiveFieldGenerator {
 
 class EnumOneofFieldGenerator : public PrimitiveOneofFieldGenerator {
  public:
-  EnumOneofFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  EnumOneofFieldGenerator(const FieldDescriptor* descriptor,
+                          int fieldOrdinal,
+                          const Options *options);
   ~EnumOneofFieldGenerator();
 
   virtual void GenerateParsingCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -94,7 +94,8 @@ void FieldGeneratorBase::SetCommonFieldVariables(
 void FieldGeneratorBase::SetCommonOneofFieldVariables(
     map<string, string>* variables) {
   (*variables)["oneof_name"] = oneof_name();
-  (*variables)["has_property_check"] = oneof_name() + "Case_ == " + oneof_property_name() +
+  (*variables)["has_property_check"] =
+    oneof_name() + "Case_ == " + oneof_property_name() +
     "OneofCase." + property_name();
   (*variables)["oneof_property_name"] = oneof_property_name();
 }
@@ -158,10 +159,11 @@ std::string FieldGeneratorBase::type_name(const FieldDescriptor* descriptor) {
     case FieldDescriptor::TYPE_MESSAGE:
     case FieldDescriptor::TYPE_GROUP:
       if (IsWrapperType(descriptor)) {
-        const FieldDescriptor* wrapped_field = descriptor->message_type()->field(0);
+        const FieldDescriptor* wrapped_field =
+            descriptor->message_type()->field(0);
         string wrapped_field_type_name = type_name(wrapped_field);
-        // String and ByteString go to the same type; other wrapped types go to the
-        // nullable equivalent.
+        // String and ByteString go to the same type; other wrapped types
+        // go to the nullable equivalent.
         if (wrapped_field->type() == FieldDescriptor::TYPE_STRING ||
             wrapped_field->type() == FieldDescriptor::TYPE_BYTES) {
           return wrapped_field_type_name;

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.h
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.h
@@ -44,7 +44,9 @@ namespace csharp {
 
 class FieldGeneratorBase : public SourceGeneratorBase {
  public:
-  FieldGeneratorBase(const FieldDescriptor* descriptor, int fieldOrdinal, const Options* options);
+  FieldGeneratorBase(const FieldDescriptor* descriptor,
+                     int fieldOrdinal,
+                     const Options* options);
   ~FieldGeneratorBase();
 
   virtual void GenerateCloningCode(io::Printer* printer) = 0;

--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -80,7 +80,7 @@ bool Generator::Generate(
       cli_options.file_extension = options[i].second;
     } else if (options[i].first == "base_namespace") {
       cli_options.base_namespace = options[i].second;
-      cli_options.generate_directories = true;
+      cli_options.base_namespace_specified = true;
     } else {
       *error = "Unknown generator option: " + options[i].first;
       return false;
@@ -90,7 +90,7 @@ bool Generator::Generate(
   string filename_error = "";
   std::string filename = GetOutputFile(file,
       cli_options.file_extension,
-      cli_options.generate_directories,
+      cli_options.base_namespace_specified,
       cli_options.base_namespace,
       &filename_error);
 

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.cc
@@ -128,7 +128,8 @@ std::string GetFileNameBase(const FileDescriptor* descriptor) {
 }
 
 std::string GetReflectionClassUnqualifiedName(const FileDescriptor* descriptor) {
-  // TODO: Detect collisions with existing messages, and append an underscore if necessary.
+  // TODO: Detect collisions with existing messages,
+  // and append an underscore if necessary.
   return GetFileNameBase(descriptor) + "Reflection";
 }
 
@@ -352,7 +353,8 @@ std::string FileDescriptorToBase64(const FileDescriptor* descriptor) {
 }
 
 FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor,
-                                         int fieldOrdinal, const Options* options) {
+                                         int fieldOrdinal,
+                                         const Options* options) {
   switch (descriptor->type()) {
     case FieldDescriptor::TYPE_GROUP:
     case FieldDescriptor::TYPE_MESSAGE:

--- a/src/google/protobuf/compiler/csharp/csharp_helpers.h
+++ b/src/google/protobuf/compiler/csharp/csharp_helpers.h
@@ -83,7 +83,9 @@ std::string GetPropertyName(const FieldDescriptor* descriptor);
 
 int GetFixedSize(FieldDescriptor::Type type);
 
-std::string UnderscoresToCamelCase(const std::string& input, bool cap_next_letter, bool preserve_period);
+std::string UnderscoresToCamelCase(const std::string& input,
+                                   bool cap_next_letter,
+                                   bool preserve_period);
 
 inline std::string UnderscoresToCamelCase(const std::string& input, bool cap_next_letter) {
   return UnderscoresToCamelCase(input, cap_next_letter, false);
@@ -96,17 +98,19 @@ std::string StringToBase64(const std::string& input);
 
 std::string FileDescriptorToBase64(const FileDescriptor* descriptor);
 
-FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options* options);
+FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor,
+                                         int fieldOrdinal,
+                                         const Options* options);
 
-// Determines whether the given message is a map entry message, i.e. one implicitly created
-// by protoc due to a map<key, value> field.
+// Determines whether the given message is a map entry message,
+// i.e. one implicitly created by protoc due to a map<key, value> field.
 inline bool IsMapEntryMessage(const Descriptor* descriptor) {
   return descriptor->options().map_entry();
 }
 
-// Determines whether we're generating code for the proto representation of descriptors etc,
-// for use in the runtime. This is the only type which is allowed to use proto2 syntax,
-// and it generates internal classes.
+// Determines whether we're generating code for the proto representation of
+// descriptors etc, for use in the runtime. This is the only type which is
+// allowed to use proto2 syntax, and it generates internal classes.
 inline bool IsDescriptorProto(const FileDescriptor* descriptor) {
   return descriptor->name() == "google/protobuf/descriptor.proto";
 }

--- a/src/google/protobuf/compiler/csharp/csharp_map_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_map_field.cc
@@ -63,8 +63,10 @@ void MapFieldGenerator::GenerateMembers(io::Printer* printer) {
       descriptor_->message_type()->FindFieldByName("value");
   variables_["key_type_name"] = type_name(key_descriptor);
   variables_["value_type_name"] = type_name(value_descriptor);
-  scoped_ptr<FieldGeneratorBase> key_generator(CreateFieldGenerator(key_descriptor, 1, this->options()));
-  scoped_ptr<FieldGeneratorBase> value_generator(CreateFieldGenerator(value_descriptor, 2, this->options()));
+  scoped_ptr<FieldGeneratorBase> key_generator(
+      CreateFieldGenerator(key_descriptor, 1, this->options()));
+  scoped_ptr<FieldGeneratorBase> value_generator(
+      CreateFieldGenerator(value_descriptor, 2, this->options()));
 
   printer->Print(
     variables_,

--- a/src/google/protobuf/compiler/csharp/csharp_map_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_map_field.h
@@ -43,7 +43,9 @@ namespace csharp {
 
 class MapFieldGenerator : public FieldGeneratorBase {
  public:
-  MapFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options* options);
+  MapFieldGenerator(const FieldDescriptor* descriptor,
+                    int fieldOrdinal,
+                    const Options* options);
   ~MapFieldGenerator();
 
   virtual void GenerateCloningCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -60,7 +60,8 @@ bool CompareFieldNumbers(const FieldDescriptor* d1, const FieldDescriptor* d2) {
   return d1->number() < d2->number();
 }
 
-MessageGenerator::MessageGenerator(const Descriptor* descriptor, const Options* options)
+MessageGenerator::MessageGenerator(const Descriptor* descriptor,
+                                   const Options* options)
     : SourceGeneratorBase(descriptor->file(), options),
       descriptor_(descriptor) {
 
@@ -185,7 +186,8 @@ void MessageGenerator::Generate(io::Printer* printer) {
     }
     printer->Outdent();
     printer->Print("}\n");
-    // TODO: Should we put the oneof .proto comments here? It's unclear exactly where they should go.
+    // TODO: Should we put the oneof .proto comments here?
+    // It's unclear exactly where they should go.
     printer->Print(
       vars,
       "private $property_name$OneofCase $name$Case_ = $property_name$OneofCase.None;\n"
@@ -220,7 +222,8 @@ void MessageGenerator::Generate(io::Printer* printer) {
     for (int i = 0; i < descriptor_->nested_type_count(); i++) {
       // Don't generate nested types for maps...
       if (!IsMapEntryMessage(descriptor_->nested_type(i))) {
-        MessageGenerator messageGenerator(descriptor_->nested_type(i), this->options());
+        MessageGenerator messageGenerator(
+            descriptor_->nested_type(i), this->options());
         messageGenerator.Generate(printer);
       }
     }
@@ -268,7 +271,8 @@ void MessageGenerator::GenerateCloningCode(io::Printer* printer) {
   // Clone just the right field for each oneof
   for (int i = 0; i < descriptor_->oneof_decl_count(); ++i) {
     vars["name"] = UnderscoresToCamelCase(descriptor_->oneof_decl(i)->name(), false);
-    vars["property_name"] = UnderscoresToCamelCase(descriptor_->oneof_decl(i)->name(), true);
+    vars["property_name"] = UnderscoresToCamelCase(
+        descriptor_->oneof_decl(i)->name(), true);
     printer->Print(vars, "switch (other.$property_name$Case) {\n");
     printer->Indent();
     for (int j = 0; j < descriptor_->oneof_decl(i)->field_count(); j++) {
@@ -449,7 +453,8 @@ void MessageGenerator::GenerateMergingMethods(io::Printer* printer) {
     uint32 tag = internal::WireFormatLite::MakeTag(field->number(), wt);
     // Handle both packed and unpacked repeated fields with the same Read*Array call;
     // the two generated cases are the packed and unpacked tags.
-    // TODO(jonskeet): Check that is_packable is equivalent to is_repeated && wt in { VARINT, FIXED32, FIXED64 }.
+    // TODO(jonskeet): Check that is_packable is equivalent to
+    // is_repeated && wt in { VARINT, FIXED32, FIXED64 }.
     // It looks like it is...
     if (field->is_packable()) {
       printer->Print(

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.cc
@@ -49,7 +49,8 @@ namespace compiler {
 namespace csharp {
 
 MessageFieldGenerator::MessageFieldGenerator(const FieldDescriptor* descriptor,
-                                             int fieldOrdinal, const Options *options)
+                                             int fieldOrdinal,
+                                             const Options *options)
     : FieldGeneratorBase(descriptor, fieldOrdinal, options) {
   variables_["has_property_check"] = name() + "_ != null";
   variables_["has_not_property_check"] = name() + "_ == null";
@@ -144,8 +145,10 @@ void MessageFieldGenerator::GenerateCodecCode(io::Printer* printer) {
     "pb::FieldCodec.ForMessage($tag$, $type_name$.Parser)");
 }
 
-MessageOneofFieldGenerator::MessageOneofFieldGenerator(const FieldDescriptor* descriptor,
-						       int fieldOrdinal, const Options *options)
+MessageOneofFieldGenerator::MessageOneofFieldGenerator(
+    const FieldDescriptor* descriptor,
+	  int fieldOrdinal,
+    const Options *options)
     : MessageFieldGenerator(descriptor, fieldOrdinal, options) {
   SetCommonOneofFieldVariables(&variables_);
 }

--- a/src/google/protobuf/compiler/csharp/csharp_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message_field.h
@@ -43,7 +43,9 @@ namespace csharp {
 
 class MessageFieldGenerator : public FieldGeneratorBase {
  public:
-  MessageFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  MessageFieldGenerator(const FieldDescriptor* descriptor,
+                        int fieldOrdinal,
+                        const Options *options);
   ~MessageFieldGenerator();
 
   virtual void GenerateCodecCode(io::Printer* printer);
@@ -65,7 +67,9 @@ class MessageFieldGenerator : public FieldGeneratorBase {
 
 class MessageOneofFieldGenerator : public MessageFieldGenerator {
  public:
-  MessageOneofFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  MessageOneofFieldGenerator(const FieldDescriptor* descriptor,
+                             int fieldOrdinal,
+                             const Options *options);
   ~MessageOneofFieldGenerator();
 
   virtual void GenerateCloningCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_options.h
+++ b/src/google/protobuf/compiler/csharp/csharp_options.h
@@ -41,7 +41,10 @@ namespace csharp {
 
 // Generator options (used by csharp_generator.cc):
 struct Options {
-  Options() : file_extension(".cs"), base_namespace(""), generate_directories(false) {
+  Options() :
+      file_extension(".cs"),
+      base_namespace(""),
+      generate_directories(false) {
   }
   // Extension of the generated file. Defaults to ".cs"
   string file_extension;

--- a/src/google/protobuf/compiler/csharp/csharp_options.h
+++ b/src/google/protobuf/compiler/csharp/csharp_options.h
@@ -44,14 +44,26 @@ struct Options {
   Options() :
       file_extension(".cs"),
       base_namespace(""),
-      generate_directories(false) {
+      base_namespace_specified(false) {
   }
   // Extension of the generated file. Defaults to ".cs"
   string file_extension;
-  // Base namespace to use to create directory hierarchy. Defaults to ""
+  // Base namespace to use to create directory hierarchy. Defaults to "".
+  // This option allows the simple creation of a conventional C# file layout,
+  // where directories are created relative to a project-specific base
+  // namespace. For example, in a project with a base namespace of PetShop, a
+  // proto of user.proto with a C# namespace of PetShop.Model.Shared would
+  // generate Model/Shared/User.cs underneath the specified --csharp_out
+  // directory.
+  //
+  // If no base namespace is specified, all files are generated in the
+  // --csharp_out directory, with no subdirectories created automatically.
   string base_namespace;
-  // Whether or not to generate directory hierarchy. Defaults to false
-  bool generate_directories;
+  // Whether the base namespace has been explicitly specified by the user.
+  // This is required as the base namespace can be explicitly set to the empty
+  // string, meaning "create a full directory hierarchy, starting from the first
+  // segment of the namespace."
+  bool base_namespace_specified;
 };
 
 }  // namespace csharp

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
@@ -45,7 +45,9 @@ struct Options;
 
 class PrimitiveFieldGenerator : public FieldGeneratorBase {
  public:
-  PrimitiveFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  PrimitiveFieldGenerator(const FieldDescriptor* descriptor,
+                          int fieldOrdinal,
+                          const Options *options);
   ~PrimitiveFieldGenerator();
 
   virtual void GenerateCodecCode(io::Printer* printer);
@@ -69,7 +71,9 @@ class PrimitiveFieldGenerator : public FieldGeneratorBase {
 
 class PrimitiveOneofFieldGenerator : public PrimitiveFieldGenerator {
  public:
-  PrimitiveOneofFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  PrimitiveOneofFieldGenerator(const FieldDescriptor* descriptor,
+                               int fieldOrdinal,
+                               const Options *options);
   ~PrimitiveOneofFieldGenerator();
 
   virtual void GenerateCloningCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_reflection_class.h
+++ b/src/google/protobuf/compiler/csharp/csharp_reflection_class.h
@@ -56,7 +56,9 @@ class ReflectionClassGenerator : public SourceGeneratorBase {
 
   void WriteIntroduction(io::Printer* printer);
   void WriteDescriptor(io::Printer* printer);
-  void WriteGeneratedCodeInfo(const Descriptor* descriptor, io::Printer* printer, bool last);
+  void WriteGeneratedCodeInfo(const Descriptor* descriptor,
+                              io::Printer* printer,
+                              bool last);
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ReflectionClassGenerator);
 };

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
@@ -45,7 +45,9 @@ namespace csharp {
 // should probably have a RepeatedFieldGeneratorBase.
 class RepeatedEnumFieldGenerator : public FieldGeneratorBase {
  public:
-  RepeatedEnumFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  RepeatedEnumFieldGenerator(const FieldDescriptor* descriptor,
+                             int fieldOrdinal,
+                             const Options *options);
   ~RepeatedEnumFieldGenerator();
 
   virtual void GenerateCloningCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
@@ -66,10 +66,12 @@ void RepeatedMessageFieldGenerator::GenerateMembers(io::Printer* printer) {
   // "create single field generator for this repeated field"
   // function, but it doesn't seem worth it for just this.
   if (IsWrapperType(descriptor_)) {
-    scoped_ptr<FieldGeneratorBase> single_generator(new WrapperFieldGenerator(descriptor_, fieldOrdinal_, this->options()));
+    scoped_ptr<FieldGeneratorBase> single_generator(
+      new WrapperFieldGenerator(descriptor_, fieldOrdinal_, this->options()));
     single_generator->GenerateCodecCode(printer);
   } else {
-    scoped_ptr<FieldGeneratorBase> single_generator(new MessageFieldGenerator(descriptor_, fieldOrdinal_, this->options()));
+    scoped_ptr<FieldGeneratorBase> single_generator(
+      new MessageFieldGenerator(descriptor_, fieldOrdinal_, this->options()));
     single_generator->GenerateCodecCode(printer);
   }
   printer->Print(";\n");

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
@@ -45,7 +45,9 @@ struct Options;
 
 class RepeatedMessageFieldGenerator : public FieldGeneratorBase {
  public:
-  RepeatedMessageFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  RepeatedMessageFieldGenerator(const FieldDescriptor* descriptor,
+                                int fieldOrdinal,
+                                const Options *options);
   ~RepeatedMessageFieldGenerator();
 
   virtual void GenerateCloningCode(io::Printer* printer);

--- a/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
@@ -47,7 +47,8 @@ namespace protobuf {
 namespace compiler {
 namespace csharp {
 
-SourceGeneratorBase::SourceGeneratorBase(const FileDescriptor* descriptor, const Options *options)
+SourceGeneratorBase::SourceGeneratorBase(const FileDescriptor* descriptor,
+                                         const Options *options)
     : descriptor_(descriptor), options_(options) {
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
@@ -152,8 +152,8 @@ void WrapperFieldGenerator::GenerateCodecCode(io::Printer* printer) {
   }
 }
 
-WrapperOneofFieldGenerator::WrapperOneofFieldGenerator(const FieldDescriptor* descriptor,
-    int fieldOrdinal, const Options *options)
+WrapperOneofFieldGenerator::WrapperOneofFieldGenerator(
+    const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options)
     : WrapperFieldGenerator(descriptor, fieldOrdinal, options) {
     SetCommonOneofFieldVariables(&variables_);
 }

--- a/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+++ b/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
@@ -45,7 +45,9 @@ struct Options;
 
 class WrapperFieldGenerator : public FieldGeneratorBase {
  public:
-  WrapperFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  WrapperFieldGenerator(const FieldDescriptor* descriptor,
+                        int fieldOrdinal,
+                        const Options *options);
   ~WrapperFieldGenerator();
 
   virtual void GenerateCodecCode(io::Printer* printer);
@@ -67,7 +69,9 @@ class WrapperFieldGenerator : public FieldGeneratorBase {
 
 class WrapperOneofFieldGenerator : public WrapperFieldGenerator {
  public:
-  WrapperOneofFieldGenerator(const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options);
+  WrapperOneofFieldGenerator(const FieldDescriptor* descriptor,
+                             int fieldOrdinal,
+                             const Options *options);
   ~WrapperOneofFieldGenerator();
 
   virtual void GenerateMembers(io::Printer* printer);


### PR DESCRIPTION
Separated into two commits for simplicity.

No behavioral change in either commit, but the first is really *just* source layout, whereas the second changes naming and documentation.