### PR TITLE
Fix cp -r usage to be portable.

### DIFF
--- a/objectivec/generate_well_known_types.sh
+++ b/objectivec/generate_well_known_types.sh
@@ -73,4 +73,4 @@ fi
 
 # Copy them over.
 echo "Copying over updated WellKnownType sources."
-cp -r "${TMP_DIR}/google/" "${ProtoRootDir}/objectivec/google/"
+cp -r "${TMP_DIR}/google/." "${ProtoRootDir}/objectivec/google/"


### PR DESCRIPTION
cp -r foo/ bar/ in linux will create a bar/foo directoy. In the
objectivec generate descritpor case, well known types will be created in
objectivec/google/google/protobuf/.. if the command is run under linux.

Adding the trailing period fixes the behavior inconsistency.