### PR TITLE
Remove googletest.h header from stringprintf.cc

### DIFF
--- a/src/google/protobuf/stubs/stringprintf.cc
+++ b/src/google/protobuf/stubs/stringprintf.cc
@@ -37,7 +37,6 @@
 #include <stdio.h> // MSVC requires this for _vsnprintf
 #include <vector>
 #include <google/protobuf/stubs/common.h>
-#include <google/protobuf/testing/googletest.h>
 
 namespace google {
 namespace protobuf {


### PR DESCRIPTION
It doesn't seem to be necessary here, and it pulls other testing headers
during compilation of release protobuf.