### PR TITLE
Run tests in python 3.5 and add official support

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -233,7 +233,7 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
-        ],
+      ],
       namespace_packages=['google'],
       packages=find_packages(
           exclude=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -232,6 +232,7 @@ if __name__ == '__main__':
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         ],
       namespace_packages=['google'],
       packages=find_packages(

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34}-{cpp,python}
+    py{26,27,33,34,35}-{cpp,python}
 
 [testenv]
 usedevelop=true

--- a/tests.sh
+++ b/tests.sh
@@ -191,6 +191,7 @@ internal_install_python_deps() {
     sudo apt-get install -y python2.6 python2.6-dev
     sudo apt-get install -y python3.3 python3.3-dev
     sudo apt-get install -y python3.4 python3.4-dev
+    sudo apt-get install -y python3.5 python3.5-dev
   fi
 }
 
@@ -255,7 +256,7 @@ build_python() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34\}-python
+    envlist=py\{26,27,33,34,35\}-python
   else
     envlist=py27-python
   fi
@@ -272,7 +273,7 @@ build_python_cpp() {
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
     # py26 is currently disabled due to json_format
-    envlist=py\{27,33,34\}-cpp
+    envlist=py\{27,33,34,35\}-cpp
   else
     envlist=py27-cpp
   fi


### PR DESCRIPTION
The tests are all passing, so just a matter of adding it to `setup.py` and the testing script.