### PR TITLE
Make the CocoaPods integration tests more robust

### DIFF
--- a/objectivec/Tests/CocoaPods/OSXCocoaPodsTester/Podfile-framework
+++ b/objectivec/Tests/CocoaPods/OSXCocoaPodsTester/Podfile-framework
@@ -3,9 +3,7 @@ platform :osx, '10.9'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-if ENV['USE_FRAMEWORKS'] == 'YES' then
-  use_frameworks!
-end
+use_frameworks!
 
 target 'OSXCocoaPodsTester' do
   pod 'Protobuf', :path => '../../../..'

--- a/objectivec/Tests/CocoaPods/OSXCocoaPodsTester/Podfile-static
+++ b/objectivec/Tests/CocoaPods/OSXCocoaPodsTester/Podfile-static
@@ -1,12 +1,8 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :osx, '10.9'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-if ENV['USE_FRAMEWORKS'] == 'YES' then
-  use_frameworks!
-end
-
-target 'iOSCocoaPodsTester' do
+target 'OSXCocoaPodsTester' do
   pod 'Protobuf', :path => '../../../..'
 end

--- a/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-framework
+++ b/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-framework
@@ -1,0 +1,10 @@
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '8.0'
+
+install! 'cocoapods', :deterministic_uuids => false
+
+use_frameworks!
+
+target 'iOSCocoaPodsTester' do
+  pod 'Protobuf', :path => '../../../..'
+end

--- a/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-static
+++ b/objectivec/Tests/CocoaPods/iOSCocoaPodsTester/Podfile-static
@@ -1,0 +1,8 @@
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '8.0'
+
+install! 'cocoapods', :deterministic_uuids => false
+
+target 'iOSCocoaPodsTester' do
+  pod 'Protobuf', :path => '../../../..'
+end


### PR DESCRIPTION
- Env solution doesn't seem to always work, use template pod files and copy
  them in place instead.
- Flush the pods cache before and after runs.
- Make pod install verbose to have the info incase something goes wrong.