### PR TITLE
Make protobuf-config-version.cmake.in set the required variables

### DIFF
--- a/cmake/protobuf-config-version.cmake.in
+++ b/cmake/protobuf-config-version.cmake.in
@@ -1,1 +1,36 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is derived from the format suggested in the CMake module
+# CMakePackageConfigHelpers. introduced in CMake 2.8.8.
+# If the cmake_minimum_required version is ever bumped to 2.8.8 or
+# above, this file may be deleted and replaced with a call to
+# write_basic_package_version_file(...)
+
 set(PACKAGE_VERSION @protobuf_VERSION@)
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+
+  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL @protobuf_VERSION_MAJOR@)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+   return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+  math(EXPR installedBits "@CMAKE_SIZEOF_VOID_P@ * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()


### PR DESCRIPTION
CMake requires that PACKAGE_VERSION_EXACT, PACKAGE_VERSION_COMPATIBLE, and PACKAGE_VERSION_UNSUITABLE be set by the configuration file. (See https://cmake.org/cmake/help/v3.4/manual/cmake-packages.7.html#package-version-file)

These updates bring the file in line with that requirement based on the template provided by the CMakePackageConfigHelpers module. 

An alternative PR would update the minimum required CMake version to 2.8.8 and simply use the write_basic_package_version_file function defined in the CMakePackageConfigHelpers module.