### PR TITLE
Workaround for gcc-4.4 incompatibility

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -587,7 +587,7 @@ class Map {
     explicit MapAllocator(Arena* arena) : arena_(arena) {}
     template <typename X>
     MapAllocator(const MapAllocator<X>& allocator)
-        : arena_(allocator.arena_internal_only()) {}
+        : arena_(allocator.arena()) {}
 
     pointer allocate(size_type n, const_pointer hint = 0) {
       // If arena is not given, malloc needs to be called which doesn't
@@ -652,7 +652,7 @@ class Map {
 
     // To support gcc-4.4, which does not properly
     // support templated friend classes
-    Arena* arena_internal_only() const {
+    Arena* arena() const {
       return arena_;
     }
 

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -587,7 +587,7 @@ class Map {
     explicit MapAllocator(Arena* arena) : arena_(arena) {}
     template <typename X>
     MapAllocator(const MapAllocator<X>& allocator)
-        : arena_(allocator.arena_) {}
+        : arena_(allocator.arena_internal_only()) {}
 
     pointer allocate(size_type n, const_pointer hint = 0) {
       // If arena is not given, malloc needs to be called which doesn't
@@ -650,12 +650,15 @@ class Map {
       return std::numeric_limits<size_type>::max();
     }
 
+    // To support gcc-4.4, which does not properly
+    // support templated friend classes
+    Arena* arena_internal_only() const {
+      return arena_;
+    }
+
    private:
     typedef void DestructorSkippable_;
     Arena* const arena_;
-
-    template <typename X>
-    friend class MapAllocator;
   };
 
   // InnerMap's key type is Key and its value type is value_type*.  We use a


### PR DESCRIPTION
Remove a friend-class template that is only used for the constructor of MapAllocator, and instead create an _internal_only getter that gets the needed information. This is a workaround for a deficiency in gcc-4.4 that does not properly support templated friend classes.

This was discovered as I was working on grpc/grpc#6863 . I believe it is the only place where protobuf is incompatible with gcc-4.4

