### PR TITLE
Add js/binary/encoder.js to js_EXTRA_DIST.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -675,6 +675,7 @@ js_EXTRA_DIST=              \
   js/binary/constants.js    \
   js/binary/decoder.js      \
   js/binary/decoder_test.js \
+  js/binary/encoder.js      \
   js/binary/proto_test.js   \
   js/binary/reader.js       \
   js/binary/reader_test.js  \


### PR DESCRIPTION
Currently encoder.js is missing from the JS alpha release archives.