### PR TITLE
Bump cmake minimum required version to 2.8.12

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Project
 project(protobuf C CXX)


### PR DESCRIPTION
cmake_policy(SET CMP0022 NEW) causes compilation failures on any version earlier than this.