### PR TITLE
Fix Windows phone build

### DIFF
--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -123,7 +123,7 @@ Atomic32 Barrier_AtomicIncrement(volatile Atomic32* ptr,
 // ensure that no later memory access can be reordered ahead of the operation.
 // "Release" operations ensure that no previous memory access can be reordered
 // after the operation.  "Barrier" operations have both "Acquire" and "Release"
-// semantics.   A MemoryBarrier() has "Barrier" semantics, but does no memory
+// semantics.   A MemoryBarrierInternal() has "Barrier" semantics, but does no memory
 // access.
 Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
                                 Atomic32 old_value,
@@ -132,10 +132,7 @@ Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
                                 Atomic32 old_value,
                                 Atomic32 new_value);
 
-#if defined(__MINGW32__) && defined(MemoryBarrier)
-#undef MemoryBarrier
-#endif
-void MemoryBarrier();
+void MemoryBarrierInternal();
 void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value);
 void Acquire_Store(volatile Atomic32* ptr, Atomic32 value);
 void Release_Store(volatile Atomic32* ptr, Atomic32 value);
@@ -180,7 +177,7 @@ Atomic64 Release_Load(volatile const Atomic64* ptr);
 #include <google/protobuf/stubs/atomicops_internals_tsan.h>
 // MSVC.
 #elif defined(_MSC_VER)
-#if defined(GOOGLE_PROTOBUF_ARCH_IA32) || defined(GOOGLE_PROTOBUF_ARCH_X64)
+#if defined(GOOGLE_PROTOBUF_ARCH_IA32) || defined(GOOGLE_PROTOBUF_ARCH_X64) || defined(GOOGLE_PROTOBUF_ARCH_ARM)
 #include <google/protobuf/stubs/atomicops_internals_x86_msvc.h>
 #else
 #error GOOGLE_PROTOBUF_ATOMICOPS_ERROR

--- a/src/google/protobuf/stubs/atomicops_internals_x86_msvc.cc
+++ b/src/google/protobuf/stubs/atomicops_internals_x86_msvc.cc
@@ -44,7 +44,7 @@ namespace google {
 namespace protobuf {
 namespace internal {
 
-inline void MemoryBarrier() {
+inline void MemoryBarrierInternal() {
   // We use MemoryBarrier from WinNT.h
   ::MemoryBarrier();
 }

--- a/src/google/protobuf/stubs/atomicops_internals_x86_msvc.h
+++ b/src/google/protobuf/stubs/atomicops_internals_x86_msvc.h
@@ -82,7 +82,7 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
 }
 
 inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
+  MemoryBarrierInternal();
   return *ptr;
 }
 
@@ -125,7 +125,7 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
 }
 
 inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
+  MemoryBarrierInternal();
   return *ptr;
 }
 

--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -47,7 +47,7 @@
 #elif defined(__QNX__)
 #define GOOGLE_PROTOBUF_ARCH_ARM_QNX 1
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
-#elif defined(__ARMEL__)
+#elif defined(__ARMEL__) || defined(_M_ARM)
 #define GOOGLE_PROTOBUF_ARCH_ARM 1
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
 #elif defined(__aarch64__)


### PR DESCRIPTION
I don't understand the complexity of stuff around MemoryBarrier. I couldn't determine why defines instead *Internal function name was used.

This changes unblocks build of libprotobuf and libprotobuf-lite. I was unable to build tests, as gtest and gmock are outdated and can't be build for windows store apps. At least 1.7.0 versions (as from cmake visual studio guide). I've tried to compile their latest master and looks like they compile for winstore.
