### PR TITLE
Fix bug with silent message corruption in LITE_RUNTIME.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -3080,7 +3080,10 @@ GenerateMergeFromCodedStream(io::Printer* printer) {
         } else {
           const FieldDescriptor* next_field = ordered_fields[i + 1];
           printer->Print(
-            "if (input->ExpectTag($next_tag$)) goto parse_$next_name$;\n",
+            "if (input->ExpectTag($next_tag$)) {\n"
+            "    tag = $next_tag$;\n"
+            "    goto parse_$next_name$;\n"
+            "}\n",
             "next_tag", SimpleItoa(WireFormat::MakeTag(next_field)),
             "next_name", next_field->name());
           need_label = true;

--- a/src/google/protobuf/unittest_lite.proto
+++ b/src/google/protobuf/unittest_lite.proto
@@ -386,3 +386,22 @@ message TestEmptyMessageLite{
 message TestEmptyMessageWithExtensionsLite {
   extensions 1 to max;
 }
+
+enum V1EnumLite {
+    V1_FIRST = 1;
+}
+
+enum V2EnumLite {
+    V2_FIRST = 1;
+    V2_SECOND = 2;
+}
+
+message V1MessageLite {
+    required int32 int_field = 1;
+    optional V1EnumLite enum_field = 2 [ default = V1_FIRST ];
+}
+
+message V2MessageLite {
+    required int32 int_field = 1;
+    optional V2EnumLite enum_field = 2 [ default = V2_FIRST ];
+}


### PR DESCRIPTION
A protobuf message will be corrupted in the following scenario:
  1. Use LITE_RUNTIME.
  2. Have an optional enum field following some other field.
  3. Update protocol by adding new values to the enum.
  4. Have an old client parse and serialize a message having enum field
      set to a value the client does not understand.
  5. Field preceeding the enum is now corrupted.

The bug is due to the fact that optimized fallthrough in parser code
does not update variablle 'tag' when jumping to the parser code for the
next field.