### PR TITLE
Added serialVersionUID to ExtendableMessage.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessage.java
@@ -795,6 +795,8 @@ public abstract class GeneratedMessage extends AbstractMessage
       extends GeneratedMessage
       implements ExtendableMessageOrBuilder<MessageType> {
 
+    private static final long serialVersionUID = 1L;
+
     private final FieldSet<FieldDescriptor> extensions;
 
     protected ExtendableMessage() {


### PR DESCRIPTION
We've been experiencing problems (`java.io.InvalidClassException`) when serialising and deserialising messages with extensions (maybe because classes were compiled in a slightly different way at both ends?). Adding `serialVersionUID` to `ExtendableMessage` fixed the problem.

It turns out that having `serialVersionUID` set in the parent class is not enough. Anyway, this patch shouldn't hurt and it follows the recommendation that `serialVersionUID` should be declared in every `Serializable` class.