### PR TITLE
Make cmake configuration file install path configurable

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -83,9 +83,15 @@ foreach(_file ${nobase_dist_proto_DATA})
 endforeach()
 
 # Export configuration
+set(_cmakedir_desc "Directory relative to CMAKE_INSTALL to install the cmake configuration files")
+if(NOT MSVC)
+  set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/protobuf" CACHE STRING "${_cmakedir_desc")
+else()
+  set(CMAKE_INSTALL_CMAKEDIR "cmake" CACHE STRING "${_cmakedir_desc}")
+endif()
 
 install(EXPORT protobuf-targets
-  DESTINATION "lib/cmake/protobuf"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT protobuf-export)
 
 configure_file(protobuf-config.cmake.in
@@ -99,5 +105,5 @@ install(FILES
   "${protobuf_BINARY_DIR}/protobuf-config.cmake"
   "${protobuf_BINARY_DIR}/protobuf-config-version.cmake"
   "${protobuf_BINARY_DIR}/protobuf-module.cmake"
-  DESTINATION "lib/cmake/protobuf"
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
   COMPONENT protobuf-export)


### PR DESCRIPTION
Make the cmake configuration file install path configurable and provide reasonable defaults for GNU and Windows systems.

*.cmake files are now installed to ${CMAKE_INSTALL_LIBDIR}/cmake/<name> on GNU systems, and <name>/cmake on MSVC. I chose to branch on MSVC rather than WIN32 out of consideration for CYGWIN environments which would likely favor the GNU install format.

(See the description of cmake's config search behavior on https://cmake.org/cmake/help/v3.4/command/find_package.html)