### PR TITLE
Fix C++ Boost incompatibility on Windows/MSVC

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -276,10 +276,8 @@ inline void GOOGLE_UNALIGNED_STORE64(void *p, uint64 v) {
 #define GOOGLE_THREAD_LOCAL __thread
 #endif
 
-// The following guarantees declaration of the byte swap functions, and
-// defines __BYTE_ORDER for MSVC
+// The following guarantees declaration of the byte swap functions.
 #ifdef _MSC_VER
-#define __BYTE_ORDER __LITTLE_ENDIAN
 #define bswap_16(x) _byteswap_ushort(x)
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)


### PR DESCRIPTION
Removes the #definition of __BYTE_ORDER on Windows which is unused by the rest of the Protobuf library (at least according to grep)

 __LITTLE_ENDIAN and __BIG_ENDIAN are both undefined, meaning that
` __BYTE_ORDER == __LITTLE_ENDIAN`
and
`__BYTE_ORDER == __BIG_ENDIAN` both wind up evaluating to true.

This breaks boost/predef/other/endian.h, which checks for the existence of sys/param.h by looking for __BYTE_ORDER, and assumes that if __BYTE_ORDER is defined, then both __LITTLE_ENDIAN and __BIG_ENDIAN will be.

If these variables are required, a more complete windows shim of sys/param.h should be created.