### PR TITLE
CMake Fix WITH_ZLIB

### DIFF
--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -56,7 +56,7 @@ set(libprotobuf_files
 
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
   ${libprotobuf_lite_files} ${libprotobuf_files})
-target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} $<BUILD_INTERFACE:${ZLIB_LIBRARIES}>)
 target_include_directories(libprotobuf PUBLIC ${protobuf_source_dir}/src)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotobuf

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,10 @@ if(protobuf_VERBOSE)
   message(STATUS "Using Protocol Buffers ${Protobuf_VERSION}")
 endif()
 
+if(protobuf_WITH_ZLIB)
+  find_package(ZLIB)
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 
 # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F


### PR DESCRIPTION
Examples currently fail with unknown target ZLIB::ZLIB when protobuf is built using protobuf_WITH_ZLIB.

This fix causes the examples to search for ZLIB when the above flag is set.

Particularly helpful in conjunction with #1665 
