### PR TITLE
Fix to csharp_options - initialize internal_access to false.

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_options.h
+++ b/src/google/protobuf/compiler/csharp/csharp_options.h
@@ -44,7 +44,8 @@ struct Options {
   Options() :
       file_extension(".cs"),
       base_namespace(""),
-      base_namespace_specified(false) {
+      base_namespace_specified(false),
+      internal_access(false) {
   }
   // Extension of the generated file. Defaults to ".cs"
   string file_extension;


### PR DESCRIPTION
This is a fix to #1393. Without it, all my types were being generated as internal on Windows - other platforms may have other behavior, I suspect.

// cc @gvaish