### PR TITLE
Xml-doc comments for CodedInputStream.ReadEnum (C#) out-of-date

### DIFF
--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -612,9 +612,7 @@ namespace Google.Protobuf
         }
 
         /// <summary>
-        /// Reads an enum field value from the stream. If the enum is valid for type T,
-        /// then the ref value is set and it returns true.  Otherwise the unknown output
-        /// value is set and this method returns false.
+        /// Reads an enum field value from the stream.
         /// </summary>   
         public int ReadEnum()
         {


### PR DESCRIPTION
The original documentation seemed to imply a different function usage with a different signature.  Corrected comment to say what the method actually does.