### PR TITLE
Support Windows in gulpfile.js

### DIFF
--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -1,6 +1,10 @@
 var gulp = require('gulp');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var glob = require('glob');
+
+function exec(command, cb) {
+  execFile('sh', ['-c', command], cb);
+}
 
 var protoc = process.env.PROTOC || '../src/protoc';
 

--- a/js/package.json
+++ b/js/package.json
@@ -13,7 +13,7 @@
     "glob": "~6.0.4"
   },
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js test"
+    "test": "node ./node_modules/gulp/bin/gulp.js test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, running `npm test` on Windows fails with:

```
'.' is not recognized as an internal or external command,
operable program or batch file.
```

Because npm tries to run `./node_modules/gulp/bin/gulp.js test` in `cmd`, which chokes on this syntax and doesn't know anything about shebangs. Adding `node` in front of the command fixes it.

Another problem is `exec` in gulpfile.js, which is not portable, since it uses `cmd` on Windows. I monkey-patched it with a wrapper around `execFile` that always runs `sh`. This way, the script will run in Git Bash or MSYS2, or even in `cmd` if `sh` is in `PATH`.

By the way, I initially tried to make gulpfile.js truly portable by eliminating the usage of the shell. But then I realized that I'm basically using Node.js to reinvent things that bash is _designed_ for. It's not unreasonable to expect Windows developers to have bash, as it comes with git.