### PR TITLE
Fix delete_if for repeated_field, tests for same

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -150,13 +150,13 @@ module Google
       end
 
 
-      %w(delete delete_at delete_if shift slice! unshift).each do |method_name|
+      %w(delete delete_at shift slice! unshift).each do |method_name|
         define_array_wrapper_method(method_name)
       end
 
 
       %w(collect! compact! fill flatten! insert reverse!
-        rotate! select! shuffle! sort! sort_by! uniq!).each do |method_name|
+        rotate! select! shuffle! sort! sort_by! uniq! delete_if).each do |method_name|
         define_array_wrapper_with_result_method(method_name)
       end
       alias_method :keep_if, :select!

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -363,6 +363,16 @@ class RepeatedFieldTest < Test::Unit::TestCase
     end
   end
 
+  def test_delete_if
+    m = TestMessage.new
+    reference_arr = %w(foo barb az)
+    m.repeated_string += reference_arr.clone
+
+    check_self_modifying_method(m.repeated_string, reference_arr) do |arr|
+      arr.delete_if { |x| x.length.even? }
+    end
+  end
+
   def test_fill
     m = TestMessage.new
     reference_arr = %w(foo bar baz)


### PR DESCRIPTION
delete_if was under the define_array_wrapper_method's, but this made it not evaluate blocks passed in correctly(as it would return an enumerator, and never reach evaluating the block), which is contrary to
how delete_if is implemented for arrays

Let me know if you have any questions/tweaks.
