### PR TITLE
[C#] Implement setter for Repeated field

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs
@@ -656,5 +656,97 @@ namespace Google.Protobuf.Collections
             var text = list.ToString();
             Assert.AreEqual(text, "[ { \"foo\": 20 } ]", message.ToString());
         }
+
+        [Test]
+        public void Snapshot_Equal()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            Assert.AreEqual(snapshot, original);
+        }
+
+        [Test]
+        public void Snapshot_Insert()
+        {
+            var original = new RepeatedField<string> { "foo", "bar" };
+            var snapshot = original.Snapshot();
+            snapshot.Insert(1, "baz");
+            Assert.AreEqual(new RepeatedField<string> { "foo", "baz", "bar" }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original.Insert(1, "baz");
+            Assert.AreNotEqual(original, snapshot);
+        }
+
+        [Test]
+        public void Snapshot_Remove()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            snapshot.Remove("foo");
+            Assert.AreEqual(new RepeatedField<string> { }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original.Remove("foo");
+            Assert.AreNotEqual(original, snapshot);
+        }
+
+        [Test]
+        public void Snapshot_RemoveAt()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            snapshot.RemoveAt(0);
+            Assert.AreEqual(new RepeatedField<string> { }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original.RemoveAt(0);
+            Assert.AreNotEqual(original, snapshot);
+        }
+
+        [Test]
+        public void Snapshot_SetAt()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            snapshot[0] = "bar";
+            Assert.AreEqual(new RepeatedField<string> { "bar" }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original[0] = "bar";
+            Assert.AreNotEqual(original, snapshot);
+        }
+
+        [Test]
+        public void Snapshot_Add()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            snapshot.Add("bar");
+            Assert.AreEqual(new RepeatedField<string> { "foo", "bar" }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original.Add("bar");
+            Assert.AreNotEqual(original, snapshot);
+        }
+
+        [Test]
+        public void Snapshot_Add_Repeated()
+        {
+            var original = new RepeatedField<string> { "foo" };
+            var snapshot = original.Snapshot();
+            snapshot.Add(new RepeatedField<string> { "bar" });
+            Assert.AreEqual(new RepeatedField<string> { "foo", "bar" }, snapshot);
+            Assert.AreNotEqual(original, snapshot);
+
+            snapshot = original.Snapshot();
+            original.Add(new RepeatedField<string> { "bar" });
+            Assert.AreNotEqual(original, snapshot);
+        }
     }
 }

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc
@@ -62,13 +62,14 @@ void RepeatedEnumFieldGenerator::GenerateMembers(io::Printer* printer) {
     "private static readonly pb::FieldCodec<$type_name$> _repeated_$name$_codec\n"
     "    = pb::FieldCodec.ForEnum($tag$, x => (int) x, x => ($type_name$) x);\n");
   printer->Print(variables_,
-    "private readonly pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
+    "private pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
   WritePropertyDocComment(printer, descriptor_);
   AddDeprecatedFlag(printer);
   printer->Print(
     variables_,
     "$access_level$ pbc::RepeatedField<$type_name$> $property_name$ {\n"
     "  get { return $name$_; }\n"
+    "  set { $name$_ = value.Snapshot(); }\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc
@@ -77,13 +77,14 @@ void RepeatedMessageFieldGenerator::GenerateMembers(io::Printer* printer) {
   printer->Print(";\n");
   printer->Print(
     variables_,
-    "private readonly pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
+    "private pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
   WritePropertyDocComment(printer, descriptor_);
   AddDeprecatedFlag(printer);
   printer->Print(
     variables_,
     "$access_level$ pbc::RepeatedField<$type_name$> $property_name$ {\n"
     "  get { return $name$_; }\n"
+    "  set { $name$_ = value.Snapshot(); }\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc
@@ -62,13 +62,14 @@ void RepeatedPrimitiveFieldGenerator::GenerateMembers(io::Printer* printer) {
     "private static readonly pb::FieldCodec<$type_name$> _repeated_$name$_codec\n"
     "    = pb::FieldCodec.For$capitalized_type_name$($tag$);\n");
   printer->Print(variables_,
-    "private readonly pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
+    "private pbc::RepeatedField<$type_name$> $name$_ = new pbc::RepeatedField<$type_name$>();\n");
   WritePropertyDocComment(printer, descriptor_);
   AddDeprecatedFlag(printer);
   printer->Print(
     variables_,
     "$access_level$ pbc::RepeatedField<$type_name$> $property_name$ {\n"
     "  get { return $name$_; }\n"
+    "  set { $name$_ = value.Snapshot(); }\n"
     "}\n");
 }
 


### PR DESCRIPTION
Fixes #1681 using the proposed solution, there.

>  1. Add a setter to the generated C# messages which takes the form `set { myField_ = value.Snapshot(); }`
>  1. Implement `Snapshot()` on `RepeatedField` which sets a flag on the field to force a copy of the underlying array before any future mutation (add/remove/update) and return a new instance that shares the underlying array and also has this flag set.

Also added test cases