### PR TITLE
Fixes Xcode 8 analyzer warning saying that it was missing a release in dealloc

### DIFF
--- a/objectivec/GPBDescriptor.m
+++ b/objectivec/GPBDescriptor.m
@@ -271,6 +271,11 @@ static NSArray *NewFieldsArrayForHasIndex(int hasIndex,
   return self;
 }
 
+- (void)dealloc {
+  [package_ release];
+  [super dealloc];
+}
+
 @end
 
 @implementation GPBOneofDescriptor


### PR DESCRIPTION
Caught when using the new Xcode 8 beta