### PR TITLE
Added dig and bsearch_index to RepeatedField methods forwarded to array

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -69,8 +69,8 @@ module Google
       #        relationship explicit instead of implicit
       def_delegators :to_ary,
         :&, :*, :-, :'<=>',
-        :assoc, :bsearch, :combination, :compact, :count, :cycle,
-        :drop, :drop_while, :eql?, :fetch, :find_index, :flatten,
+        :assoc, :bsearch, :bsearch_index, :combination, :compact, :count,
+        :cycle, :dig, :drop, :drop_while, :eql?, :fetch, :find_index, :flatten,
         :include?, :index, :inspect, :join,
         :pack, :permutation, :product, :pretty_print, :pretty_print_cycle,
         :rassoc, :repeated_combination, :repeated_permutation, :reverse,


### PR DESCRIPTION
This fixes the test_acts_likes_an_array test in RepeatedFieldTest, which
checks that repeated fields respond to the same methods as regular Ruby
arrays. The bsearch_index and dig array methods seem to be new in Ruby
2.3 and so we should support those.