### PR TITLE
added missing closing bracket for _cmakedir_desc in cmake/install.cmake:88

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -85,7 +85,7 @@ endforeach()
 # Export configuration
 set(_cmakedir_desc "Directory relative to CMAKE_INSTALL to install the cmake configuration files")
 if(NOT MSVC)
-  set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/protobuf" CACHE STRING "${_cmakedir_desc")
+  set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/protobuf" CACHE STRING "${_cmakedir_desc}")
 else()
   set(CMAKE_INSTALL_CMAKEDIR "cmake" CACHE STRING "${_cmakedir_desc}")
 endif()


### PR DESCRIPTION
This prevented me from generating Makefiles via cmake with the following error:

CMake Error at install.cmake:88 (set):
  Syntax error in cmake code at

    /home/jeff/libs/protobuf/cmake/install.cmake:88

  when parsing string

    ${_cmakedir_desc

  syntax error, unexpected $end, expecting } (16)
Call Stack (most recent call first):
  CMakeLists.txt:153 (include)

Adding the closing bracket fixed this issue.