### PR TITLE
Fix return type of the DeleteMapValue(const MapKey& map_key) function

### DIFF
--- a/src/google/protobuf/map_field_inl.h
+++ b/src/google/protobuf/map_field_inl.h
@@ -288,7 +288,7 @@ bool MapField<Key, T, kKeyFieldType, kValueFieldType,
               default_enum_value>::DeleteMapValue(
                   const MapKey& map_key) {
   const Key& key = UnwrapMapKey<Key>(map_key);
-  return MutableMap()->erase(key);
+  return MutableMap()->erase(key) == 1 ? true : false;
 }
 
 template <typename Key, typename T,


### PR DESCRIPTION
The function fixed return value from size_type to bool.
The "Map::erase(const key_type& key)" function return type of size_type but the "MapField<Key, T, kKeyFieldType, kValueFieldType, default_enum_value>::DeleteMapValue(const MapKey& map_key)" function return type of bool.

I use to Map for the proto message in UnrealEngine4 C++ project on Windows Platform.
But This project does compile to build error in Warning 4800.
Because the way UnrealEngine4 engine code is written about "#pragma warning (error: 4800)".
