### PR TITLE
Fix some unused parameter warnings

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -800,13 +800,13 @@ class LIBPROTOBUF_EXPORT Arena {
   }
   template <typename T>
   static void CreateInArenaStorageInternal(
-      T* ptr, Arena* arena, google::protobuf::internal::false_type) {
+      T* ptr, Arena*, google::protobuf::internal::false_type) {
     new (ptr) T;
   }
 
   template <typename T>
   static void RegisterDestructorInternal(
-      T* ptr, Arena* arena, google::protobuf::internal::true_type) {}
+      T*, Arena*, google::protobuf::internal::true_type) {}
   template <typename T>
   static void RegisterDestructorInternal(
       T* ptr, Arena* arena, google::protobuf::internal::false_type) {
@@ -841,7 +841,7 @@ class LIBPROTOBUF_EXPORT Arena {
   }
 
   template<typename T> GOOGLE_ATTRIBUTE_ALWAYS_INLINE
-  static ::google::protobuf::Arena* GetArenaInternal(const T* value, ...) {
+  static ::google::protobuf::Arena* GetArenaInternal(const T*, ...) {
     return NULL;
   }
 

--- a/src/google/protobuf/stubs/shared_ptr.h
+++ b/src/google/protobuf/stubs/shared_ptr.h
@@ -438,8 +438,8 @@ class enable_shared_from_this {
 
  protected:
   enable_shared_from_this() { }
-  enable_shared_from_this(const enable_shared_from_this& other) { }
-  enable_shared_from_this& operator=(const enable_shared_from_this& other) {
+  enable_shared_from_this(const enable_shared_from_this&) { }
+  enable_shared_from_this& operator=(const enable_shared_from_this&) {
     return *this;
   }
   ~enable_shared_from_this() { }


### PR DESCRIPTION
These files are included from the generated proto header files so they
will generate warnings for each user and preventing them from compiling
with -Werror.
