### PR TITLE
CMake crosscompiling support

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -4,6 +4,24 @@ include("${CMAKE_CURRENT_LIST_DIR}/protobuf-options.cmake")
 # Imported targets
 include("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets.cmake")
 
+# Allow override of protoc for cross-compiling environments
+set(protobuf_PROTOC_LOCATION "" CACHE FILEPATH "Specify a protoc executable. Useful for cross-compiling.")
+if(NOT CMAKE_CROSSCOMPILNG)
+  mark_as_advanced(protobuf_PROTOC_LOCATION)
+endif()
+
+if(protobuf_PROTOC_LOCATION)
+  find_program(protobuf_PROTOC_LOCATION protoc HINTS "${protobuf_PROTOC_LOCATION}" NO_DEFAULT_PATH)
+
+  set_property(TARGET protobuf::protoc PROPERTY
+    IMPORTED_LOCATION "${protobuf_PROTOC_LOCATION}")
+
+  #Clear configuration specific locations
+  foreach(_config ${CMAKE_CONFIGURATION_TYPES})
+    set_property(TARGET protobuf::protoc PROPERTY IMPORTED_LOCATION_${_config} "")
+  endforeach()
+endif()
+
 # CMake FindProtobuf module compatible file
 if(protobuf_MODULE_COMPATIBLE)
   include("${CMAKE_CURRENT_LIST_DIR}/protobuf-module.cmake")


### PR DESCRIPTION
Adds an option, protobuf_PROTOC_LOCATION which allows users to override the location of protoc reported by the find_package command.
When not cross-compiling, the option is marked as advanced.