### PR TITLE
Add protobuf:: namespace to installed targets

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -92,6 +92,7 @@ endif()
 
 install(EXPORT protobuf-targets
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+  NAMESPACE protobuf::
   COMPONENT protobuf-export)
 
 configure_file(protobuf-config.cmake.in


### PR DESCRIPTION
CMake standards recommend that exported targets be given a namespace.