### PR TITLE
Added options to CMake configuration to enable/disable certain compilers

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -23,6 +23,47 @@ else (MSVC)
   set(protobuf_WITH_ZLIB_DEFAULT ON)
 endif (MSVC)
 option(protobuf_WITH_ZLIB "Build with zlib support" ${protobuf_WITH_ZLIB_DEFAULT})
+
+option(protobuf_WITHOUT_CPP_COMPILER "Build with C++ compiler support" ON)
+if (protobuf_WITHOUT_CPP_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_CPP)
+endif ()
+
+option(protobuf_WITHOUT_JAVA_COMPILER "Build with Java compiler support" ON)
+if (protobuf_WITHOUT_JAVA_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_JAVA)
+endif ()
+
+option(protobuf_WITHOUT_CSHARP_COMPILER "Build with C# compiler support" ON)
+if (protobuf_WITHOUT_CSHARP_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_CSHARP)
+endif()
+
+option(protobuf_WITHOUT_OBJC_COMPILER "Build with Objective-C compiler support" ON)
+if (protobuf_WITHOUT_OBJC_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_OBJC)
+endif()
+
+option(protobuf_WITHOUT_JAVANANO_COMPILER "Build with Java Nano compiler support" ON)
+if (protobuf_WITHOUT_JAVANANO_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_JAVANANO)
+endif()
+
+option(protobuf_WITHOUT_JS_COMPILER "Build with JavaScript compiler support" ON)
+if (protobuf_WITHOUT_JS_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUFC_NO_JS)
+endif()
+
+option(protobuf_WITHOUT_PYTHON_COMPILER "Build with Python compiler support" ON)
+if (protobuf_WITHOUT_PYTHON_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUF_NO_PYTHON)
+endif()
+
+option(protobuf_WITHOUT_RUBY_COMPILER "Build with Ruby compiler support" ON)
+if (protobuf_WITHOUT_RUBY_COMPILER)
+    add_definitions(-DGOOGLE_PROTOBUF_NO_RUBY)
+endif()
+
 set(protobuf_DEBUG_POSTFIX "d"
   CACHE STRING "Default debug postfix")
 

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -1,6 +1,4 @@
-set(libprotoc_files
-  ${protobuf_source_dir}/src/google/protobuf/compiler/code_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/command_line_interface.cc
+set(libprotoc_files_cpp
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_extension.cc
@@ -14,22 +12,9 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
+)
+
+set(libprotoc_files_java
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_context.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_doc_comment.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum.cc
@@ -60,18 +45,28 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_shared_code_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_extension.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_file.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_helpers.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_map_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
+)
+
+set(libprotoc_files_csharp
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_generator.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc
+)
+
+set(libprotoc_files_objc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -84,13 +79,74 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc
+)
+
+set(libprotoc_files_javanano
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_extension.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_file.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_generator.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_helpers.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_map_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message_field.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
+)
+
+set(libprotoc_files_js
+  ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
+)
+
+set(libprotoc_files_python
+  ${protobuf_source_dir}/src/google/protobuf/compiler/python/python_generator.cc
+)
+
+set(libprotoc_files_ruby
+  ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
+)
+
+set(libprotoc_files
+  ${protobuf_source_dir}/src/google/protobuf/compiler/code_generator.cc
+  ${protobuf_source_dir}/src/google/protobuf/compiler/command_line_interface.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/python/python_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
 )
+
+if (protobuf_WITHOUT_CPP_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_cpp})
+endif()
+
+if (protobuf_WITHOUT_JAVA_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_java})
+endif()
+
+if (protobuf_WITHOUT_CSHARP_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_csharp})
+endif()
+
+if (protobuf_WITHOUT_OBJC_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_objc})
+endif()
+
+if (protobuf_WITHOUT_JAVANANO_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_javanano})
+endif()
+
+if (protobuf_WITHOUT_JS_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_js})
+endif()
+
+if (protobuf_WITHOUT_PYTHON_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_python})
+endif()
+
+if (protobuf_WITHOUT_RUBY_COMPILER)
+    list(APPEND libprotoc_files ${libprotoc_files_ruby})
+endif()
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
   ${libprotoc_files})

--- a/src/google/protobuf/compiler/main.cc
+++ b/src/google/protobuf/compiler/main.cc
@@ -46,45 +46,60 @@ int main(int argc, char* argv[]) {
   cli.AllowPlugins("protoc-");
 
   // Proto2 C++
+#ifndef GOOGLE_PROTOBUFC_NO_CPP
   google::protobuf::compiler::cpp::CppGenerator cpp_generator;
   cli.RegisterGenerator("--cpp_out", "--cpp_opt", &cpp_generator,
                         "Generate C++ header and source.");
+#endif
 
   // Proto2 Java
+#ifndef GOOGLE_PROTOBUFC_NO_JAVA
   google::protobuf::compiler::java::JavaGenerator java_generator;
   cli.RegisterGenerator("--java_out", &java_generator,
                         "Generate Java source file.");
-
+#endif
 
   // Proto2 Python
+#ifndef GOOGLE_PROTOBUFC_NO_PYTHON
   google::protobuf::compiler::python::Generator py_generator;
   cli.RegisterGenerator("--python_out", &py_generator,
                         "Generate Python source file.");
+#endif
 
   // Java Nano
+#ifndef GOOGLE_PROTOBUFC_NO_JAVANANO
   google::protobuf::compiler::javanano::JavaNanoGenerator javanano_generator;
   cli.RegisterGenerator("--javanano_out", &javanano_generator,
                         "Generate Java Nano source file.");
+#endif
 
   // Ruby
+#ifndef GOOGLE_PROTOBUFC_NO_RUBY
   google::protobuf::compiler::ruby::Generator rb_generator;
   cli.RegisterGenerator("--ruby_out", &rb_generator,
                         "Generate Ruby source file.");
+#endif
 
   // CSharp
+#ifndef GOOGLE_PROTOBUFC_NO_CSHARP
   google::protobuf::compiler::csharp::Generator csharp_generator;
   cli.RegisterGenerator("--csharp_out", "--csharp_opt", &csharp_generator,
                         "Generate C# source file.");
+#endif
 
   // Objective C
+#ifndef GOOGLE_PROTOBUFC_NO_OBJC
   google::protobuf::compiler::objectivec::ObjectiveCGenerator objc_generator;
   cli.RegisterGenerator("--objc_out", "--objc_opt", &objc_generator,
                         "Generate Objective C header and source.");
+#endif
 
   // JavaScript
+#ifndef GOOGLE_PROTOBUFC_NO_JS
   google::protobuf::compiler::js::Generator js_generator;
   cli.RegisterGenerator("--js_out", &js_generator,
                         "Generate JavaScript source.");
+#endif
 
   return cli.Run(argc, argv);
 }


### PR DESCRIPTION
Added option to enable/disable support for certain language compilers in `protoc`. This allows the user to disable support for compilers that they don't need. Most people will never need this. However, there's a group of users out there (myself included) who have Protobuf as a subtree in their repository and compile it from source every time (similar to how Chromium does this for third party dependencies). Disabling support for certain compilers reduces compile time.

By default, support for all languages is compiled. The following options have been added to the CMake configuration:

     option(protobuf_WITH_CPP_COMPILER "Build with C++ compiler support" ON)
     option(protobuf_WITH_JAVA_COMPILER "Build with Java compiler support" ON)
     option(protobuf_WITH_CSHARP_COMPILER "Build with C# compiler support" ON)
     option(protobuf_WITH_OBJC_COMPILER "Build with Objective-C compiler support" ON)
     option(protobuf_WITH_JAVANANO_COMPILER "Build with Java Nano compiler support" ON)
     option(protobuf_WITH_JS_COMPILER "Build with JavaScript compiler support" ON)
     option(protobuf_WITH_PYTHON_COMPILER "Build with Python compiler support" ON)
     option(protobuf_WITH_RUBY_COMPILER "Build with Ruby compiler support" ON)