### PR TITLE
Fix  _PROTOBUF_IMPORT_PREFIX calculation

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -6,14 +6,10 @@ set(PROTOBUF_VERSION_STRING "@protobuf_VERSION_STRING@")
 include("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets.cmake")
 
 # Compute the installation prefix relative to this file.
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_PACKAGE_PREFIX}" PATH)
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_IMPORT_PREFIX}" PATH)
-get_filename_component(_PROTOBUF_IMPORT_PREFIX
-  "${_PROTOBUF_IMPORT_PREFIX}" PATH)
+file(RELATIVE_PATH _relative_path "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_CMAKEDIR@" "@CMAKE_INSTALL_PREFIX@")
+get_filename_component(_PROTOBUF_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/${_relative_path}" ABSOLUTE)
 
 # CMake FindProtobuf module compatible file
 if(NOT DEFINED PROTOBUF_MODULE_COMPATIBLE OR "${PROTOBUF_MODULE_COMPATIBLE}")
-  include("${_PROTOBUF_PACKAGE_PREFIX}/protobuf-module.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/protobuf-module.cmake")
 endif()


### PR DESCRIPTION
Obsolete if #1615 is merged.

Fixes the the way the config file computes the root of the protobuf install to account for different cmake install structures.

Previously would go three directories up from the location of the config file.

