### PR TITLE
CMake prerelease versioning

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -44,16 +44,23 @@ string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\2"
 string(REGEX REPLACE        "${protobuf_AC_INIT_REGEX}" "\\3"
     protobuf_CONTACT        "${protobuf_AC_INIT_LINE}")
 # Parse version tweaks
-set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+).*$")
+set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)-?(.*)$")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\1"
   protobuf_VERSION_MAJOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\2"
   protobuf_VERSION_MINOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\3"
   protobuf_VERSION_PATCH "${protobuf_VERSION_STRING}")
+string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\4"
+  protobuf_VERSION_PRERELEASE "${protobuf_VERSION_STRING}")
+
 # Package version
 set(protobuf_VERSION
   "${protobuf_VERSION_MAJOR}.${protobuf_VERSION_MINOR}.${protobuf_VERSION_PATCH}")
+
+if(protobuf_VERSION_PRERELEASE)
+  set(protobuf_VERSION "${protobuf_VERSION}-${protobuf_VERSION_PRERELEASE}")
+endif()
 
 if(protobuf_VERBOSE)
   message(STATUS "Configuration script parsing status [")

--- a/cmake/protobuf-config-version.cmake.in
+++ b/cmake/protobuf-config-version.cmake.in
@@ -1,27 +1,31 @@
-# This is a basic version file for the Config-mode of find_package().
-# It is derived from the format suggested in the CMake module
-# CMakePackageConfigHelpers. introduced in CMake 2.8.8.
-# If the cmake_minimum_required version is ever bumped to 2.8.8 or
-# above, this file may be deleted and replaced with a call to
-# write_basic_package_version_file(...)
+set(PACKAGE_VERSION "@protobuf_VERSION@")
 
-set(PACKAGE_VERSION @protobuf_VERSION@)
-
-if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
-  set(PACKAGE_VERSION_COMPATIBLE FALSE)
-else()
-
-  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL @protobuf_VERSION_MAJOR@)
-    set(PACKAGE_VERSION_COMPATIBLE TRUE)
-  else()
-    set(PACKAGE_VERSION_COMPATIBLE FALSE)
-  endif()
-
-  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
-      set(PACKAGE_VERSION_EXACT TRUE)
-  endif()
+if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+  set(PACKAGE_VERSION_EXACT TRUE)
 endif()
 
+set(PACKAGE_VERSION_COMPATIBLE TRUE) #Assume true until shown otherwise
+
+# Handle prerelease versions
+set(PACKAGE_FIND_VERSION_PRERELEASE "${${PACKAGE_FIND_NAME}_FIND_VERSION_PRERELEASE}")
+if(NOT "@protobuf_VERSION_PRERELEASE@" STREQUAL "")
+  if(NOT ${PACKAGE_FIND_NAME}_FIND_VERSION_PRERELEASE)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    message(AUTHOR_WARNING "To use this prerelease version of ${PACKAGE_FIND_NAME}, set ${PACKAGE_FIND_NAME}_FIND_VERSION_PRERELEASE to '@protobuf_VERSION_PRERELEASE@'.")
+  endif()
+
+  if(NOT "${PACKAGE_FIND_VERSION}-${PACKAGE_FIND_VERSION_PRERELEASE}" STREQUAL "${PACKAGE_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+else()
+  if(NOT PACKAGE_FIND_VERSION_MAJOR EQUAL "@protobuf_VERSION_MAJOR@")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  elseif(PACKAGE_FIND_VERSION VERSION_GREATER PACKAGE_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+endif()
 
 # if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
 if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
@@ -34,3 +38,5 @@ if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "@CMAKE_SIZEOF_VOID_P@")
   set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
   set(PACKAGE_VERSION_UNSUITABLE TRUE)
 endif()
+
+set(${PACKAGE_FIND_NAME}_VERSION_PRERELEASE "@protobuf_VERSION_PRERELEASE@" PARENT_SCOPE)


### PR DESCRIPTION
Allows CMake users to differentiate between prerelease builds and pick between them successfully.
Requires exact version number matches for prerelease builds.

E.x. To use protobuf 3.0.0-beta-3:
```
set(protobuf_FIND_VERSION_PRERELEASE beta-3)
find_package(protobuf 3.0.0 EXACT)
```

Fixes #1579