### PR TITLE
Add missing PY2AND3 srcs_versions attributes to Python Bazel build targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -535,9 +535,9 @@ java_library(
         "java/util/src/main/java/com/google/protobuf/util/*.java",
     ]),
     deps = [
-      "protobuf_java",
-      "//external:gson",
-      "//external:guava",
+        "protobuf_java",
+        "//external:gson",
+        "//external:guava",
     ],
     visibility = ["//visibility:public"],
 )
@@ -558,6 +558,7 @@ py_library(
             "python/google/protobuf/internal/test_util.py",
         ],
     ),
+    srcs_version = "PY2AND3",
     imports = ["python"],
 )
 
@@ -642,6 +643,7 @@ py_proto_library(
     include = "src",
     default_runtime = "",
     protoc = ":protoc",
+    srcs_version = "PY2AND3",
     deps = [":protobuf_python"],
 )
 
@@ -654,6 +656,7 @@ py_proto_library(
     include = "python",
     default_runtime = ":protobuf_python",
     protoc = ":protoc",
+    srcs_version = "PY2AND3",
     deps = [":python_common_test_protos"],
 )
 


### PR DESCRIPTION
This is to fix the build break in tensorflow/tensorflow#1289

+cc @martinwicke @podsvirov 
