### PR TITLE
Fix #1682 by adding CopyTo() overload to copy a subset of the byte array

### DIFF
--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -167,5 +167,27 @@ namespace Google.Protobuf
             // Optimization which also fixes issue 61.
             Assert.AreSame(ByteString.Empty, ByteString.FromBase64(""));
         }
+
+        [Test]
+        public void CopyTo()
+        {
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
+            var bs = ByteString.CopyFrom(data);
+            var buffer = new byte[data.Length];
+            bs.CopyTo(buffer, 0);
+            Assert.AreEqual(data, buffer);
+        }
+
+        [Test]
+        public void CopyTo_Subset()
+        {
+            var data = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
+            var bs = ByteString.CopyFrom(data);
+            var buffer = new byte[data.Length];
+            bs.CopyTo(buffer, 3, 1, 3);
+            Assert.AreEqual(new byte[] { 0, 0, 0, 1, 2, 3, 0 }, buffer);
+        }
+
+
     }
 }

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -331,7 +331,15 @@ namespace Google.Protobuf
         /// </summary>
         public void CopyTo(byte[] array, int position)
         {
-            ByteArray.Copy(bytes, 0, array, position, bytes.Length);
+            CopyTo(array, position, 0, bytes.Length);
+        }
+
+        /// <summary>
+        /// Copies a subset of the byte array to the destination array provided at the offset specified.
+        /// </summary>
+        public void CopyTo(byte[] dest, int destOffset, int srcOffset, int length)
+        {
+            ByteArray.Copy(bytes, srcOffset, dest, destOffset, length);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for #1682, adding a simple overload of CopyTo() which provides a mechanism for copying a subset of the byte array instead of the whole thing.

Also added test cases for overload and original implementation.
