### PR TITLE
Fix _PROTOBUF_IMPORT_PREFIX

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -10,12 +10,8 @@ get_filename_component(_PROTOBUF_PACKAGE_PREFIX
 include("${_PROTOBUF_PACKAGE_PREFIX}/protobuf-targets.cmake")
 
 # Compute the installation prefix relative to this file.
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_PACKAGE_PREFIX}" PATH)
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_IMPORT_PREFIX}" PATH)
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_IMPORT_PREFIX}" PATH)
+file(RELATIVE_PATH _PROTOBUF_RELATIVE_PATH "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_CMAKEDIR@" "@CMAKE_INSTALL_PREFIX@")
+get_filename_component(_PROTOBUF_IMPORT_PREFIX  "${_PROTOBUF_PACKAGE_PREFIX}/${_PROTOBUF_RELATIVE_PATH}" ABSOLUTE)
 
 # CMake FindProtobuf module compatible file
 if(NOT DEFINED PROTOBUF_MODULE_COMPATIBLE OR "${PROTOBUF_MODULE_COMPATIBLE}")


### PR DESCRIPTION
Fixed  _PROTOBUF_IMPORT_PREFIX computation to work with different values of CMAKE_INSTALL_CMAKEDIR. Previously it would only work if the cmake directory was 3 directories deeper than the root install directory.