### PR TITLE
Fix some deprecation warnings introduced in 3.0.0-beta-3

### DIFF
--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -887,8 +887,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->is_packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.writeEnumNoTag($name$_.get(i));\n"
@@ -920,7 +920,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
       "if (!get$capitalized_name$List().isEmpty()) {"
       "  size += $tag_size$;\n"
       "  size += com.google.protobuf.CodedOutputStream\n"
-      "    .computeRawVarint32Size(dataSize);\n"
+      "    .computeUInt32SizeNoTag(dataSize);\n"
       "}");
   } else {
     printer->Print(variables_,

--- a/src/google/protobuf/compiler/java/java_enum_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field_lite.cc
@@ -885,8 +885,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->options().packed()) {
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.writeEnumNoTag($name$_.getInt(i));\n"
@@ -918,7 +918,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
       "if (!get$capitalized_name$List().isEmpty()) {"
       "  size += $tag_size$;\n"
       "  size += com.google.protobuf.CodedOutputStream\n"
-      "    .computeRawVarint32Size(dataSize);\n"
+      "    .computeUInt32SizeNoTag(dataSize);\n"
       "}");
   } else {
     printer->Print(variables_,

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -777,8 +777,8 @@ GenerateSerializationCode(io::Printer* printer) const {
     // That makes it safe to rely on the memoized size here.
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.write$capitalized_type$NoTag($name$_.get(i));\n"

--- a/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
@@ -817,8 +817,8 @@ GenerateSerializationCode(io::Printer* printer) const {
     // That makes it safe to rely on the memoized size here.
     printer->Print(variables_,
       "if (get$capitalized_name$List().size() > 0) {\n"
-      "  output.writeRawVarint32($tag$);\n"
-      "  output.writeRawVarint32($name$MemoizedSerializedSize);\n"
+      "  output.writeUInt32NoTag($tag$);\n"
+      "  output.writeUInt32NoTag($name$MemoizedSerializedSize);\n"
       "}\n"
       "for (int i = 0; i < $name$_.size(); i++) {\n"
       "  output.write$capitalized_type$NoTag($repeated_get$(i));\n"

--- a/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
@@ -471,10 +471,10 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->options().packed()) {
     GenerateRepeatedDataSizeCode(printer);
     printer->Print(variables_,
-      "output.writeRawVarint32($tag$);\n"
-      "output.writeRawVarint32(dataSize);\n"
+      "output.writeUInt32NoTag($tag$);\n"
+      "output.writeUInt32NoTag(dataSize);\n"
       "for (int i = 0; i < this.$name$.length; i++) {\n"
-      "  output.writeRawVarint32(this.$name$[i]);\n"
+      "  output.writeUInt32NoTag(this.$name$[i]);\n"
       "}\n");
   } else {
     printer->Print(variables_,
@@ -502,7 +502,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "size += $tag_size$;\n"
       "size += com.google.protobuf.nano.CodedOutputByteBufferNano\n"
-      "    .computeRawVarint32Size(dataSize);\n");
+      "    .computeUInt32SizeNoTag(dataSize);\n");
   } else {
     printer->Print(variables_,
       "size += $tag_size$ * this.$name$.length;\n");

--- a/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
@@ -893,8 +893,8 @@ GenerateSerializationCode(io::Printer* printer) const {
   if (descriptor_->is_packable() && descriptor_->options().packed()) {
     GenerateRepeatedDataSizeCode(printer);
     printer->Print(variables_,
-      "output.writeRawVarint32($tag$);\n"
-      "output.writeRawVarint32(dataSize);\n"
+      "output.writeUInt32NoTag($tag$);\n"
+      "output.writeUInt32NoTag(dataSize);\n"
       "for (int i = 0; i < this.$name$.length; i++) {\n"
       "  output.write$capitalized_type$NoTag(this.$name$[i]);\n"
       "}\n");
@@ -931,7 +931,7 @@ GenerateSerializedSizeCode(io::Printer* printer) const {
     printer->Print(variables_,
       "size += $tag_size$;\n"
       "size += com.google.protobuf.nano.CodedOutputByteBufferNano\n"
-      "    .computeRawVarint32Size(dataSize);\n");
+      "    .computeUInt32SizeNoTag(dataSize);\n");
   } else if (IsReferenceType(GetJavaType(descriptor_))) {
     printer->Print(variables_,
       "size += $tag_size$ * dataCount;\n");


### PR DESCRIPTION
Replace writeRawVarint32 with writeUInt32NoTag.
Replace computeRawVarint32Size with computeUInt32SizeNoTag.

Addresses #1596