### PR TITLE
Add prerelease version tracking to CMake config file

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -44,16 +44,59 @@ string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\2"
 string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\3"
     protobuf_CONTACT        "${protobuf_AC_INIT_LINE}")
 # Parse version tweaks
-set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*$")
+set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)-?(.*)$")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\1"
   protobuf_VERSION_MAJOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\2"
   protobuf_VERSION_MINOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\3"
   protobuf_VERSION_PATCH "${protobuf_VERSION_STRING}")
+string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\4"
+  protobuf_VERSION_PRERELEASE_STRING "${protobuf_VERSION_STRING}")
+
 # Package version
 set(protobuf_VERSION
   "${protobuf_VERSION_MAJOR}.${protobuf_VERSION_MINOR}.${protobuf_VERSION_PATCH}")
+
+# Form an encoded number based on the prerelease string that enables simple comparison.
+# First digit: 1 = alpha, 2 = beta, 3 = rc.
+# Second digit: The number of the release.
+# Third digit: 0 = prerelease, 1 = release.
+# Ex: alpha-3-pre = 103, beta-2 = 212
+# This will allow users to pick between different prerelease versions using find_package.
+if(protobuf_VERSION_PRERELEASE_STRING)
+  set(protobuf_PRERELEASE_TYPES alpha beta rc) #protobuf_PRERELEASE_TYPE uses indexes in this list to determine value
+
+  string(REPLACE ";" "|" protobuf_PRERELEASE_TYPES_REGEX "${protobuf_PRERELEASE_TYPES}")
+  set(protobuf_PRERELEASE_REGEX "^(${protobuf_PRERELEASE_TYPES_REGEX})[-\\.]([0-9]+).*")
+  string(REGEX REPLACE "${protobuf_PRERELEASE_REGEX}" "\\1"
+    protobuf_PRERELEASE_TYPE "${protobuf_VERSION_PRERELEASE_STRING}")
+  string(REGEX REPLACE "${protobuf_PRERELEASE_REGEX}" "\\2"
+    protobuf_PRERELEASE_NUM "${protobuf_VERSION_PRERELEASE_STRING}")
+  string(REGEX MATCH ".*(pre|SNAPSHOT).*"
+    protobuf_PRERELEASE_SNAPSHOT "${protobuf_VERSION_PRERELEASE_STRING}")
+
+  list(FIND protobuf_PRERELEASE_TYPES "${protobuf_PRERELEASE_TYPE}" protobuf_PRERELEASE_TYPE)
+  math(EXPR protobuf_PRERELEASE_TYPE "(0${protobuf_PRERELEASE_TYPE})+1")
+
+  if("${protobuf_PRERELEASE_NUM}" STREQUAL "${protobuf_VERSION_PRERELEASE_STRING}")
+    set(protobuf_PRERELEASE_NUM 0)
+  endif()
+
+  if(protobuf_PRERELEASE_SNAPSHOT)
+    set(protobuf_PRERELEASE_SNAPSHOT 1)
+  else()
+    set(protobuf_PRERELEASE_SNAPSHOT 0)
+  endif()
+
+  if("${protobuf_PRERELEASE_TYPE}" STREQUAL "${protobuf_VERSION_PRERELEASE_STRING}" AND NOT protobuf_PRERELEASE_SNAPSHOT)
+    message(FATAL_ERROR "Detected a prerelease version with an unknown format (${protobuf_VERSION_PRERELEASE_STRING}).
+     Please update the prerelease version string parser.")
+  endif()
+
+  set(protobuf_VERSION_TWEAK "${protobuf_PRERELEASE_TYPE}${protobuf_PRERELEASE_NUM}${protobuf_PRERELEASE_SNAPSHOT}")
+  set(protobuf_VERSION "${protobuf_VERSION}.${protobuf_VERSION_TWEAK}")
+endif()
 
 if(protobuf_VERBOSE)
   message(STATUS "Configuration script parsing status [")

--- a/cmake/protobuf-config-version.cmake.in
+++ b/cmake/protobuf-config-version.cmake.in
@@ -1,27 +1,25 @@
-# This is a basic version file for the Config-mode of find_package().
-# It is derived from the format suggested in the CMake module
-# CMakePackageConfigHelpers. introduced in CMake 2.8.8.
-# If the cmake_minimum_required version is ever bumped to 2.8.8 or
-# above, this file may be deleted and replaced with a call to
-# write_basic_package_version_file(...)
-
 set(PACKAGE_VERSION @protobuf_VERSION@)
 
-if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+# Implement rough Sematic Versioning rules - Major versions must match, minor, patch and tweak
+# versionsmust be greater, and a version with no tweak(prerelease) beats equal versions with one.
+
+# To allow matching of prerelease versions in find_package, users must specify a tweak version
+# greater than 0
+
+set(PACKAGE_VERSION_COMPATIBLE TRUE) #Assume true until shown otherwise
+
+if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+  set(PACKAGE_VERSION_EXACT TRUE)
+elseif(NOT PACKAGE_FIND_VERSION_MAJOR EQUAL "@protobuf_VERSION_MAJOR@")
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
-else()
-
-  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL @protobuf_VERSION_MAJOR@)
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-  else()
-    set(PACKAGE_VERSION_COMPATIBLE FALSE)
-  endif()
-
-  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
-      set(PACKAGE_VERSION_EXACT TRUE)
-  endif()
+elseif(PACKAGE_FIND_VERSION_MINOR GREATER "@protobuf_VERSION_MINOR@")
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+elseif(PACKAGE_FIND_VERSION_PATCH GREATER "@protobuf_VERSION_PATCH@")
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+elseif(("@protobuf_VERSION_TWEAK@" AND NOT PACKAGE_FIND_VERSION_TWEAK) OR
+       (PACKAGE_FIND_VERSION_TWEAK GREATER "@protobuf_VERSION_TWEAK@"))
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
 endif()
-
 
 # if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
 if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")


### PR DESCRIPTION
Encodes the prerelease string in the 'tweak' version, and make the config-version module use a rough Semantic Versioning scheme to accept or reject matches.

Previously find_package(protobuf 3.0.0) would match any prerelease version *and* the eventual proper 3.0.0 release. Under the new scheme, it will only find the proper 3.0.0 release. For prerelease versions, users may enter find_package(protobuf 3.0.0.x) where x is > 0.

The encoding scheme chosen means that alpha-2 < beta-1 < beta-1-pre.

Currently supported prerelease types are 'alpha', 'beta', and 'rc'.