### PR TITLE
Option to preserve json field names for Python.

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -125,6 +125,21 @@ class JsonFormatTest(JsonFormatBase):
     parsed_message = json_format_proto3_pb2.TestMessage()
     self.CheckParseBack(message, parsed_message)
 
+  def testPreserveCaseMessageToJson(self):
+    message = json_format_proto3_pb2.TestMessage(
+        string_value='test',
+        repeated_int32_value=[89, 4])
+    self.assertEqual(json.loads(json_format.MessageToJson(
+            message, preserve_field_names=True)),
+                     json.loads('{"string_value": "test", '
+                                '"repeated_int32_value": [89, 4]}'))
+    parsed_message = json_format_proto3_pb2.TestMessage()
+    json_format.Parse(json_format.MessageToJson(message,
+                                                preserve_field_names=True),
+                      parsed_message,
+                      preserve_field_names=True)
+    self.assertEqual(message, parsed_message)
+
   def testAllFieldsToJson(self):
     message = json_format_proto3_pb2.TestMessage()
     text = ('{"int32Value": 20, '


### PR DESCRIPTION
Mainly, I would just like some way to be able to preserve field names when going back and forth between protobuf messages and JSON. If this PR isn't appropriate, could you suggest some other way this feature might be implemented?

Currently field names are converted to and from camel case when converting protobuf message to JSON. This pull request adds an option to preserve the field names during the conversion process.
