### PR TITLE
JSON format for Any message must print @type first

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -458,6 +458,22 @@ class JsonFormatTest(JsonFormatBase):
             '}\n'))
     parsed_message = json_format_proto3_pb2.TestAny()
     self.CheckParseBack(message, parsed_message)
+    # Must print @type first
+    test_message = json_format_proto3_pb2.TestMessage(
+        bool_value=True,
+        int32_value=20,
+        int64_value=-20,
+        uint32_value=20,
+        uint64_value=20,
+        double_value=3.14,
+        string_value='foo')
+    message.Clear()
+    message.value.Pack(test_message)
+    self.assertEqual(
+        json_format.MessageToJson(message, False)[0:68],
+        '{\n'
+        '  "value": {\n'
+        '    "@type": "type.googleapis.com/proto3.TestMessage"')
 
   def testWellKnownInAnyMessage(self):
     message = any_pb2.Any()

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -42,6 +42,10 @@ Simple usage example:
 
 __author__ = 'jieluo@google.com (Jie Luo)'
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict  #PY26
 import base64
 import json
 import math
@@ -208,7 +212,8 @@ def _AnyMessageToJsonObject(message, including_default):
   """Converts Any message according to Proto3 JSON Specification."""
   if not message.ListFields():
     return {}
-  js = {}
+  # Must print @type first, use OrderedDict instead of {}
+  js = OrderedDict()
   type_url = message.type_url
   js['@type'] = type_url
   sub_message = _CreateMessageFromTypeUrl(type_url)


### PR DESCRIPTION
JSON format for Any message must print @type first, use OrderedDict instead of {}