### PR TITLE
CMake code generator function

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -98,6 +98,8 @@ configure_file(protobuf-module.cmake.in
   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-module.cmake @ONLY)
 configure_file(protobuf-options.cmake
   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-options.cmake @ONLY)
+configure_file(protobuf-generators.cmake
+  ${CMAKE_INSTALL_CMAKEDIR}/protobuf-generators.cmake @ONLY)
 
 # Allows the build directory to be used as a find directory.
 export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc

--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -8,3 +8,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/protobuf-targets.cmake")
 if(protobuf_MODULE_COMPATIBLE)
   include("${CMAKE_CURRENT_LIST_DIR}/protobuf-module.cmake")
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/protobuf-generators.cmake")

--- a/cmake/protobuf-generators.cmake
+++ b/cmake/protobuf-generators.cmake
@@ -1,0 +1,134 @@
+# Helpful macro used for generating source files.
+# Usage:
+# protobuf_generate(<output_var> [NO_DEFAULT_PATH] [GENERATED_OUT <var>]
+#   [IMPORT_DIRS ...] [LANGUAGES ...])
+#
+# Sets up rules to generate source files for the given languages from the set
+# of protobuf files in a given source list (or target in CMake 3+) and appends
+# them to the list of sources. By default, it will set -I for each of the
+# directories containing a protobuf file.
+#
+# NO_DEFAULT_PATH causes the function to only include CMAKE_CURRENT_SOURCE_DIR
+#
+# GENERATED_SRCS if provided will be filled with the names of the generated sources
+#
+# IMPORT_DIRS will set additional include directories to use with protoc
+#
+# Entries in LANGUAGES are the names of generators, such as cpp and python.
+# Additional languages can be added by setting `protobuf_${lang}_outputs`
+# to a list of strings representing the outputs of that generator.
+# '<filename>' will be replaced by the basenamee of the .proto file in such strings.
+# If not given, it will default to 'cpp'.
+#
+function(PROTOBUF_GENERATE target)
+  set(_options NO_DEFAULT_PATH)
+  set(_singlevalue GENERATED_SRCS)
+  set(_multivalue IMPORT_DIRS LANGUAGES)
+
+  include(CMakeParseArguments)
+  cmake_parse_arguments(protobuf_generate "${_options}" "${_singlevalue}" "${_multivalue}" ${ARGN})
+
+  if(NOT protobuf_generate_LANGUAGES)
+    set(protobuf_generate_LANGUAGES cpp)
+  endif()
+
+  if(protobuf_VERBOSE)
+    message(STATUS "protobuf_generate() on ${target} for languages: ${protobuf_generate_LANGUAGES}")
+  endif()
+
+  # Parse the source list and identify .proto files
+  if(TARGET ${target})
+    if(CMAKE_MAJOR_VERSION EQUAL 2)
+      message(FATAL_ERROR "protobuf_generate() cannot operate on targets prior to CMake 3.0.0. Please pass a source list variable instead.")
+    endif()
+
+    get_target_property(_source_list ${target} SOURCES)
+  elseif(NOT DEFINED ${target})
+    message(FATAL_ERROR "protobuf_generate() passed undefined variable '${target}'")
+  else()
+    set(_source_list ${${target}})
+  endif()
+
+  foreach(_src_file ${_source_list})
+    if(_src_file MATCHES "\\.proto$")
+      list(APPEND _proto_list ${_src_file})
+    endif()
+  endforeach()
+
+  if(NOT _proto_list)
+    message(AUTHOR_WARNING "protobuf_generate() could not find any .proto files in the list given by ${target}")
+    return()
+  endif()
+
+  if(protobuf_VERBOSE)
+    message(STATUS "Found proto files: ${_proto_list}")
+  endif()
+
+  # Generate the list of include paths
+  if(NOT protobuf_generate_NO_DEFAULT_PATH)
+    # Create an include path for each file specified
+    foreach(file ${_proto_list})
+      get_filename_component(abs_file ${file} ABSOLUTE)
+      get_filename_component(abs_path ${abs_file} PATH)
+	    list(APPEND _include_paths ${abs_path})
+    endforeach()
+  else()
+    set(_include_paths ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  foreach(import_dir ${protobuf_generate_IMPORT_DIRS})
+    get_filename_component(abs_path ${import_dir} ABSOLUTE)
+	  list(APPEND _include_paths ${abs_path})
+  endforeach()
+
+  if(protobuf_VERBOSE)
+    message(STATUS "Using include paths: ${_include_paths}")
+  endif()
+
+  list(REMOVE_DUPLICATES _include_paths)
+  string(REPLACE ";" ";-I;" _include_string ";${_include_paths}")
+
+  # Output lists for the built-in languages
+  set(protobuf_cpp_outputs "${CMAKE_CURRENT_BINARY_DIR}/<filename>.pb.cc"
+                  "${CMAKE_CURRENT_BINARY_DIR}/<filename>.pb.h")
+  set(protobuf_python_outputs "${CMAKE_CURRENT_BINARY_DIR}/<filename>_pb3.py")
+
+  foreach(_proto_file ${_proto_list})
+    get_filename_component(abs_file ${_proto_file} ABSOLUTE)
+    get_filename_component(base_file ${_proto_file} NAME_WE)
+
+    foreach(lang ${protobuf_generate_LANGUAGES})
+      if(NOT DEFINED protobuf_${lang}_outputs)
+        message(FATAL_ERROR "Unknown language ${lang}: protobuf_${lang}_outputs not defined")
+      endif()
+
+      string(REPLACE "<filename>" "${base_file}" _outputs "${protobuf_${lang}_outputs}")
+      list(APPEND _generated_files ${_outputs})
+
+      add_custom_command(
+        OUTPUT ${_outputs}
+        COMMAND protobuf::protoc
+        ARGS --${lang}_out  ${CMAKE_CURRENT_BINARY_DIR} ${_include_string} ${abs_file}
+        DEPENDS ${_proto_file} protobuf::protoc
+        COMMENT "Running ${lang} protocol buffer compiler on ${_proto_file}"
+        VERBATIM)
+    endforeach()
+  endforeach()
+
+  if(protobuf_VERBOSE)
+    message(STATUS "protobuf_generate() created ${_generated_files}")
+  endif()
+
+  set_source_files_properties(${_generated_files} PROPERTIES GENERATED TRUE)
+
+  if(protobuf_generate_GENERATED_SRCS)
+    set(${protobuf_generate_GENERATED_SRCS} ${_generated_files} PARENT_SCOPE)
+  endif()
+
+  if(TARGET ${target})
+    target_sources(${target} PRIVATE ${_generated_files})
+  else()
+    list(APPEND ${target} ${_generated_files})
+    set(${target} ${${target}} PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -6,50 +6,30 @@ function(PROTOBUF_GENERATE_CPP SRCS HDRS)
     return()
   endif()
 
-  if(PROTOBUF_GENERATE_CPP_APPEND_PATH)
-    # Create an include path for each file specified
-    foreach(FIL ${ARGN})
-      get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
-      get_filename_component(ABS_PATH ${ABS_FIL} PATH)
-      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-      if(${_contains_already} EQUAL -1)
-          list(APPEND _protobuf_include_path -I ${ABS_PATH})
-      endif()
-    endforeach()
-  else()
-    set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
+  set(_arg_no_default "")
+  if(NOT PROTOBUF_GENERATE_CPP_APPEND_PATH)
+    set(_arg_no_default NO_DEFAULT_PATH)
   endif()
 
-  if(DEFINED Protobuf_IMPORT_DIRS)
-    foreach(DIR ${Protobuf_IMPORT_DIRS})
-      get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
-      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-      if(${_contains_already} EQUAL -1)
-          list(APPEND _protobuf_include_path -I ${ABS_PATH})
-      endif()
-    endforeach()
+  set(_arg_imports "")
+  if(DEFINED ${Protobuf_IMPORT_DIRS})
+    set(_arg_imports IMPORT_DIRS ${Protobuf_IMPORT_DIRS})
   endif()
 
   set(${SRCS})
   set(${HDRS})
-  foreach(FIL ${ARGN})
-    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
-    get_filename_component(FIL_WE ${FIL} NAME_WE)
+  set(_src_list ${ARGN})
+  set(_generated)
+  protobuf_generate(_src_list ${_arg_no_default} ${_arg_imports} GENERATED_SRCS _generated)
 
-    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc")
-    list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h")
-
-    add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
-             "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
-      COMMAND  ${Protobuf_PROTOC_EXECUTABLE}
-      ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
-      DEPENDS ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
-      COMMENT "Running C++ protocol buffer compiler on ${FIL}"
-      VERBATIM )
+  foreach(_file ${_generated})
+    if(_file MATCHES "\\.*\\.pb\\.h")
+      list(APPEND ${HDRS} "${_file}")
+    elseif(_file MATCHES ".*\\.pb\\.cc")
+      list(APPEND ${SRCS} "${_file}")
+    endif()
   endforeach()
 
-  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
   set(${HDRS} ${${HDRS}} PARENT_SCOPE)
 endfunction()
@@ -60,43 +40,21 @@ function(PROTOBUF_GENERATE_PYTHON SRCS)
     return()
   endif()
 
-  if(PROTOBUF_GENERATE_CPP_APPEND_PATH)
-    # Create an include path for each file specified
-    foreach(FIL ${ARGN})
-      get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
-      get_filename_component(ABS_PATH ${ABS_FIL} PATH)
-      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-      if(${_contains_already} EQUAL -1)
-          list(APPEND _protobuf_include_path -I ${ABS_PATH})
-      endif()
-    endforeach()
-  else()
-    set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
+  set(_arg_no_default "")
+  if(NOT PROTOBUF_GENERATE_CPP_APPEND_PATH)
+    set(_arg_no_default NO_DEFAULT_PATH)
   endif()
 
-  if(DEFINED Protobuf_IMPORT_DIRS)
-    foreach(DIR ${Protobuf_IMPORT_DIRS})
-      get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
-      list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-      if(${_contains_already} EQUAL -1)
-          list(APPEND _protobuf_include_path -I ${ABS_PATH})
-      endif()
-    endforeach()
+  set(_arg_imports "")
+  if(DEFINED ${Protobuf_IMPORT_DIRS})
+    set(_arg_imports IMPORT_DIRS ${Protobuf_IMPORT_DIRS})
   endif()
 
   set(${SRCS})
-  foreach(FIL ${ARGN})
-    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
-    get_filename_component(FIL_WE ${FIL} NAME_WE)
 
-    list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}_pb2.py")
-    add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}_pb2.py"
-      COMMAND  ${Protobuf_PROTOC_EXECUTABLE} --python_out ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
-      DEPENDS ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
-      COMMENT "Running Python protocol buffer compiler on ${FIL}"
-      VERBATIM )
-  endforeach()
+  set(_src_list ${ARGN})
+  set(_generated)
+  protobuf_generate(_src_list ${_arg_no_default} ${_arg_imports} GENERATED_SRCS _generated)
 
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
-# http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+# http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime
 if(MSVC AND protobuf_MSVC_STATIC_RUNTIME)
   foreach(flag_var
       CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
@@ -27,37 +27,28 @@ endif()
 foreach(example add_person list_people)
   set(${example}_SRCS ${example}.cc)
   set(${example}_PROTOS addressbook.proto)
+  set(executable_name ${example}_cpp)
 
-  #Code Generation
-  if(protobuf_MODULE_COMPATIBLE) #Legacy Support
+  # Legacy Support - set protobuf_MODULE_COMPATIBLE to allow compatibility
+  # with the CMake FindProbuf module.
+  if(protobuf_MODULE_COMPATIBLE)
     protobuf_generate_cpp(${example}_PROTO_SRCS ${example}_PROTO_HDRS ${${example}_PROTOS})
     list(APPEND ${example}_SRCS ${${example}_PROTO_SRCS} ${${example}_PROTO_HDRS})
-  else()
 
-    foreach(proto_file ${${example}_PROTOS})
-      get_filename_component(proto_file_abs ${proto_file} ABSOLUTE)
-      get_filename_component(basename ${proto_file} NAME_WE)
-      set(generated_files ${basename}.pb.cc ${basename}.pb.h)
-      list(APPEND ${example}_SRCS ${generated_files})
-
-      add_custom_command(
-        OUTPUT ${generated_files}
-        COMMAND protobuf::protoc
-        ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR} -I ${CMAKE_CURRENT_SOURCE_DIR} ${proto_file_abs}
-        COMMENT "Generating ${generated_files} from ${proto_file}"
-        VERBATIM
-      )
-    endforeach()
-  endif()
-
-  #Executable setup
-  set(executable_name ${example}_cpp)
-  add_executable(${executable_name} ${${example}_SRCS} ${${example}_PROTOS})
-  if(protobuf_MODULE_COMPATIBLE) #Legacy mode
-    target_include_directories(${executable_name} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
+    add_executable(${executable_name} ${${example}_SRCS} ${${example}_PROTOS})
+	  target_include_directories(${executable_name} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
     target_link_libraries(${executable_name} ${PROTOBUF_LIBRARIES})
   else()
+    list(APPEND ${example}_SRCS ${${example}_PROTOS})
+
+    if(CMAKE_MAJOR_VERSION LESS 3)
+      protobuf_generate(${example}_SRCS)
+      add_executable(${executable_name} ${${example}_SRCS})
+    else()
+      add_executable(${executable_name} ${${example}_SRCS})
+      protobuf_generate(${executable_name})
+    endif()
+
     target_link_libraries(${executable_name} protobuf::libprotobuf)
   endif()
-
 endforeach()


### PR DESCRIPTION
Adds a documented, extensible function for generating source files from .proto files with simpler syntax than the legacy alternative.

In CMake 3+, takes advantage of the target_sources command to add the generated sources to a given target automatically. Otherwise appends to the given source file list.

Options are provided and parsed using cmake_parse_arguments rather than setting global variables.
