### PR TITLE
Rename methods to avoid ObjC KVC collisions.

### DIFF
--- a/objectivec/GPBDictionary.h
+++ b/objectivec/GPBDictionary.h
@@ -38,12 +38,12 @@
 // Note: These are not meant to be subclassed.
 
 // Note on naming: for the classes holding numeric values, a more natural
-// natural naming of the method might be things like "-valueForKey:",
-// "-setValue:forKey:"; etc. But those selectors are also define by Key Value
+// naming of the method might be things like "-valueForKey:",
+// "-setValue:forKey:"; etc. But those selectors are also defined by Key Value
 // Coding (KVC) as categories on NSObject. So "overloading" the selectors with
 // other meanings can cause warnings (based on compiler settings), but more
 // importantly, some of those selector get called as KVC breaks up keypaths.
-// So if those selectors are used, using KVC will compiling cleanly, but could
+// So if those selectors are used, using KVC will compile cleanly, but could
 // crash as it invokes those selectors with the wrong types of arguments.
 
 NS_ASSUME_NONNULL_BEGIN
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint32_t)key;
 
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(uint32_t)key;
 
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint32_t)key;
 
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(uint32_t)key;
 
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(uint32_t)key;
 
@@ -257,7 +257,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(uint32_t)key;
 
@@ -294,7 +294,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(uint32_t)key;
 
@@ -343,7 +343,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(uint32_t)key;
 
@@ -353,7 +353,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(uint32_t)key;
 
@@ -436,7 +436,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int32_t)key;
 
@@ -473,7 +473,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(int32_t)key;
 
@@ -510,7 +510,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int32_t)key;
 
@@ -547,7 +547,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(int32_t)key;
 
@@ -584,7 +584,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(int32_t)key;
 
@@ -621,7 +621,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(int32_t)key;
 
@@ -658,7 +658,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(int32_t)key;
 
@@ -707,7 +707,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(int32_t)key;
 
@@ -717,7 +717,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(int32_t)key;
 
@@ -800,7 +800,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint64_t)key;
 
@@ -837,7 +837,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(uint64_t)key;
 
@@ -874,7 +874,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint64_t)key;
 
@@ -911,7 +911,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(uint64_t)key;
 
@@ -948,7 +948,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(uint64_t)key;
 
@@ -985,7 +985,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(uint64_t)key;
 
@@ -1022,7 +1022,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBUInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(uint64_t)key;
 
@@ -1071,7 +1071,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(uint64_t)key;
 
@@ -1081,7 +1081,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(uint64_t)key;
 
@@ -1164,7 +1164,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int64_t)key;
 
@@ -1201,7 +1201,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(int64_t)key;
 
@@ -1238,7 +1238,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int64_t)key;
 
@@ -1275,7 +1275,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(int64_t)key;
 
@@ -1312,7 +1312,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(int64_t)key;
 
@@ -1349,7 +1349,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(int64_t)key;
 
@@ -1386,7 +1386,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(int64_t)key;
 
@@ -1435,7 +1435,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(int64_t)key;
 
@@ -1445,7 +1445,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(int64_t)key;
 
@@ -1528,7 +1528,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(BOOL)key;
 
@@ -1565,7 +1565,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(BOOL)key;
 
@@ -1602,7 +1602,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(BOOL)key;
 
@@ -1639,7 +1639,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(BOOL)key;
 
@@ -1676,7 +1676,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(BOOL)key;
 
@@ -1713,7 +1713,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(BOOL)key;
 
@@ -1750,7 +1750,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBBoolDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(BOOL)key;
 
@@ -1799,7 +1799,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(BOOL)key;
 
@@ -1809,7 +1809,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(BOOL)key;
 
@@ -1892,7 +1892,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt32:(nullable uint32_t *)value forKey:(NSString *)key;
 
@@ -1929,7 +1929,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt32:(nullable int32_t *)value forKey:(NSString *)key;
 
@@ -1966,7 +1966,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getUInt64:(nullable uint64_t *)value forKey:(NSString *)key;
 
@@ -2003,7 +2003,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getInt64:(nullable int64_t *)value forKey:(NSString *)key;
 
@@ -2040,7 +2040,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getBool:(nullable BOOL *)value forKey:(NSString *)key;
 
@@ -2077,7 +2077,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getFloat:(nullable float *)value forKey:(NSString *)key;
 
@@ -2114,7 +2114,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDictionary:(GPBStringDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getDouble:(nullable double *)value forKey:(NSString *)key;
 
@@ -2163,7 +2163,7 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getEnum:(nullable int32_t *)value forKey:(NSString *)key;
 
@@ -2173,7 +2173,7 @@ NS_ASSUME_NONNULL_BEGIN
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-// Returns YES/NO indicate if the key was found or not, filling in the value
+// Returns YES/NO to indicate if the key was found or not, filling in the value
 // only when the key was found.
 - (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(NSString *)key;
 
@@ -2228,7 +2228,7 @@ NS_ASSUME_NONNULL_END
 //%PDDM-DEFINE DICTIONARY_POD_KEY_TO_OBJECT_INTERFACE(KEY_NAME, KEY_TYPE, VALUE_NAME, VALUE_TYPE)
 //%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, , POD, VALUE_NAME, VALUE_TYPE, OBJECT, Object, object)
 //%PDDM-DEFINE VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE, VNAME)
-//%// Returns YES/NO indicate if the key was found or not, filling in the value
+//%// Returns YES/NO to indicate if the key was found or not, filling in the value
 //%// only when the key was found.
 //%- (BOOL)get##VNAME##:(nullable VALUE_TYPE *)value forKey:(KEY_TYPE)key;
 //%PDDM-DEFINE VALUE_FOR_KEY_OBJECT(KEY_TYPE, VALUE_TYPE, VNAME)
@@ -2319,7 +2319,7 @@ NS_ASSUME_NONNULL_END
 //%// These methods bypass the validationFunc to provide access to values that were not
 //%// known at the time the binary was compiled.
 //%
-//%// Returns YES/NO indicate if the key was found or not, filling in the value
+//%// Returns YES/NO to indicate if the key was found or not, filling in the value
 //%// only when the key was found.
 //%- (BOOL)getRawValue:(nullable VALUE_TYPE *)rawValue forKey:(KEY_TYPE##KisP$S##KisP)key;
 //%

--- a/objectivec/GPBDictionary.h
+++ b/objectivec/GPBDictionary.h
@@ -37,13 +37,16 @@
 
 // Note: These are not meant to be subclassed.
 
-NS_ASSUME_NONNULL_BEGIN
+// Note on naming: for the classes holding numeric values, a more natural
+// natural naming of the method might be things like "-valueForKey:",
+// "-setValue:forKey:"; etc. But those selectors are also define by Key Value
+// Coding (KVC) as categories on NSObject. So "overloading" the selectors with
+// other meanings can cause warnings (based on compiler settings), but more
+// importantly, some of those selector get called as KVC breaks up keypaths.
+// So if those selectors are used, using KVC will compiling cleanly, but could
+// crash as it invokes those selectors with the wrong types of arguments.
 
-// Disable -Woverriding-method-mismatch until resolving the accidental conflict
-// with NSObject's KVC category.
-// https://github.com/google/protobuf/issues/1616 opened to resolve this.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverriding-method-mismatch"
+NS_ASSUME_NONNULL_BEGIN
 
 //%PDDM-EXPAND DECLARE_DICTIONARIES()
 // This block of code is generated, do not edit it directly.
@@ -55,30 +58,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(uint32_t)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(uint32_t key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32UInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(uint32_t)key;
+- (void)setUInt32:(uint32_t)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeUInt32ForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -90,30 +95,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32Int32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32Int32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(uint32_t)key;
+- (void)setInt32:(int32_t)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeInt32ForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -125,30 +132,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(uint32_t)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(uint32_t key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32UInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(uint32_t)key;
+- (void)setUInt64:(uint64_t)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeUInt64ForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -160,30 +169,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32Int64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(uint32_t key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32Int64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(uint32_t)key;
+- (void)setInt64:(int64_t)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeInt64ForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -195,30 +206,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(uint32_t)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const uint32_t [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32BoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const uint32_t [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(uint32_t key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32BoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(uint32_t)key;
+- (void)setBool:(BOOL)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeBoolForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -230,30 +243,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32FloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(uint32_t key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32FloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(uint32_t)key;
+- (void)setFloat:(float)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeFloatForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -265,30 +280,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(uint32_t)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(uint32_t)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt32DoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(uint32_t key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt32DoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(uint32_t)key;
+- (void)setDouble:(double)value forKey:(uint32_t)key;
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeDoubleForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -326,15 +343,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(uint32_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(uint32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(uint32_t)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(uint32_t)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(uint32_t key, int32_t rawValue, BOOL *stop))block;
@@ -346,7 +367,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(uint32_t)key;
+- (void)setEnum:(int32_t)value forKey:(uint32_t)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -354,7 +375,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(uint32_t)aKey;
+- (void)removeEnumForKey:(uint32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -401,30 +422,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(int32_t)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32UInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(int32_t key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32UInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(int32_t)key;
+- (void)setUInt32:(uint32_t)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeUInt32ForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -436,30 +459,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32Int32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32Int32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(int32_t)key;
+- (void)setInt32:(int32_t)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeInt32ForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -471,30 +496,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(int32_t)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32UInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(int32_t key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32UInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(int32_t)key;
+- (void)setUInt64:(uint64_t)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeUInt64ForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -506,30 +533,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32Int64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(int32_t key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32Int64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(int32_t)key;
+- (void)setInt64:(int64_t)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeInt64ForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -541,30 +570,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(int32_t)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const int32_t [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32BoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const int32_t [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(int32_t key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32BoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(int32_t)key;
+- (void)setBool:(BOOL)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeBoolForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -576,30 +607,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32FloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(int32_t key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32FloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(int32_t)key;
+- (void)setFloat:(float)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeFloatForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -611,30 +644,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(int32_t)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(int32_t)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt32DoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt32DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(int32_t key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt32DoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(int32_t)key;
+- (void)setDouble:(double)value forKey:(int32_t)key;
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeDoubleForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -672,15 +707,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(int32_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(int32_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(int32_t)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(int32_t)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(int32_t key, int32_t rawValue, BOOL *stop))block;
@@ -692,7 +731,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(int32_t)key;
+- (void)setEnum:(int32_t)value forKey:(int32_t)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -700,7 +739,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(int32_t)aKey;
+- (void)removeEnumForKey:(int32_t)aKey;
 - (void)removeAll;
 
 @end
@@ -747,30 +786,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(uint64_t)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(uint64_t key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64UInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(uint64_t)key;
+- (void)setUInt32:(uint32_t)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeUInt32ForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -782,30 +823,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64Int32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64Int32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(uint64_t)key;
+- (void)setInt32:(int32_t)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeInt32ForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -817,30 +860,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(uint64_t)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(uint64_t key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64UInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(uint64_t)key;
+- (void)setUInt64:(uint64_t)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeUInt64ForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -852,30 +897,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64Int64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(uint64_t key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64Int64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(uint64_t)key;
+- (void)setInt64:(int64_t)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeInt64ForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -887,30 +934,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(uint64_t)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const uint64_t [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64BoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const uint64_t [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(uint64_t key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64BoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(uint64_t)key;
+- (void)setBool:(BOOL)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeBoolForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -922,30 +971,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64FloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(uint64_t key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64FloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(uint64_t)key;
+- (void)setFloat:(float)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeFloatForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -957,30 +1008,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(uint64_t)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(uint64_t)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBUInt64DoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBUInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(uint64_t key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBUInt64DoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(uint64_t)key;
+- (void)setDouble:(double)value forKey:(uint64_t)key;
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeDoubleForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1018,15 +1071,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(uint64_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(uint64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(uint64_t)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(uint64_t)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(uint64_t key, int32_t rawValue, BOOL *stop))block;
@@ -1038,7 +1095,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(uint64_t)key;
+- (void)setEnum:(int32_t)value forKey:(uint64_t)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -1046,7 +1103,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(uint64_t)aKey;
+- (void)removeEnumForKey:(uint64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1093,30 +1150,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(int64_t)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64UInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64UInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(int64_t key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64UInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(int64_t)key;
+- (void)setUInt32:(uint32_t)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeUInt32ForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1128,30 +1187,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64Int32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64Int32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64Int32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(int64_t)key;
+- (void)setInt32:(int32_t)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeInt32ForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1163,30 +1224,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(int64_t)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64UInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64UInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(int64_t key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64UInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(int64_t)key;
+- (void)setUInt64:(uint64_t)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeUInt64ForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1198,30 +1261,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64Int64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64Int64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(int64_t key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64Int64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(int64_t)key;
+- (void)setInt64:(int64_t)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeInt64ForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1233,30 +1298,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(int64_t)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const int64_t [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64BoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const int64_t [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64BoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(int64_t key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64BoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(int64_t)key;
+- (void)setBool:(BOOL)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeBoolForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1268,30 +1335,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64FloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64FloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(int64_t key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64FloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(int64_t)key;
+- (void)setFloat:(float)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeFloatForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1303,30 +1372,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(int64_t)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(int64_t)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBInt64DoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBInt64DoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(int64_t key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBInt64DoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(int64_t)key;
+- (void)setDouble:(double)value forKey:(int64_t)key;
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeDoubleForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1364,15 +1435,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(int64_t)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(int64_t)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(int64_t)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(int64_t)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(int64_t key, int32_t rawValue, BOOL *stop))block;
@@ -1384,7 +1459,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(int64_t)key;
+- (void)setEnum:(int32_t)value forKey:(int64_t)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -1392,7 +1467,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(int64_t)aKey;
+- (void)removeEnumForKey:(int64_t)aKey;
 - (void)removeAll;
 
 @end
@@ -1439,30 +1514,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(BOOL)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolUInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(BOOL key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolUInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(BOOL)key;
+- (void)setUInt32:(uint32_t)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeUInt32ForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1474,30 +1551,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(BOOL)key;
+- (void)setInt32:(int32_t)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeInt32ForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1509,30 +1588,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(BOOL)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolUInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(BOOL key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolUInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(BOOL)key;
+- (void)setUInt64:(uint64_t)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeUInt64ForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1544,30 +1625,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(BOOL key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(BOOL)key;
+- (void)setInt64:(int64_t)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeInt64ForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1579,30 +1662,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(BOOL)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const BOOL [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolBoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const BOOL [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(BOOL key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolBoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(BOOL)key;
+- (void)setBool:(BOOL)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeBoolForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1614,30 +1699,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolFloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(BOOL key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolFloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(BOOL)key;
+- (void)setFloat:(float)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeFloatForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1649,30 +1736,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(BOOL)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(BOOL)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBBoolDoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBBoolDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(BOOL key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBBoolDoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(BOOL)key;
+- (void)setDouble:(double)value forKey:(BOOL)key;
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeDoubleForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1710,15 +1799,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(BOOL)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(BOOL)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(BOOL)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(BOOL)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(BOOL key, int32_t rawValue, BOOL *stop))block;
@@ -1730,7 +1823,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(BOOL)key;
+- (void)setEnum:(int32_t)value forKey:(BOOL)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -1738,7 +1831,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(BOOL)aKey;
+- (void)removeEnumForKey:(BOOL)aKey;
 - (void)removeAll;
 
 @end
@@ -1785,30 +1878,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(NSString *)key;
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringUInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringUInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable uint32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(NSString *key, uint32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringUInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(uint32_t)value forKey:(NSString *)key;
+- (void)setUInt32:(uint32_t)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeUInt32ForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1820,30 +1915,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringInt32Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringInt32Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringInt32Dictionary *)otherDictionary;
 
-- (void)setValue:(int32_t)value forKey:(NSString *)key;
+- (void)setInt32:(int32_t)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeInt32ForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1855,30 +1952,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(NSString *)key;
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringUInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringUInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable uint64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(NSString *key, uint64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringUInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(uint64_t)value forKey:(NSString *)key;
+- (void)setUInt64:(uint64_t)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeUInt64ForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1890,30 +1989,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringInt64Dictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringInt64Dictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable int64_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(NSString *key, int64_t value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringInt64Dictionary *)otherDictionary;
 
-- (void)setValue:(int64_t)value forKey:(NSString *)key;
+- (void)setInt64:(int64_t)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeInt64ForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1925,30 +2026,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(NSString *)key;
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                              count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringBoolDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                        count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringBoolDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable BOOL *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getBool:(nullable BOOL *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(NSString *key, BOOL value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringBoolDictionary *)otherDictionary;
 
-- (void)setValue:(BOOL)value forKey:(NSString *)key;
+- (void)setBool:(BOOL)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeBoolForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1960,30 +2063,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringFloatDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringFloatDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable float *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getFloat:(nullable float *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(NSString *key, float value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringFloatDictionary *)otherDictionary;
 
-- (void)setValue:(float)value forKey:(NSString *)key;
+- (void)setFloat:(float)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeFloatForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -1995,30 +2100,32 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 + (instancetype)dictionary;
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(NSString *)key;
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                               count:(NSUInteger)count;
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(NSString *)key;
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                                count:(NSUInteger)count;
 + (instancetype)dictionaryWithDictionary:(GPBStringDoubleDictionary *)dictionary;
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
-                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithDictionary:(GPBStringDoubleDictionary *)dictionary;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable double *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getDouble:(nullable double *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(NSString *key, double value, BOOL *stop))block;
 
 - (void)addEntriesFromDictionary:(GPBStringDoubleDictionary *)otherDictionary;
 
-- (void)setValue:(double)value forKey:(NSString *)key;
+- (void)setDouble:(double)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeDoubleForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
@@ -2056,15 +2163,19 @@ NS_ASSUME_NONNULL_BEGIN
 // is not a valid enumerator as defined by validationFunc. If the actual value is
 // desired, use "raw" version of the method.
 
-- (BOOL)valueForKey:(NSString *)key value:(nullable int32_t *)value;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getEnum:(nullable int32_t *)value forKey:(NSString *)key;
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block;
 
 // These methods bypass the validationFunc to provide access to values that were not
 // known at the time the binary was compiled.
 
-- (BOOL)valueForKey:(NSString *)key rawValue:(nullable int32_t *)rawValue;
+// Returns YES/NO indicate if the key was found or not, filling in the value
+// only when the key was found.
+- (BOOL)getRawValue:(nullable int32_t *)rawValue forKey:(NSString *)key;
 
 - (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(NSString *key, int32_t rawValue, BOOL *stop))block;
@@ -2076,7 +2187,7 @@ NS_ASSUME_NONNULL_BEGIN
 // to the default value. Use the rawValue methods below to assign non enumerator
 // values.
 
-- (void)setValue:(int32_t)value forKey:(NSString *)key;
+- (void)setEnum:(int32_t)value forKey:(NSString *)key;
 
 // This method bypass the validationFunc to provide setting of values that were not
 // known at the time the binary was compiled.
@@ -2084,14 +2195,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 // No validation applies to these methods.
 
-- (void)removeValueForKey:(NSString *)aKey;
+- (void)removeEnumForKey:(NSString *)aKey;
 - (void)removeAll;
 
 @end
 
 //%PDDM-EXPAND-END DECLARE_DICTIONARIES()
-
-#pragma clang diagnostic pop
 
 NS_ASSUME_NONNULL_END
 
@@ -2115,15 +2224,17 @@ NS_ASSUME_NONNULL_END
 //%DICTIONARY_KEY_TO_POD_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, Double, double)
 //%DICTIONARY_KEY_TO_ENUM_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, Enum, int32_t)
 //%PDDM-DEFINE DICTIONARY_KEY_TO_POD_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, VALUE_NAME, VALUE_TYPE)
-//%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, VALUE_NAME, VALUE_TYPE, POD, value)
+//%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, VALUE_NAME, VALUE_TYPE, POD, VALUE_NAME, value)
 //%PDDM-DEFINE DICTIONARY_POD_KEY_TO_OBJECT_INTERFACE(KEY_NAME, KEY_TYPE, VALUE_NAME, VALUE_TYPE)
-//%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, , POD, VALUE_NAME, VALUE_TYPE, OBJECT, object)
-//%PDDM-DEFINE VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE)
-//%- (BOOL)valueForKey:(KEY_TYPE)key value:(nullable VALUE_TYPE *)value;
-//%PDDM-DEFINE VALUE_FOR_KEY_OBJECT(KEY_TYPE, VALUE_TYPE)
+//%DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, , POD, VALUE_NAME, VALUE_TYPE, OBJECT, Object, object)
+//%PDDM-DEFINE VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE, VNAME)
+//%// Returns YES/NO indicate if the key was found or not, filling in the value
+//%// only when the key was found.
+//%- (BOOL)get##VNAME##:(nullable VALUE_TYPE *)value forKey:(KEY_TYPE)key;
+//%PDDM-DEFINE VALUE_FOR_KEY_OBJECT(KEY_TYPE, VALUE_TYPE, VNAME)
 //%- (VALUE_TYPE)objectForKey:(KEY_TYPE)key;
-//%PDDM-DEFINE VALUE_FOR_KEY_Enum(KEY_TYPE, VALUE_TYPE)
-//%VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE)
+//%PDDM-DEFINE VALUE_FOR_KEY_Enum(KEY_TYPE, VALUE_TYPE, VNAME)
+//%VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_TYPE, VNAME)
 //%PDDM-DEFINE ARRAY_ARG_MODIFIERPOD()
 // Nothing
 //%PDDM-DEFINE ARRAY_ARG_MODIFIEREnum()
@@ -2136,7 +2247,7 @@ NS_ASSUME_NONNULL_END
 //%GPB##KEY_NAME##VALUE_NAME##Dictionary
 //%PDDM-DEFINE DICTIONARY_CLASS_DECLOBJECT(KEY_NAME, VALUE_NAME, VALUE_TYPE)
 //%GPB##KEY_NAME##VALUE_NAME##Dictionary<__covariant VALUE_TYPE>
-//%PDDM-DEFINE DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME)
+//%PDDM-DEFINE DICTIONARY_COMMON_INTERFACE(KEY_NAME, KEY_TYPE, KisP, KHELPER, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME, VNAME_VAR)
 //%#pragma mark - KEY_NAME -> VALUE_NAME
 //%
 //%@interface DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) : NSObject <NSCopying>
@@ -2144,25 +2255,25 @@ NS_ASSUME_NONNULL_END
 //%@property(nonatomic, readonly) NSUInteger count;
 //%
 //%+ (instancetype)dictionary;
-//%+ (instancetype)dictionaryWith##VNAME$u##:(VALUE_TYPE)##VNAME
+//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)##VNAME_VAR
 //%                       ##VNAME$S## forKey:(KEY_TYPE##KisP$S##KisP)key;
-//%+ (instancetype)dictionaryWith##VNAME$u##s:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])##VNAME##s
+//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])##VNAME_VAR##s
 //%                      ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[])keys
 //%                      ##VNAME$S##    count:(NSUInteger)count;
 //%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
 //%+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 //%
-//%- (instancetype)initWith##VNAME$u##s:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])##VNAME##s
+//%- (instancetype)initWith##VNAME##s:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[])##VNAME_VAR##s
 //%                ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[])keys
 //%                ##VNAME$S##    count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 //%- (instancetype)initWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
 //%- (instancetype)initWithCapacity:(NSUInteger)numItems;
 //%
-//%DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME)
+//%DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME, VNAME_VAR)
 //%
 //%- (void)addEntriesFromDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)otherDictionary;
 //%
-//%DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME)
+//%DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME, VNAME_VAR)
 //%
 //%@end
 //%
@@ -2203,12 +2314,14 @@ NS_ASSUME_NONNULL_END
 //%// is not a valid enumerator as defined by validationFunc. If the actual value is
 //%// desired, use "raw" version of the method.
 //%
-//%DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, value)
+//%DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, Enum, value)
 //%
 //%// These methods bypass the validationFunc to provide access to values that were not
 //%// known at the time the binary was compiled.
 //%
-//%- (BOOL)valueForKey:(KEY_TYPE##KisP$S##KisP)key rawValue:(nullable VALUE_TYPE *)rawValue;
+//%// Returns YES/NO indicate if the key was found or not, filling in the value
+//%// only when the key was found.
+//%- (BOOL)getRawValue:(nullable VALUE_TYPE *)rawValue forKey:(KEY_TYPE##KisP$S##KisP)key;
 //%
 //%- (void)enumerateKeysAndRawValuesUsingBlock:
 //%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE rawValue, BOOL *stop))block;
@@ -2220,21 +2333,21 @@ NS_ASSUME_NONNULL_END
 //%// to the default value. Use the rawValue methods below to assign non enumerator
 //%// values.
 //%
-//%DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, value)
+//%DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, Enum, value)
 //%
 //%@end
 //%
 
-//%PDDM-DEFINE DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME)
-//%VALUE_FOR_KEY_##VHELPER(KEY_TYPE##KisP$S##KisP, VALUE_TYPE)
+//%PDDM-DEFINE DICTIONARY_IMMUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME, VNAME_VAR)
+//%VALUE_FOR_KEY_##VHELPER(KEY_TYPE##KisP$S##KisP, VALUE_TYPE, VNAME)
 //%
-//%- (void)enumerateKeysAnd##VNAME$u##sUsingBlock:
-//%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE VNAME, BOOL *stop))block;
+//%- (void)enumerateKeysAnd##VNAME##sUsingBlock:
+//%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE VNAME_VAR, BOOL *stop))block;
 
-//%PDDM-DEFINE DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME)
-//%- (void)set##VNAME$u##:(VALUE_TYPE)##VNAME forKey:(KEY_TYPE##KisP$S##KisP)key;
+//%PDDM-DEFINE DICTIONARY_MUTABLE_INTERFACE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, VHELPER, VNAME, VNAME_VAR)
+//%- (void)set##VNAME##:(VALUE_TYPE)##VNAME_VAR forKey:(KEY_TYPE##KisP$S##KisP)key;
 //%DICTIONARY_EXTRA_MUTABLE_METHODS_##VHELPER(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE)
-//%- (void)remove##VNAME$u##ForKey:(KEY_TYPE##KisP$S##KisP)aKey;
+//%- (void)remove##VNAME##ForKey:(KEY_TYPE##KisP$S##KisP)aKey;
 //%- (void)removeAll;
 
 //%PDDM-DEFINE DICTIONARY_EXTRA_MUTABLE_METHODS_POD(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE)

--- a/objectivec/GPBDictionary.m
+++ b/objectivec/GPBDictionary.m
@@ -577,12 +577,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%DICTIONARY_KEY_TO_ENUM_IMPL(KEY_NAME, KEY_TYPE, KisP, Enum, int32_t, KHELPER)
 
 //%PDDM-DEFINE DICTIONARY_KEY_TO_POD_IMPL(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER)
-//%DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, POD, value)
+//%DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, POD, VALUE_NAME, value)
 
 //%PDDM-DEFINE DICTIONARY_POD_KEY_TO_OBJECT_IMPL(KEY_NAME, KEY_TYPE, VALUE_NAME, VALUE_TYPE)
-//%DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, , VALUE_NAME, VALUE_TYPE, POD, OBJECT, object)
+//%DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, , VALUE_NAME, VALUE_TYPE, POD, OBJECT, Object, object)
 
-//%PDDM-DEFINE DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME)
+//%PDDM-DEFINE DICTIONARY_COMMON_IMPL(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_VAR)
 //%#pragma mark - KEY_NAME -> VALUE_NAME
 //%
 //%@implementation GPB##KEY_NAME##VALUE_NAME##Dictionary {
@@ -591,24 +591,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%+ (instancetype)dictionary {
-//%  return [[[self alloc] initWith##VNAME$u##s:NULL forKeys:NULL count:0] autorelease];
+//%  return [[[self alloc] initWith##VNAME##s:NULL forKeys:NULL count:0] autorelease];
 //%}
 //%
-//%+ (instancetype)dictionaryWith##VNAME$u##:(VALUE_TYPE)##VNAME
+//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)##VNAME_VAR
 //%                      ##VNAME$S##  forKey:(KEY_TYPE##KisP$S##KisP)key {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME$u##s:forKeys:count:
+//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
 //%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME$u##s:&##VNAME
+//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:&##VNAME_VAR
 //%               KEY_NAME$S VALUE_NAME$S                        ##VNAME$S##  forKeys:&key
 //%               KEY_NAME$S VALUE_NAME$S                        ##VNAME$S##    count:1] autorelease];
 //%}
 //%
-//%+ (instancetype)dictionaryWith##VNAME$u##s:(const VALUE_TYPE [])##VNAME##s
+//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE [])##VNAME_VAR##s
 //%                      ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
 //%                      ##VNAME$S##    count:(NSUInteger)count {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME$u##s:forKeys:count:
+//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
 //%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME$u##s:##VNAME##s
+//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:##VNAME_VAR##s
 //%               KEY_NAME$S VALUE_NAME$S                               forKeys:keys
 //%               KEY_NAME$S VALUE_NAME$S                                 count:count] autorelease];
 //%}
@@ -624,18 +624,18 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%- (instancetype)init {
-//%  return [self initWith##VNAME$u##s:NULL forKeys:NULL count:0];
+//%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%}
 //%
-//%- (instancetype)initWith##VNAME$u##s:(const VALUE_TYPE [])##VNAME##s
+//%- (instancetype)initWith##VNAME##s:(const VALUE_TYPE [])##VNAME_VAR##s
 //%                ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
 //%                ##VNAME$S##    count:(NSUInteger)count {
 //%  self = [super init];
 //%  if (self) {
 //%    _dictionary = [[NSMutableDictionary alloc] init];
-//%    if (count && VNAME##s && keys) {
+//%    if (count && VNAME_VAR##s && keys) {
 //%      for (NSUInteger i = 0; i < count; ++i) {
-//%DICTIONARY_VALIDATE_VALUE_##VHELPER(VNAME##s[i], ______)##DICTIONARY_VALIDATE_KEY_##KHELPER(keys[i], ______)        [_dictionary setObject:WRAPPED##VHELPER(VNAME##s[i]) forKey:WRAPPED##KHELPER(keys[i])];
+//%DICTIONARY_VALIDATE_VALUE_##VHELPER(VNAME_VAR##s[i], ______)##DICTIONARY_VALIDATE_KEY_##KHELPER(keys[i], ______)        [_dictionary setObject:WRAPPED##VHELPER(VNAME_VAR##s[i]) forKey:WRAPPED##KHELPER(keys[i])];
 //%      }
 //%    }
 //%  }
@@ -643,7 +643,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%- (instancetype)initWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary {
-//%  self = [self initWith##VNAME$u##s:NULL forKeys:NULL count:0];
+//%  self = [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%  if (self) {
 //%    if (dictionary) {
 //%      [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -654,14 +654,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%
 //%- (instancetype)initWithCapacity:(NSUInteger)numItems {
 //%  #pragma unused(numItems)
-//%  return [self initWith##VNAME$u##s:NULL forKeys:NULL count:0];
+//%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%}
 //%
-//%DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, )
+//%DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_VAR, )
 //%
 //%VALUE_FOR_KEY_##VHELPER(KEY_TYPE##KisP$S##KisP, VALUE_NAME, VALUE_TYPE, KHELPER)
 //%
-//%DICTIONARY_MUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, )
+//%DICTIONARY_MUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_VAR, )
 //%
 //%@end
 //%
@@ -771,9 +771,9 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  return [self initWithValidationFunction:func rawValues:NULL forKeys:NULL count:0];
 //%}
 //%
-//%DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, value, Raw)
+//%DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, Value, value, Raw)
 //%
-//%- (BOOL)valueForKey:(KEY_TYPE##KisP$S##KisP)key value:(VALUE_TYPE *)value {
+//%- (BOOL)getEnum:(VALUE_TYPE *)value forKey:(KEY_TYPE##KisP$S##KisP)key {
 //%  NSNumber *wrapped = [_dictionary objectForKey:WRAPPED##KHELPER(key)];
 //%  if (wrapped && value) {
 //%    VALUE_TYPE result = UNWRAP##VALUE_NAME(wrapped);
@@ -785,7 +785,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  return (wrapped != NULL);
 //%}
 //%
-//%- (BOOL)valueForKey:(KEY_TYPE##KisP$S##KisP)key rawValue:(VALUE_TYPE *)rawValue {
+//%- (BOOL)getRawValue:(VALUE_TYPE *)rawValue forKey:(KEY_TYPE##KisP$S##KisP)key {
 //%  NSNumber *wrapped = [_dictionary objectForKey:WRAPPED##KHELPER(key)];
 //%  if (wrapped && rawValue) {
 //%    *rawValue = UNWRAP##VALUE_NAME(wrapped);
@@ -793,7 +793,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  return (wrapped != NULL);
 //%}
 //%
-//%- (void)enumerateKeysAndValuesUsingBlock:
+//%- (void)enumerateKeysAndEnumsUsingBlock:
 //%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE value, BOOL *stop))block {
 //%  GPBEnumValidationFunc func = _validationFunc;
 //%  [_dictionary enumerateKeysAndObjectsUsingBlock:^(ENUM_TYPE##KHELPER(KEY_TYPE)##aKey,
@@ -807,9 +807,9 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  }];
 //%}
 //%
-//%DICTIONARY_MUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, value, Raw)
+//%DICTIONARY_MUTABLE_CORE2(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, Value, Enum, value, Raw)
 //%
-//%- (void)setValue:(VALUE_TYPE)value forKey:(KEY_TYPE##KisP$S##KisP)key {
+//%- (void)setEnum:(VALUE_TYPE)value forKey:(KEY_TYPE##KisP$S##KisP)key {
 //%DICTIONARY_VALIDATE_KEY_##KHELPER(key, )  if (!_validationFunc(value)) {
 //%    [NSException raise:NSInvalidArgumentException
 //%                format:@"GPB##KEY_NAME##VALUE_NAME##Dictionary: Attempt to set an unknown enum value (%d)",
@@ -825,7 +825,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%@end
 //%
 
-//%PDDM-DEFINE DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, ACCESSOR_NAME)
+//%PDDM-DEFINE DICTIONARY_IMMUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_VAR, ACCESSOR_NAME)
 //%- (void)dealloc {
 //%  NSAssert(!_autocreator,
 //%           @"%@: Autocreator must be cleared before release, autocreator: %@",
@@ -861,12 +861,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  return _dictionary.count;
 //%}
 //%
-//%- (void)enumerateKeysAnd##ACCESSOR_NAME##VNAME$u##sUsingBlock:
-//%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE VNAME, BOOL *stop))block {
+//%- (void)enumerateKeysAnd##ACCESSOR_NAME##VNAME##sUsingBlock:
+//%    (void (^)(KEY_TYPE KisP##key, VALUE_TYPE VNAME_VAR, BOOL *stop))block {
 //%  [_dictionary enumerateKeysAndObjectsUsingBlock:^(ENUM_TYPE##KHELPER(KEY_TYPE)##aKey,
-//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME$u,
+//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME_VAR$u,
 //%                                                   BOOL *stop) {
-//%      block(UNWRAP##KEY_NAME(aKey), UNWRAP##VALUE_NAME(a##VNAME$u), stop);
+//%      block(UNWRAP##KEY_NAME(aKey), UNWRAP##VALUE_NAME(a##VNAME_VAR$u), stop);
 //%  }];
 //%}
 //%
@@ -880,11 +880,11 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  GPBDataType keyDataType = field.mapKeyDataType;
 //%  __block size_t result = 0;
 //%  [_dictionary enumerateKeysAndObjectsUsingBlock:^(ENUM_TYPE##KHELPER(KEY_TYPE)##aKey,
-//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME$u##,
+//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME_VAR$u##,
 //%                                                   BOOL *stop) {
 //%    #pragma unused(stop)
 //%    size_t msgSize = ComputeDict##KEY_NAME##FieldSize(UNWRAP##KEY_NAME(aKey), kMapKeyFieldNumber, keyDataType);
-//%    msgSize += ComputeDict##VALUE_NAME##FieldSize(UNWRAP##VALUE_NAME(a##VNAME$u), kMapValueFieldNumber, valueDataType);
+//%    msgSize += ComputeDict##VALUE_NAME##FieldSize(UNWRAP##VALUE_NAME(a##VNAME_VAR$u), kMapValueFieldNumber, valueDataType);
 //%    result += GPBComputeRawVarint32SizeForInteger(msgSize) + msgSize;
 //%  }];
 //%  size_t tagSize = GPBComputeWireFormatTagSize(GPBFieldNumber(field), GPBDataTypeMessage);
@@ -898,18 +898,18 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  GPBDataType keyDataType = field.mapKeyDataType;
 //%  uint32_t tag = GPBWireFormatMakeTag(GPBFieldNumber(field), GPBWireFormatLengthDelimited);
 //%  [_dictionary enumerateKeysAndObjectsUsingBlock:^(ENUM_TYPE##KHELPER(KEY_TYPE)##aKey,
-//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME$u,
+//%                                                   ENUM_TYPE##VHELPER(VALUE_TYPE)##a##VNAME_VAR$u,
 //%                                                   BOOL *stop) {
 //%    #pragma unused(stop)
 //%    // Write the tag.
 //%    [outputStream writeInt32NoTag:tag];
 //%    // Write the size of the message.
 //%    size_t msgSize = ComputeDict##KEY_NAME##FieldSize(UNWRAP##KEY_NAME(aKey), kMapKeyFieldNumber, keyDataType);
-//%    msgSize += ComputeDict##VALUE_NAME##FieldSize(UNWRAP##VALUE_NAME(a##VNAME$u), kMapValueFieldNumber, valueDataType);
+//%    msgSize += ComputeDict##VALUE_NAME##FieldSize(UNWRAP##VALUE_NAME(a##VNAME_VAR$u), kMapValueFieldNumber, valueDataType);
 //%    [outputStream writeInt32NoTag:(int32_t)msgSize];
 //%    // Write the fields.
 //%    WriteDict##KEY_NAME##Field(outputStream, UNWRAP##KEY_NAME(aKey), kMapKeyFieldNumber, keyDataType);
-//%    WriteDict##VALUE_NAME##Field(outputStream, UNWRAP##VALUE_NAME(a##VNAME$u), kMapValueFieldNumber, valueDataType);
+//%    WriteDict##VALUE_NAME##Field(outputStream, UNWRAP##VALUE_NAME(a##VNAME_VAR$u), kMapValueFieldNumber, valueDataType);
 //%  }];
 //%}
 //%
@@ -919,12 +919,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%- (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-//%  [self enumerateKeysAnd##ACCESSOR_NAME##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##key, VALUE_TYPE VNAME, BOOL *stop) {
+//%  [self enumerateKeysAnd##ACCESSOR_NAME##VNAME##sUsingBlock:^(KEY_TYPE KisP##key, VALUE_TYPE VNAME_VAR, BOOL *stop) {
 //%      #pragma unused(stop)
-//%      block(TEXT_FORMAT_OBJ##KEY_NAME(key), TEXT_FORMAT_OBJ##VALUE_NAME(VNAME));
+//%      block(TEXT_FORMAT_OBJ##KEY_NAME(key), TEXT_FORMAT_OBJ##VALUE_NAME(VNAME_VAR));
 //%  }];
 //%}
-//%PDDM-DEFINE DICTIONARY_MUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, ACCESSOR_NAME)
+//%PDDM-DEFINE DICTIONARY_MUTABLE_CORE(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_VAR, ACCESSOR_NAME)
+//%DICTIONARY_MUTABLE_CORE2(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME, VNAME_VAR, ACCESSOR_NAME)
+//%PDDM-DEFINE DICTIONARY_MUTABLE_CORE2(KEY_NAME, KEY_TYPE, KisP, VALUE_NAME, VALUE_TYPE, KHELPER, VHELPER, VNAME, VNAME_REMOVE, VNAME_VAR, ACCESSOR_NAME)
 //%- (void)add##ACCESSOR_NAME##EntriesFromDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)otherDictionary {
 //%  if (otherDictionary) {
 //%    [_dictionary addEntriesFromDictionary:otherDictionary->_dictionary];
@@ -934,14 +936,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  }
 //%}
 //%
-//%- (void)set##ACCESSOR_NAME##VNAME$u##:(VALUE_TYPE)VNAME forKey:(KEY_TYPE##KisP$S##KisP)key {
-//%DICTIONARY_VALIDATE_VALUE_##VHELPER(VNAME, )##DICTIONARY_VALIDATE_KEY_##KHELPER(key, )  [_dictionary setObject:WRAPPED##VHELPER(VNAME) forKey:WRAPPED##KHELPER(key)];
+//%- (void)set##ACCESSOR_NAME##VNAME##:(VALUE_TYPE)VNAME_VAR forKey:(KEY_TYPE##KisP$S##KisP)key {
+//%DICTIONARY_VALIDATE_VALUE_##VHELPER(VNAME_VAR, )##DICTIONARY_VALIDATE_KEY_##KHELPER(key, )  [_dictionary setObject:WRAPPED##VHELPER(VNAME_VAR) forKey:WRAPPED##KHELPER(key)];
 //%  if (_autocreator) {
 //%    GPBAutocreatedDictionaryModified(_autocreator, self);
 //%  }
 //%}
 //%
-//%- (void)remove##VNAME$u##ForKey:(KEY_TYPE##KisP$S##KisP)aKey {
+//%- (void)remove##VNAME_REMOVE##ForKey:(KEY_TYPE##KisP$S##KisP)aKey {
 //%  [_dictionary removeObjectForKey:WRAPPED##KHELPER(aKey)];
 //%}
 //%
@@ -954,11 +956,11 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //
 
 //%PDDM-DEFINE DICTIONARY_BOOL_KEY_TO_POD_IMPL(VALUE_NAME, VALUE_TYPE)
-//%DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, POD, value)
+//%DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, POD, VALUE_NAME, value)
 //%PDDM-DEFINE DICTIONARY_BOOL_KEY_TO_OBJECT_IMPL(VALUE_NAME, VALUE_TYPE)
-//%DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, OBJECT, object)
+//%DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, OBJECT, Object, object)
 
-//%PDDM-DEFINE DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, HELPER, VNAME)
+//%PDDM-DEFINE DICTIONARY_BOOL_KEY_TO_VALUE_IMPL(VALUE_NAME, VALUE_TYPE, HELPER, VNAME, VNAME_VAR)
 //%#pragma mark - Bool -> VALUE_NAME
 //%
 //%@implementation GPBBool##VALUE_NAME##Dictionary {
@@ -967,24 +969,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%BOOL_DICT_HAS_STORAGE_##HELPER()}
 //%
 //%+ (instancetype)dictionary {
-//%  return [[[self alloc] initWith##VNAME$u##s:NULL forKeys:NULL count:0] autorelease];
+//%  return [[[self alloc] initWith##VNAME##s:NULL forKeys:NULL count:0] autorelease];
 //%}
 //%
-//%+ (instancetype)dictionaryWith##VNAME$u##:(VALUE_TYPE)VNAME
+//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)VNAME_VAR
 //%                      ##VNAME$S##  forKey:(BOOL)key {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME$u##s:forKeys:count:
+//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
 //%  // on to get the type correct.
-//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME$u##s:&##VNAME
+//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:&##VNAME_VAR
 //%                    VALUE_NAME$S                        ##VNAME$S##  forKeys:&key
 //%                    VALUE_NAME$S                        ##VNAME$S##    count:1] autorelease];
 //%}
 //%
-//%+ (instancetype)dictionaryWith##VNAME$u##s:(const VALUE_TYPE [])##VNAME##s
+//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE [])##VNAME_VAR##s
 //%                      ##VNAME$S##  forKeys:(const BOOL [])keys
 //%                      ##VNAME$S##    count:(NSUInteger)count {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME$u##s:forKeys:count:
+//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
 //%  // on to get the type correct.
-//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME$u##s:##VNAME##s
+//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:##VNAME_VAR##s
 //%                    VALUE_NAME$S                        ##VNAME$S##  forKeys:keys
 //%                    VALUE_NAME$S                        ##VNAME$S##    count:count] autorelease];
 //%}
@@ -1000,14 +1002,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%- (instancetype)init {
-//%  return [self initWith##VNAME$u##s:NULL forKeys:NULL count:0];
+//%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%}
 //%
 //%BOOL_DICT_INITS_##HELPER(VALUE_NAME, VALUE_TYPE)
 //%
 //%- (instancetype)initWithCapacity:(NSUInteger)numItems {
 //%  #pragma unused(numItems)
-//%  return [self initWith##VNAME$u##s:NULL forKeys:NULL count:0];
+//%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%}
 //%
 //%BOOL_DICT_DEALLOC##HELPER()
@@ -1055,7 +1057,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  return (BOOL_DICT_W_HAS##HELPER(0, ) ? 1 : 0) + (BOOL_DICT_W_HAS##HELPER(1, ) ? 1 : 0);
 //%}
 //%
-//%BOOL_VALUE_FOR_KEY_##HELPER(VALUE_TYPE)
+//%BOOL_VALUE_FOR_KEY_##HELPER(VALUE_NAME, VALUE_TYPE)
 //%
 //%BOOL_SET_GPBVALUE_FOR_KEY_##HELPER(VALUE_NAME, VALUE_TYPE, VisP)
 //%
@@ -1068,8 +1070,8 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  }
 //%}
 //%
-//%- (void)enumerateKeysAnd##VNAME$u##sUsingBlock:
-//%    (void (^)(BOOL key, VALUE_TYPE VNAME, BOOL *stop))block {
+//%- (void)enumerateKeysAnd##VNAME##sUsingBlock:
+//%    (void (^)(BOOL key, VALUE_TYPE VNAME_VAR, BOOL *stop))block {
 //%  BOOL stop = NO;
 //%  if (BOOL_DICT_HAS##HELPER(0, )) {
 //%    block(NO, _values[0], &stop);
@@ -1126,7 +1128,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //
 
 //%PDDM-DEFINE VALUE_FOR_KEY_POD(KEY_TYPE, VALUE_NAME, VALUE_TYPE, KHELPER)
-//%- (BOOL)valueForKey:(KEY_TYPE)key value:(VALUE_TYPE *)value {
+//%- (BOOL)get##VALUE_NAME##:(nullable VALUE_TYPE *)value forKey:(KEY_TYPE)key {
 //%  NSNumber *wrapped = [_dictionary objectForKey:WRAPPED##KHELPER(key)];
 //%  if (wrapped && value) {
 //%    *value = UNWRAP##VALUE_NAME(wrapped);
@@ -1216,9 +1218,9 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  BOOL _valueSet[2];
 //%
 //%PDDM-DEFINE BOOL_DICT_INITS_POD(VALUE_NAME, VALUE_TYPE)
-//%- (instancetype)initWithValues:(const VALUE_TYPE [])values
-//%                       forKeys:(const BOOL [])keys
-//%                         count:(NSUInteger)count {
+//%- (instancetype)initWith##VALUE_NAME##s:(const VALUE_TYPE [])values
+//%                 ##VALUE_NAME$S## forKeys:(const BOOL [])keys
+//%                 ##VALUE_NAME$S##   count:(NSUInteger)count {
 //%  self = [super init];
 //%  if (self) {
 //%    for (NSUInteger i = 0; i < count; ++i) {
@@ -1231,7 +1233,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%- (instancetype)initWithDictionary:(GPBBool##VALUE_NAME##Dictionary *)dictionary {
-//%  self = [self initWithValues:NULL forKeys:NULL count:0];
+//%  self = [self initWith##VALUE_NAME##s:NULL forKeys:NULL count:0];
 //%  if (self) {
 //%    if (dictionary) {
 //%      for (int i = 0; i < 2; ++i) {
@@ -1257,8 +1259,8 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%BOOL_DICT_HASPOD(IDX, REF)
 //%PDDM-DEFINE BOOL_DICT_HASPOD(IDX, REF)
 //%REF##_valueSet[IDX]
-//%PDDM-DEFINE BOOL_VALUE_FOR_KEY_POD(VALUE_TYPE)
-//%- (BOOL)valueForKey:(BOOL)key value:(VALUE_TYPE *)value {
+//%PDDM-DEFINE BOOL_VALUE_FOR_KEY_POD(VALUE_NAME, VALUE_TYPE)
+//%- (BOOL)get##VALUE_NAME##:(VALUE_TYPE *)value forKey:(BOOL)key {
 //%  int idx = (key ? 1 : 0);
 //%  if (_valueSet[idx]) {
 //%    if (value) {
@@ -1290,7 +1292,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  }
 //%}
 //%
-//%- (void)setValue:(VALUE_TYPE)value forKey:(BOOL)key {
+//%- (void)set##VALUE_NAME:(VALUE_TYPE)value forKey:(BOOL)key {
 //%  int idx = (key ? 1 : 0);
 //%  _values[idx] = value;
 //%  _valueSet[idx] = YES;
@@ -1299,7 +1301,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  }
 //%}
 //%
-//%- (void)removeValueForKey:(BOOL)aKey {
+//%- (void)remove##VALUE_NAME##ForKey:(BOOL)aKey {
 //%  _valueSet[aKey ? 1 : 0] = NO;
 //%}
 //%
@@ -1460,7 +1462,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%(BOOL_DICT_HASOBJECT(IDX, REF))
 //%PDDM-DEFINE BOOL_DICT_HASOBJECT(IDX, REF)
 //%REF##_values[IDX] != nil
-//%PDDM-DEFINE BOOL_VALUE_FOR_KEY_OBJECT(VALUE_TYPE)
+//%PDDM-DEFINE BOOL_VALUE_FOR_KEY_OBJECT(VALUE_NAME, VALUE_TYPE)
 //%- (VALUE_TYPE)objectForKey:(BOOL)key {
 //%  return _values[key ? 1 : 0];
 //%}
@@ -1527,24 +1529,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(uint32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithUInt32s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -1560,12 +1562,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -1579,7 +1581,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -1590,7 +1592,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -1628,7 +1630,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(uint32_t key, uint32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -1686,13 +1688,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, uint32_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt32sUsingBlock:^(uint32_t key, uint32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%u", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedIntValue];
@@ -1709,14 +1711,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(uint32_t)key {
+- (void)setUInt32:(uint32_t)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeUInt32ForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -1734,24 +1736,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithInt32s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithInt32s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -1767,10 +1769,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -1786,7 +1788,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32Int32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -1797,7 +1799,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -1835,7 +1837,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -1893,13 +1895,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, int32_t value, BOOL *stop) {
+  [self enumerateKeysAndInt32sUsingBlock:^(uint32_t key, int32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%d", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(int32_t *)value {
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped intValue];
@@ -1916,14 +1918,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(uint32_t)key {
+- (void)setInt32:(int32_t)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeInt32ForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -1941,24 +1943,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(uint32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithUInt64s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -1974,12 +1976,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -1993,7 +1995,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -2004,7 +2006,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -2042,7 +2044,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(uint32_t key, uint64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -2100,13 +2102,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, uint64_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt64sUsingBlock:^(uint32_t key, uint64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%llu", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedLongLongValue];
@@ -2123,14 +2125,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(uint32_t)key {
+- (void)setUInt64:(uint64_t)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeUInt64ForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -2148,24 +2150,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithInt64s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithInt64s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -2181,10 +2183,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -2200,7 +2202,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32Int64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -2211,7 +2213,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -2249,7 +2251,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(uint32_t key, int64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -2307,13 +2309,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, int64_t value, BOOL *stop) {
+  [self enumerateKeysAndInt64sUsingBlock:^(uint32_t key, int64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%lld", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(int64_t *)value {
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped longLongValue];
@@ -2330,14 +2332,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(uint32_t)key {
+- (void)setInt64:(int64_t)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeInt64ForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -2355,24 +2357,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(uint32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithBools:&value
+                                                        forKeys:&key
+                                                          count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const uint32_t [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithBools:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -2388,12 +2390,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const uint32_t [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -2407,7 +2409,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32BoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -2418,7 +2420,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -2456,7 +2458,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(uint32_t key, BOOL value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -2514,13 +2516,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, BOOL value, BOOL *stop) {
+  [self enumerateKeysAndBoolsUsingBlock:^(uint32_t key, BOOL value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], (value ? @"true" : @"false"));
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(BOOL *)value {
+- (BOOL)getBool:(nullable BOOL *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped boolValue];
@@ -2537,14 +2539,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(uint32_t)key {
+- (void)setBool:(BOOL)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeBoolForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -2562,24 +2564,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithFloats:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const uint32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithFloats:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -2595,10 +2597,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const uint32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -2614,7 +2616,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32FloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -2625,7 +2627,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -2663,7 +2665,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(uint32_t key, float value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -2721,13 +2723,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, float value, BOOL *stop) {
+  [self enumerateKeysAndFloatsUsingBlock:^(uint32_t key, float value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%.*g", FLT_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(float *)value {
+- (BOOL)getFloat:(nullable float *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped floatValue];
@@ -2744,14 +2746,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(uint32_t)key {
+- (void)setFloat:(float)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeFloatForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -2769,24 +2771,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(uint32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const uint32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithDoubles:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -2802,12 +2804,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const uint32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -2821,7 +2823,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt32DoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -2832,7 +2834,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -2870,7 +2872,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(uint32_t key, double value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -2928,13 +2930,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint32_t key, double value, BOOL *stop) {
+  [self enumerateKeysAndDoublesUsingBlock:^(uint32_t key, double value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%u", key], [NSString stringWithFormat:@"%.*lg", DBL_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(double *)value {
+- (BOOL)getDouble:(nullable double *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped doubleValue];
@@ -2951,14 +2953,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(uint32_t)key {
+- (void)setDouble:(double)value forKey:(uint32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeDoubleForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -3181,7 +3183,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }];
 }
 
-- (BOOL)valueForKey:(uint32_t)key value:(int32_t *)value {
+- (BOOL)getEnum:(int32_t *)value forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     int32_t result = [wrapped intValue];
@@ -3193,7 +3195,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (BOOL)valueForKey:(uint32_t)key rawValue:(int32_t *)rawValue {
+- (BOOL)getRawValue:(int32_t *)rawValue forKey:(uint32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && rawValue) {
     *rawValue = [wrapped intValue];
@@ -3201,7 +3203,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(uint32_t key, int32_t value, BOOL *stop))block {
   GPBEnumValidationFunc func = _validationFunc;
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
@@ -3231,7 +3233,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(uint32_t)aKey {
+- (void)removeEnumForKey:(uint32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -3239,7 +3241,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   [_dictionary removeAllObjects];
 }
 
-- (void)setValue:(int32_t)value forKey:(uint32_t)key {
+- (void)setEnum:(int32_t)value forKey:(uint32_t)key {
   if (!_validationFunc(value)) {
     [NSException raise:NSInvalidArgumentException
                 format:@"GPBUInt32EnumDictionary: Attempt to set an unknown enum value (%d)",
@@ -3500,24 +3502,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(int32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithUInt32s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -3533,12 +3535,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -3552,7 +3554,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32UInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -3563,7 +3565,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -3601,7 +3603,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(int32_t key, uint32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -3659,13 +3661,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, uint32_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt32sUsingBlock:^(int32_t key, uint32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%u", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedIntValue];
@@ -3682,14 +3684,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(int32_t)key {
+- (void)setUInt32:(uint32_t)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeUInt32ForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -3707,24 +3709,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithInt32s:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithInt32s:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -3740,10 +3742,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -3759,7 +3761,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32Int32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -3770,7 +3772,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -3808,7 +3810,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -3866,13 +3868,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, int32_t value, BOOL *stop) {
+  [self enumerateKeysAndInt32sUsingBlock:^(int32_t key, int32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%d", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(int32_t *)value {
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped intValue];
@@ -3889,14 +3891,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(int32_t)key {
+- (void)setInt32:(int32_t)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeInt32ForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -3914,24 +3916,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(int32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithUInt64s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -3947,12 +3949,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -3966,7 +3968,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32UInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -3977,7 +3979,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -4015,7 +4017,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(int32_t key, uint64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -4073,13 +4075,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, uint64_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt64sUsingBlock:^(int32_t key, uint64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%llu", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedLongLongValue];
@@ -4096,14 +4098,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(int32_t)key {
+- (void)setUInt64:(uint64_t)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeUInt64ForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -4121,24 +4123,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithInt64s:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithInt64s:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -4154,10 +4156,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -4173,7 +4175,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32Int64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -4184,7 +4186,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -4222,7 +4224,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(int32_t key, int64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -4280,13 +4282,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, int64_t value, BOOL *stop) {
+  [self enumerateKeysAndInt64sUsingBlock:^(int32_t key, int64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%lld", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(int64_t *)value {
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped longLongValue];
@@ -4303,14 +4305,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(int32_t)key {
+- (void)setInt64:(int64_t)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeInt64ForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -4328,24 +4330,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(int32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32BoolDictionary*)[self alloc] initWithValues:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
+  return [[(GPBInt32BoolDictionary*)[self alloc] initWithBools:&value
+                                                       forKeys:&key
+                                                         count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const int32_t [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32BoolDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32BoolDictionary*)[self alloc] initWithBools:values
                                                         forKeys:keys
                                                           count:count] autorelease];
 }
@@ -4361,12 +4363,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const int32_t [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -4380,7 +4382,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32BoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -4391,7 +4393,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -4429,7 +4431,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(int32_t key, BOOL value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -4487,13 +4489,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, BOOL value, BOOL *stop) {
+  [self enumerateKeysAndBoolsUsingBlock:^(int32_t key, BOOL value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], (value ? @"true" : @"false"));
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(BOOL *)value {
+- (BOOL)getBool:(nullable BOOL *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped boolValue];
@@ -4510,14 +4512,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(int32_t)key {
+- (void)setBool:(BOOL)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeBoolForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -4535,24 +4537,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32FloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt32FloatDictionary*)[self alloc] initWithFloats:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const int32_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32FloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32FloatDictionary*)[self alloc] initWithFloats:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -4568,10 +4570,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const int32_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -4587,7 +4589,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32FloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -4598,7 +4600,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -4636,7 +4638,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(int32_t key, float value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -4694,13 +4696,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, float value, BOOL *stop) {
+  [self enumerateKeysAndFloatsUsingBlock:^(int32_t key, float value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%.*g", FLT_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(float *)value {
+- (BOOL)getFloat:(nullable float *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped floatValue];
@@ -4717,14 +4719,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(int32_t)key {
+- (void)setFloat:(float)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeFloatForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -4742,24 +4744,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(int32_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const int32_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithDoubles:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -4775,12 +4777,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const int32_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -4794,7 +4796,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt32DoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -4805,7 +4807,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -4843,7 +4845,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(int32_t key, double value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -4901,13 +4903,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int32_t key, double value, BOOL *stop) {
+  [self enumerateKeysAndDoublesUsingBlock:^(int32_t key, double value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%d", key], [NSString stringWithFormat:@"%.*lg", DBL_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(double *)value {
+- (BOOL)getDouble:(nullable double *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped doubleValue];
@@ -4924,14 +4926,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(int32_t)key {
+- (void)setDouble:(double)value forKey:(int32_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeDoubleForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -5154,7 +5156,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }];
 }
 
-- (BOOL)valueForKey:(int32_t)key value:(int32_t *)value {
+- (BOOL)getEnum:(int32_t *)value forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     int32_t result = [wrapped intValue];
@@ -5166,7 +5168,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (BOOL)valueForKey:(int32_t)key rawValue:(int32_t *)rawValue {
+- (BOOL)getRawValue:(int32_t *)rawValue forKey:(int32_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && rawValue) {
     *rawValue = [wrapped intValue];
@@ -5174,7 +5176,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(int32_t key, int32_t value, BOOL *stop))block {
   GPBEnumValidationFunc func = _validationFunc;
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
@@ -5204,7 +5206,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(int32_t)aKey {
+- (void)removeEnumForKey:(int32_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -5212,7 +5214,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   [_dictionary removeAllObjects];
 }
 
-- (void)setValue:(int32_t)value forKey:(int32_t)key {
+- (void)setEnum:(int32_t)value forKey:(int32_t)key {
   if (!_validationFunc(value)) {
     [NSException raise:NSInvalidArgumentException
                 format:@"GPBInt32EnumDictionary: Attempt to set an unknown enum value (%d)",
@@ -5473,24 +5475,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(uint64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithUInt32s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -5506,12 +5508,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -5525,7 +5527,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -5536,7 +5538,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -5574,7 +5576,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(uint64_t key, uint32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -5632,13 +5634,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, uint32_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt32sUsingBlock:^(uint64_t key, uint32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%u", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedIntValue];
@@ -5655,14 +5657,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(uint64_t)key {
+- (void)setUInt32:(uint32_t)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeUInt32ForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -5680,24 +5682,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithInt32s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithInt32s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -5713,10 +5715,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -5732,7 +5734,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64Int32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -5743,7 +5745,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -5781,7 +5783,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -5839,13 +5841,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, int32_t value, BOOL *stop) {
+  [self enumerateKeysAndInt32sUsingBlock:^(uint64_t key, int32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%d", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(int32_t *)value {
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped intValue];
@@ -5862,14 +5864,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(uint64_t)key {
+- (void)setInt32:(int32_t)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeInt32ForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -5887,24 +5889,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(uint64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithUInt64s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -5920,12 +5922,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -5939,7 +5941,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -5950,7 +5952,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -5988,7 +5990,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(uint64_t key, uint64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -6046,13 +6048,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, uint64_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt64sUsingBlock:^(uint64_t key, uint64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%llu", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedLongLongValue];
@@ -6069,14 +6071,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(uint64_t)key {
+- (void)setUInt64:(uint64_t)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeUInt64ForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -6094,24 +6096,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithInt64s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithInt64s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -6127,10 +6129,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -6146,7 +6148,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64Int64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -6157,7 +6159,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -6195,7 +6197,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(uint64_t key, int64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -6253,13 +6255,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, int64_t value, BOOL *stop) {
+  [self enumerateKeysAndInt64sUsingBlock:^(uint64_t key, int64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%lld", value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(int64_t *)value {
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped longLongValue];
@@ -6276,14 +6278,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(uint64_t)key {
+- (void)setInt64:(int64_t)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeInt64ForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -6301,24 +6303,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(uint64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithBools:&value
+                                                        forKeys:&key
+                                                          count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const uint64_t [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithBools:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -6334,12 +6336,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const uint64_t [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -6353,7 +6355,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64BoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -6364,7 +6366,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -6402,7 +6404,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(uint64_t key, BOOL value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -6460,13 +6462,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, BOOL value, BOOL *stop) {
+  [self enumerateKeysAndBoolsUsingBlock:^(uint64_t key, BOOL value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], (value ? @"true" : @"false"));
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(BOOL *)value {
+- (BOOL)getBool:(nullable BOOL *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped boolValue];
@@ -6483,14 +6485,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(uint64_t)key {
+- (void)setBool:(BOOL)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeBoolForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -6508,24 +6510,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithFloats:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const uint64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithFloats:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -6541,10 +6543,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const uint64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -6560,7 +6562,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64FloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -6571,7 +6573,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -6609,7 +6611,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(uint64_t key, float value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -6667,13 +6669,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, float value, BOOL *stop) {
+  [self enumerateKeysAndFloatsUsingBlock:^(uint64_t key, float value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%.*g", FLT_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(float *)value {
+- (BOOL)getFloat:(nullable float *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped floatValue];
@@ -6690,14 +6692,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(uint64_t)key {
+- (void)setFloat:(float)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeFloatForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -6715,24 +6717,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(uint64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const uint64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithValues:values
+  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithDoubles:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -6748,12 +6750,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const uint64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -6767,7 +6769,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBUInt64DoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -6778,7 +6780,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -6816,7 +6818,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(uint64_t key, double value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -6874,13 +6876,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(uint64_t key, double value, BOOL *stop) {
+  [self enumerateKeysAndDoublesUsingBlock:^(uint64_t key, double value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%llu", key], [NSString stringWithFormat:@"%.*lg", DBL_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(double *)value {
+- (BOOL)getDouble:(nullable double *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped doubleValue];
@@ -6897,14 +6899,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(uint64_t)key {
+- (void)setDouble:(double)value forKey:(uint64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeDoubleForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -7127,7 +7129,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }];
 }
 
-- (BOOL)valueForKey:(uint64_t)key value:(int32_t *)value {
+- (BOOL)getEnum:(int32_t *)value forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     int32_t result = [wrapped intValue];
@@ -7139,7 +7141,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (BOOL)valueForKey:(uint64_t)key rawValue:(int32_t *)rawValue {
+- (BOOL)getRawValue:(int32_t *)rawValue forKey:(uint64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && rawValue) {
     *rawValue = [wrapped intValue];
@@ -7147,7 +7149,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(uint64_t key, int32_t value, BOOL *stop))block {
   GPBEnumValidationFunc func = _validationFunc;
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
@@ -7177,7 +7179,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(uint64_t)aKey {
+- (void)removeEnumForKey:(uint64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -7185,7 +7187,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   [_dictionary removeAllObjects];
 }
 
-- (void)setValue:(int32_t)value forKey:(uint64_t)key {
+- (void)setEnum:(int32_t)value forKey:(uint64_t)key {
   if (!_validationFunc(value)) {
     [NSException raise:NSInvalidArgumentException
                 format:@"GPBUInt64EnumDictionary: Attempt to set an unknown enum value (%d)",
@@ -7446,24 +7448,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(int64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithUInt32s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -7479,12 +7481,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -7498,7 +7500,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64UInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -7509,7 +7511,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -7547,7 +7549,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(int64_t key, uint32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -7605,13 +7607,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, uint32_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt32sUsingBlock:^(int64_t key, uint32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%u", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedIntValue];
@@ -7628,14 +7630,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(int64_t)key {
+- (void)setUInt32:(uint32_t)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeUInt32ForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -7653,24 +7655,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithInt32s:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithInt32s:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -7686,10 +7688,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -7705,7 +7707,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64Int32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -7716,7 +7718,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -7754,7 +7756,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -7812,13 +7814,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, int32_t value, BOOL *stop) {
+  [self enumerateKeysAndInt32sUsingBlock:^(int64_t key, int32_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%d", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(int32_t *)value {
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped intValue];
@@ -7835,14 +7837,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(int64_t)key {
+- (void)setInt32:(int32_t)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeInt32ForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -7860,24 +7862,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(int64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithUInt64s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -7893,12 +7895,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -7912,7 +7914,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64UInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -7923,7 +7925,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -7961,7 +7963,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(int64_t key, uint64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -8019,13 +8021,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, uint64_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt64sUsingBlock:^(int64_t key, uint64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%llu", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped unsignedLongLongValue];
@@ -8042,14 +8044,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(int64_t)key {
+- (void)setUInt64:(uint64_t)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeUInt64ForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -8067,24 +8069,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithInt64s:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithInt64s:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -8100,10 +8102,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -8119,7 +8121,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64Int64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -8130,7 +8132,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -8168,7 +8170,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(int64_t key, int64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -8226,13 +8228,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, int64_t value, BOOL *stop) {
+  [self enumerateKeysAndInt64sUsingBlock:^(int64_t key, int64_t value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%lld", value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(int64_t *)value {
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped longLongValue];
@@ -8249,14 +8251,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(int64_t)key {
+- (void)setInt64:(int64_t)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeInt64ForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -8274,24 +8276,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(int64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64BoolDictionary*)[self alloc] initWithValues:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
+  return [[(GPBInt64BoolDictionary*)[self alloc] initWithBools:&value
+                                                       forKeys:&key
+                                                         count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const int64_t [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64BoolDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64BoolDictionary*)[self alloc] initWithBools:values
                                                         forKeys:keys
                                                           count:count] autorelease];
 }
@@ -8307,12 +8309,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const int64_t [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -8326,7 +8328,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64BoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -8337,7 +8339,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -8375,7 +8377,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(int64_t key, BOOL value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -8433,13 +8435,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, BOOL value, BOOL *stop) {
+  [self enumerateKeysAndBoolsUsingBlock:^(int64_t key, BOOL value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], (value ? @"true" : @"false"));
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(BOOL *)value {
+- (BOOL)getBool:(nullable BOOL *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped boolValue];
@@ -8456,14 +8458,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(int64_t)key {
+- (void)setBool:(BOOL)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeBoolForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -8481,24 +8483,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64FloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBInt64FloatDictionary*)[self alloc] initWithFloats:&value
                                                          forKeys:&key
                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const int64_t [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64FloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64FloatDictionary*)[self alloc] initWithFloats:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -8514,10 +8516,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const int64_t [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -8533,7 +8535,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64FloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -8544,7 +8546,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -8582,7 +8584,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(int64_t key, float value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -8640,13 +8642,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, float value, BOOL *stop) {
+  [self enumerateKeysAndFloatsUsingBlock:^(int64_t key, float value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%.*g", FLT_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(float *)value {
+- (BOOL)getFloat:(nullable float *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped floatValue];
@@ -8663,14 +8665,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(int64_t)key {
+- (void)setFloat:(float)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeFloatForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -8688,24 +8690,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(int64_t)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithValues:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
+  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                           forKeys:&key
+                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const int64_t [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithValues:values
+  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithDoubles:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -8721,12 +8723,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const int64_t [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -8740,7 +8742,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBInt64DoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -8751,7 +8753,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -8789,7 +8791,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(int64_t key, double value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
                                                    NSNumber *aValue,
@@ -8847,13 +8849,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(int64_t key, double value, BOOL *stop) {
+  [self enumerateKeysAndDoublesUsingBlock:^(int64_t key, double value, BOOL *stop) {
       #pragma unused(stop)
       block([NSString stringWithFormat:@"%lld", key], [NSString stringWithFormat:@"%.*lg", DBL_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(double *)value {
+- (BOOL)getDouble:(nullable double *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     *value = [wrapped doubleValue];
@@ -8870,14 +8872,14 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(int64_t)key {
+- (void)setDouble:(double)value forKey:(int64_t)key {
   [_dictionary setObject:@(value) forKey:@(key)];
   if (_autocreator) {
     GPBAutocreatedDictionaryModified(_autocreator, self);
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeDoubleForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -9100,7 +9102,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }];
 }
 
-- (BOOL)valueForKey:(int64_t)key value:(int32_t *)value {
+- (BOOL)getEnum:(int32_t *)value forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && value) {
     int32_t result = [wrapped intValue];
@@ -9112,7 +9114,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (BOOL)valueForKey:(int64_t)key rawValue:(int32_t *)rawValue {
+- (BOOL)getRawValue:(int32_t *)rawValue forKey:(int64_t)key {
   NSNumber *wrapped = [_dictionary objectForKey:@(key)];
   if (wrapped && rawValue) {
     *rawValue = [wrapped intValue];
@@ -9120,7 +9122,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(int64_t key, int32_t value, BOOL *stop))block {
   GPBEnumValidationFunc func = _validationFunc;
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSNumber *aKey,
@@ -9150,7 +9152,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(int64_t)aKey {
+- (void)removeEnumForKey:(int64_t)aKey {
   [_dictionary removeObjectForKey:@(aKey)];
 }
 
@@ -9158,7 +9160,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   [_dictionary removeAllObjects];
 }
 
-- (void)setValue:(int32_t)value forKey:(int64_t)key {
+- (void)setEnum:(int32_t)value forKey:(int64_t)key {
   if (!_validationFunc(value)) {
     [NSException raise:NSInvalidArgumentException
                 format:@"GPBInt64EnumDictionary: Attempt to set an unknown enum value (%d)",
@@ -9419,24 +9421,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(NSString *)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const NSString * [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithUInt32s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -9452,12 +9454,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const NSString * [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -9475,7 +9477,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringUInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -9486,7 +9488,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -9524,7 +9526,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(NSString *key, uint32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -9582,13 +9584,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, uint32_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt32sUsingBlock:^(NSString *key, uint32_t value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%u", value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(nullable uint32_t *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped unsignedIntValue];
@@ -9605,7 +9607,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(NSString *)key {
+- (void)setUInt32:(uint32_t)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -9616,7 +9618,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeUInt32ForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -9634,24 +9636,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringInt32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBStringInt32Dictionary*)[self alloc] initWithInt32s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const NSString * [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringInt32Dictionary*)[self alloc] initWithInt32s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -9667,10 +9669,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const NSString * [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -9690,7 +9692,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -9701,7 +9703,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -9739,7 +9741,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -9797,13 +9799,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, int32_t value, BOOL *stop) {
+  [self enumerateKeysAndInt32sUsingBlock:^(NSString *key, int32_t value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%d", value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(int32_t *)value {
+- (BOOL)getInt32:(nullable int32_t *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped intValue];
@@ -9820,7 +9822,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(NSString *)key {
+- (void)setInt32:(int32_t)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -9831,7 +9833,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeInt32ForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -9849,24 +9851,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(NSString *)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const NSString * [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithUInt64s:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -9882,12 +9884,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const NSString * [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -9905,7 +9907,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringUInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -9916,7 +9918,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -9954,7 +9956,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(NSString *key, uint64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -10012,13 +10014,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, uint64_t value, BOOL *stop) {
+  [self enumerateKeysAndUInt64sUsingBlock:^(NSString *key, uint64_t value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%llu", value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(nullable uint64_t *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped unsignedLongLongValue];
@@ -10035,7 +10037,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(NSString *)key {
+- (void)setUInt64:(uint64_t)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -10046,7 +10048,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeUInt64ForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -10064,24 +10066,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringInt64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBStringInt64Dictionary*)[self alloc] initWithInt64s:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const NSString * [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringInt64Dictionary*)[self alloc] initWithInt64s:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -10097,10 +10099,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const NSString * [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -10120,7 +10122,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -10131,7 +10133,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -10169,7 +10171,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(NSString *key, int64_t value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -10227,13 +10229,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, int64_t value, BOOL *stop) {
+  [self enumerateKeysAndInt64sUsingBlock:^(NSString *key, int64_t value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%lld", value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(int64_t *)value {
+- (BOOL)getInt64:(nullable int64_t *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped longLongValue];
@@ -10250,7 +10252,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(NSString *)key {
+- (void)setInt64:(int64_t)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -10261,7 +10263,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeInt64ForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -10279,24 +10281,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(NSString *)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringBoolDictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBStringBoolDictionary*)[self alloc] initWithBools:&value
+                                                        forKeys:&key
+                                                          count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const NSString * [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringBoolDictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringBoolDictionary*)[self alloc] initWithBools:values
                                                          forKeys:keys
                                                            count:count] autorelease];
 }
@@ -10312,12 +10314,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const NSString * [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -10335,7 +10337,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringBoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -10346,7 +10348,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -10384,7 +10386,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(NSString *key, BOOL value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -10442,13 +10444,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, BOOL value, BOOL *stop) {
+  [self enumerateKeysAndBoolsUsingBlock:^(NSString *key, BOOL value, BOOL *stop) {
       #pragma unused(stop)
       block(key, (value ? @"true" : @"false"));
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(BOOL *)value {
+- (BOOL)getBool:(nullable BOOL *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped boolValue];
@@ -10465,7 +10467,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(NSString *)key {
+- (void)setBool:(BOOL)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -10476,7 +10478,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeBoolForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -10494,24 +10496,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringFloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBStringFloatDictionary*)[self alloc] initWithFloats:&value
                                                           forKeys:&key
                                                             count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const NSString * [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringFloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringFloatDictionary*)[self alloc] initWithFloats:values
                                                           forKeys:keys
                                                             count:count] autorelease];
 }
@@ -10527,10 +10529,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const NSString * [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -10550,7 +10552,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringFloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -10561,7 +10563,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -10599,7 +10601,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(NSString *key, float value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -10657,13 +10659,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, float value, BOOL *stop) {
+  [self enumerateKeysAndFloatsUsingBlock:^(NSString *key, float value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%.*g", FLT_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(float *)value {
+- (BOOL)getFloat:(nullable float *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped floatValue];
@@ -10680,7 +10682,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(NSString *)key {
+- (void)setFloat:(float)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -10691,7 +10693,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeFloatForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -10709,24 +10711,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(NSString *)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringDoubleDictionary*)[self alloc] initWithValues:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
+  return [[(GPBStringDoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                            forKeys:&key
+                                                              count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const NSString * [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBStringDoubleDictionary*)[self alloc] initWithValues:values
+  return [[(GPBStringDoubleDictionary*)[self alloc] initWithDoubles:values
                                                            forKeys:keys
                                                              count:count] autorelease];
 }
@@ -10742,12 +10744,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const NSString * [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     _dictionary = [[NSMutableDictionary alloc] init];
@@ -10765,7 +10767,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBStringDoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       [_dictionary addEntriesFromDictionary:dictionary->_dictionary];
@@ -10776,7 +10778,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 - (void)dealloc {
@@ -10814,7 +10816,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return _dictionary.count;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(NSString *key, double value, BOOL *stop))block {
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
                                                    NSNumber *aValue,
@@ -10872,13 +10874,13 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (void)enumerateForTextFormat:(void (^)(id keyObj, id valueObj))block {
-  [self enumerateKeysAndValuesUsingBlock:^(NSString *key, double value, BOOL *stop) {
+  [self enumerateKeysAndDoublesUsingBlock:^(NSString *key, double value, BOOL *stop) {
       #pragma unused(stop)
       block(key, [NSString stringWithFormat:@"%.*lg", DBL_DIG, value]);
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(double *)value {
+- (BOOL)getDouble:(nullable double *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     *value = [wrapped doubleValue];
@@ -10895,7 +10897,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(NSString *)key {
+- (void)setDouble:(double)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -10906,7 +10908,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeDoubleForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -11133,7 +11135,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }];
 }
 
-- (BOOL)valueForKey:(NSString *)key value:(int32_t *)value {
+- (BOOL)getEnum:(int32_t *)value forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && value) {
     int32_t result = [wrapped intValue];
@@ -11145,7 +11147,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (BOOL)valueForKey:(NSString *)key rawValue:(int32_t *)rawValue {
+- (BOOL)getRawValue:(int32_t *)rawValue forKey:(NSString *)key {
   NSNumber *wrapped = [_dictionary objectForKey:key];
   if (wrapped && rawValue) {
     *rawValue = [wrapped intValue];
@@ -11153,7 +11155,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (wrapped != NULL);
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(NSString *key, int32_t value, BOOL *stop))block {
   GPBEnumValidationFunc func = _validationFunc;
   [_dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *aKey,
@@ -11187,7 +11189,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(NSString *)aKey {
+- (void)removeEnumForKey:(NSString *)aKey {
   [_dictionary removeObjectForKey:aKey];
 }
 
@@ -11195,7 +11197,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   [_dictionary removeAllObjects];
 }
 
-- (void)setValue:(int32_t)value forKey:(NSString *)key {
+- (void)setEnum:(int32_t)value forKey:(NSString *)key {
   if (!key) {
     [NSException raise:NSInvalidArgumentException
                 format:@"Attempting to add nil key to a Dictionary"];
@@ -11229,26 +11231,26 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint32_t)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32:(uint32_t)value
+                              forKey:(BOOL)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithUInt32s:&value
+                                                          forKeys:&key
+                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint32_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithValues:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
+  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithUInt32s:values
+                                                          forKeys:keys
+                                                            count:count] autorelease];
 }
 
 + (instancetype)dictionaryWithDictionary:(GPBBoolUInt32Dictionary *)dictionary {
@@ -11262,12 +11264,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint32_t [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt32s:(const uint32_t [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     for (NSUInteger i = 0; i < count; ++i) {
@@ -11280,7 +11282,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolUInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -11296,7 +11298,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -11351,7 +11353,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(uint32_t *)value {
+- (BOOL)getUInt32:(uint32_t *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -11378,7 +11380,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt32sUsingBlock:
     (void (^)(BOOL key, uint32_t value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -11439,7 +11441,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint32_t)value forKey:(BOOL)key {
+- (void)setUInt32:(uint32_t)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -11448,7 +11450,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeUInt32ForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -11471,24 +11473,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int32_t)value
++ (instancetype)dictionaryWithInt32:(int32_t)value
                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithInt32s:&value
                                                         forKeys:&key
                                                           count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int32_t [])values
++ (instancetype)dictionaryWithInt32s:(const int32_t [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithInt32s:values
                                                         forKeys:keys
                                                           count:count] autorelease];
 }
@@ -11504,10 +11506,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithInt32s:(const int32_t [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -11522,7 +11524,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolInt32Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt32s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -11538,7 +11540,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt32s:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -11593,7 +11595,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(int32_t *)value {
+- (BOOL)getInt32:(int32_t *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -11620,7 +11622,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt32sUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -11681,7 +11683,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(BOOL)key {
+- (void)setInt32:(int32_t)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -11690,7 +11692,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeInt32ForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -11713,26 +11715,26 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(uint64_t)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64:(uint64_t)value
+                              forKey:(BOOL)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithUInt64s:&value
+                                                          forKeys:&key
+                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const uint64_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithValues:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
+  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithUInt64s:values
+                                                          forKeys:keys
+                                                            count:count] autorelease];
 }
 
 + (instancetype)dictionaryWithDictionary:(GPBBoolUInt64Dictionary *)dictionary {
@@ -11746,12 +11748,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const uint64_t [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithUInt64s:(const uint64_t [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     for (NSUInteger i = 0; i < count; ++i) {
@@ -11764,7 +11766,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolUInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithUInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -11780,7 +11782,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -11835,7 +11837,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(uint64_t *)value {
+- (BOOL)getUInt64:(uint64_t *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -11862,7 +11864,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndUInt64sUsingBlock:
     (void (^)(BOOL key, uint64_t value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -11923,7 +11925,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(uint64_t)value forKey:(BOOL)key {
+- (void)setUInt64:(uint64_t)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -11932,7 +11934,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeUInt64ForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -11955,24 +11957,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(int64_t)value
++ (instancetype)dictionaryWithInt64:(int64_t)value
                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithValues:&value
+  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithInt64s:&value
                                                         forKeys:&key
                                                           count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const int64_t [])values
++ (instancetype)dictionaryWithInt64s:(const int64_t [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithValues:values
+  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithInt64s:values
                                                         forKeys:keys
                                                           count:count] autorelease];
 }
@@ -11988,10 +11990,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithInt64s:(const int64_t [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -12006,7 +12008,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolInt64Dictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithInt64s:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -12022,7 +12024,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithInt64s:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -12077,7 +12079,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(int64_t *)value {
+- (BOOL)getInt64:(int64_t *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -12104,7 +12106,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndInt64sUsingBlock:
     (void (^)(BOOL key, int64_t value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -12165,7 +12167,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int64_t)value forKey:(BOOL)key {
+- (void)setInt64:(int64_t)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -12174,7 +12176,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeInt64ForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -12197,26 +12199,26 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(BOOL)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBool:(BOOL)value
+                            forKey:(BOOL)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolBoolDictionary*)[self alloc] initWithValues:&value
-                                                       forKeys:&key
-                                                         count:1] autorelease];
+  return [[(GPBBoolBoolDictionary*)[self alloc] initWithBools:&value
+                                                      forKeys:&key
+                                                        count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const BOOL [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithBools:(const BOOL [])values
+                            forKeys:(const BOOL [])keys
+                              count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolBoolDictionary*)[self alloc] initWithValues:values
-                                                       forKeys:keys
-                                                         count:count] autorelease];
+  return [[(GPBBoolBoolDictionary*)[self alloc] initWithBools:values
+                                                      forKeys:keys
+                                                        count:count] autorelease];
 }
 
 + (instancetype)dictionaryWithDictionary:(GPBBoolBoolDictionary *)dictionary {
@@ -12230,12 +12232,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const BOOL [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithBools:(const BOOL [])values
+                      forKeys:(const BOOL [])keys
+                        count:(NSUInteger)count {
   self = [super init];
   if (self) {
     for (NSUInteger i = 0; i < count; ++i) {
@@ -12248,7 +12250,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolBoolDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithBools:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -12264,7 +12266,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithBools:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -12319,7 +12321,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(BOOL *)value {
+- (BOOL)getBool:(BOOL *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -12346,7 +12348,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndBoolsUsingBlock:
     (void (^)(BOOL key, BOOL value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -12407,7 +12409,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(BOOL)value forKey:(BOOL)key {
+- (void)setBool:(BOOL)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -12416,7 +12418,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeBoolForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -12439,24 +12441,24 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(float)value
++ (instancetype)dictionaryWithFloat:(float)value
                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolFloatDictionary*)[self alloc] initWithValues:&value
+  return [[(GPBBoolFloatDictionary*)[self alloc] initWithFloats:&value
                                                         forKeys:&key
                                                           count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const float [])values
++ (instancetype)dictionaryWithFloats:(const float [])values
                              forKeys:(const BOOL [])keys
                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
+  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolFloatDictionary*)[self alloc] initWithValues:values
+  return [[(GPBBoolFloatDictionary*)[self alloc] initWithFloats:values
                                                         forKeys:keys
                                                           count:count] autorelease];
 }
@@ -12472,10 +12474,10 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithFloats:(const float [])values
                        forKeys:(const BOOL [])keys
                          count:(NSUInteger)count {
   self = [super init];
@@ -12490,7 +12492,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolFloatDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithFloats:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -12506,7 +12508,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithFloats:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -12561,7 +12563,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(float *)value {
+- (BOOL)getFloat:(float *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -12588,7 +12590,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndFloatsUsingBlock:
     (void (^)(BOOL key, float value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -12649,7 +12651,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(float)value forKey:(BOOL)key {
+- (void)setFloat:(float)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -12658,7 +12660,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeFloatForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -12681,26 +12683,26 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 + (instancetype)dictionary {
-  return [[[self alloc] initWithValues:NULL forKeys:NULL count:0] autorelease];
+  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
 }
 
-+ (instancetype)dictionaryWithValue:(double)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDouble:(double)value
+                              forKey:(BOOL)key {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithValues:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
+  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithDoubles:&value
+                                                          forKeys:&key
+                                                            count:1] autorelease];
 }
 
-+ (instancetype)dictionaryWithValues:(const double [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
++ (instancetype)dictionaryWithDoubles:(const double [])values
+                              forKeys:(const BOOL [])keys
+                                count:(NSUInteger)count {
+  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
   // on to get the type correct.
-  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithValues:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
+  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithDoubles:values
+                                                          forKeys:keys
+                                                            count:count] autorelease];
 }
 
 + (instancetype)dictionaryWithDictionary:(GPBBoolDoubleDictionary *)dictionary {
@@ -12714,12 +12716,12 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)init {
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
-- (instancetype)initWithValues:(const double [])values
-                       forKeys:(const BOOL [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithDoubles:(const double [])values
+                        forKeys:(const BOOL [])keys
+                          count:(NSUInteger)count {
   self = [super init];
   if (self) {
     for (NSUInteger i = 0; i < count; ++i) {
@@ -12732,7 +12734,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)initWithDictionary:(GPBBoolDoubleDictionary *)dictionary {
-  self = [self initWithValues:NULL forKeys:NULL count:0];
+  self = [self initWithDoubles:NULL forKeys:NULL count:0];
   if (self) {
     if (dictionary) {
       for (int i = 0; i < 2; ++i) {
@@ -12748,7 +12750,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems {
   #pragma unused(numItems)
-  return [self initWithValues:NULL forKeys:NULL count:0];
+  return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
 
 #if !defined(NS_BLOCK_ASSERTIONS)
@@ -12803,7 +12805,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(double *)value {
+- (BOOL)getDouble:(double *)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -12830,7 +12832,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndDoublesUsingBlock:
     (void (^)(BOOL key, double value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -12891,7 +12893,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(double)value forKey:(BOOL)key {
+- (void)setDouble:(double)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   _values[idx] = value;
   _valueSet[idx] = YES;
@@ -12900,7 +12902,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeDoubleForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 
@@ -13335,7 +13337,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return (_valueSet[0] ? 1 : 0) + (_valueSet[1] ? 1 : 0);
 }
 
-- (BOOL)valueForKey:(BOOL)key value:(int32_t*)value {
+- (BOOL)getEnum:(int32_t*)value forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (value) {
@@ -13350,7 +13352,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return NO;
 }
 
-- (BOOL)valueForKey:(BOOL)key rawValue:(int32_t*)rawValue {
+- (BOOL)getRawValue:(int32_t*)rawValue forKey:(BOOL)key {
   int idx = (key ? 1 : 0);
   if (_valueSet[idx]) {
     if (rawValue) {
@@ -13361,7 +13363,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   return NO;
 }
 
-- (void)enumerateKeysAndValuesUsingBlock:
+- (void)enumerateKeysAndRawValuesUsingBlock:
     (void (^)(BOOL key, int32_t value, BOOL *stop))block {
   BOOL stop = NO;
   if (_valueSet[0]) {
@@ -13372,7 +13374,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)enumerateKeysAndRawValuesUsingBlock:
+- (void)enumerateKeysAndEnumsUsingBlock:
     (void (^)(BOOL key, int32_t rawValue, BOOL *stop))block {
   BOOL stop = NO;
   GPBEnumValidationFunc func = _validationFunc;
@@ -13477,7 +13479,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)setValue:(int32_t)value forKey:(BOOL)key {
+- (void)setEnum:(int32_t)value forKey:(BOOL)key {
   if (!_validationFunc(value)) {
     [NSException raise:NSInvalidArgumentException
                 format:@"GPBBoolEnumDictionary: Attempt to set an unknown enum value (%d)",
@@ -13500,7 +13502,7 @@ void GPBDictionaryReadEntry(id mapDictionary,
   }
 }
 
-- (void)removeValueForKey:(BOOL)aKey {
+- (void)removeEnumForKey:(BOOL)aKey {
   _valueSet[aKey ? 1 : 0] = NO;
 }
 

--- a/objectivec/GPBProtocolBuffers.m
+++ b/objectivec/GPBProtocolBuffers.m
@@ -31,6 +31,14 @@
 // If you want to build protocol buffers in your own project without adding the
 // project dependency, you can just add this file.
 
+
+// This warning seems to treat code differently when it is #imported then when
+// it is inline in the file.  GPBDictionary.m compiles cleanly in other targets,
+// but when #imported here it triggers a bunch of warnings that don't make
+// much sense, and don't trigger when compiled directly.  So we shut off the
+// warnings here.
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
 #import "GPBArray.m"
 #import "GPBCodedInputStream.m"
 #import "GPBCodedOutputStream.m"

--- a/objectivec/GPBProtocolBuffers.m
+++ b/objectivec/GPBProtocolBuffers.m
@@ -32,7 +32,7 @@
 // project dependency, you can just add this file.
 
 
-// This warning seems to treat code differently when it is #imported then when
+// This warning seems to treat code differently when it is #imported than when
 // it is inline in the file.  GPBDictionary.m compiles cleanly in other targets,
 // but when #imported here it triggers a bunch of warnings that don't make
 // much sense, and don't trigger when compiled directly.  So we shut off the

--- a/objectivec/Tests/GPBDictionaryTests+Bool.m
+++ b/objectivec/Tests/GPBDictionaryTests+Bool.m
@@ -54,8 +54,8 @@
   GPBBoolUInt32Dictionary *dict = [[GPBBoolUInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:YES]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -63,15 +63,15 @@
 }
 
 - (void)testOne {
-  GPBBoolUInt32Dictionary *dict = [GPBBoolUInt32Dictionary dictionaryWithValue:100U forKey:YES];
+  GPBBoolUInt32Dictionary *dict = [GPBBoolUInt32Dictionary dictionaryWithUInt32:100U forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:NO]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -82,23 +82,23 @@
   const BOOL kKeys[] = { YES, NO };
   const uint32_t kValues[] = { 100U, 101U };
   GPBBoolUInt32Dictionary *dict =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   uint32_t *seenValues = malloc(2 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -120,7 +120,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(BOOL aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -136,29 +136,29 @@
   const uint32_t kValues2[] = { 101U, 100U };
   const uint32_t kValues3[] = { 101U };
   GPBBoolUInt32Dictionary *dict1 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolUInt32Dictionary *dict1prime =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolUInt32Dictionary *dict2 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues2
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolUInt32Dictionary *dict3 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolUInt32Dictionary *dict4 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues3
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -187,9 +187,9 @@
   const BOOL kKeys[] = { YES, NO };
   const uint32_t kValues[] = { 100U, 101U };
   GPBBoolUInt32Dictionary *dict =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolUInt32Dictionary *dict2 = [dict copy];
@@ -208,9 +208,9 @@
   const BOOL kKeys[] = { YES, NO };
   const uint32_t kValues[] = { 100U, 101U };
   GPBBoolUInt32Dictionary *dict =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolUInt32Dictionary *dict2 =
@@ -228,25 +228,25 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:YES];
+  [dict setUInt32:100U forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const uint32_t kValues[] = { 101U };
   GPBBoolUInt32Dictionary *dict2 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
   [dict2 release];
 }
@@ -255,32 +255,32 @@
   const BOOL kKeys[] = { YES, NO};
   const uint32_t kValues[] = { 100U, 101U };
   GPBBoolUInt32Dictionary *dict =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                        forKeys:kKeys
+                                          count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeUInt32ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeUInt32ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:YES]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:NO]);
   [dict release];
 }
 
@@ -288,51 +288,51 @@
   const BOOL kKeys[] = { YES, NO };
   const uint32_t kValues[] = { 100U, 101U };
   GPBBoolUInt32Dictionary *dict =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
 
-  [dict setValue:101U forKey:YES];
+  [dict setUInt32:101U forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
 
-  [dict setValue:100U forKey:NO];
+  [dict setUInt32:100U forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 100U);
 
   const BOOL kKeys2[] = { NO, YES };
   const uint32_t kValues2[] = { 101U, 100U };
   GPBBoolUInt32Dictionary *dict2 =
-      [[GPBBoolUInt32Dictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolUInt32Dictionary alloc] initWithUInt32s:kValues2
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt32:&value forKey:YES]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -355,8 +355,8 @@
   GPBBoolInt32Dictionary *dict = [[GPBBoolInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:YES]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -364,15 +364,15 @@
 }
 
 - (void)testOne {
-  GPBBoolInt32Dictionary *dict = [GPBBoolInt32Dictionary dictionaryWithValue:200 forKey:YES];
+  GPBBoolInt32Dictionary *dict = [GPBBoolInt32Dictionary dictionaryWithInt32:200 forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:NO]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -383,23 +383,23 @@
   const BOOL kKeys[] = { YES, NO };
   const int32_t kValues[] = { 200, 201 };
   GPBBoolInt32Dictionary *dict =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   int32_t *seenValues = malloc(2 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -421,7 +421,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(BOOL aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -437,27 +437,27 @@
   const int32_t kValues2[] = { 201, 200 };
   const int32_t kValues3[] = { 201 };
   GPBBoolInt32Dictionary *dict1 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolInt32Dictionary *dict1prime =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolInt32Dictionary *dict2 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues2
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues2
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolInt32Dictionary *dict3 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues1
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolInt32Dictionary *dict4 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues3
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues3
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -488,7 +488,7 @@
   const BOOL kKeys[] = { YES, NO };
   const int32_t kValues[] = { 200, 201 };
   GPBBoolInt32Dictionary *dict =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -509,7 +509,7 @@
   const BOOL kKeys[] = { YES, NO };
   const int32_t kValues[] = { 200, 201 };
   GPBBoolInt32Dictionary *dict =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -529,13 +529,13 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:YES];
+  [dict setInt32:200 forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const int32_t kValues[] = { 201 };
   GPBBoolInt32Dictionary *dict2 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -543,11 +543,11 @@
   XCTAssertEqual(dict.count, 2U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
   [dict2 release];
 }
@@ -556,32 +556,32 @@
   const BOOL kKeys[] = { YES, NO};
   const int32_t kValues[] = { 200, 201 };
   GPBBoolInt32Dictionary *dict =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
                                       forKeys:kKeys
                                         count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeInt32ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeInt32ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:YES]);
+  XCTAssertFalse([dict getInt32:NULL forKey:NO]);
   [dict release];
 }
 
@@ -589,51 +589,51 @@
   const BOOL kKeys[] = { YES, NO };
   const int32_t kValues[] = { 200, 201 };
   GPBBoolInt32Dictionary *dict =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
 
-  [dict setValue:201 forKey:YES];
+  [dict setInt32:201 forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
 
-  [dict setValue:200 forKey:NO];
+  [dict setInt32:200 forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 200);
 
   const BOOL kKeys2[] = { NO, YES };
   const int32_t kValues2[] = { 201, 200 };
   GPBBoolInt32Dictionary *dict2 =
-      [[GPBBoolInt32Dictionary alloc] initWithValues:kValues2
+      [[GPBBoolInt32Dictionary alloc] initWithInt32s:kValues2
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt32:&value forKey:YES]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -656,8 +656,8 @@
   GPBBoolUInt64Dictionary *dict = [[GPBBoolUInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:YES]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -665,15 +665,15 @@
 }
 
 - (void)testOne {
-  GPBBoolUInt64Dictionary *dict = [GPBBoolUInt64Dictionary dictionaryWithValue:300U forKey:YES];
+  GPBBoolUInt64Dictionary *dict = [GPBBoolUInt64Dictionary dictionaryWithUInt64:300U forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:NO]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -684,23 +684,23 @@
   const BOOL kKeys[] = { YES, NO };
   const uint64_t kValues[] = { 300U, 301U };
   GPBBoolUInt64Dictionary *dict =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   uint64_t *seenValues = malloc(2 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -722,7 +722,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(BOOL aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -738,29 +738,29 @@
   const uint64_t kValues2[] = { 301U, 300U };
   const uint64_t kValues3[] = { 301U };
   GPBBoolUInt64Dictionary *dict1 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolUInt64Dictionary *dict1prime =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolUInt64Dictionary *dict2 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues2
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolUInt64Dictionary *dict3 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolUInt64Dictionary *dict4 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues3
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -789,9 +789,9 @@
   const BOOL kKeys[] = { YES, NO };
   const uint64_t kValues[] = { 300U, 301U };
   GPBBoolUInt64Dictionary *dict =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolUInt64Dictionary *dict2 = [dict copy];
@@ -810,9 +810,9 @@
   const BOOL kKeys[] = { YES, NO };
   const uint64_t kValues[] = { 300U, 301U };
   GPBBoolUInt64Dictionary *dict =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolUInt64Dictionary *dict2 =
@@ -830,25 +830,25 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:YES];
+  [dict setUInt64:300U forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const uint64_t kValues[] = { 301U };
   GPBBoolUInt64Dictionary *dict2 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
   [dict2 release];
 }
@@ -857,32 +857,32 @@
   const BOOL kKeys[] = { YES, NO};
   const uint64_t kValues[] = { 300U, 301U };
   GPBBoolUInt64Dictionary *dict =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                        forKeys:kKeys
+                                          count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeUInt64ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeUInt64ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:YES]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:NO]);
   [dict release];
 }
 
@@ -890,51 +890,51 @@
   const BOOL kKeys[] = { YES, NO };
   const uint64_t kValues[] = { 300U, 301U };
   GPBBoolUInt64Dictionary *dict =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
 
-  [dict setValue:301U forKey:YES];
+  [dict setUInt64:301U forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
 
-  [dict setValue:300U forKey:NO];
+  [dict setUInt64:300U forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 300U);
 
   const BOOL kKeys2[] = { NO, YES };
   const uint64_t kValues2[] = { 301U, 300U };
   GPBBoolUInt64Dictionary *dict2 =
-      [[GPBBoolUInt64Dictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolUInt64Dictionary alloc] initWithUInt64s:kValues2
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getUInt64:&value forKey:YES]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -957,8 +957,8 @@
   GPBBoolInt64Dictionary *dict = [[GPBBoolInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:YES]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -966,15 +966,15 @@
 }
 
 - (void)testOne {
-  GPBBoolInt64Dictionary *dict = [GPBBoolInt64Dictionary dictionaryWithValue:400 forKey:YES];
+  GPBBoolInt64Dictionary *dict = [GPBBoolInt64Dictionary dictionaryWithInt64:400 forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:NO]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -985,23 +985,23 @@
   const BOOL kKeys[] = { YES, NO };
   const int64_t kValues[] = { 400, 401 };
   GPBBoolInt64Dictionary *dict =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   int64_t *seenValues = malloc(2 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1023,7 +1023,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(BOOL aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1039,27 +1039,27 @@
   const int64_t kValues2[] = { 401, 400 };
   const int64_t kValues3[] = { 401 };
   GPBBoolInt64Dictionary *dict1 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolInt64Dictionary *dict1prime =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolInt64Dictionary *dict2 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues2
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues2
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolInt64Dictionary *dict3 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues1
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolInt64Dictionary *dict4 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues3
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues3
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1090,7 +1090,7 @@
   const BOOL kKeys[] = { YES, NO };
   const int64_t kValues[] = { 400, 401 };
   GPBBoolInt64Dictionary *dict =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1111,7 +1111,7 @@
   const BOOL kKeys[] = { YES, NO };
   const int64_t kValues[] = { 400, 401 };
   GPBBoolInt64Dictionary *dict =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1131,13 +1131,13 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:YES];
+  [dict setInt64:400 forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const int64_t kValues[] = { 401 };
   GPBBoolInt64Dictionary *dict2 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1145,11 +1145,11 @@
   XCTAssertEqual(dict.count, 2U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
   [dict2 release];
 }
@@ -1158,32 +1158,32 @@
   const BOOL kKeys[] = { YES, NO};
   const int64_t kValues[] = { 400, 401 };
   GPBBoolInt64Dictionary *dict =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
                                       forKeys:kKeys
                                         count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeInt64ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeInt64ForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:YES]);
+  XCTAssertFalse([dict getInt64:NULL forKey:NO]);
   [dict release];
 }
 
@@ -1191,51 +1191,51 @@
   const BOOL kKeys[] = { YES, NO };
   const int64_t kValues[] = { 400, 401 };
   GPBBoolInt64Dictionary *dict =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
 
-  [dict setValue:401 forKey:YES];
+  [dict setInt64:401 forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
 
-  [dict setValue:400 forKey:NO];
+  [dict setInt64:400 forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 400);
 
   const BOOL kKeys2[] = { NO, YES };
   const int64_t kValues2[] = { 401, 400 };
   GPBBoolInt64Dictionary *dict2 =
-      [[GPBBoolInt64Dictionary alloc] initWithValues:kValues2
+      [[GPBBoolInt64Dictionary alloc] initWithInt64s:kValues2
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:YES]);
+  XCTAssertTrue([dict getInt64:&value forKey:YES]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:NO]);
+  XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1258,8 +1258,8 @@
   GPBBoolBoolDictionary *dict = [[GPBBoolBoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:YES]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1267,15 +1267,15 @@
 }
 
 - (void)testOne {
-  GPBBoolBoolDictionary *dict = [GPBBoolBoolDictionary dictionaryWithValue:NO forKey:YES];
+  GPBBoolBoolDictionary *dict = [GPBBoolBoolDictionary dictionaryWithBool:NO forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:NO]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, NO);
     XCTAssertNotEqual(stop, NULL);
@@ -1286,23 +1286,23 @@
   const BOOL kKeys[] = { YES, NO };
   const BOOL kValues[] = { NO, YES };
   GPBBoolBoolDictionary *dict =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                            forKeys:kKeys
-                                              count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                           forKeys:kKeys
+                                             count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   BOOL *seenValues = malloc(2 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1324,7 +1324,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(BOOL aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1340,29 +1340,29 @@
   const BOOL kValues2[] = { YES, NO };
   const BOOL kValues3[] = { YES };
   GPBBoolBoolDictionary *dict1 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues1
-                                            forKeys:kKeys1
-                                              count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues1
+                                           forKeys:kKeys1
+                                             count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolBoolDictionary *dict1prime =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues1
-                                            forKeys:kKeys1
-                                              count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues1
+                                           forKeys:kKeys1
+                                             count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolBoolDictionary *dict2 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues2
-                                            forKeys:kKeys1
-                                              count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues2
+                                           forKeys:kKeys1
+                                             count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolBoolDictionary *dict3 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues1
-                                            forKeys:kKeys2
-                                              count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues1
+                                           forKeys:kKeys2
+                                             count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolBoolDictionary *dict4 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues3
-                                            forKeys:kKeys1
-                                              count:GPBARRAYSIZE(kValues3)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues3
+                                           forKeys:kKeys1
+                                             count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1391,9 +1391,9 @@
   const BOOL kKeys[] = { YES, NO };
   const BOOL kValues[] = { NO, YES };
   GPBBoolBoolDictionary *dict =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                            forKeys:kKeys
-                                              count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                           forKeys:kKeys
+                                             count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolBoolDictionary *dict2 = [dict copy];
@@ -1412,9 +1412,9 @@
   const BOOL kKeys[] = { YES, NO };
   const BOOL kValues[] = { NO, YES };
   GPBBoolBoolDictionary *dict =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                            forKeys:kKeys
-                                              count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                           forKeys:kKeys
+                                             count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolBoolDictionary *dict2 =
@@ -1432,25 +1432,25 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:NO forKey:YES];
+  [dict setBool:NO forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const BOOL kValues[] = { YES };
   GPBBoolBoolDictionary *dict2 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                            forKeys:kKeys
-                                              count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                           forKeys:kKeys
+                                             count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
   [dict2 release];
 }
@@ -1459,32 +1459,32 @@
   const BOOL kKeys[] = { YES, NO};
   const BOOL kValues[] = { NO, YES };
   GPBBoolBoolDictionary *dict =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                     forKeys:kKeys
-                                       count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                    forKeys:kKeys
+                                      count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeBoolForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeBoolForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:YES]);
+  XCTAssertFalse([dict getBool:NULL forKey:NO]);
   [dict release];
 }
 
@@ -1492,51 +1492,51 @@
   const BOOL kKeys[] = { YES, NO };
   const BOOL kValues[] = { NO, YES };
   GPBBoolBoolDictionary *dict =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues
-                                     forKeys:kKeys
-                                       count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues
+                                           forKeys:kKeys
+                                             count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
 
-  [dict setValue:YES forKey:YES];
+  [dict setBool:YES forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
 
-  [dict setValue:NO forKey:NO];
+  [dict setBool:NO forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, NO);
 
   const BOOL kKeys2[] = { NO, YES };
   const BOOL kValues2[] = { YES, NO };
   GPBBoolBoolDictionary *dict2 =
-      [[GPBBoolBoolDictionary alloc] initWithValues:kValues2
-                                            forKeys:kKeys2
-                                              count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolBoolDictionary alloc] initWithBools:kValues2
+                                           forKeys:kKeys2
+                                             count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:YES]);
+  XCTAssertTrue([dict getBool:&value forKey:YES]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:NO]);
+  XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1559,8 +1559,8 @@
   GPBBoolFloatDictionary *dict = [[GPBBoolFloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:YES]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1568,15 +1568,15 @@
 }
 
 - (void)testOne {
-  GPBBoolFloatDictionary *dict = [GPBBoolFloatDictionary dictionaryWithValue:500.f forKey:YES];
+  GPBBoolFloatDictionary *dict = [GPBBoolFloatDictionary dictionaryWithFloat:500.f forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:NO]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1587,23 +1587,23 @@
   const BOOL kKeys[] = { YES, NO };
   const float kValues[] = { 500.f, 501.f };
   GPBBoolFloatDictionary *dict =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   float value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   float *seenValues = malloc(2 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1625,7 +1625,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(BOOL aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1641,27 +1641,27 @@
   const float kValues2[] = { 501.f, 500.f };
   const float kValues3[] = { 501.f };
   GPBBoolFloatDictionary *dict1 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues1
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolFloatDictionary *dict1prime =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues1
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues1
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolFloatDictionary *dict2 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues2
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues2
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolFloatDictionary *dict3 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues1
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues1
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolFloatDictionary *dict4 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues3
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues3
                                              forKeys:kKeys1
                                                count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1692,7 +1692,7 @@
   const BOOL kKeys[] = { YES, NO };
   const float kValues[] = { 500.f, 501.f };
   GPBBoolFloatDictionary *dict =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1713,7 +1713,7 @@
   const BOOL kKeys[] = { YES, NO };
   const float kValues[] = { 500.f, 501.f };
   GPBBoolFloatDictionary *dict =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1733,13 +1733,13 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:YES];
+  [dict setFloat:500.f forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const float kValues[] = { 501.f };
   GPBBoolFloatDictionary *dict2 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
                                              forKeys:kKeys
                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1747,11 +1747,11 @@
   XCTAssertEqual(dict.count, 2U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
   [dict2 release];
 }
@@ -1760,32 +1760,32 @@
   const BOOL kKeys[] = { YES, NO};
   const float kValues[] = { 500.f, 501.f };
   GPBBoolFloatDictionary *dict =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
                                       forKeys:kKeys
                                         count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeFloatForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeFloatForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:YES]);
+  XCTAssertFalse([dict getFloat:NULL forKey:NO]);
   [dict release];
 }
 
@@ -1793,51 +1793,51 @@
   const BOOL kKeys[] = { YES, NO };
   const float kValues[] = { 500.f, 501.f };
   GPBBoolFloatDictionary *dict =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   float value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
 
-  [dict setValue:501.f forKey:YES];
+  [dict setFloat:501.f forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
 
-  [dict setValue:500.f forKey:NO];
+  [dict setFloat:500.f forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 500.f);
 
   const BOOL kKeys2[] = { NO, YES };
   const float kValues2[] = { 501.f, 500.f };
   GPBBoolFloatDictionary *dict2 =
-      [[GPBBoolFloatDictionary alloc] initWithValues:kValues2
+      [[GPBBoolFloatDictionary alloc] initWithFloats:kValues2
                                              forKeys:kKeys2
                                                count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:YES]);
+  XCTAssertTrue([dict getFloat:&value forKey:YES]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:NO]);
+  XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -1860,8 +1860,8 @@
   GPBBoolDoubleDictionary *dict = [[GPBBoolDoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:YES]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1869,15 +1869,15 @@
 }
 
 - (void)testOne {
-  GPBBoolDoubleDictionary *dict = [GPBBoolDoubleDictionary dictionaryWithValue:600. forKey:YES];
+  GPBBoolDoubleDictionary *dict = [GPBBoolDoubleDictionary dictionaryWithDouble:600. forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:NO]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
     XCTAssertEqual(aKey, YES);
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -1888,23 +1888,23 @@
   const BOOL kKeys[] = { YES, NO };
   const double kValues[] = { 600., 601. };
   GPBBoolDoubleDictionary *dict =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   double value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
 
   __block NSUInteger idx = 0;
   BOOL *seenKeys = malloc(2 * sizeof(BOOL));
   double *seenValues = malloc(2 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 2U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1926,7 +1926,7 @@
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(BOOL aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 0) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1942,29 +1942,29 @@
   const double kValues2[] = { 601., 600. };
   const double kValues3[] = { 601. };
   GPBBoolDoubleDictionary *dict1 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBBoolDoubleDictionary *dict1prime =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues1
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBBoolDoubleDictionary *dict2 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues2
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBBoolDoubleDictionary *dict3 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues1
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBBoolDoubleDictionary *dict4 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues3
+                                               forKeys:kKeys1
+                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1993,9 +1993,9 @@
   const BOOL kKeys[] = { YES, NO };
   const double kValues[] = { 600., 601. };
   GPBBoolDoubleDictionary *dict =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolDoubleDictionary *dict2 = [dict copy];
@@ -2014,9 +2014,9 @@
   const BOOL kKeys[] = { YES, NO };
   const double kValues[] = { 600., 601. };
   GPBBoolDoubleDictionary *dict =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBBoolDoubleDictionary *dict2 =
@@ -2034,25 +2034,25 @@
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:YES];
+  [dict setDouble:600. forKey:YES];
   XCTAssertEqual(dict.count, 1U);
 
   const BOOL kKeys[] = { NO };
   const double kValues[] = { 601. };
   GPBBoolDoubleDictionary *dict2 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
   [dict2 release];
 }
@@ -2061,32 +2061,32 @@
   const BOOL kKeys[] = { YES, NO};
   const double kValues[] = { 600., 601. };
   GPBBoolDoubleDictionary *dict =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                        forKeys:kKeys
+                                          count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
 
-  [dict removeValueForKey:NO];
+  [dict removeDoubleForKey:NO];
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:NO]);
 
   // Remove again does nothing.
-  [dict removeValueForKey:NO];
+  [dict removeDoubleForKey:NO];
   XCTAssertEqual(dict.count, 1U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:NO]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:YES value:NULL]);
-  XCTAssertFalse([dict valueForKey:NO value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:YES]);
+  XCTAssertFalse([dict getDouble:NULL forKey:NO]);
   [dict release];
 }
 
@@ -2094,51 +2094,51 @@
   const BOOL kKeys[] = { YES, NO };
   const double kValues[] = { 600., 601. };
   GPBBoolDoubleDictionary *dict =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   double value;
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
 
-  [dict setValue:601. forKey:YES];
+  [dict setDouble:601. forKey:YES];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
 
-  [dict setValue:600. forKey:NO];
+  [dict setDouble:600. forKey:NO];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 600.);
 
   const BOOL kKeys2[] = { NO, YES };
   const double kValues2[] = { 601., 600. };
   GPBBoolDoubleDictionary *dict2 =
-      [[GPBBoolDoubleDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBBoolDoubleDictionary alloc] initWithDoubles:kValues2
+                                               forKeys:kKeys2
+                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:YES value:NULL]);
-  XCTAssertTrue([dict valueForKey:YES value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:YES]);
+  XCTAssertTrue([dict getDouble:&value forKey:YES]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:NO value:NULL]);
-  XCTAssertTrue([dict valueForKey:NO value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:NO]);
+  XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2378,8 +2378,8 @@
   const NSString* kObjects[] = { @"abc", @"def" };
   GPBBoolObjectDictionary<NSString*> *dict =
       [[GPBBoolObjectDictionary alloc] initWithObjects:kObjects
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kObjects)];
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 2U);
   XCTAssertEqualObjects([dict objectForKey:YES], @"abc");

--- a/objectivec/Tests/GPBDictionaryTests+Int32.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int32.m
@@ -45,10 +45,10 @@
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBInt32EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(int32_t)key;
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count;
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(int32_t)key;
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const int32_t [])keys
+                        count:(NSUInteger)count;
 @end
 
 static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -64,7 +64,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 @implementation GPBInt32EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(int32_t)key {
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(int32_t)key {
   // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
   // type correct.
   return [[(GPBInt32EnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -72,9 +72,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
                                                                     forKeys:&key
                                                                       count:1] autorelease];
 }
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const int32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const int32_t [])keys
+                        count:(NSUInteger)count {
   return [self initWithValidationFunction:TestingEnum_IsValidValue
                                 rawValues:values
                                   forKeys:keys
@@ -94,8 +94,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32UInt32Dictionary *dict = [[GPBInt32UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:11]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -103,15 +103,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32UInt32Dictionary *dict = [GPBInt32UInt32Dictionary dictionaryWithValue:100U forKey:11];
+  GPBInt32UInt32Dictionary *dict = [GPBInt32UInt32Dictionary dictionaryWithUInt32:100U forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:12]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -122,27 +122,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const uint32_t kValues[] = { 100U, 101U, 102U };
   GPBInt32UInt32Dictionary *dict =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   uint32_t *seenValues = malloc(3 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -164,7 +164,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int32_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -180,29 +180,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kValues2[] = { 100U, 103U, 102U };
   const uint32_t kValues3[] = { 100U, 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict1 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32UInt32Dictionary *dict1prime =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32UInt32Dictionary *dict2 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32UInt32Dictionary *dict3 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32UInt32Dictionary *dict4 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -231,9 +231,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32UInt32Dictionary *dict2 = [dict copy];
@@ -252,9 +252,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32UInt32Dictionary *dict2 =
@@ -272,31 +272,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:11];
+  [dict setUInt32:100U forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const uint32_t kValues[] = { 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict2 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
 }
@@ -305,57 +305,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeUInt32ForKey:12];
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeUInt32ForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
 
-  [dict removeValueForKey:14];
+  [dict removeUInt32ForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:11]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:12]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:13]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:14]);
   [dict release];
 }
 
@@ -363,75 +363,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt32UInt32Dictionary *dict =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:103U forKey:11];
+  [dict setUInt32:103U forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:101U forKey:14];
+  [dict setUInt32:101U forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 101U);
 
   const int32_t kKeys2[] = { 12, 13 };
   const uint32_t kValues2[] = { 102U, 100U };
   GPBInt32UInt32Dictionary *dict2 =
-      [[GPBInt32UInt32Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt32:&value forKey:11]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt32:&value forKey:12]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt32:&value forKey:13]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -451,8 +451,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32Int32Dictionary *dict = [[GPBInt32Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:11]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -460,15 +460,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32Int32Dictionary *dict = [GPBInt32Int32Dictionary dictionaryWithValue:200 forKey:11];
+  GPBInt32Int32Dictionary *dict = [GPBInt32Int32Dictionary dictionaryWithInt32:200 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:12]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -479,27 +479,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const int32_t kValues[] = { 200, 201, 202 };
   GPBInt32Int32Dictionary *dict =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -521,7 +521,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -537,27 +537,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 200, 203, 202 };
   const int32_t kValues3[] = { 200, 201, 202, 203 };
   GPBInt32Int32Dictionary *dict1 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32Int32Dictionary *dict1prime =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32Int32Dictionary *dict2 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32Int32Dictionary *dict3 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32Int32Dictionary *dict4 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues3
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -588,7 +588,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt32Int32Dictionary *dict =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -609,7 +609,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt32Int32Dictionary *dict =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -629,13 +629,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:11];
+  [dict setInt32:200 forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const int32_t kValues[] = { 201, 202, 203 };
   GPBInt32Int32Dictionary *dict2 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -643,17 +643,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
   [dict2 release];
 }
@@ -662,57 +662,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt32Int32Dictionary *dict =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeInt32ForKey:12];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeInt32ForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
 
-  [dict removeValueForKey:14];
+  [dict removeInt32ForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:11]);
+  XCTAssertFalse([dict getInt32:NULL forKey:12]);
+  XCTAssertFalse([dict getInt32:NULL forKey:13]);
+  XCTAssertFalse([dict getInt32:NULL forKey:14]);
   [dict release];
 }
 
@@ -720,75 +720,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt32Int32Dictionary *dict =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:203 forKey:11];
+  [dict setInt32:203 forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:201 forKey:14];
+  [dict setInt32:201 forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 201);
 
   const int32_t kKeys2[] = { 12, 13 };
   const int32_t kValues2[] = { 202, 200 };
   GPBInt32Int32Dictionary *dict2 =
-      [[GPBInt32Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBInt32Int32Dictionary alloc] initWithInt32s:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:11]);
+  XCTAssertTrue([dict getInt32:&value forKey:11]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:12]);
+  XCTAssertTrue([dict getInt32:&value forKey:12]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:13]);
+  XCTAssertTrue([dict getInt32:&value forKey:13]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:14]);
+  XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -808,8 +808,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32UInt64Dictionary *dict = [[GPBInt32UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:11]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -817,15 +817,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32UInt64Dictionary *dict = [GPBInt32UInt64Dictionary dictionaryWithValue:300U forKey:11];
+  GPBInt32UInt64Dictionary *dict = [GPBInt32UInt64Dictionary dictionaryWithUInt64:300U forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:12]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -836,27 +836,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const uint64_t kValues[] = { 300U, 301U, 302U };
   GPBInt32UInt64Dictionary *dict =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   uint64_t *seenValues = malloc(3 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -878,7 +878,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int32_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -894,29 +894,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kValues2[] = { 300U, 303U, 302U };
   const uint64_t kValues3[] = { 300U, 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict1 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32UInt64Dictionary *dict1prime =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32UInt64Dictionary *dict2 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32UInt64Dictionary *dict3 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32UInt64Dictionary *dict4 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -945,9 +945,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32UInt64Dictionary *dict2 = [dict copy];
@@ -966,9 +966,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32UInt64Dictionary *dict2 =
@@ -986,31 +986,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:11];
+  [dict setUInt64:300U forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const uint64_t kValues[] = { 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict2 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
 }
@@ -1019,57 +1019,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeUInt64ForKey:12];
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeUInt64ForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
 
-  [dict removeValueForKey:14];
+  [dict removeUInt64ForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:11]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:12]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:13]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:14]);
   [dict release];
 }
 
@@ -1077,75 +1077,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt32UInt64Dictionary *dict =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:303U forKey:11];
+  [dict setUInt64:303U forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:301U forKey:14];
+  [dict setUInt64:301U forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 301U);
 
   const int32_t kKeys2[] = { 12, 13 };
   const uint64_t kValues2[] = { 302U, 300U };
   GPBInt32UInt64Dictionary *dict2 =
-      [[GPBInt32UInt64Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getUInt64:&value forKey:11]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getUInt64:&value forKey:12]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getUInt64:&value forKey:13]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -1165,8 +1165,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32Int64Dictionary *dict = [[GPBInt32Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:11]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1174,15 +1174,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32Int64Dictionary *dict = [GPBInt32Int64Dictionary dictionaryWithValue:400 forKey:11];
+  GPBInt32Int64Dictionary *dict = [GPBInt32Int64Dictionary dictionaryWithInt64:400 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:12]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -1193,27 +1193,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const int64_t kValues[] = { 400, 401, 402 };
   GPBInt32Int64Dictionary *dict =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   int64_t *seenValues = malloc(3 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1235,7 +1235,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(int32_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1251,27 +1251,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kValues2[] = { 400, 403, 402 };
   const int64_t kValues3[] = { 400, 401, 402, 403 };
   GPBInt32Int64Dictionary *dict1 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32Int64Dictionary *dict1prime =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32Int64Dictionary *dict2 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32Int64Dictionary *dict3 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32Int64Dictionary *dict4 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues3
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1302,7 +1302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt32Int64Dictionary *dict =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1323,7 +1323,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt32Int64Dictionary *dict =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1343,13 +1343,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:11];
+  [dict setInt64:400 forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const int64_t kValues[] = { 401, 402, 403 };
   GPBInt32Int64Dictionary *dict2 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1357,17 +1357,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
   [dict2 release];
 }
@@ -1376,57 +1376,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt32Int64Dictionary *dict =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeInt64ForKey:12];
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeInt64ForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
 
-  [dict removeValueForKey:14];
+  [dict removeInt64ForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:11]);
+  XCTAssertFalse([dict getInt64:NULL forKey:12]);
+  XCTAssertFalse([dict getInt64:NULL forKey:13]);
+  XCTAssertFalse([dict getInt64:NULL forKey:14]);
   [dict release];
 }
 
@@ -1434,75 +1434,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt32Int64Dictionary *dict =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:403 forKey:11];
+  [dict setInt64:403 forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:401 forKey:14];
+  [dict setInt64:401 forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 401);
 
   const int32_t kKeys2[] = { 12, 13 };
   const int64_t kValues2[] = { 402, 400 };
   GPBInt32Int64Dictionary *dict2 =
-      [[GPBInt32Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBInt32Int64Dictionary alloc] initWithInt64s:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:11]);
+  XCTAssertTrue([dict getInt64:&value forKey:11]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:12]);
+  XCTAssertTrue([dict getInt64:&value forKey:12]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:13]);
+  XCTAssertTrue([dict getInt64:&value forKey:13]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:14]);
+  XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1522,8 +1522,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32BoolDictionary *dict = [[GPBInt32BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:11]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1531,15 +1531,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32BoolDictionary *dict = [GPBInt32BoolDictionary dictionaryWithValue:YES forKey:11];
+  GPBInt32BoolDictionary *dict = [GPBInt32BoolDictionary dictionaryWithBool:YES forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:12]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
@@ -1550,27 +1550,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const BOOL kValues[] = { YES, YES, NO };
   GPBInt32BoolDictionary *dict =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   BOOL *seenValues = malloc(3 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1592,7 +1592,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(int32_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1608,29 +1608,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const BOOL kValues2[] = { YES, NO, NO };
   const BOOL kValues3[] = { YES, YES, NO, NO };
   GPBInt32BoolDictionary *dict1 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32BoolDictionary *dict1prime =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32BoolDictionary *dict2 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues2
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32BoolDictionary *dict3 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32BoolDictionary *dict4 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues3
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues3
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1659,9 +1659,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt32BoolDictionary *dict =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32BoolDictionary *dict2 = [dict copy];
@@ -1680,9 +1680,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt32BoolDictionary *dict =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32BoolDictionary *dict2 =
@@ -1700,31 +1700,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:YES forKey:11];
+  [dict setBool:YES forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const BOOL kValues[] = { YES, NO, NO };
   GPBInt32BoolDictionary *dict2 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
   [dict2 release];
 }
@@ -1733,57 +1733,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt32BoolDictionary *dict =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeBoolForKey:12];
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeBoolForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
 
-  [dict removeValueForKey:14];
+  [dict removeBoolForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:11]);
+  XCTAssertFalse([dict getBool:NULL forKey:12]);
+  XCTAssertFalse([dict getBool:NULL forKey:13]);
+  XCTAssertFalse([dict getBool:NULL forKey:14]);
   [dict release];
 }
 
@@ -1791,75 +1791,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt32BoolDictionary *dict =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:NO forKey:11];
+  [dict setBool:NO forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:YES forKey:14];
+  [dict setBool:YES forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, YES);
 
   const int32_t kKeys2[] = { 12, 13 };
   const BOOL kValues2[] = { NO, YES };
   GPBInt32BoolDictionary *dict2 =
-      [[GPBInt32BoolDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32BoolDictionary alloc] initWithBools:kValues2
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:11]);
+  XCTAssertTrue([dict getBool:&value forKey:11]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:12]);
+  XCTAssertTrue([dict getBool:&value forKey:12]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:13]);
+  XCTAssertTrue([dict getBool:&value forKey:13]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:14]);
+  XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1879,8 +1879,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32FloatDictionary *dict = [[GPBInt32FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:11]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1888,15 +1888,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32FloatDictionary *dict = [GPBInt32FloatDictionary dictionaryWithValue:500.f forKey:11];
+  GPBInt32FloatDictionary *dict = [GPBInt32FloatDictionary dictionaryWithFloat:500.f forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:12]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1907,27 +1907,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const float kValues[] = { 500.f, 501.f, 502.f };
   GPBInt32FloatDictionary *dict =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   float *seenValues = malloc(3 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1949,7 +1949,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(int32_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1965,27 +1965,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const float kValues2[] = { 500.f, 503.f, 502.f };
   const float kValues3[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict1 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32FloatDictionary *dict1prime =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32FloatDictionary *dict2 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues2
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32FloatDictionary *dict3 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32FloatDictionary *dict4 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues3
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -2016,7 +2016,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2037,7 +2037,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2057,13 +2057,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:11];
+  [dict setFloat:500.f forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const float kValues[] = { 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict2 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -2071,17 +2071,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
 }
@@ -2090,57 +2090,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeFloatForKey:12];
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeFloatForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
 
-  [dict removeValueForKey:14];
+  [dict removeFloatForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:11]);
+  XCTAssertFalse([dict getFloat:NULL forKey:12]);
+  XCTAssertFalse([dict getFloat:NULL forKey:13]);
+  XCTAssertFalse([dict getFloat:NULL forKey:14]);
   [dict release];
 }
 
@@ -2148,75 +2148,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt32FloatDictionary *dict =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   float value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:503.f forKey:11];
+  [dict setFloat:503.f forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:501.f forKey:14];
+  [dict setFloat:501.f forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 501.f);
 
   const int32_t kKeys2[] = { 12, 13 };
   const float kValues2[] = { 502.f, 500.f };
   GPBInt32FloatDictionary *dict2 =
-      [[GPBInt32FloatDictionary alloc] initWithValues:kValues2
+      [[GPBInt32FloatDictionary alloc] initWithFloats:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:11]);
+  XCTAssertTrue([dict getFloat:&value forKey:11]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:12]);
+  XCTAssertTrue([dict getFloat:&value forKey:12]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:13]);
+  XCTAssertTrue([dict getFloat:&value forKey:13]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:14]);
+  XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -2236,8 +2236,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32DoubleDictionary *dict = [[GPBInt32DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:11]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2245,15 +2245,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32DoubleDictionary *dict = [GPBInt32DoubleDictionary dictionaryWithValue:600. forKey:11];
+  GPBInt32DoubleDictionary *dict = [GPBInt32DoubleDictionary dictionaryWithDouble:600. forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:12]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -2264,27 +2264,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const double kValues[] = { 600., 601., 602. };
   GPBInt32DoubleDictionary *dict =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   double *seenValues = malloc(3 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2306,7 +2306,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(int32_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2322,29 +2322,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const double kValues2[] = { 600., 603., 602. };
   const double kValues3[] = { 600., 601., 602., 603. };
   GPBInt32DoubleDictionary *dict1 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32DoubleDictionary *dict1prime =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32DoubleDictionary *dict2 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32DoubleDictionary *dict3 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32DoubleDictionary *dict4 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2373,9 +2373,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt32DoubleDictionary *dict =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32DoubleDictionary *dict2 = [dict copy];
@@ -2394,9 +2394,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt32DoubleDictionary *dict =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32DoubleDictionary *dict2 =
@@ -2414,31 +2414,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:11];
+  [dict setDouble:600. forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const double kValues[] = { 601., 602., 603. };
   GPBInt32DoubleDictionary *dict2 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
 }
@@ -2447,57 +2447,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt32DoubleDictionary *dict =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeDoubleForKey:12];
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeDoubleForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
 
-  [dict removeValueForKey:14];
+  [dict removeDoubleForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:11]);
+  XCTAssertFalse([dict getDouble:NULL forKey:12]);
+  XCTAssertFalse([dict getDouble:NULL forKey:13]);
+  XCTAssertFalse([dict getDouble:NULL forKey:14]);
   [dict release];
 }
 
@@ -2505,75 +2505,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt32DoubleDictionary *dict =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   double value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:603. forKey:11];
+  [dict setDouble:603. forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:601. forKey:14];
+  [dict setDouble:601. forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 601.);
 
   const int32_t kKeys2[] = { 12, 13 };
   const double kValues2[] = { 602., 600. };
   GPBInt32DoubleDictionary *dict2 =
-      [[GPBInt32DoubleDictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32DoubleDictionary alloc] initWithDoubles:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:11]);
+  XCTAssertTrue([dict getDouble:&value forKey:11]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:12]);
+  XCTAssertTrue([dict getDouble:&value forKey:12]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:13]);
+  XCTAssertTrue([dict getDouble:&value forKey:13]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:14]);
+  XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2593,8 +2593,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt32EnumDictionary *dict = [[GPBInt32EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:11]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2602,15 +2602,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32EnumDictionary *dict = [GPBInt32EnumDictionary dictionaryWithValue:700 forKey:11];
+  GPBInt32EnumDictionary *dict = [GPBInt32EnumDictionary dictionaryWithEnum:700 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 11);
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
@@ -2621,27 +2621,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13 };
   const int32_t kValues[] = { 700, 701, 702 };
   GPBInt32EnumDictionary *dict =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2663,7 +2663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2679,29 +2679,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 700, 703, 702 };
   const int32_t kValues3[] = { 700, 701, 702, 703 };
   GPBInt32EnumDictionary *dict1 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt32EnumDictionary *dict1prime =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt32EnumDictionary *dict2 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues2
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt32EnumDictionary *dict3 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt32EnumDictionary *dict4 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues3
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues3
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2730,9 +2730,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt32EnumDictionary *dict =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32EnumDictionary *dict2 = [dict copy];
@@ -2751,9 +2751,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt32EnumDictionary *dict =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt32EnumDictionary *dict2 =
@@ -2771,31 +2771,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:700 forKey:11];
+  [dict setEnum:700 forKey:11];
   XCTAssertEqual(dict.count, 1U);
 
   const int32_t kKeys[] = { 12, 13, 14 };
   const int32_t kValues[] = { 701, 702, 703 };
   GPBInt32EnumDictionary *dict2 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
   [dict2 release];
 }
@@ -2804,57 +2804,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt32EnumDictionary *dict =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeEnumForKey:12];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeEnumForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
 
-  [dict removeValueForKey:14];
+  [dict removeEnumForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:11]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertFalse([dict getEnum:NULL forKey:13]);
+  XCTAssertFalse([dict getEnum:NULL forKey:14]);
   [dict release];
 }
 
@@ -2862,75 +2862,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 12, 13, 14 };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt32EnumDictionary *dict =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:703 forKey:11];
+  [dict setEnum:703 forKey:11];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:701 forKey:14];
+  [dict setEnum:701 forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 701);
 
   const int32_t kKeys2[] = { 12, 13 };
   const int32_t kValues2[] = { 702, 700 };
   GPBInt32EnumDictionary *dict2 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues2
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 701);
 
   [dict2 release];
@@ -2958,24 +2958,24 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 3U);
   XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:11 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:11]);
+  XCTAssertTrue([dict getRawValue:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:13 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:13]);
+  XCTAssertTrue([dict getRawValue:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:14 rawValue:NULL]);
+  XCTAssertFalse([dict getRawValue:NULL forKey:14]);
 
   __block NSUInteger idx = 0;
   int32_t *seenKeys = malloc(3 * sizeof(int32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -3136,7 +3136,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertThrowsSpecificNamed([dict setValue:801 forKey:12],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:801 forKey:12],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 0U);
   [dict setRawValue:801 forKey:12];  // Unknown
@@ -3145,31 +3145,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kKeys[] = { 11, 13, 14 };
   const int32_t kValues[] = { 700, 702, 803 };  // Unknown
   GPBInt32EnumDictionary *dict2 =
-      [[GPBInt32EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt32EnumDictionary alloc] initWithEnums:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
   [dict2 release];
 }
@@ -3185,51 +3185,51 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:12];
+  [dict removeEnumForKey:12];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
 
   // Remove again does nothing.
-  [dict removeValueForKey:12];
+  [dict removeEnumForKey:12];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
 
-  [dict removeValueForKey:14];
+  [dict removeEnumForKey:14];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:14]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:11 value:NULL]);
-  XCTAssertFalse([dict valueForKey:12 value:NULL]);
-  XCTAssertFalse([dict valueForKey:13 value:NULL]);
-  XCTAssertFalse([dict valueForKey:14 value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:11]);
+  XCTAssertFalse([dict getEnum:NULL forKey:12]);
+  XCTAssertFalse([dict getEnum:NULL forKey:13]);
+  XCTAssertFalse([dict getEnum:NULL forKey:14]);
   [dict release];
 }
 
@@ -3244,63 +3244,63 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
 
-  XCTAssertThrowsSpecificNamed([dict setValue:803 forKey:11],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:803 forKey:11],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 value:NULL]);
-  XCTAssertTrue([dict valueForKey:11 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:11]);
+  XCTAssertTrue([dict getEnum:&value forKey:11]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:803 forKey:11];  // Unknown
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:11 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:11]);
+  XCTAssertTrue([dict getRawValue:&value forKey:11]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:14 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:14]);
+  XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:700 forKey:14];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:11 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:11]);
+  XCTAssertTrue([dict getRawValue:&value forKey:11]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:12 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:12 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:12]);
+  XCTAssertTrue([dict getRawValue:&value forKey:12]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:13 value:NULL]);
-  XCTAssertTrue([dict valueForKey:13 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:13]);
+  XCTAssertTrue([dict getEnum:&value forKey:13]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 700);
 
   const int32_t kKeys2[] = { 12, 13 };
@@ -3313,17 +3313,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:11 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:11 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:11]);
+  XCTAssertTrue([dict getRawValue:&value forKey:11]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:12 value:NULL]);
-  XCTAssertTrue([dict valueForKey:12 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:12]);
+  XCTAssertTrue([dict getEnum:&value forKey:12]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:13 rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:13 rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:13]);
+  XCTAssertTrue([dict getRawValue:&value forKey:13]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:14 value:NULL]);
-  XCTAssertTrue([dict valueForKey:14 value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:14]);
+  XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 700);
 
   [dict2 release];
@@ -3559,8 +3559,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBInt32ObjectDictionary<NSString*> *dict =
       [[GPBInt32ObjectDictionary alloc] initWithObjects:kObjects
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kObjects)];
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
@@ -3600,8 +3600,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBInt32ObjectDictionary<NSString*> *dict =
       [[GPBInt32ObjectDictionary alloc] initWithObjects:kObjects
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kObjects)];
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   XCTAssertEqualObjects([dict objectForKey:11], @"abc");

--- a/objectivec/Tests/GPBDictionaryTests+Int64.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int64.m
@@ -45,10 +45,10 @@
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBInt64EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(int64_t)key;
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count;
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(int64_t)key;
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const int64_t [])keys
+                        count:(NSUInteger)count;
 @end
 
 static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -64,7 +64,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 @implementation GPBInt64EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(int64_t)key {
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(int64_t)key {
   // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
   // type correct.
   return [[(GPBInt64EnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -72,9 +72,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
                                                                     forKeys:&key
                                                                       count:1] autorelease];
 }
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const int64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const int64_t [])keys
+                        count:(NSUInteger)count {
   return [self initWithValidationFunction:TestingEnum_IsValidValue
                                 rawValues:values
                                   forKeys:keys
@@ -94,8 +94,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64UInt32Dictionary *dict = [[GPBInt64UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:21LL]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -103,15 +103,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64UInt32Dictionary *dict = [GPBInt64UInt32Dictionary dictionaryWithValue:100U forKey:21LL];
+  GPBInt64UInt32Dictionary *dict = [GPBInt64UInt32Dictionary dictionaryWithUInt32:100U forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:22LL]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -122,27 +122,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const uint32_t kValues[] = { 100U, 101U, 102U };
   GPBInt64UInt32Dictionary *dict =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   uint32_t *seenValues = malloc(3 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -164,7 +164,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(int64_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -180,29 +180,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kValues2[] = { 100U, 103U, 102U };
   const uint32_t kValues3[] = { 100U, 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict1 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64UInt32Dictionary *dict1prime =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64UInt32Dictionary *dict2 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64UInt32Dictionary *dict3 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64UInt32Dictionary *dict4 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -231,9 +231,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64UInt32Dictionary *dict2 = [dict copy];
@@ -252,9 +252,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64UInt32Dictionary *dict2 =
@@ -272,31 +272,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:21LL];
+  [dict setUInt32:100U forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const uint32_t kValues[] = { 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict2 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
 }
@@ -305,57 +305,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeUInt32ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeUInt32ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
 
-  [dict removeValueForKey:24LL];
+  [dict removeUInt32ForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -363,75 +363,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBInt64UInt32Dictionary *dict =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:103U forKey:21LL];
+  [dict setUInt32:103U forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:101U forKey:24LL];
+  [dict setUInt32:101U forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 101U);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const uint32_t kValues2[] = { 102U, 100U };
   GPBInt64UInt32Dictionary *dict2 =
-      [[GPBInt64UInt32Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -451,8 +451,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64Int32Dictionary *dict = [[GPBInt64Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:21LL]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -460,15 +460,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64Int32Dictionary *dict = [GPBInt64Int32Dictionary dictionaryWithValue:200 forKey:21LL];
+  GPBInt64Int32Dictionary *dict = [GPBInt64Int32Dictionary dictionaryWithInt32:200 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:22LL]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -479,27 +479,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const int32_t kValues[] = { 200, 201, 202 };
   GPBInt64Int32Dictionary *dict =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -521,7 +521,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -537,27 +537,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 200, 203, 202 };
   const int32_t kValues3[] = { 200, 201, 202, 203 };
   GPBInt64Int32Dictionary *dict1 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64Int32Dictionary *dict1prime =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64Int32Dictionary *dict2 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64Int32Dictionary *dict3 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64Int32Dictionary *dict4 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues3
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -588,7 +588,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt64Int32Dictionary *dict =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -609,7 +609,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt64Int32Dictionary *dict =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -629,13 +629,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:21LL];
+  [dict setInt32:200 forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 201, 202, 203 };
   GPBInt64Int32Dictionary *dict2 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -643,17 +643,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
   [dict2 release];
 }
@@ -662,57 +662,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt64Int32Dictionary *dict =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeInt32ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeInt32ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
 
-  [dict removeValueForKey:24LL];
+  [dict removeInt32ForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:21LL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:22LL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:23LL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -720,75 +720,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBInt64Int32Dictionary *dict =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:203 forKey:21LL];
+  [dict setInt32:203 forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:201 forKey:24LL];
+  [dict setInt32:201 forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 201);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const int32_t kValues2[] = { 202, 200 };
   GPBInt64Int32Dictionary *dict2 =
-      [[GPBInt64Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBInt64Int32Dictionary alloc] initWithInt32s:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:21LL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:22LL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:23LL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -808,8 +808,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64UInt64Dictionary *dict = [[GPBInt64UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:21LL]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -817,15 +817,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64UInt64Dictionary *dict = [GPBInt64UInt64Dictionary dictionaryWithValue:300U forKey:21LL];
+  GPBInt64UInt64Dictionary *dict = [GPBInt64UInt64Dictionary dictionaryWithUInt64:300U forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:22LL]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -836,27 +836,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const uint64_t kValues[] = { 300U, 301U, 302U };
   GPBInt64UInt64Dictionary *dict =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   uint64_t *seenValues = malloc(3 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -878,7 +878,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(int64_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -894,29 +894,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kValues2[] = { 300U, 303U, 302U };
   const uint64_t kValues3[] = { 300U, 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict1 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64UInt64Dictionary *dict1prime =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64UInt64Dictionary *dict2 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64UInt64Dictionary *dict3 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64UInt64Dictionary *dict4 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -945,9 +945,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64UInt64Dictionary *dict2 = [dict copy];
@@ -966,9 +966,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64UInt64Dictionary *dict2 =
@@ -986,31 +986,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:21LL];
+  [dict setUInt64:300U forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const uint64_t kValues[] = { 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict2 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
 }
@@ -1019,57 +1019,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeUInt64ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeUInt64ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
 
-  [dict removeValueForKey:24LL];
+  [dict removeUInt64ForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -1077,75 +1077,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBInt64UInt64Dictionary *dict =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:303U forKey:21LL];
+  [dict setUInt64:303U forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:301U forKey:24LL];
+  [dict setUInt64:301U forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 301U);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const uint64_t kValues2[] = { 302U, 300U };
   GPBInt64UInt64Dictionary *dict2 =
-      [[GPBInt64UInt64Dictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -1165,8 +1165,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64Int64Dictionary *dict = [[GPBInt64Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:21LL]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1174,15 +1174,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64Int64Dictionary *dict = [GPBInt64Int64Dictionary dictionaryWithValue:400 forKey:21LL];
+  GPBInt64Int64Dictionary *dict = [GPBInt64Int64Dictionary dictionaryWithInt64:400 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:22LL]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -1193,27 +1193,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const int64_t kValues[] = { 400, 401, 402 };
   GPBInt64Int64Dictionary *dict =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   int64_t *seenValues = malloc(3 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1235,7 +1235,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(int64_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1251,27 +1251,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kValues2[] = { 400, 403, 402 };
   const int64_t kValues3[] = { 400, 401, 402, 403 };
   GPBInt64Int64Dictionary *dict1 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64Int64Dictionary *dict1prime =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64Int64Dictionary *dict2 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64Int64Dictionary *dict3 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64Int64Dictionary *dict4 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues3
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1302,7 +1302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt64Int64Dictionary *dict =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1323,7 +1323,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt64Int64Dictionary *dict =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1343,13 +1343,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:21LL];
+  [dict setInt64:400 forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const int64_t kValues[] = { 401, 402, 403 };
   GPBInt64Int64Dictionary *dict2 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1357,17 +1357,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
   [dict2 release];
 }
@@ -1376,57 +1376,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt64Int64Dictionary *dict =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeInt64ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeInt64ForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
 
-  [dict removeValueForKey:24LL];
+  [dict removeInt64ForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:21LL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:22LL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:23LL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -1434,75 +1434,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBInt64Int64Dictionary *dict =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:403 forKey:21LL];
+  [dict setInt64:403 forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:401 forKey:24LL];
+  [dict setInt64:401 forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 401);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const int64_t kValues2[] = { 402, 400 };
   GPBInt64Int64Dictionary *dict2 =
-      [[GPBInt64Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBInt64Int64Dictionary alloc] initWithInt64s:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:21LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:21LL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:22LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:22LL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:23LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:23LL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:24LL]);
+  XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1522,8 +1522,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64BoolDictionary *dict = [[GPBInt64BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:21LL]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1531,15 +1531,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64BoolDictionary *dict = [GPBInt64BoolDictionary dictionaryWithValue:YES forKey:21LL];
+  GPBInt64BoolDictionary *dict = [GPBInt64BoolDictionary dictionaryWithBool:YES forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:22LL]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
@@ -1550,27 +1550,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const BOOL kValues[] = { YES, YES, NO };
   GPBInt64BoolDictionary *dict =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   BOOL *seenValues = malloc(3 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1592,7 +1592,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(int64_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1608,29 +1608,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const BOOL kValues2[] = { YES, NO, NO };
   const BOOL kValues3[] = { YES, YES, NO, NO };
   GPBInt64BoolDictionary *dict1 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64BoolDictionary *dict1prime =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64BoolDictionary *dict2 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues2
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64BoolDictionary *dict3 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues1
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64BoolDictionary *dict4 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues3
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues3
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1659,9 +1659,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt64BoolDictionary *dict =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64BoolDictionary *dict2 = [dict copy];
@@ -1680,9 +1680,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt64BoolDictionary *dict =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64BoolDictionary *dict2 =
@@ -1700,31 +1700,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:YES forKey:21LL];
+  [dict setBool:YES forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const BOOL kValues[] = { YES, NO, NO };
   GPBInt64BoolDictionary *dict2 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
   [dict2 release];
 }
@@ -1733,57 +1733,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt64BoolDictionary *dict =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeBoolForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeBoolForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
 
-  [dict removeValueForKey:24LL];
+  [dict removeBoolForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:21LL]);
+  XCTAssertFalse([dict getBool:NULL forKey:22LL]);
+  XCTAssertFalse([dict getBool:NULL forKey:23LL]);
+  XCTAssertFalse([dict getBool:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -1791,75 +1791,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBInt64BoolDictionary *dict =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:NO forKey:21LL];
+  [dict setBool:NO forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:YES forKey:24LL];
+  [dict setBool:YES forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, YES);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const BOOL kValues2[] = { NO, YES };
   GPBInt64BoolDictionary *dict2 =
-      [[GPBInt64BoolDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64BoolDictionary alloc] initWithBools:kValues2
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:21LL]);
+  XCTAssertTrue([dict getBool:&value forKey:21LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:22LL]);
+  XCTAssertTrue([dict getBool:&value forKey:22LL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:23LL]);
+  XCTAssertTrue([dict getBool:&value forKey:23LL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:24LL]);
+  XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1879,8 +1879,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64FloatDictionary *dict = [[GPBInt64FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:21LL]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1888,15 +1888,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64FloatDictionary *dict = [GPBInt64FloatDictionary dictionaryWithValue:500.f forKey:21LL];
+  GPBInt64FloatDictionary *dict = [GPBInt64FloatDictionary dictionaryWithFloat:500.f forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:22LL]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1907,27 +1907,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const float kValues[] = { 500.f, 501.f, 502.f };
   GPBInt64FloatDictionary *dict =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   float *seenValues = malloc(3 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1949,7 +1949,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(int64_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1965,27 +1965,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const float kValues2[] = { 500.f, 503.f, 502.f };
   const float kValues3[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict1 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64FloatDictionary *dict1prime =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64FloatDictionary *dict2 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues2
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues2
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64FloatDictionary *dict3 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues1
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64FloatDictionary *dict4 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues3
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues3
                                               forKeys:kKeys1
                                                 count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -2016,7 +2016,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2037,7 +2037,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2057,13 +2057,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:21LL];
+  [dict setFloat:500.f forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const float kValues[] = { 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict2 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
                                               forKeys:kKeys
                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -2071,17 +2071,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
 }
@@ -2090,57 +2090,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeFloatForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeFloatForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict removeValueForKey:24LL];
+  [dict removeFloatForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:21LL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:22LL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:23LL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -2148,75 +2148,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBInt64FloatDictionary *dict =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   float value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:503.f forKey:21LL];
+  [dict setFloat:503.f forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:501.f forKey:24LL];
+  [dict setFloat:501.f forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 501.f);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const float kValues2[] = { 502.f, 500.f };
   GPBInt64FloatDictionary *dict2 =
-      [[GPBInt64FloatDictionary alloc] initWithValues:kValues2
+      [[GPBInt64FloatDictionary alloc] initWithFloats:kValues2
                                               forKeys:kKeys2
                                                 count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:21LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:21LL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:22LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:22LL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:23LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:23LL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:24LL]);
+  XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -2236,8 +2236,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64DoubleDictionary *dict = [[GPBInt64DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:21LL]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2245,15 +2245,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64DoubleDictionary *dict = [GPBInt64DoubleDictionary dictionaryWithValue:600. forKey:21LL];
+  GPBInt64DoubleDictionary *dict = [GPBInt64DoubleDictionary dictionaryWithDouble:600. forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:22LL]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -2264,27 +2264,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const double kValues[] = { 600., 601., 602. };
   GPBInt64DoubleDictionary *dict =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   double *seenValues = malloc(3 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2306,7 +2306,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(int64_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2322,29 +2322,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const double kValues2[] = { 600., 603., 602. };
   const double kValues3[] = { 600., 601., 602., 603. };
   GPBInt64DoubleDictionary *dict1 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64DoubleDictionary *dict1prime =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64DoubleDictionary *dict2 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues2
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64DoubleDictionary *dict3 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues1
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64DoubleDictionary *dict4 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues3
-                                               forKeys:kKeys1
-                                                 count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues3
+                                                forKeys:kKeys1
+                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2373,9 +2373,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt64DoubleDictionary *dict =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64DoubleDictionary *dict2 = [dict copy];
@@ -2394,9 +2394,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt64DoubleDictionary *dict =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64DoubleDictionary *dict2 =
@@ -2414,31 +2414,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:21LL];
+  [dict setDouble:600. forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const double kValues[] = { 601., 602., 603. };
   GPBInt64DoubleDictionary *dict2 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                               forKeys:kKeys
-                                                 count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
 }
@@ -2447,57 +2447,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt64DoubleDictionary *dict =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeDoubleForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeDoubleForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
 
-  [dict removeValueForKey:24LL];
+  [dict removeDoubleForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:21LL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:22LL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:23LL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -2505,75 +2505,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBInt64DoubleDictionary *dict =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   double value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:603. forKey:21LL];
+  [dict setDouble:603. forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:601. forKey:24LL];
+  [dict setDouble:601. forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 601.);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const double kValues2[] = { 602., 600. };
   GPBInt64DoubleDictionary *dict2 =
-      [[GPBInt64DoubleDictionary alloc] initWithValues:kValues2
-                                               forKeys:kKeys2
-                                                 count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64DoubleDictionary alloc] initWithDoubles:kValues2
+                                                forKeys:kKeys2
+                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:21LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:21LL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:22LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:22LL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:23LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:23LL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:24LL]);
+  XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2593,8 +2593,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBInt64EnumDictionary *dict = [[GPBInt64EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:21LL]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2602,15 +2602,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64EnumDictionary *dict = [GPBInt64EnumDictionary dictionaryWithValue:700 forKey:21LL];
+  GPBInt64EnumDictionary *dict = [GPBInt64EnumDictionary dictionaryWithEnum:700 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 21LL);
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
@@ -2621,27 +2621,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL };
   const int32_t kValues[] = { 700, 701, 702 };
   GPBInt64EnumDictionary *dict =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2663,7 +2663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2679,29 +2679,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 700, 703, 702 };
   const int32_t kValues3[] = { 700, 701, 702, 703 };
   GPBInt64EnumDictionary *dict1 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBInt64EnumDictionary *dict1prime =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBInt64EnumDictionary *dict2 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues2
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBInt64EnumDictionary *dict3 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues1
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues1)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues1
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBInt64EnumDictionary *dict4 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues3
-                                             forKeys:kKeys1
-                                               count:GPBARRAYSIZE(kValues3)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues3
+                                            forKeys:kKeys1
+                                              count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2730,9 +2730,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt64EnumDictionary *dict =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64EnumDictionary *dict2 = [dict copy];
@@ -2751,9 +2751,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt64EnumDictionary *dict =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBInt64EnumDictionary *dict2 =
@@ -2771,31 +2771,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:700 forKey:21LL];
+  [dict setEnum:700 forKey:21LL];
   XCTAssertEqual(dict.count, 1U);
 
   const int64_t kKeys[] = { 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 701, 702, 703 };
   GPBInt64EnumDictionary *dict2 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
   [dict2 release];
 }
@@ -2804,57 +2804,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt64EnumDictionary *dict =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeEnumForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeEnumForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
 
-  [dict removeValueForKey:24LL];
+  [dict removeEnumForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:21LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:23LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -2862,75 +2862,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 22LL, 23LL, 24LL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBInt64EnumDictionary *dict =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                      forKeys:kKeys
-                                        count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                            forKeys:kKeys
+                                              count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:703 forKey:21LL];
+  [dict setEnum:703 forKey:21LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:701 forKey:24LL];
+  [dict setEnum:701 forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 701);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
   const int32_t kValues2[] = { 702, 700 };
   GPBInt64EnumDictionary *dict2 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues2
-                                             forKeys:kKeys2
-                                               count:GPBARRAYSIZE(kValues2)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues2
+                                            forKeys:kKeys2
+                                              count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 701);
 
   [dict2 release];
@@ -2958,24 +2958,24 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 3U);
   XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:21LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:23LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:24LL rawValue:NULL]);
+  XCTAssertFalse([dict getRawValue:NULL forKey:24LL]);
 
   __block NSUInteger idx = 0;
   int64_t *seenKeys = malloc(3 * sizeof(int64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(int64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -3136,7 +3136,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertThrowsSpecificNamed([dict setValue:801 forKey:22LL],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:801 forKey:22LL],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 0U);
   [dict setRawValue:801 forKey:22LL];  // Unknown
@@ -3145,31 +3145,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kKeys[] = { 21LL, 23LL, 24LL };
   const int32_t kValues[] = { 700, 702, 803 };  // Unknown
   GPBInt64EnumDictionary *dict2 =
-      [[GPBInt64EnumDictionary alloc] initWithValues:kValues
-                                             forKeys:kKeys
-                                               count:GPBARRAYSIZE(kValues)];
+      [[GPBInt64EnumDictionary alloc] initWithEnums:kValues
+                                              forKeys:kKeys
+                                                count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
   [dict2 release];
 }
@@ -3185,51 +3185,51 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:22LL];
+  [dict removeEnumForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
 
   // Remove again does nothing.
-  [dict removeValueForKey:22LL];
+  [dict removeEnumForKey:22LL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
 
-  [dict removeValueForKey:24LL];
+  [dict removeEnumForKey:24LL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:24LL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:21LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:22LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:23LL value:NULL]);
-  XCTAssertFalse([dict valueForKey:24LL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:21LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:22LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:23LL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:24LL]);
   [dict release];
 }
 
@@ -3244,63 +3244,63 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
 
-  XCTAssertThrowsSpecificNamed([dict setValue:803 forKey:21LL],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:803 forKey:21LL],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:21LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:21LL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:803 forKey:21LL];  // Unknown
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:21LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:21LL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:24LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:700 forKey:24LL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:21LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:21LL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:22LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:22LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:23LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:23LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:23LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 700);
 
   const int64_t kKeys2[] = { 22LL, 23LL };
@@ -3313,17 +3313,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:21LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:21LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:21LL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:22LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:22LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:22LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:22LL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:23LL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:23LL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:23LL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:23LL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:24LL value:NULL]);
-  XCTAssertTrue([dict valueForKey:24LL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:24LL]);
+  XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 700);
 
   [dict2 release];
@@ -3559,8 +3559,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBInt64ObjectDictionary<NSString*> *dict =
       [[GPBInt64ObjectDictionary alloc] initWithObjects:kObjects
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kObjects)];
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
@@ -3600,8 +3600,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBInt64ObjectDictionary<NSString*> *dict =
       [[GPBInt64ObjectDictionary alloc] initWithObjects:kObjects
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kObjects)];
+                                                forKeys:kKeys
+                                                  count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   XCTAssertEqualObjects([dict objectForKey:21LL], @"abc");

--- a/objectivec/Tests/GPBDictionaryTests+String.m
+++ b/objectivec/Tests/GPBDictionaryTests+String.m
@@ -45,10 +45,10 @@
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBStringEnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(NSString *)key;
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count;
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(NSString *)key;
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const NSString * [])keys
+                        count:(NSUInteger)count;
 @end
 
 static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -64,7 +64,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 @implementation GPBStringEnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(NSString *)key {
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(NSString *)key {
   // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
   // type correct.
   return [[(GPBStringEnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -72,9 +72,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
                                                                      forKeys:&key
                                                                        count:1] autorelease];
 }
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const NSString * [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const NSString * [])keys
+                        count:(NSUInteger)count {
   return [self initWithValidationFunction:TestingEnum_IsValidValue
                                 rawValues:values
                                   forKeys:keys
@@ -94,8 +94,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringUInt32Dictionary *dict = [[GPBStringUInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -103,15 +103,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringUInt32Dictionary *dict = [GPBStringUInt32Dictionary dictionaryWithValue:100U forKey:@"foo"];
+  GPBStringUInt32Dictionary *dict = [GPBStringUInt32Dictionary dictionaryWithUInt32:100U forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -122,27 +122,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const uint32_t kValues[] = { 100U, 101U, 102U };
   GPBStringUInt32Dictionary *dict =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   uint32_t *seenValues = malloc(3 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -164,7 +164,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(NSString *aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -180,29 +180,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kValues2[] = { 100U, 103U, 102U };
   const uint32_t kValues3[] = { 100U, 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict1 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringUInt32Dictionary *dict1prime =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringUInt32Dictionary *dict2 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringUInt32Dictionary *dict3 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringUInt32Dictionary *dict4 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -231,9 +231,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringUInt32Dictionary *dict2 = [dict copy];
@@ -252,9 +252,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringUInt32Dictionary *dict2 =
@@ -272,31 +272,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:@"foo"];
+  [dict setUInt32:100U forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const uint32_t kValues[] = { 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict2 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
 }
@@ -305,57 +305,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeUInt32ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeUInt32ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeUInt32ForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -363,75 +363,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBStringUInt32Dictionary *dict =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:103U forKey:@"foo"];
+  [dict setUInt32:103U forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:101U forKey:@"mumble"];
+  [dict setUInt32:101U forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 101U);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const uint32_t kValues2[] = { 102U, 100U };
   GPBStringUInt32Dictionary *dict2 =
-      [[GPBStringUInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringUInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -451,8 +451,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringInt32Dictionary *dict = [[GPBStringInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -460,15 +460,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringInt32Dictionary *dict = [GPBStringInt32Dictionary dictionaryWithValue:200 forKey:@"foo"];
+  GPBStringInt32Dictionary *dict = [GPBStringInt32Dictionary dictionaryWithInt32:200 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -479,27 +479,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const int32_t kValues[] = { 200, 201, 202 };
   GPBStringInt32Dictionary *dict =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -521,7 +521,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -537,27 +537,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 200, 203, 202 };
   const int32_t kValues3[] = { 200, 201, 202, 203 };
   GPBStringInt32Dictionary *dict1 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringInt32Dictionary *dict1prime =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringInt32Dictionary *dict2 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues2
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringInt32Dictionary *dict3 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringInt32Dictionary *dict4 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues3
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -588,7 +588,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBStringInt32Dictionary *dict =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -609,7 +609,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBStringInt32Dictionary *dict =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -629,13 +629,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:@"foo"];
+  [dict setInt32:200 forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 201, 202, 203 };
   GPBStringInt32Dictionary *dict2 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -643,17 +643,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
   [dict2 release];
 }
@@ -662,57 +662,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBStringInt32Dictionary *dict =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeInt32ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeInt32ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeInt32ForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getInt32:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -720,75 +720,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBStringInt32Dictionary *dict =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:203 forKey:@"foo"];
+  [dict setInt32:203 forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:201 forKey:@"mumble"];
+  [dict setInt32:201 forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 201);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const int32_t kValues2[] = { 202, 200 };
   GPBStringInt32Dictionary *dict2 =
-      [[GPBStringInt32Dictionary alloc] initWithValues:kValues2
+      [[GPBStringInt32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"foo"]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"bar"]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"baz"]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -808,8 +808,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringUInt64Dictionary *dict = [[GPBStringUInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -817,15 +817,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringUInt64Dictionary *dict = [GPBStringUInt64Dictionary dictionaryWithValue:300U forKey:@"foo"];
+  GPBStringUInt64Dictionary *dict = [GPBStringUInt64Dictionary dictionaryWithUInt64:300U forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -836,27 +836,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const uint64_t kValues[] = { 300U, 301U, 302U };
   GPBStringUInt64Dictionary *dict =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   uint64_t *seenValues = malloc(3 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -878,7 +878,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(NSString *aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -894,29 +894,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kValues2[] = { 300U, 303U, 302U };
   const uint64_t kValues3[] = { 300U, 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict1 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringUInt64Dictionary *dict1prime =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringUInt64Dictionary *dict2 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringUInt64Dictionary *dict3 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringUInt64Dictionary *dict4 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -945,9 +945,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringUInt64Dictionary *dict2 = [dict copy];
@@ -966,9 +966,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringUInt64Dictionary *dict2 =
@@ -986,31 +986,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:@"foo"];
+  [dict setUInt64:300U forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const uint64_t kValues[] = { 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict2 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
 }
@@ -1019,57 +1019,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeUInt64ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeUInt64ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeUInt64ForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -1077,75 +1077,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBStringUInt64Dictionary *dict =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:303U forKey:@"foo"];
+  [dict setUInt64:303U forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:301U forKey:@"mumble"];
+  [dict setUInt64:301U forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 301U);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const uint64_t kValues2[] = { 302U, 300U };
   GPBStringUInt64Dictionary *dict2 =
-      [[GPBStringUInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringUInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -1165,8 +1165,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringInt64Dictionary *dict = [[GPBStringInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1174,15 +1174,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringInt64Dictionary *dict = [GPBStringInt64Dictionary dictionaryWithValue:400 forKey:@"foo"];
+  GPBStringInt64Dictionary *dict = [GPBStringInt64Dictionary dictionaryWithInt64:400 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -1193,27 +1193,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const int64_t kValues[] = { 400, 401, 402 };
   GPBStringInt64Dictionary *dict =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   int64_t *seenValues = malloc(3 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1235,7 +1235,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(NSString *aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1251,27 +1251,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kValues2[] = { 400, 403, 402 };
   const int64_t kValues3[] = { 400, 401, 402, 403 };
   GPBStringInt64Dictionary *dict1 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringInt64Dictionary *dict1prime =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringInt64Dictionary *dict2 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues2
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringInt64Dictionary *dict3 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues1
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringInt64Dictionary *dict4 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues3
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1302,7 +1302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBStringInt64Dictionary *dict =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1323,7 +1323,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBStringInt64Dictionary *dict =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1343,13 +1343,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:@"foo"];
+  [dict setInt64:400 forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const int64_t kValues[] = { 401, 402, 403 };
   GPBStringInt64Dictionary *dict2 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1357,17 +1357,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
   [dict2 release];
 }
@@ -1376,57 +1376,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBStringInt64Dictionary *dict =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeInt64ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeInt64ForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeInt64ForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getInt64:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -1434,75 +1434,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBStringInt64Dictionary *dict =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:403 forKey:@"foo"];
+  [dict setInt64:403 forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:401 forKey:@"mumble"];
+  [dict setInt64:401 forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 401);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const int64_t kValues2[] = { 402, 400 };
   GPBStringInt64Dictionary *dict2 =
-      [[GPBStringInt64Dictionary alloc] initWithValues:kValues2
+      [[GPBStringInt64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"foo"]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"bar"]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"baz"]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1522,8 +1522,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringBoolDictionary *dict = [[GPBStringBoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1531,15 +1531,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringBoolDictionary *dict = [GPBStringBoolDictionary dictionaryWithValue:YES forKey:@"foo"];
+  GPBStringBoolDictionary *dict = [GPBStringBoolDictionary dictionaryWithBool:YES forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
@@ -1550,27 +1550,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const BOOL kValues[] = { YES, YES, NO };
   GPBStringBoolDictionary *dict =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   BOOL *seenValues = malloc(3 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1592,7 +1592,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(NSString *aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1608,29 +1608,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const BOOL kValues2[] = { YES, NO, NO };
   const BOOL kValues3[] = { YES, YES, NO, NO };
   GPBStringBoolDictionary *dict1 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringBoolDictionary *dict1prime =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringBoolDictionary *dict2 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringBoolDictionary *dict3 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringBoolDictionary *dict4 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1659,9 +1659,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBStringBoolDictionary *dict =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringBoolDictionary *dict2 = [dict copy];
@@ -1680,9 +1680,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBStringBoolDictionary *dict =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringBoolDictionary *dict2 =
@@ -1700,31 +1700,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:YES forKey:@"foo"];
+  [dict setBool:YES forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const BOOL kValues[] = { YES, NO, NO };
   GPBStringBoolDictionary *dict2 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
   [dict2 release];
 }
@@ -1733,57 +1733,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBStringBoolDictionary *dict =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeBoolForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeBoolForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeBoolForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getBool:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -1791,75 +1791,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBStringBoolDictionary *dict =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:NO forKey:@"foo"];
+  [dict setBool:NO forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:YES forKey:@"mumble"];
+  [dict setBool:YES forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, YES);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const BOOL kValues2[] = { NO, YES };
   GPBStringBoolDictionary *dict2 =
-      [[GPBStringBoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringBoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"foo"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"bar"]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"baz"]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1879,8 +1879,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringFloatDictionary *dict = [[GPBStringFloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1888,15 +1888,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringFloatDictionary *dict = [GPBStringFloatDictionary dictionaryWithValue:500.f forKey:@"foo"];
+  GPBStringFloatDictionary *dict = [GPBStringFloatDictionary dictionaryWithFloat:500.f forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1907,27 +1907,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const float kValues[] = { 500.f, 501.f, 502.f };
   GPBStringFloatDictionary *dict =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   float *seenValues = malloc(3 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1949,7 +1949,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(NSString *aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1965,27 +1965,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const float kValues2[] = { 500.f, 503.f, 502.f };
   const float kValues3[] = { 500.f, 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict1 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues1
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringFloatDictionary *dict1prime =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues1
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringFloatDictionary *dict2 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues2
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringFloatDictionary *dict3 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues1
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringFloatDictionary *dict4 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues3
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -2016,7 +2016,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2037,7 +2037,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2057,13 +2057,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:@"foo"];
+  [dict setFloat:500.f forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const float kValues[] = { 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict2 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -2071,17 +2071,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
 }
@@ -2090,57 +2090,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeFloatForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeFloatForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeFloatForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getFloat:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -2148,75 +2148,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBStringFloatDictionary *dict =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   float value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:503.f forKey:@"foo"];
+  [dict setFloat:503.f forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:501.f forKey:@"mumble"];
+  [dict setFloat:501.f forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 501.f);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const float kValues2[] = { 502.f, 500.f };
   GPBStringFloatDictionary *dict2 =
-      [[GPBStringFloatDictionary alloc] initWithValues:kValues2
+      [[GPBStringFloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"foo"]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"bar"]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"baz"]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -2236,8 +2236,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringDoubleDictionary *dict = [[GPBStringDoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2245,15 +2245,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringDoubleDictionary *dict = [GPBStringDoubleDictionary dictionaryWithValue:600. forKey:@"foo"];
+  GPBStringDoubleDictionary *dict = [GPBStringDoubleDictionary dictionaryWithDouble:600. forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -2264,27 +2264,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const double kValues[] = { 600., 601., 602. };
   GPBStringDoubleDictionary *dict =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   double *seenValues = malloc(3 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2306,7 +2306,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(NSString *aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2322,29 +2322,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const double kValues2[] = { 600., 603., 602. };
   const double kValues3[] = { 600., 601., 602., 603. };
   GPBStringDoubleDictionary *dict1 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringDoubleDictionary *dict1prime =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringDoubleDictionary *dict2 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringDoubleDictionary *dict3 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringDoubleDictionary *dict4 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2373,9 +2373,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBStringDoubleDictionary *dict =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringDoubleDictionary *dict2 = [dict copy];
@@ -2394,9 +2394,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBStringDoubleDictionary *dict =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringDoubleDictionary *dict2 =
@@ -2414,31 +2414,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:@"foo"];
+  [dict setDouble:600. forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const double kValues[] = { 601., 602., 603. };
   GPBStringDoubleDictionary *dict2 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
 }
@@ -2447,57 +2447,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBStringDoubleDictionary *dict =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeDoubleForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeDoubleForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeDoubleForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getDouble:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -2505,75 +2505,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBStringDoubleDictionary *dict =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   double value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:603. forKey:@"foo"];
+  [dict setDouble:603. forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:601. forKey:@"mumble"];
+  [dict setDouble:601. forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 601.);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const double kValues2[] = { 602., 600. };
   GPBStringDoubleDictionary *dict2 =
-      [[GPBStringDoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringDoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"foo"]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"bar"]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"baz"]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2593,8 +2593,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBStringEnumDictionary *dict = [[GPBStringEnumDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:@"foo"]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2602,15 +2602,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringEnumDictionary *dict = [GPBStringEnumDictionary dictionaryWithValue:700 forKey:@"foo"];
+  GPBStringEnumDictionary *dict = [GPBStringEnumDictionary dictionaryWithEnum:700 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqualObjects(aKey, @"foo");
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
@@ -2621,27 +2621,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz" };
   const int32_t kValues[] = { 700, 701, 702 };
   GPBStringEnumDictionary *dict =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2663,7 +2663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2679,29 +2679,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 700, 703, 702 };
   const int32_t kValues3[] = { 700, 701, 702, 703 };
   GPBStringEnumDictionary *dict1 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBStringEnumDictionary *dict1prime =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBStringEnumDictionary *dict2 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBStringEnumDictionary *dict3 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBStringEnumDictionary *dict4 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2730,9 +2730,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBStringEnumDictionary *dict =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringEnumDictionary *dict2 = [dict copy];
@@ -2751,9 +2751,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBStringEnumDictionary *dict =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBStringEnumDictionary *dict2 =
@@ -2771,31 +2771,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:700 forKey:@"foo"];
+  [dict setEnum:700 forKey:@"foo"];
   XCTAssertEqual(dict.count, 1U);
 
   const NSString *kKeys[] = { @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 701, 702, 703 };
   GPBStringEnumDictionary *dict2 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
   [dict2 release];
 }
@@ -2804,57 +2804,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBStringEnumDictionary *dict =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeEnumForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeEnumForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeEnumForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -2862,75 +2862,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"bar", @"baz", @"mumble" };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBStringEnumDictionary *dict =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:703 forKey:@"foo"];
+  [dict setEnum:703 forKey:@"foo"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:701 forKey:@"mumble"];
+  [dict setEnum:701 forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 701);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
   const int32_t kValues2[] = { 702, 700 };
   GPBStringEnumDictionary *dict2 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 701);
 
   [dict2 release];
@@ -2958,24 +2958,24 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 3U);
   XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:@"mumble" rawValue:NULL]);
+  XCTAssertFalse([dict getRawValue:NULL forKey:@"mumble"]);
 
   __block NSUInteger idx = 0;
   NSString **seenKeys = malloc(3 * sizeof(NSString*));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(NSString *aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -3136,7 +3136,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertThrowsSpecificNamed([dict setValue:801 forKey:@"bar"],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:801 forKey:@"bar"],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 0U);
   [dict setRawValue:801 forKey:@"bar"];  // Unknown
@@ -3145,31 +3145,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString *kKeys[] = { @"foo", @"baz", @"mumble" };
   const int32_t kValues[] = { 700, 702, 803 };  // Unknown
   GPBStringEnumDictionary *dict2 =
-      [[GPBStringEnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBStringEnumDictionary alloc] initWithEnums:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
   [dict2 release];
 }
@@ -3185,51 +3185,51 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:@"bar"];
+  [dict removeEnumForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
 
   // Remove again does nothing.
-  [dict removeValueForKey:@"bar"];
+  [dict removeEnumForKey:@"bar"];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
 
-  [dict removeValueForKey:@"mumble"];
+  [dict removeEnumForKey:@"mumble"];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"mumble"]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertFalse([dict valueForKey:@"mumble" value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertFalse([dict getEnum:NULL forKey:@"mumble"]);
   [dict release];
 }
 
@@ -3244,63 +3244,63 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
 
-  XCTAssertThrowsSpecificNamed([dict setValue:803 forKey:@"foo"],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:803 forKey:@"foo"],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"foo"]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:803 forKey:@"foo"];  // Unknown
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"foo"]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:700 forKey:@"mumble"];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"foo"]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"bar"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"baz" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"baz"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 700);
 
   const NSString *kKeys2[] = { @"bar", @"baz" };
@@ -3313,17 +3313,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"foo" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"foo"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"foo"]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:@"bar" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"bar" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"bar"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"bar"]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:@"baz" rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:@"baz" rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:@"baz"]);
+  XCTAssertTrue([dict getRawValue:&value forKey:@"baz"]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:NULL]);
-  XCTAssertTrue([dict valueForKey:@"mumble" value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:@"mumble"]);
+  XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 700);
 
   [dict2 release];

--- a/objectivec/Tests/GPBDictionaryTests+UInt32.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt32.m
@@ -45,10 +45,10 @@
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBUInt32EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(uint32_t)key;
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count;
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(uint32_t)key;
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const uint32_t [])keys
+                        count:(NSUInteger)count;
 @end
 
 static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -64,7 +64,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 @implementation GPBUInt32EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(uint32_t)key {
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(uint32_t)key {
   // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
   // type correct.
   return [[(GPBUInt32EnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -72,9 +72,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
                                                                      forKeys:&key
                                                                        count:1] autorelease];
 }
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const uint32_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const uint32_t [])keys
+                        count:(NSUInteger)count {
   return [self initWithValidationFunction:TestingEnum_IsValidValue
                                 rawValues:values
                                   forKeys:keys
@@ -94,8 +94,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32UInt32Dictionary *dict = [[GPBUInt32UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:1U]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -103,15 +103,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32UInt32Dictionary *dict = [GPBUInt32UInt32Dictionary dictionaryWithValue:100U forKey:1U];
+  GPBUInt32UInt32Dictionary *dict = [GPBUInt32UInt32Dictionary dictionaryWithUInt32:100U forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:2U]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -122,27 +122,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const uint32_t kValues[] = { 100U, 101U, 102U };
   GPBUInt32UInt32Dictionary *dict =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   uint32_t *seenValues = malloc(3 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -164,7 +164,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint32_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -180,29 +180,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kValues2[] = { 100U, 103U, 102U };
   const uint32_t kValues3[] = { 100U, 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict1 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32UInt32Dictionary *dict1prime =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32UInt32Dictionary *dict2 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32UInt32Dictionary *dict3 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32UInt32Dictionary *dict4 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -231,9 +231,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt32Dictionary *dict2 = [dict copy];
@@ -252,9 +252,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt32Dictionary *dict2 =
@@ -272,31 +272,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:1U];
+  [dict setUInt32:100U forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const uint32_t kValues[] = { 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict2 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
 }
@@ -305,57 +305,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeUInt32ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeUInt32ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
 
-  [dict removeValueForKey:4U];
+  [dict removeUInt32ForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:1U]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:2U]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:3U]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:4U]);
   [dict release];
 }
 
@@ -363,75 +363,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt32UInt32Dictionary *dict =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:103U forKey:1U];
+  [dict setUInt32:103U forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:101U forKey:4U];
+  [dict setUInt32:101U forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 101U);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const uint32_t kValues2[] = { 102U, 100U };
   GPBUInt32UInt32Dictionary *dict2 =
-      [[GPBUInt32UInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:1U]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:2U]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:3U]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -451,8 +451,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32Int32Dictionary *dict = [[GPBUInt32Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:1U]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -460,15 +460,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32Int32Dictionary *dict = [GPBUInt32Int32Dictionary dictionaryWithValue:200 forKey:1U];
+  GPBUInt32Int32Dictionary *dict = [GPBUInt32Int32Dictionary dictionaryWithInt32:200 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:2U]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -479,27 +479,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const int32_t kValues[] = { 200, 201, 202 };
   GPBUInt32Int32Dictionary *dict =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -521,7 +521,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -537,27 +537,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 200, 203, 202 };
   const int32_t kValues3[] = { 200, 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict1 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32Int32Dictionary *dict1prime =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32Int32Dictionary *dict2 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32Int32Dictionary *dict3 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32Int32Dictionary *dict4 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues3
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -588,7 +588,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -609,7 +609,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -629,13 +629,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:1U];
+  [dict setInt32:200 forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const int32_t kValues[] = { 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict2 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -643,17 +643,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
   [dict2 release];
 }
@@ -662,57 +662,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeInt32ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeInt32ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
 
-  [dict removeValueForKey:4U];
+  [dict removeInt32ForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:1U]);
+  XCTAssertFalse([dict getInt32:NULL forKey:2U]);
+  XCTAssertFalse([dict getInt32:NULL forKey:3U]);
+  XCTAssertFalse([dict getInt32:NULL forKey:4U]);
   [dict release];
 }
 
@@ -720,75 +720,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt32Int32Dictionary *dict =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:203 forKey:1U];
+  [dict setInt32:203 forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:201 forKey:4U];
+  [dict setInt32:201 forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 201);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const int32_t kValues2[] = { 202, 200 };
   GPBUInt32Int32Dictionary *dict2 =
-      [[GPBUInt32Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt32Int32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt32:&value forKey:1U]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt32:&value forKey:2U]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt32:&value forKey:3U]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -808,8 +808,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32UInt64Dictionary *dict = [[GPBUInt32UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:1U]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -817,15 +817,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32UInt64Dictionary *dict = [GPBUInt32UInt64Dictionary dictionaryWithValue:300U forKey:1U];
+  GPBUInt32UInt64Dictionary *dict = [GPBUInt32UInt64Dictionary dictionaryWithUInt64:300U forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:2U]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -836,27 +836,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const uint64_t kValues[] = { 300U, 301U, 302U };
   GPBUInt32UInt64Dictionary *dict =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   uint64_t *seenValues = malloc(3 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -878,7 +878,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint32_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -894,29 +894,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kValues2[] = { 300U, 303U, 302U };
   const uint64_t kValues3[] = { 300U, 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict1 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32UInt64Dictionary *dict1prime =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32UInt64Dictionary *dict2 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32UInt64Dictionary *dict3 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32UInt64Dictionary *dict4 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -945,9 +945,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt64Dictionary *dict2 = [dict copy];
@@ -966,9 +966,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt64Dictionary *dict2 =
@@ -986,31 +986,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:1U];
+  [dict setUInt64:300U forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const uint64_t kValues[] = { 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict2 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
 }
@@ -1019,57 +1019,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeUInt64ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeUInt64ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
 
-  [dict removeValueForKey:4U];
+  [dict removeUInt64ForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:1U]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:2U]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:3U]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:4U]);
   [dict release];
 }
 
@@ -1077,75 +1077,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt32UInt64Dictionary *dict =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:303U forKey:1U];
+  [dict setUInt64:303U forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:301U forKey:4U];
+  [dict setUInt64:301U forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 301U);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const uint64_t kValues2[] = { 302U, 300U };
   GPBUInt32UInt64Dictionary *dict2 =
-      [[GPBUInt32UInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:1U]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:2U]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:3U]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -1165,8 +1165,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32Int64Dictionary *dict = [[GPBUInt32Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:1U]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1174,15 +1174,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32Int64Dictionary *dict = [GPBUInt32Int64Dictionary dictionaryWithValue:400 forKey:1U];
+  GPBUInt32Int64Dictionary *dict = [GPBUInt32Int64Dictionary dictionaryWithInt64:400 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:2U]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -1193,27 +1193,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const int64_t kValues[] = { 400, 401, 402 };
   GPBUInt32Int64Dictionary *dict =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   int64_t *seenValues = malloc(3 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1235,7 +1235,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint32_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1251,27 +1251,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kValues2[] = { 400, 403, 402 };
   const int64_t kValues3[] = { 400, 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict1 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32Int64Dictionary *dict1prime =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32Int64Dictionary *dict2 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32Int64Dictionary *dict3 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32Int64Dictionary *dict4 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues3
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1302,7 +1302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1323,7 +1323,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1343,13 +1343,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:1U];
+  [dict setInt64:400 forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const int64_t kValues[] = { 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict2 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1357,17 +1357,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
   [dict2 release];
 }
@@ -1376,57 +1376,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeInt64ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeInt64ForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
 
-  [dict removeValueForKey:4U];
+  [dict removeInt64ForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:1U]);
+  XCTAssertFalse([dict getInt64:NULL forKey:2U]);
+  XCTAssertFalse([dict getInt64:NULL forKey:3U]);
+  XCTAssertFalse([dict getInt64:NULL forKey:4U]);
   [dict release];
 }
 
@@ -1434,75 +1434,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt32Int64Dictionary *dict =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:403 forKey:1U];
+  [dict setInt64:403 forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:401 forKey:4U];
+  [dict setInt64:401 forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 401);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const int64_t kValues2[] = { 402, 400 };
   GPBUInt32Int64Dictionary *dict2 =
-      [[GPBUInt32Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt32Int64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:1U]);
+  XCTAssertTrue([dict getInt64:&value forKey:1U]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:2U]);
+  XCTAssertTrue([dict getInt64:&value forKey:2U]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:3U]);
+  XCTAssertTrue([dict getInt64:&value forKey:3U]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:4U]);
+  XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1522,8 +1522,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32BoolDictionary *dict = [[GPBUInt32BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:1U]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1531,15 +1531,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32BoolDictionary *dict = [GPBUInt32BoolDictionary dictionaryWithValue:YES forKey:1U];
+  GPBUInt32BoolDictionary *dict = [GPBUInt32BoolDictionary dictionaryWithBool:YES forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:2U]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
@@ -1550,27 +1550,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const BOOL kValues[] = { YES, YES, NO };
   GPBUInt32BoolDictionary *dict =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   BOOL *seenValues = malloc(3 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1592,7 +1592,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint32_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1608,29 +1608,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const BOOL kValues2[] = { YES, NO, NO };
   const BOOL kValues3[] = { YES, YES, NO, NO };
   GPBUInt32BoolDictionary *dict1 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32BoolDictionary *dict1prime =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32BoolDictionary *dict2 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32BoolDictionary *dict3 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32BoolDictionary *dict4 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1659,9 +1659,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt32BoolDictionary *dict =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32BoolDictionary *dict2 = [dict copy];
@@ -1680,9 +1680,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt32BoolDictionary *dict =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32BoolDictionary *dict2 =
@@ -1700,31 +1700,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:YES forKey:1U];
+  [dict setBool:YES forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const BOOL kValues[] = { YES, NO, NO };
   GPBUInt32BoolDictionary *dict2 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
   [dict2 release];
 }
@@ -1733,57 +1733,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt32BoolDictionary *dict =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeBoolForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeBoolForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
 
-  [dict removeValueForKey:4U];
+  [dict removeBoolForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:1U]);
+  XCTAssertFalse([dict getBool:NULL forKey:2U]);
+  XCTAssertFalse([dict getBool:NULL forKey:3U]);
+  XCTAssertFalse([dict getBool:NULL forKey:4U]);
   [dict release];
 }
 
@@ -1791,75 +1791,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt32BoolDictionary *dict =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:NO forKey:1U];
+  [dict setBool:NO forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:YES forKey:4U];
+  [dict setBool:YES forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, YES);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const BOOL kValues2[] = { NO, YES };
   GPBUInt32BoolDictionary *dict2 =
-      [[GPBUInt32BoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32BoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:1U]);
+  XCTAssertTrue([dict getBool:&value forKey:1U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:2U]);
+  XCTAssertTrue([dict getBool:&value forKey:2U]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:3U]);
+  XCTAssertTrue([dict getBool:&value forKey:3U]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:4U]);
+  XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1879,8 +1879,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32FloatDictionary *dict = [[GPBUInt32FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:1U]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1888,15 +1888,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32FloatDictionary *dict = [GPBUInt32FloatDictionary dictionaryWithValue:500.f forKey:1U];
+  GPBUInt32FloatDictionary *dict = [GPBUInt32FloatDictionary dictionaryWithFloat:500.f forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:2U]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1907,27 +1907,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const float kValues[] = { 500.f, 501.f, 502.f };
   GPBUInt32FloatDictionary *dict =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   float *seenValues = malloc(3 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1949,7 +1949,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint32_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1965,27 +1965,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const float kValues2[] = { 500.f, 503.f, 502.f };
   const float kValues3[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict1 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32FloatDictionary *dict1prime =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32FloatDictionary *dict2 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues2
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32FloatDictionary *dict3 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32FloatDictionary *dict4 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues3
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -2016,7 +2016,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2037,7 +2037,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2057,13 +2057,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:1U];
+  [dict setFloat:500.f forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const float kValues[] = { 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict2 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -2071,17 +2071,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
 }
@@ -2090,57 +2090,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeFloatForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeFloatForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
 
-  [dict removeValueForKey:4U];
+  [dict removeFloatForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:1U]);
+  XCTAssertFalse([dict getFloat:NULL forKey:2U]);
+  XCTAssertFalse([dict getFloat:NULL forKey:3U]);
+  XCTAssertFalse([dict getFloat:NULL forKey:4U]);
   [dict release];
 }
 
@@ -2148,75 +2148,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt32FloatDictionary *dict =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   float value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:503.f forKey:1U];
+  [dict setFloat:503.f forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:501.f forKey:4U];
+  [dict setFloat:501.f forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 501.f);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const float kValues2[] = { 502.f, 500.f };
   GPBUInt32FloatDictionary *dict2 =
-      [[GPBUInt32FloatDictionary alloc] initWithValues:kValues2
+      [[GPBUInt32FloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:1U]);
+  XCTAssertTrue([dict getFloat:&value forKey:1U]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:2U]);
+  XCTAssertTrue([dict getFloat:&value forKey:2U]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:3U]);
+  XCTAssertTrue([dict getFloat:&value forKey:3U]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:4U]);
+  XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -2236,8 +2236,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32DoubleDictionary *dict = [[GPBUInt32DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:1U]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2245,15 +2245,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32DoubleDictionary *dict = [GPBUInt32DoubleDictionary dictionaryWithValue:600. forKey:1U];
+  GPBUInt32DoubleDictionary *dict = [GPBUInt32DoubleDictionary dictionaryWithDouble:600. forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:2U]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -2264,27 +2264,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const double kValues[] = { 600., 601., 602. };
   GPBUInt32DoubleDictionary *dict =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   double *seenValues = malloc(3 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2306,7 +2306,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint32_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2322,29 +2322,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const double kValues2[] = { 600., 603., 602. };
   const double kValues3[] = { 600., 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict1 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32DoubleDictionary *dict1prime =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32DoubleDictionary *dict2 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32DoubleDictionary *dict3 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32DoubleDictionary *dict4 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2373,9 +2373,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32DoubleDictionary *dict2 = [dict copy];
@@ -2394,9 +2394,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32DoubleDictionary *dict2 =
@@ -2414,31 +2414,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:1U];
+  [dict setDouble:600. forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const double kValues[] = { 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict2 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
 }
@@ -2447,57 +2447,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeDoubleForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeDoubleForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
 
-  [dict removeValueForKey:4U];
+  [dict removeDoubleForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:1U]);
+  XCTAssertFalse([dict getDouble:NULL forKey:2U]);
+  XCTAssertFalse([dict getDouble:NULL forKey:3U]);
+  XCTAssertFalse([dict getDouble:NULL forKey:4U]);
   [dict release];
 }
 
@@ -2505,75 +2505,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt32DoubleDictionary *dict =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   double value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:603. forKey:1U];
+  [dict setDouble:603. forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:601. forKey:4U];
+  [dict setDouble:601. forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 601.);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const double kValues2[] = { 602., 600. };
   GPBUInt32DoubleDictionary *dict2 =
-      [[GPBUInt32DoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32DoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:1U]);
+  XCTAssertTrue([dict getDouble:&value forKey:1U]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:2U]);
+  XCTAssertTrue([dict getDouble:&value forKey:2U]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:3U]);
+  XCTAssertTrue([dict getDouble:&value forKey:3U]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:4U]);
+  XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2593,8 +2593,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt32EnumDictionary *dict = [[GPBUInt32EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:1U]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2602,15 +2602,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32EnumDictionary *dict = [GPBUInt32EnumDictionary dictionaryWithValue:700 forKey:1U];
+  GPBUInt32EnumDictionary *dict = [GPBUInt32EnumDictionary dictionaryWithEnum:700 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 1U);
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
@@ -2621,27 +2621,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U };
   const int32_t kValues[] = { 700, 701, 702 };
   GPBUInt32EnumDictionary *dict =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2663,7 +2663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2679,29 +2679,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 700, 703, 702 };
   const int32_t kValues3[] = { 700, 701, 702, 703 };
   GPBUInt32EnumDictionary *dict1 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt32EnumDictionary *dict1prime =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt32EnumDictionary *dict2 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt32EnumDictionary *dict3 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt32EnumDictionary *dict4 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2730,9 +2730,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt32EnumDictionary *dict =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32EnumDictionary *dict2 = [dict copy];
@@ -2751,9 +2751,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt32EnumDictionary *dict =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt32EnumDictionary *dict2 =
@@ -2771,31 +2771,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:700 forKey:1U];
+  [dict setEnum:700 forKey:1U];
   XCTAssertEqual(dict.count, 1U);
 
   const uint32_t kKeys[] = { 2U, 3U, 4U };
   const int32_t kValues[] = { 701, 702, 703 };
   GPBUInt32EnumDictionary *dict2 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
   [dict2 release];
 }
@@ -2804,57 +2804,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt32EnumDictionary *dict =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeEnumForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeEnumForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
 
-  [dict removeValueForKey:4U];
+  [dict removeEnumForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:1U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:3U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:4U]);
   [dict release];
 }
 
@@ -2862,75 +2862,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 2U, 3U, 4U };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt32EnumDictionary *dict =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:703 forKey:1U];
+  [dict setEnum:703 forKey:1U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:701 forKey:4U];
+  [dict setEnum:701 forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 701);
 
   const uint32_t kKeys2[] = { 2U, 3U };
   const int32_t kValues2[] = { 702, 700 };
   GPBUInt32EnumDictionary *dict2 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 701);
 
   [dict2 release];
@@ -2958,24 +2958,24 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 3U);
   XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:1U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:1U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:3U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:3U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:4U rawValue:NULL]);
+  XCTAssertFalse([dict getRawValue:NULL forKey:4U]);
 
   __block NSUInteger idx = 0;
   uint32_t *seenKeys = malloc(3 * sizeof(uint32_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint32_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -3136,7 +3136,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertThrowsSpecificNamed([dict setValue:801 forKey:2U],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:801 forKey:2U],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 0U);
   [dict setRawValue:801 forKey:2U];  // Unknown
@@ -3145,31 +3145,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kKeys[] = { 1U, 3U, 4U };
   const int32_t kValues[] = { 700, 702, 803 };  // Unknown
   GPBUInt32EnumDictionary *dict2 =
-      [[GPBUInt32EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt32EnumDictionary alloc] initWithEnums:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
   [dict2 release];
 }
@@ -3185,51 +3185,51 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:2U];
+  [dict removeEnumForKey:2U];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
 
   // Remove again does nothing.
-  [dict removeValueForKey:2U];
+  [dict removeEnumForKey:2U];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
 
-  [dict removeValueForKey:4U];
+  [dict removeEnumForKey:4U];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:4U]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:1U value:NULL]);
-  XCTAssertFalse([dict valueForKey:2U value:NULL]);
-  XCTAssertFalse([dict valueForKey:3U value:NULL]);
-  XCTAssertFalse([dict valueForKey:4U value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:1U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:2U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:3U]);
+  XCTAssertFalse([dict getEnum:NULL forKey:4U]);
   [dict release];
 }
 
@@ -3244,63 +3244,63 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
 
-  XCTAssertThrowsSpecificNamed([dict setValue:803 forKey:1U],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:803 forKey:1U],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U value:NULL]);
-  XCTAssertTrue([dict valueForKey:1U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:1U]);
+  XCTAssertTrue([dict getEnum:&value forKey:1U]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:803 forKey:1U];  // Unknown
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:1U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:1U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:1U]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:4U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:4U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:700 forKey:4U];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:1U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:1U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:1U]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:2U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:2U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:2U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:2U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:3U value:NULL]);
-  XCTAssertTrue([dict valueForKey:3U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:3U]);
+  XCTAssertTrue([dict getEnum:&value forKey:3U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 700);
 
   const uint32_t kKeys2[] = { 2U, 3U };
@@ -3313,17 +3313,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:1U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:1U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:1U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:1U]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:2U value:NULL]);
-  XCTAssertTrue([dict valueForKey:2U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:2U]);
+  XCTAssertTrue([dict getEnum:&value forKey:2U]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:3U rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:3U rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:3U]);
+  XCTAssertTrue([dict getRawValue:&value forKey:3U]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:4U value:NULL]);
-  XCTAssertTrue([dict valueForKey:4U value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:4U]);
+  XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 700);
 
   [dict2 release];
@@ -3559,8 +3559,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBUInt32ObjectDictionary<NSString*> *dict =
       [[GPBUInt32ObjectDictionary alloc] initWithObjects:kObjects
-                                          forKeys:kKeys
-                                            count:GPBARRAYSIZE(kObjects)];
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
@@ -3600,8 +3600,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBUInt32ObjectDictionary<NSString*> *dict =
       [[GPBUInt32ObjectDictionary alloc] initWithObjects:kObjects
-                                          forKeys:kKeys
-                                            count:GPBARRAYSIZE(kObjects)];
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   XCTAssertEqualObjects([dict objectForKey:1U], @"abc");

--- a/objectivec/Tests/GPBDictionaryTests+UInt64.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt64.m
@@ -45,10 +45,10 @@
 
 // To let the testing macros work, add some extra methods to simplify things.
 @interface GPBUInt64EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(uint64_t)key;
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count;
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(uint64_t)key;
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const uint64_t [])keys
+                        count:(NSUInteger)count;
 @end
 
 static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -64,7 +64,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 @implementation GPBUInt64EnumDictionary (TestingTweak)
-+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(uint64_t)key {
++ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(uint64_t)key {
   // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
   // type correct.
   return [[(GPBUInt64EnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -72,9 +72,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
                                                                      forKeys:&key
                                                                        count:1] autorelease];
 }
-- (instancetype)initWithValues:(const int32_t [])values
-                       forKeys:(const uint64_t [])keys
-                         count:(NSUInteger)count {
+- (instancetype)initWithEnums:(const int32_t [])values
+                      forKeys:(const uint64_t [])keys
+                        count:(NSUInteger)count {
   return [self initWithValidationFunction:TestingEnum_IsValidValue
                                 rawValues:values
                                   forKeys:keys
@@ -94,8 +94,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64UInt32Dictionary *dict = [[GPBUInt64UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:31ULL]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -103,15 +103,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64UInt32Dictionary *dict = [GPBUInt64UInt32Dictionary dictionaryWithValue:100U forKey:31ULL];
+  GPBUInt64UInt32Dictionary *dict = [GPBUInt64UInt32Dictionary dictionaryWithUInt32:100U forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt32:NULL forKey:32ULL]);
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
@@ -122,27 +122,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const uint32_t kValues[] = { 100U, 101U, 102U };
   GPBUInt64UInt32Dictionary *dict =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   uint32_t *seenValues = malloc(3 * sizeof(uint32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -164,7 +164,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt32sUsingBlock:^(uint64_t aKey, uint32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -180,29 +180,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint32_t kValues2[] = { 100U, 103U, 102U };
   const uint32_t kValues3[] = { 100U, 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict1 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64UInt32Dictionary *dict1prime =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64UInt32Dictionary *dict2 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64UInt32Dictionary *dict3 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64UInt32Dictionary *dict4 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -231,9 +231,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt32Dictionary *dict2 = [dict copy];
@@ -252,9 +252,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt32Dictionary *dict2 =
@@ -272,31 +272,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:100U forKey:31ULL];
+  [dict setUInt32:100U forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const uint32_t kValues[] = { 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict2 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
 }
@@ -305,57 +305,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeUInt32ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeUInt32ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeUInt32ForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getUInt32:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -363,75 +363,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint32_t kValues[] = { 100U, 101U, 102U, 103U };
   GPBUInt64UInt32Dictionary *dict =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:103U forKey:31ULL];
+  [dict setUInt32:103U forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
 
-  [dict setValue:101U forKey:34ULL];
+  [dict setUInt32:101U forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 101U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 101U);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const uint32_t kValues2[] = { 102U, 100U };
   GPBUInt64UInt32Dictionary *dict2 =
-      [[GPBUInt64UInt32Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64UInt32Dictionary alloc] initWithUInt32s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 103U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 102U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 100U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 101U);
 
   [dict2 release];
@@ -451,8 +451,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64Int32Dictionary *dict = [[GPBUInt64Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:31ULL]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -460,15 +460,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64Int32Dictionary *dict = [GPBUInt64Int32Dictionary dictionaryWithValue:200 forKey:31ULL];
+  GPBUInt64Int32Dictionary *dict = [GPBUInt64Int32Dictionary dictionaryWithInt32:200 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt32:NULL forKey:32ULL]);
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
@@ -479,27 +479,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const int32_t kValues[] = { 200, 201, 202 };
   GPBUInt64Int32Dictionary *dict =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -521,7 +521,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt32sUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -537,27 +537,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 200, 203, 202 };
   const int32_t kValues3[] = { 200, 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict1 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64Int32Dictionary *dict1prime =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64Int32Dictionary *dict2 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64Int32Dictionary *dict3 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64Int32Dictionary *dict4 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues3
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -588,7 +588,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -609,7 +609,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -629,13 +629,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:200 forKey:31ULL];
+  [dict setInt32:200 forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict2 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -643,17 +643,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
   [dict2 release];
 }
@@ -662,57 +662,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeInt32ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeInt32ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeInt32ForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getInt32:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -720,75 +720,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 200, 201, 202, 203 };
   GPBUInt64Int32Dictionary *dict =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:203 forKey:31ULL];
+  [dict setInt32:203 forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
 
-  [dict setValue:201 forKey:34ULL];
+  [dict setInt32:201 forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 201);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 201);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const int32_t kValues2[] = { 202, 200 };
   GPBUInt64Int32Dictionary *dict2 =
-      [[GPBUInt64Int32Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt64Int32Dictionary alloc] initWithInt32s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:31ULL]);
   XCTAssertEqual(value, 203);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:32ULL]);
   XCTAssertEqual(value, 202);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:33ULL]);
   XCTAssertEqual(value, 200);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt32:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 201);
 
   [dict2 release];
@@ -808,8 +808,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64UInt64Dictionary *dict = [[GPBUInt64UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:31ULL]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -817,15 +817,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64UInt64Dictionary *dict = [GPBUInt64UInt64Dictionary dictionaryWithValue:300U forKey:31ULL];
+  GPBUInt64UInt64Dictionary *dict = [GPBUInt64UInt64Dictionary dictionaryWithUInt64:300U forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getUInt64:NULL forKey:32ULL]);
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
@@ -836,27 +836,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const uint64_t kValues[] = { 300U, 301U, 302U };
   GPBUInt64UInt64Dictionary *dict =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   uint64_t *seenValues = malloc(3 * sizeof(uint64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -878,7 +878,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndUInt64sUsingBlock:^(uint64_t aKey, uint64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -894,29 +894,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kValues2[] = { 300U, 303U, 302U };
   const uint64_t kValues3[] = { 300U, 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict1 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64UInt64Dictionary *dict1prime =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64UInt64Dictionary *dict2 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64UInt64Dictionary *dict3 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64UInt64Dictionary *dict4 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -945,9 +945,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt64Dictionary *dict2 = [dict copy];
@@ -966,9 +966,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt64Dictionary *dict2 =
@@ -986,31 +986,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:300U forKey:31ULL];
+  [dict setUInt64:300U forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const uint64_t kValues[] = { 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict2 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
 }
@@ -1019,57 +1019,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeUInt64ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeUInt64ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeUInt64ForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getUInt64:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -1077,75 +1077,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const uint64_t kValues[] = { 300U, 301U, 302U, 303U };
   GPBUInt64UInt64Dictionary *dict =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   uint64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:303U forKey:31ULL];
+  [dict setUInt64:303U forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
 
-  [dict setValue:301U forKey:34ULL];
+  [dict setUInt64:301U forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 301U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 301U);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const uint64_t kValues2[] = { 302U, 300U };
   GPBUInt64UInt64Dictionary *dict2 =
-      [[GPBUInt64UInt64Dictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64UInt64Dictionary alloc] initWithUInt64s:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 303U);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 302U);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 300U);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getUInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 301U);
 
   [dict2 release];
@@ -1165,8 +1165,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64Int64Dictionary *dict = [[GPBUInt64Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:31ULL]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1174,15 +1174,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64Int64Dictionary *dict = [GPBUInt64Int64Dictionary dictionaryWithValue:400 forKey:31ULL];
+  GPBUInt64Int64Dictionary *dict = [GPBUInt64Int64Dictionary dictionaryWithInt64:400 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getInt64:NULL forKey:32ULL]);
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
@@ -1193,27 +1193,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const int64_t kValues[] = { 400, 401, 402 };
   GPBUInt64Int64Dictionary *dict =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   int64_t *seenValues = malloc(3 * sizeof(int64_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1235,7 +1235,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndInt64sUsingBlock:^(uint64_t aKey, int64_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1251,27 +1251,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int64_t kValues2[] = { 400, 403, 402 };
   const int64_t kValues3[] = { 400, 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict1 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64Int64Dictionary *dict1prime =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64Int64Dictionary *dict2 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64Int64Dictionary *dict3 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues1
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64Int64Dictionary *dict4 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues3
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -1302,7 +1302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1323,7 +1323,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -1343,13 +1343,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:400 forKey:31ULL];
+  [dict setInt64:400 forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const int64_t kValues[] = { 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict2 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -1357,17 +1357,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   int64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
   [dict2 release];
 }
@@ -1376,57 +1376,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeInt64ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeInt64ForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeInt64ForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getInt64:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -1434,75 +1434,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int64_t kValues[] = { 400, 401, 402, 403 };
   GPBUInt64Int64Dictionary *dict =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int64_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:403 forKey:31ULL];
+  [dict setInt64:403 forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
 
-  [dict setValue:401 forKey:34ULL];
+  [dict setInt64:401 forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 401);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 401);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const int64_t kValues2[] = { 402, 400 };
   GPBUInt64Int64Dictionary *dict2 =
-      [[GPBUInt64Int64Dictionary alloc] initWithValues:kValues2
+      [[GPBUInt64Int64Dictionary alloc] initWithInt64s:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:31ULL]);
   XCTAssertEqual(value, 403);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:32ULL]);
   XCTAssertEqual(value, 402);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:33ULL]);
   XCTAssertEqual(value, 400);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getInt64:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 401);
 
   [dict2 release];
@@ -1522,8 +1522,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64BoolDictionary *dict = [[GPBUInt64BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:31ULL]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1531,15 +1531,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64BoolDictionary *dict = [GPBUInt64BoolDictionary dictionaryWithValue:YES forKey:31ULL];
+  GPBUInt64BoolDictionary *dict = [GPBUInt64BoolDictionary dictionaryWithBool:YES forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
+  XCTAssertFalse([dict getBool:NULL forKey:32ULL]);
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
@@ -1550,27 +1550,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const BOOL kValues[] = { YES, YES, NO };
   GPBUInt64BoolDictionary *dict =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   BOOL *seenValues = malloc(3 * sizeof(BOOL));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1592,7 +1592,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
+  [dict enumerateKeysAndBoolsUsingBlock:^(uint64_t aKey, BOOL aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1608,29 +1608,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const BOOL kValues2[] = { YES, NO, NO };
   const BOOL kValues3[] = { YES, YES, NO, NO };
   GPBUInt64BoolDictionary *dict1 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64BoolDictionary *dict1prime =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64BoolDictionary *dict2 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64BoolDictionary *dict3 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64BoolDictionary *dict4 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -1659,9 +1659,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt64BoolDictionary *dict =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64BoolDictionary *dict2 = [dict copy];
@@ -1680,9 +1680,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt64BoolDictionary *dict =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64BoolDictionary *dict2 =
@@ -1700,31 +1700,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:YES forKey:31ULL];
+  [dict setBool:YES forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const BOOL kValues[] = { YES, NO, NO };
   GPBUInt64BoolDictionary *dict2 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   BOOL value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
   [dict2 release];
 }
@@ -1733,57 +1733,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt64BoolDictionary *dict =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeBoolForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeBoolForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeBoolForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getBool:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -1791,75 +1791,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const BOOL kValues[] = { YES, YES, NO, NO };
   GPBUInt64BoolDictionary *dict =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   BOOL value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:NO forKey:31ULL];
+  [dict setBool:NO forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
 
-  [dict setValue:YES forKey:34ULL];
+  [dict setBool:YES forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, YES);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const BOOL kValues2[] = { NO, YES };
   GPBUInt64BoolDictionary *dict2 =
-      [[GPBUInt64BoolDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64BoolDictionary alloc] initWithBools:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:31ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:32ULL]);
   XCTAssertEqual(value, NO);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:33ULL]);
   XCTAssertEqual(value, YES);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getBool:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, YES);
 
   [dict2 release];
@@ -1879,8 +1879,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64FloatDictionary *dict = [[GPBUInt64FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:31ULL]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -1888,15 +1888,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64FloatDictionary *dict = [GPBUInt64FloatDictionary dictionaryWithValue:500.f forKey:31ULL];
+  GPBUInt64FloatDictionary *dict = [GPBUInt64FloatDictionary dictionaryWithFloat:500.f forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
+  XCTAssertFalse([dict getFloat:NULL forKey:32ULL]);
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
@@ -1907,27 +1907,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const float kValues[] = { 500.f, 501.f, 502.f };
   GPBUInt64FloatDictionary *dict =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   float *seenValues = malloc(3 * sizeof(float));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -1949,7 +1949,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
+  [dict enumerateKeysAndFloatsUsingBlock:^(uint64_t aKey, float aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -1965,27 +1965,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const float kValues2[] = { 500.f, 503.f, 502.f };
   const float kValues3[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict1 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64FloatDictionary *dict1prime =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64FloatDictionary *dict2 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues2
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64FloatDictionary *dict3 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues1
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues1
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64FloatDictionary *dict4 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues3
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues3
                                                forKeys:kKeys1
                                                  count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
@@ -2016,7 +2016,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2037,7 +2037,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
@@ -2057,13 +2057,13 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:500.f forKey:31ULL];
+  [dict setFloat:500.f forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const float kValues[] = { 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict2 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
                                                forKeys:kKeys
                                                  count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
@@ -2071,17 +2071,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 4U);
 
   float value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
 }
@@ -2090,57 +2090,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeFloatForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   float value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeFloatForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeFloatForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getFloat:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -2148,75 +2148,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const float kValues[] = { 500.f, 501.f, 502.f, 503.f };
   GPBUInt64FloatDictionary *dict =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues
-                                        forKeys:kKeys
-                                          count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   float value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:503.f forKey:31ULL];
+  [dict setFloat:503.f forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
 
-  [dict setValue:501.f forKey:34ULL];
+  [dict setFloat:501.f forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 501.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 501.f);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const float kValues2[] = { 502.f, 500.f };
   GPBUInt64FloatDictionary *dict2 =
-      [[GPBUInt64FloatDictionary alloc] initWithValues:kValues2
+      [[GPBUInt64FloatDictionary alloc] initWithFloats:kValues2
                                                forKeys:kKeys2
                                                  count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:31ULL]);
   XCTAssertEqual(value, 503.f);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:32ULL]);
   XCTAssertEqual(value, 502.f);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:33ULL]);
   XCTAssertEqual(value, 500.f);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getFloat:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 501.f);
 
   [dict2 release];
@@ -2236,8 +2236,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64DoubleDictionary *dict = [[GPBUInt64DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:31ULL]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2245,15 +2245,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64DoubleDictionary *dict = [GPBUInt64DoubleDictionary dictionaryWithValue:600. forKey:31ULL];
+  GPBUInt64DoubleDictionary *dict = [GPBUInt64DoubleDictionary dictionaryWithDouble:600. forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
+  XCTAssertFalse([dict getDouble:NULL forKey:32ULL]);
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
@@ -2264,27 +2264,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const double kValues[] = { 600., 601., 602. };
   GPBUInt64DoubleDictionary *dict =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   double *seenValues = malloc(3 * sizeof(double));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2306,7 +2306,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
+  [dict enumerateKeysAndDoublesUsingBlock:^(uint64_t aKey, double aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2322,29 +2322,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const double kValues2[] = { 600., 603., 602. };
   const double kValues3[] = { 600., 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict1 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64DoubleDictionary *dict1prime =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64DoubleDictionary *dict2 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64DoubleDictionary *dict3 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues1
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues1
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64DoubleDictionary *dict4 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues3
-                                                forKeys:kKeys1
-                                                  count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues3
+                                                 forKeys:kKeys1
+                                                   count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2373,9 +2373,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64DoubleDictionary *dict2 = [dict copy];
@@ -2394,9 +2394,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64DoubleDictionary *dict2 =
@@ -2414,31 +2414,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:600. forKey:31ULL];
+  [dict setDouble:600. forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const double kValues[] = { 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict2 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                                forKeys:kKeys
-                                                  count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   double value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
 }
@@ -2447,57 +2447,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeDoubleForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   double value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeDoubleForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeDoubleForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getDouble:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -2505,75 +2505,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const double kValues[] = { 600., 601., 602., 603. };
   GPBUInt64DoubleDictionary *dict =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues
-                                         forKeys:kKeys
-                                           count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   double value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:603. forKey:31ULL];
+  [dict setDouble:603. forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
 
-  [dict setValue:601. forKey:34ULL];
+  [dict setDouble:601. forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 601.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 601.);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const double kValues2[] = { 602., 600. };
   GPBUInt64DoubleDictionary *dict2 =
-      [[GPBUInt64DoubleDictionary alloc] initWithValues:kValues2
-                                                forKeys:kKeys2
-                                                  count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64DoubleDictionary alloc] initWithDoubles:kValues2
+                                                 forKeys:kKeys2
+                                                   count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:31ULL]);
   XCTAssertEqual(value, 603.);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:32ULL]);
   XCTAssertEqual(value, 602.);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:33ULL]);
   XCTAssertEqual(value, 600.);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getDouble:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 601.);
 
   [dict2 release];
@@ -2593,8 +2593,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   GPBUInt64EnumDictionary *dict = [[GPBUInt64EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:31ULL]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue, stop)
     XCTFail(@"Shouldn't get here!");
   }];
@@ -2602,15 +2602,15 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64EnumDictionary *dict = [GPBUInt64EnumDictionary dictionaryWithValue:700 forKey:31ULL];
+  GPBUInt64EnumDictionary *dict = [GPBUInt64EnumDictionary dictionaryWithEnum:700 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertEqual(aKey, 31ULL);
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
@@ -2621,27 +2621,27 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL };
   const int32_t kValues[] = { 700, 701, 702 };
   GPBUInt64EnumDictionary *dict =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -2663,7 +2663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 
   // Stopping the enumeration.
   idx = 0;
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     #pragma unused(aKey, aValue)
     if (idx == 1) *stop = YES;
     XCTAssertNotEqual(idx, 2U);
@@ -2679,29 +2679,29 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const int32_t kValues2[] = { 700, 703, 702 };
   const int32_t kValues3[] = { 700, 701, 702, 703 };
   GPBUInt64EnumDictionary *dict1 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1);
   GPBUInt64EnumDictionary *dict1prime =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict1prime);
   GPBUInt64EnumDictionary *dict2 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   GPBUInt64EnumDictionary *dict3 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues1
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues1)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues1
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues1)];
   XCTAssertNotNil(dict3);
   GPBUInt64EnumDictionary *dict4 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues3
-                                              forKeys:kKeys1
-                                                count:GPBARRAYSIZE(kValues3)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues3
+                                             forKeys:kKeys1
+                                               count:GPBARRAYSIZE(kValues3)];
   XCTAssertNotNil(dict4);
 
   // 1/1Prime should be different objects, but equal.
@@ -2730,9 +2730,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt64EnumDictionary *dict =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64EnumDictionary *dict2 = [dict copy];
@@ -2751,9 +2751,9 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt64EnumDictionary *dict =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
 
   GPBUInt64EnumDictionary *dict2 =
@@ -2771,31 +2771,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  [dict setValue:700 forKey:31ULL];
+  [dict setEnum:700 forKey:31ULL];
   XCTAssertEqual(dict.count, 1U);
 
   const uint64_t kKeys[] = { 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 701, 702, 703 };
   GPBUInt64EnumDictionary *dict2 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
   [dict2 release];
 }
@@ -2804,57 +2804,57 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt64EnumDictionary *dict =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeEnumForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeEnumForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeEnumForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -2862,75 +2862,75 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 32ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 700, 701, 702, 703 };
   GPBUInt64EnumDictionary *dict =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                       forKeys:kKeys
-                                         count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                             forKeys:kKeys
+                                               count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:703 forKey:31ULL];
+  [dict setEnum:703 forKey:31ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
 
-  [dict setValue:701 forKey:34ULL];
+  [dict setEnum:701 forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 701);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 701);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
   const int32_t kValues2[] = { 702, 700 };
   GPBUInt64EnumDictionary *dict2 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues2
-                                              forKeys:kKeys2
-                                                count:GPBARRAYSIZE(kValues2)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues2
+                                             forKeys:kKeys2
+                                               count:GPBARRAYSIZE(kValues2)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 703);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 701);
 
   [dict2 release];
@@ -2958,24 +2958,24 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqual(dict.count, 3U);
   XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:34ULL rawValue:NULL]);
+  XCTAssertFalse([dict getRawValue:NULL forKey:34ULL]);
 
   __block NSUInteger idx = 0;
   uint64_t *seenKeys = malloc(3 * sizeof(uint64_t));
   int32_t *seenValues = malloc(3 * sizeof(int32_t));
-  [dict enumerateKeysAndValuesUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
+  [dict enumerateKeysAndEnumsUsingBlock:^(uint64_t aKey, int32_t aValue, BOOL *stop) {
     XCTAssertLessThan(idx, 3U);
     seenKeys[idx] = aKey;
     seenValues[idx] = aValue;
@@ -3136,7 +3136,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertThrowsSpecificNamed([dict setValue:801 forKey:32ULL],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:801 forKey:32ULL],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 0U);
   [dict setRawValue:801 forKey:32ULL];  // Unknown
@@ -3145,31 +3145,31 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const uint64_t kKeys[] = { 31ULL, 33ULL, 34ULL };
   const int32_t kValues[] = { 700, 702, 803 };  // Unknown
   GPBUInt64EnumDictionary *dict2 =
-      [[GPBUInt64EnumDictionary alloc] initWithValues:kValues
-                                              forKeys:kKeys
-                                                count:GPBARRAYSIZE(kValues)];
+      [[GPBUInt64EnumDictionary alloc] initWithEnums:kValues
+                                               forKeys:kKeys
+                                                 count:GPBARRAYSIZE(kValues)];
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
 
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, kGPBUnrecognizedEnumeratorValue);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
   [dict2 release];
 }
@@ -3185,51 +3185,51 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
-  [dict removeValueForKey:32ULL];
+  [dict removeEnumForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
 
   // Remove again does nothing.
-  [dict removeValueForKey:32ULL];
+  [dict removeEnumForKey:32ULL];
   XCTAssertEqual(dict.count, 3U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
 
-  [dict removeValueForKey:34ULL];
+  [dict removeEnumForKey:34ULL];
   XCTAssertEqual(dict.count, 2U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:34ULL]);
 
   [dict removeAll];
   XCTAssertEqual(dict.count, 0U);
-  XCTAssertFalse([dict valueForKey:31ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:32ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:33ULL value:NULL]);
-  XCTAssertFalse([dict valueForKey:34ULL value:NULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertFalse([dict getEnum:NULL forKey:34ULL]);
   [dict release];
 }
 
@@ -3244,63 +3244,63 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   int32_t value;
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
 
-  XCTAssertThrowsSpecificNamed([dict setValue:803 forKey:31ULL],  // Unknown
+  XCTAssertThrowsSpecificNamed([dict setEnum:803 forKey:31ULL],  // Unknown
                                NSException, NSInvalidArgumentException);
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:31ULL]);
   XCTAssertEqual(value, 700);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:803 forKey:31ULL];  // Unknown
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:31ULL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
 
   [dict setRawValue:700 forKey:34ULL];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:31ULL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:32ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:33ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:33ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 700);
 
   const uint64_t kKeys2[] = { 32ULL, 33ULL };
@@ -3313,17 +3313,17 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict2);
   [dict addRawEntriesFromDictionary:dict2];
   XCTAssertEqual(dict.count, 4U);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:31ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:31ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:31ULL]);
   XCTAssertEqual(value, 803);
-  XCTAssertTrue([dict valueForKey:32ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:32ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:32ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:32ULL]);
   XCTAssertEqual(value, 702);
-  XCTAssertTrue([dict valueForKey:33ULL rawValue:NULL]);
-  XCTAssertTrue([dict valueForKey:33ULL rawValue:&value]);
+  XCTAssertTrue([dict getRawValue:NULL forKey:33ULL]);
+  XCTAssertTrue([dict getRawValue:&value forKey:33ULL]);
   XCTAssertEqual(value, 801);
-  XCTAssertTrue([dict valueForKey:34ULL value:NULL]);
-  XCTAssertTrue([dict valueForKey:34ULL value:&value]);
+  XCTAssertTrue([dict getEnum:NULL forKey:34ULL]);
+  XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 700);
 
   [dict2 release];
@@ -3559,8 +3559,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBUInt64ObjectDictionary<NSString*> *dict =
       [[GPBUInt64ObjectDictionary alloc] initWithObjects:kObjects
-                                          forKeys:kKeys
-                                            count:GPBARRAYSIZE(kObjects)];
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
 
@@ -3600,8 +3600,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   const NSString* kObjects[] = { @"abc", @"def", @"ghi", @"jkl" };
   GPBUInt64ObjectDictionary<NSString*> *dict =
       [[GPBUInt64ObjectDictionary alloc] initWithObjects:kObjects
-                                          forKeys:kKeys
-                                            count:GPBARRAYSIZE(kObjects)];
+                                                 forKeys:kKeys
+                                                   count:GPBARRAYSIZE(kObjects)];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 4U);
   XCTAssertEqualObjects([dict objectForKey:31ULL], @"abc");

--- a/objectivec/Tests/GPBDictionaryTests.pddm
+++ b/objectivec/Tests/GPBDictionaryTests.pddm
@@ -69,8 +69,8 @@
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 0U);
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY1)
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY1)
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
 //%    #pragma unused(aKey, a##VNAME$u, stop)
 //%    XCTFail(@"Shouldn't get here!");
 //%  }];
@@ -78,12 +78,12 @@
 //%}
 //%
 //%- (void)testOne {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VNAME$u##:VAL1 forKey:KEY1];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VALUE_NAME$u##:VAL1 forKey:KEY1];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 1U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
 //%    XCTAssertEqual##KSUFFIX(aKey, KEY1);
 //%    XCTAssertEqual##VSUFFIX(a##VNAME$u, VAL1);
 //%    XCTAssertNotEqual(stop, NULL);
@@ -94,20 +94,20 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2, KEY3 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2, VAL3 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME$u##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 3U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%
 //%  __block NSUInteger idx = 0;
 //%  KEY_TYPE KisP##*seenKeys = malloc(3 * sizeof(KEY_TYPE##KisP));
 //%  VALUE_TYPE *seen##VNAME$u##s = malloc(3 * sizeof(VALUE_TYPE));
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
 //%    XCTAssertLessThan(idx, 3U);
 //%    seenKeys[idx] = aKey;
 //%    seen##VNAME$u##s[idx] = a##VNAME$u##;
@@ -129,7 +129,7 @@
 //%
 //%  // Stopping the enumeration.
 //%  idx = 0;
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
 //%    #pragma unused(aKey, a##VNAME$u)
 //%    if (idx == 1) *stop = YES;
 //%    XCTAssertNotEqual(idx, 2U);
@@ -145,29 +145,29 @@
 //%  const VALUE_TYPE k##VNAME$u##s2[] = { VAL1, VAL4, VAL3 };
 //%  const VALUE_TYPE k##VNAME$u##s3[] = { VAL1, VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict1 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict1);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict1prime =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict1prime);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
 //%  XCTAssertNotNil(dict2);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict3 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict3);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict4 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s3
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s3)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s3
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s3)];
 //%  XCTAssertNotNil(dict4);
 //%
 //%  // 1/1Prime should be different objects, but equal.
@@ -196,9 +196,9 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2, KEY3, KEY4 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 = [dict copy];
@@ -217,9 +217,9 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2, KEY3, KEY4 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
@@ -237,23 +237,23 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
-//%  [dict set##VNAME$u##:VAL1 forKey:KEY1];
+//%  [dict set##VALUE_NAME##:VAL1 forKey:KEY1];
 //%  XCTAssertEqual(dict.count, 1U);
 //%
 //%  const KEY_TYPE KisP##kKeys[] = { KEY2, KEY3, KEY4 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict2);
 //%  [dict add##VACCESSOR##EntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 4U);
 //%
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL4)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%  [dict2 release];
 //%}
 //%
@@ -261,40 +261,40 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2, KEY3, KEY4 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 4U);
 //%
-//%  [dict remove##VNAME$u##ForKey:KEY2];
+//%  [dict remove##VALUE_NAME##ForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 3U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL4)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%
 //%  // Remove again does nothing.
-//%  [dict remove##VNAME$u##ForKey:KEY2];
+//%  [dict remove##VALUE_NAME##ForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 3U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%
-//%  [dict remove##VNAME$u##ForKey:KEY4];
+//%  [dict remove##VALUE_NAME##ForKey:KEY4];
 //%  XCTAssertEqual(dict.count, 2U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%
 //%  [dict removeAll];
 //%  XCTAssertEqual(dict.count, 0U);
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY3)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY3)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%  [dict release];
 //%}
 //%
@@ -302,43 +302,43 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2, KEY3, KEY4 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2, VAL3, VAL4 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 4U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL4)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%
-//%  [dict set##VNAME$u##:VAL4 forKey:KEY1];
+//%  [dict set##VALUE_NAME##:VAL4 forKey:KEY1];
 //%  XCTAssertEqual(dict.count, 4U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL4)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%
-//%  [dict set##VNAME$u##:VAL2 forKey:KEY4];
+//%  [dict set##VALUE_NAME##:VAL2 forKey:KEY4];
 //%  XCTAssertEqual(dict.count, 4U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL4)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL2)
 //%
 //%  const KEY_TYPE KisP##kKeys2[] = { KEY2, KEY3 };
 //%  const VALUE_TYPE k##VNAME$u##s2[] = { VAL3, VAL1 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
 //%  XCTAssertNotNil(dict2);
 //%  [dict add##VACCESSOR##EntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 4U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL4)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL3)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY3, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY4, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL2)
 //%
 //%  [dict2 release];
 //%  [dict release];
@@ -369,15 +369,15 @@
 //%  XCTAssertEqual(dict.count, 3U);
 //%  XCTAssertTrue(dict.validationFunc == TestingEnum_IsValidValue);  // Pointer comparison
 //%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_RAW_VALUE##VHELPER(dict, value, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, value, KEY2, kGPBUnrecognizedEnumeratorValue)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY2, kGPBUnrecognizedEnumeratorValue)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY3, VAL3)
-//%RAW_VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%RAW_VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%
 //%  __block NSUInteger idx = 0;
 //%  KEY_TYPE KisP##*seenKeys = malloc(3 * sizeof(KEY_TYPE##KisP));
 //%  VALUE_TYPE *seenValues = malloc(3 * sizeof(VALUE_TYPE));
-//%  [dict enumerateKeysAndValuesUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE aValue, BOOL *stop) {
+//%  [dict enumerateKeysAndEnumsUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE aValue, BOOL *stop) {
 //%    XCTAssertLessThan(idx, 3U);
 //%    seenKeys[idx] = aKey;
 //%    seenValues[idx] = aValue;
@@ -538,7 +538,7 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
-//%  XCTAssertThrowsSpecificNamed([dict setValue:VAL2 forKey:KEY2],  // Unknown
+//%  XCTAssertThrowsSpecificNamed([dict setEnum:VAL2 forKey:KEY2],  // Unknown
 //%                               NSException, NSInvalidArgumentException);
 //%  XCTAssertEqual(dict.count, 0U);
 //%  [dict setRawValue:VAL2 forKey:KEY2];  // Unknown
@@ -547,18 +547,18 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY3, KEY4 };
 //%  const VALUE_TYPE kValues[] = { VAL1, VAL3, VAL4 };  // Unknown
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithValues:kValues
-//%           KEY_NAME$S VALUE_NAME$S                        forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                          count:GPBARRAYSIZE(kValues)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithEnums:kValues
+//%           KEY_NAME$S VALUE_NAME$S                         forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                           count:GPBARRAYSIZE(kValues)];
 //%  XCTAssertNotNil(dict2);
 //%  [dict addRawEntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 4U);
 //%
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, value, KEY2, kGPBUnrecognizedEnumeratorValue)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY2, kGPBUnrecognizedEnumeratorValue)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, value, KEY4, kGPBUnrecognizedEnumeratorValue)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY4, kGPBUnrecognizedEnumeratorValue)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%  [dict2 release];
 //%}
@@ -574,34 +574,34 @@
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 4U);
 //%
-//%  [dict removeValueForKey:KEY2];
+//%  [dict removeEnumForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 3U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%
 //%  // Remove again does nothing.
-//%  [dict removeValueForKey:KEY2];
+//%  [dict removeEnumForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 3U);
-//%TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%
-//%  [dict removeValueForKey:KEY4];
+//%  [dict removeEnumForKey:KEY4];
 //%  XCTAssertEqual(dict.count, 2U);
-//%TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%
 //%  [dict removeAll];
 //%  XCTAssertEqual(dict.count, 0U);
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY3)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY4)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY3)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY4)
 //%  [dict release];
 //%}
 //%
@@ -615,32 +615,32 @@
 //%           KEY_NAME$S VALUE_NAME$S                                      count:GPBARRAYSIZE(kValues)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 4U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, value)TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%
-//%  XCTAssertThrowsSpecificNamed([dict setValue:VAL4 forKey:KEY1],  // Unknown
+//%  XCTAssertThrowsSpecificNamed([dict setEnum:VAL4 forKey:KEY1],  // Unknown
 //%                               NSException, NSInvalidArgumentException);
 //%  XCTAssertEqual(dict.count, 4U);
-//%TEST_VALUE##VHELPER(dict, value, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY1, VAL1)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%
 //%  [dict setRawValue:VAL4 forKey:KEY1];  // Unknown
 //%  XCTAssertEqual(dict.count, 4U);
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY1, VAL4)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%
 //%  [dict setRawValue:VAL1 forKey:KEY4];
 //%  XCTAssertEqual(dict.count, 4U);
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY1, VAL4)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY2, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY3, VAL3)
-//%TEST_VALUE##VHELPER(dict, value, KEY4, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY3, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY4, VAL1)
 //%
 //%  const KEY_TYPE KisP##kKeys2[] = { KEY2, KEY3 };
 //%  const VALUE_TYPE kValues2[] = { VAL3, VAL2 };  // Unknown
@@ -653,9 +653,9 @@
 //%  [dict addRawEntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 4U);
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY1, VAL4)
-//%TEST_VALUE##VHELPER(dict, value, KEY2, VAL3)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY2, VAL3)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY3, VAL2)
-//%TEST_VALUE##VHELPER(dict, value, KEY4, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY4, VAL1)
 //%
 //%  [dict2 release];
 //%  [dict release];
@@ -694,19 +694,19 @@
 //%PDDM-DEFINE DECLARE_VALUE_STORAGEPOD(VALUE_TYPE, NAME)
 //%  VALUE_TYPE NAME;
 //%
-//%PDDM-DEFINE VALUE_NOT_FOUNDPOD(DICT, KEY)
-//%  XCTAssertFalse([DICT valueForKey:KEY value:NULL]);
-//%PDDM-DEFINE TEST_VALUEPOD(DICT, STORAGE, KEY, VALUE)
-//%  XCTAssertTrue([DICT valueForKey:KEY value:NULL]);
-//%  XCTAssertTrue([DICT valueForKey:KEY value:&STORAGE]);
+//%PDDM-DEFINE VALUE_NOT_FOUNDPOD(VALUE_NAME, DICT, KEY)
+//%  XCTAssertFalse([DICT get##VALUE_NAME##:NULL forKey:KEY]);
+//%PDDM-DEFINE TEST_VALUEPOD(VALUE_NAME, DICT, STORAGE, KEY, VALUE)
+//%  XCTAssertTrue([DICT get##VALUE_NAME##:NULL forKey:KEY]);
+//%  XCTAssertTrue([DICT get##VALUE_NAME##:&STORAGE forKey:KEY]);
 //%  XCTAssertEqual(STORAGE, VALUE);
 //%PDDM-DEFINE COMPARE_KEYS(KEY1, KEY2)
 //%KEY1 == KEY2
-//%PDDM-DEFINE RAW_VALUE_NOT_FOUNDPOD(DICT, KEY)
-//%  XCTAssertFalse([DICT valueForKey:KEY rawValue:NULL]);
+//%PDDM-DEFINE RAW_VALUE_NOT_FOUNDPOD(VALUE_NAME, DICT, KEY)
+//%  XCTAssertFalse([DICT getRawValue:NULL forKey:KEY]);
 //%PDDM-DEFINE TEST_RAW_VALUEPOD(DICT, STORAGE, KEY, VALUE)
-//%  XCTAssertTrue([DICT valueForKey:KEY rawValue:NULL]);
-//%  XCTAssertTrue([DICT valueForKey:KEY rawValue:&STORAGE]);
+//%  XCTAssertTrue([DICT getRawValue:NULL forKey:KEY]);
+//%  XCTAssertTrue([DICT getRawValue:&STORAGE forKey:KEY]);
 //%  XCTAssertEqual(STORAGE, VALUE);
 
 //
@@ -715,9 +715,9 @@
 
 //%PDDM-DEFINE DECLARE_VALUE_STORAGEOBJECT(VALUE_TYPE, NAME)
 // Empty
-//%PDDM-DEFINE VALUE_NOT_FOUNDOBJECT(DICT, KEY)
+//%PDDM-DEFINE VALUE_NOT_FOUNDOBJECT(VALUE_NAME, DICT, KEY)
 //%  XCTAssertNil([DICT objectForKey:KEY]);
-//%PDDM-DEFINE TEST_VALUEOBJECT(DICT, STORAGE, KEY, VALUE)
+//%PDDM-DEFINE TEST_VALUEOBJECT(VALUE_NAME, DICT, STORAGE, KEY, VALUE)
 //%  XCTAssertEqualObjects([DICT objectForKey:KEY], VALUE);
 //%PDDM-DEFINE COMPARE_KEYSObjects(KEY1, KEY2)
 //%[KEY1 isEqual:KEY2]
@@ -729,10 +729,10 @@
 //%PDDM-DEFINE TEST_HELPERS(KEY_NAME, KEY_TYPE, KisP)
 //%// To let the testing macros work, add some extra methods to simplify things.
 //%@interface GPB##KEY_NAME##EnumDictionary (TestingTweak)
-//%+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(KEY_TYPE##KisP$S##KisP)key;
-//%- (instancetype)initWithValues:(const int32_t [])values
-//%                       forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
-//%                         count:(NSUInteger)count;
+//%+ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(KEY_TYPE##KisP$S##KisP)key;
+//%- (instancetype)initWithEnums:(const int32_t [])values
+//%                      forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
+//%                        count:(NSUInteger)count;
 //%@end
 //%
 //%static BOOL TestingEnum_IsValidValue(int32_t value) {
@@ -748,7 +748,7 @@
 //%}
 //%
 //%@implementation GPB##KEY_NAME##EnumDictionary (TestingTweak)
-//%+ (instancetype)dictionaryWithValue:(int32_t)value forKey:(KEY_TYPE##KisP$S##KisP)key {
+//%+ (instancetype)dictionaryWithEnum:(int32_t)value forKey:(KEY_TYPE##KisP$S##KisP)key {
 //%  // Cast is needed to compiler knows what class we are invoking initWithValues: on to get the
 //%  // type correct.
 //%  return [[(GPB##KEY_NAME##EnumDictionary*)[self alloc] initWithValidationFunction:TestingEnum_IsValidValue
@@ -756,9 +756,9 @@
 //%                KEY_NAME$S                                               forKeys:&key
 //%                KEY_NAME$S                                                 count:1] autorelease];
 //%}
-//%- (instancetype)initWithValues:(const int32_t [])values
-//%                       forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
-//%                         count:(NSUInteger)count {
+//%- (instancetype)initWithEnums:(const int32_t [])values
+//%                      forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
+//%                        count:(NSUInteger)count {
 //%  return [self initWithValidationFunction:TestingEnum_IsValidValue
 //%                                rawValues:values
 //%                                  forKeys:keys
@@ -792,8 +792,8 @@
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 0U);
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY1)
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY1)
+//%  [dict enumerateKeysAnd##VALUE_NAME##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
 //%    #pragma unused(aKey, a##VNAME$u##, stop)
 //%    XCTFail(@"Shouldn't get here!");
 //%  }];
@@ -801,12 +801,12 @@
 //%}
 //%
 //%- (void)testOne {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VNAME$u##:VAL1 forKey:KEY1];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VALUE_NAME$u##:VAL1 forKey:KEY1];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 1U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u, BOOL *stop) {
 //%    XCTAssertEqual##KSUFFIX(aKey, KEY1);
 //%    XCTAssertEqual##VSUFFIX(a##VNAME$u, VAL1);
 //%    XCTAssertNotEqual(stop, NULL);
@@ -817,18 +817,18 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 2U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%
 //%  __block NSUInteger idx = 0;
 //%  KEY_TYPE KisP##*seenKeys = malloc(2 * sizeof(KEY_TYPE##KisP));
 //%  VALUE_TYPE *seen##VNAME$u##s = malloc(2 * sizeof(VALUE_TYPE));
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
 //%    XCTAssertLessThan(idx, 2U);
 //%    seenKeys[idx] = aKey;
 //%    seen##VNAME$u##s[idx] = a##VNAME$u;
@@ -850,7 +850,7 @@
 //%
 //%  // Stopping the enumeration.
 //%  idx = 0;
-//%  [dict enumerateKeysAnd##VNAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
+//%  [dict enumerateKeysAnd##VALUE_NAME$u##sUsingBlock:^(KEY_TYPE KisP##aKey, VALUE_TYPE a##VNAME$u##, BOOL *stop) {
 //%    #pragma unused(aKey, a##VNAME$u)
 //%    if (idx == 0) *stop = YES;
 //%    XCTAssertNotEqual(idx, 2U);
@@ -866,29 +866,29 @@
 //%  const VALUE_TYPE k##VNAME$u##s2[] = { VAL2, VAL1 };
 //%  const VALUE_TYPE k##VNAME$u##s3[] = { VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict1 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict1);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict1prime =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict1prime);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
 //%  XCTAssertNotNil(dict2);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict3 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s1)];
 //%  XCTAssertNotNil(dict3);
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict4 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s3
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys1
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s3)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s3
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys1
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s3)];
 //%  XCTAssertNotNil(dict4);
 //%
 //%  // 1/1Prime should be different objects, but equal.
@@ -917,9 +917,9 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 = [dict copy];
@@ -938,9 +938,9 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
@@ -958,21 +958,21 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
-//%  [dict set##VNAME$u:VAL1 forKey:KEY1];
+//%  [dict set##VALUE_NAME:VAL1 forKey:KEY1];
 //%  XCTAssertEqual(dict.count, 1U);
 //%
 //%  const KEY_TYPE KisP##kKeys[] = { KEY2 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict2);
 //%  [dict addEntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 2U);
 //%
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%  [dict2 release];
 //%}
 //%
@@ -980,27 +980,27 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2};
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S          ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S          ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 2U);
 //%
-//%  [dict remove##VNAME$u##ForKey:KEY2];
+//%  [dict remove##VALUE_NAME##ForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 1U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
 //%
 //%  // Remove again does nothing.
-//%  [dict remove##VNAME$u##ForKey:KEY2];
+//%  [dict remove##VALUE_NAME##ForKey:KEY2];
 //%  XCTAssertEqual(dict.count, 1U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
 //%
 //%  [dict removeAll];
 //%  XCTAssertEqual(dict.count, 0U);
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY1)
-//%VALUE_NOT_FOUND##VHELPER(dict, KEY2)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY1)
+//%VALUE_NOT_FOUND##VHELPER(VALUE_NAME, dict, KEY2)
 //%  [dict release];
 //%}
 //%
@@ -1008,35 +1008,35 @@
 //%  const KEY_TYPE KisP##kKeys[] = { KEY1, KEY2 };
 //%  const VALUE_TYPE k##VNAME$u##s[] = { VAL1, VAL2 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##  forKeys:kKeys
-//%           KEY_NAME$S VALUE_NAME$S          ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s)];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 2U);
-//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
+//%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%
-//%  [dict set##VNAME$u##:VAL2 forKey:KEY1];
+//%  [dict set##VALUE_NAME##:VAL2 forKey:KEY1];
 //%  XCTAssertEqual(dict.count, 2U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%
-//%  [dict set##VNAME$u##:VAL1 forKey:KEY2];
+//%  [dict set##VALUE_NAME##:VAL1 forKey:KEY2];
 //%  XCTAssertEqual(dict.count, 2U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL2)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL1)
 //%
 //%  const KEY_TYPE KisP##kKeys2[] = { KEY2, KEY1 };
 //%  const VALUE_TYPE k##VNAME$u##s2[] = { VAL2, VAL1 };
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VNAME$u##s:k##VNAME$u##s2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##  forKeys:kKeys2
-//%           KEY_NAME$S VALUE_NAME$S                 ##VNAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWith##VALUE_NAME##s:k##VNAME$u##s2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##  forKeys:kKeys2
+//%           KEY_NAME$S VALUE_NAME$S                 ##VALUE_NAME$S##    count:GPBARRAYSIZE(k##VNAME$u##s2)];
 //%  XCTAssertNotNil(dict2);
 //%  [dict addEntriesFromDictionary:dict2];
 //%  XCTAssertEqual(dict.count, 2U);
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY1, VAL1)
-//%TEST_VALUE##VHELPER(dict, VNAME, KEY2, VAL2)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
+//%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%
 //%  [dict2 release];
 //%  [dict release];

--- a/objectivec/Tests/GPBMessageTests+Serialization.m
+++ b/objectivec/Tests/GPBMessageTests+Serialization.m
@@ -987,7 +987,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:1 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:1]);
   XCTAssertEqual(val, 1);
 
   [msg release];
@@ -1001,7 +1001,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:2 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:2]);
   XCTAssertEqual(val, 1);
 
   [msg release];
@@ -1015,7 +1015,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:2 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:2]);
   XCTAssertEqual(val, 1);
 
   [msg release];
@@ -1029,7 +1029,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:1 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:1]);
   XCTAssertEqual(val, 2);
 
   [msg release];
@@ -1043,7 +1043,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:0 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:0]);
   XCTAssertEqual(val, 1);
 
   [msg release];
@@ -1057,7 +1057,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:1 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:1]);
   XCTAssertEqual(val, 0);
 
   [msg release];
@@ -1071,7 +1071,7 @@ static NSData *DataFromCStr(const char *str) {
   TestMap *msg = [[TestMap alloc] initWithData:data error:NULL];
   XCTAssertEqual(msg.mapInt32Int32.count, 1U);
   int32_t val = 666;
-  XCTAssertTrue([msg.mapInt32Int32 valueForKey:2 value:&val]);
+  XCTAssertTrue([msg.mapInt32Int32 getInt32:&val forKey:2]);
   XCTAssertEqual(val, 3);
 
   [msg release];
@@ -1098,17 +1098,17 @@ static NSData *DataFromCStr(const char *str) {
       dictionaryWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue];
   orig.unknownMapField = [GPBInt32EnumDictionary
       dictionaryWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue];
-  [orig.knownMapField setValue:Proto2MapEnumPlusExtra_EProto2MapEnumFoo
-                        forKey:0];
-  [orig.unknownMapField setValue:Proto2MapEnumPlusExtra_EProto2MapEnumExtra
-                          forKey:0];
+  [orig.knownMapField setEnum:Proto2MapEnumPlusExtra_EProto2MapEnumFoo
+                       forKey:0];
+  [orig.unknownMapField setEnum:Proto2MapEnumPlusExtra_EProto2MapEnumExtra
+                         forKey:0];
 
   NSData *data = [orig data];
   XCTAssertNotNil(data);
   TestEnumMap *msg1 = [TestEnumMap parseFromData:data error:NULL];
   XCTAssertEqual(msg1.knownMapField.count, 1U);
   int32_t val = -1;
-  XCTAssertTrue([msg1.knownMapField valueForKey:0 value:&val]);
+  XCTAssertTrue([msg1.knownMapField getEnum:&val forKey:0]);
   XCTAssertEqual(val, Proto2MapEnum_Proto2MapEnumFoo);
   XCTAssertEqual(msg1.unknownFields.countOfFields, 1U);
 
@@ -1117,11 +1117,11 @@ static NSData *DataFromCStr(const char *str) {
       [TestEnumMapPlusExtra parseFromData:data error:NULL];
   val = -1;
   XCTAssertEqual(msg2.knownMapField.count, 1U);
-  XCTAssertTrue([msg2.knownMapField valueForKey:0 value:&val]);
+  XCTAssertTrue([msg2.knownMapField getEnum:&val forKey:0]);
   XCTAssertEqual(val, Proto2MapEnumPlusExtra_EProto2MapEnumFoo);
   val = -1;
   XCTAssertEqual(msg2.unknownMapField.count, 1U);
-  XCTAssertTrue([msg2.unknownMapField valueForKey:0 value:&val]);
+  XCTAssertTrue([msg2.unknownMapField getEnum:&val forKey:0]);
   XCTAssertEqual(val, Proto2MapEnumPlusExtra_EProto2MapEnumExtra);
   XCTAssertEqual(msg2.unknownFields.countOfFields, 0U);
 
@@ -1137,32 +1137,32 @@ static NSData *DataFromCStr(const char *str) {
 
   // Key/Value data should result in different byte lengths on wire to ensure
   // everything is right.
-  [msg.mapInt32Int32 setValue:1000 forKey:200];
-  [msg.mapInt32Int32 setValue:101 forKey:2001];
-  [msg.mapInt64Int64 setValue:1002 forKey:202];
-  [msg.mapInt64Int64 setValue:103 forKey:2003];
-  [msg.mapUint32Uint32 setValue:1004 forKey:204];
-  [msg.mapUint32Uint32 setValue:105 forKey:2005];
-  [msg.mapUint64Uint64 setValue:1006 forKey:206];
-  [msg.mapUint64Uint64 setValue:107 forKey:2007];
-  [msg.mapSint32Sint32 setValue:1008 forKey:208];
-  [msg.mapSint32Sint32 setValue:109 forKey:2009];
-  [msg.mapSint64Sint64 setValue:1010 forKey:210];
-  [msg.mapSint64Sint64 setValue:111 forKey:2011];
-  [msg.mapFixed32Fixed32 setValue:1012 forKey:212];
-  [msg.mapFixed32Fixed32 setValue:113 forKey:2013];
-  [msg.mapFixed64Fixed64 setValue:1014 forKey:214];
-  [msg.mapFixed64Fixed64 setValue:115 forKey:2015];
-  [msg.mapSfixed32Sfixed32 setValue:1016 forKey:216];
-  [msg.mapSfixed32Sfixed32 setValue:117 forKey:2017];
-  [msg.mapSfixed64Sfixed64 setValue:1018 forKey:218];
-  [msg.mapSfixed64Sfixed64 setValue:119 forKey:2019];
-  [msg.mapInt32Float setValue:1020.f forKey:220];
-  [msg.mapInt32Float setValue:121.f forKey:2021];
-  [msg.mapInt32Double setValue:1022. forKey:222];
-  [msg.mapInt32Double setValue:123. forKey:2023];
-  [msg.mapBoolBool setValue:false forKey:true];
-  [msg.mapBoolBool setValue:true forKey:false];
+  [msg.mapInt32Int32 setInt32:1000 forKey:200];
+  [msg.mapInt32Int32 setInt32:101 forKey:2001];
+  [msg.mapInt64Int64 setInt64:1002 forKey:202];
+  [msg.mapInt64Int64 setInt64:103 forKey:2003];
+  [msg.mapUint32Uint32 setUInt32:1004 forKey:204];
+  [msg.mapUint32Uint32 setUInt32:105 forKey:2005];
+  [msg.mapUint64Uint64 setUInt64:1006 forKey:206];
+  [msg.mapUint64Uint64 setUInt64:107 forKey:2007];
+  [msg.mapSint32Sint32 setInt32:1008 forKey:208];
+  [msg.mapSint32Sint32 setInt32:109 forKey:2009];
+  [msg.mapSint64Sint64 setInt64:1010 forKey:210];
+  [msg.mapSint64Sint64 setInt64:111 forKey:2011];
+  [msg.mapFixed32Fixed32 setUInt32:1012 forKey:212];
+  [msg.mapFixed32Fixed32 setUInt32:113 forKey:2013];
+  [msg.mapFixed64Fixed64 setUInt64:1014 forKey:214];
+  [msg.mapFixed64Fixed64 setUInt64:115 forKey:2015];
+  [msg.mapSfixed32Sfixed32 setInt32:1016 forKey:216];
+  [msg.mapSfixed32Sfixed32 setInt32:117 forKey:2017];
+  [msg.mapSfixed64Sfixed64 setInt64:1018 forKey:218];
+  [msg.mapSfixed64Sfixed64 setInt64:119 forKey:2019];
+  [msg.mapInt32Float setFloat:1020.f forKey:220];
+  [msg.mapInt32Float setFloat:121.f forKey:2021];
+  [msg.mapInt32Double setDouble:1022. forKey:222];
+  [msg.mapInt32Double setDouble:123. forKey:2023];
+  [msg.mapBoolBool setBool:false forKey:true];
+  [msg.mapBoolBool setBool:true forKey:false];
   msg.mapStringString[@"224"] = @"1024";
   msg.mapStringString[@"2025"] = @"125";
   msg.mapStringBytes[@"226"] = DataFromCStr("1026");
@@ -1171,12 +1171,12 @@ static NSData *DataFromCStr(const char *str) {
   val1.optionalInt32 = 1028;
   Message2 *val2 = [[Message2 alloc] init];
   val2.optionalInt32 = 129;
-  [msg.mapStringMessage setValue:val1 forKey:@"228"];
-  [msg.mapStringMessage setValue:val2 forKey:@"2029"];
+  [msg.mapStringMessage setObject:val1 forKey:@"228"];
+  [msg.mapStringMessage setObject:val2 forKey:@"2029"];
   [msg.mapInt32Bytes setObject:DataFromCStr("1030 bytes") forKey:230];
   [msg.mapInt32Bytes setObject:DataFromCStr("131") forKey:2031];
-  [msg.mapInt32Enum setValue:Message2_Enum_Bar forKey:232];
-  [msg.mapInt32Enum setValue:Message2_Enum_Baz forKey:2033];
+  [msg.mapInt32Enum setEnum:Message2_Enum_Bar forKey:232];
+  [msg.mapInt32Enum setEnum:Message2_Enum_Baz forKey:2033];
   Message2 *val3 = [[Message2 alloc] init];
   val3.optionalInt32 = 1034;
   Message2 *val4 = [[Message2 alloc] init];

--- a/objectivec/Tests/GPBMessageTests.m
+++ b/objectivec/Tests/GPBMessageTests.m
@@ -1171,7 +1171,7 @@
   XCTAssertFalse([message2.a hasA]);
 
   // But adding an element to the map should.
-  [message.a.a.iToI setValue:100 forKey:200];
+  [message.a.a.iToI setInt32:100 forKey:200];
   XCTAssertTrue([message hasA]);
   XCTAssertTrue([message.a hasA]);
   XCTAssertEqual([message.a.a.iToI count], (NSUInteger)1);
@@ -1190,7 +1190,7 @@
   message1a.a.iToI = message1b.a.iToI;
   XCTAssertTrue([message1a hasA]);
   XCTAssertFalse([message1b hasA]);
-  [message1a.a.iToI setValue:1 forKey:2];
+  [message1a.a.iToI setInt32:1 forKey:2];
   XCTAssertTrue([message1a hasA]);
   XCTAssertTrue([message1b hasA]);
   XCTAssertEqual(message1a.a.iToI, message1b.a.iToI);
@@ -1224,7 +1224,7 @@
   // with different objects that are equal).
   TestRecursiveMessageWithRepeatedField *message3 =
       [TestRecursiveMessageWithRepeatedField message];
-  message3.iToI = [GPBInt32Int32Dictionary dictionaryWithValue:10 forKey:20];
+  message3.iToI = [GPBInt32Int32Dictionary dictionaryWithInt32:10 forKey:20];
   message3.strToStr =
       [NSMutableDictionary dictionaryWithObject:@"abc" forKey:@"123"];
   XCTAssertNotNil(message.iToI);
@@ -1292,7 +1292,7 @@
     XCTAssertFalse([message hasA]);
     GPBInt32Int32Dictionary *iToI = [message.a.iToI retain];
     XCTAssertEqual(iToI->_autocreator, message.a);  // Pointer comparision
-    message.a.iToI = [GPBInt32Int32Dictionary dictionaryWithValue:6 forKey:7];
+    message.a.iToI = [GPBInt32Int32Dictionary dictionaryWithInt32:6 forKey:7];
     XCTAssertTrue([message hasA]);
     XCTAssertNotEqual(message.a.iToI, iToI);  // Pointer comparision
     XCTAssertNil(iToI->_autocreator);

--- a/objectivec/Tests/GPBSwiftTests.swift
+++ b/objectivec/Tests/GPBSwiftTests.swift
@@ -53,12 +53,12 @@ class GPBBridgeTests: XCTestCase {
     msg.repeatedStringArray.addObject("pqr")
     msg.repeatedEnumArray.addValue(Message2_Enum.Bar.rawValue)
     msg.repeatedEnumArray.addValue(Message2_Enum.Baz.rawValue)
-    msg.mapInt32Int32.setValue(400, forKey:500)
-    msg.mapInt32Int32.setValue(401, forKey:501)
+    msg.mapInt32Int32.setInt32(400, forKey:500)
+    msg.mapInt32Int32.setInt32(401, forKey:501)
     msg.mapStringString.setObject("foo", forKey:"bar")
     msg.mapStringString.setObject("abc", forKey:"xyz")
-    msg.mapInt32Enum.setValue(Message2_Enum.Bar.rawValue, forKey:600)
-    msg.mapInt32Enum.setValue(Message2_Enum.Baz.rawValue, forKey:601)
+    msg.mapInt32Enum.setEnum(Message2_Enum.Bar.rawValue, forKey:600)
+    msg.mapInt32Enum.setEnum(Message2_Enum.Baz.rawValue, forKey:601)
 
     // Check has*.
     XCTAssertTrue(msg.hasOptionalInt32)
@@ -90,18 +90,18 @@ class GPBBridgeTests: XCTestCase {
     XCTAssertEqual(msg.repeatedEnumArray.valueAtIndex(1), Message2_Enum.Baz.rawValue)
     XCTAssertEqual(msg.repeatedInt64Array.count, UInt(0))
     XCTAssertEqual(msg.mapInt32Int32.count, UInt(2))
-    var intValue: Int32 = 0;
-    XCTAssertTrue(msg.mapInt32Int32.valueForKey(500, value:&intValue))
+    var intValue: Int32 = 0
+    XCTAssertTrue(msg.mapInt32Int32.getInt32(&intValue, forKey: 500))
     XCTAssertEqual(intValue, Int32(400))
-    XCTAssertTrue(msg.mapInt32Int32.valueForKey(501, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Int32.getInt32(&intValue, forKey: 501))
     XCTAssertEqual(intValue, Int32(401))
     XCTAssertEqual(msg.mapStringString.count, Int(2))
     XCTAssertEqual(msg.mapStringString.objectForKey("bar") as? String, "foo")
     XCTAssertEqual(msg.mapStringString.objectForKey("xyz") as? String, "abc")
     XCTAssertEqual(msg.mapInt32Enum.count, UInt(2))
-    XCTAssertTrue(msg.mapInt32Enum.valueForKey(600, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Enum.getEnum(&intValue, forKey:600))
     XCTAssertEqual(intValue, Message2_Enum.Bar.rawValue)
-    XCTAssertTrue(msg.mapInt32Enum.valueForKey(601, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Enum.getEnum(&intValue, forKey:601))
     XCTAssertEqual(intValue, Message2_Enum.Baz.rawValue)
 
     // Clearing a string with nil.
@@ -151,11 +151,11 @@ class GPBBridgeTests: XCTestCase {
     msg.repeatedEnumArray.addValue(Message3_Enum.Bar.rawValue)
     msg.repeatedEnumArray.addRawValue(666)
     SetMessage3_OptionalEnum_RawValue(msg2, 666)
-    msg.mapInt32Int32.setValue(400, forKey:500)
-    msg.mapInt32Int32.setValue(401, forKey:501)
+    msg.mapInt32Int32.setInt32(400, forKey:500)
+    msg.mapInt32Int32.setInt32(401, forKey:501)
     msg.mapStringString.setObject("foo", forKey:"bar")
     msg.mapStringString.setObject("abc", forKey:"xyz")
-    msg.mapInt32Enum.setValue(Message2_Enum.Bar.rawValue, forKey:600)
+    msg.mapInt32Enum.setEnum(Message2_Enum.Bar.rawValue, forKey:600)
     // "proto3" syntax lets enum get unknown values.
     msg.mapInt32Enum.setRawValue(666, forKey:601)
 
@@ -183,20 +183,20 @@ class GPBBridgeTests: XCTestCase {
     XCTAssertEqual(msg2.optionalEnum, Message3_Enum.GPBUnrecognizedEnumeratorValue)
     XCTAssertEqual(Message3_OptionalEnum_RawValue(msg2), Int32(666))
     XCTAssertEqual(msg.mapInt32Int32.count, UInt(2))
-    var intValue: Int32 = 0;
-    XCTAssertTrue(msg.mapInt32Int32.valueForKey(500, value:&intValue))
+    var intValue: Int32 = 0
+    XCTAssertTrue(msg.mapInt32Int32.getInt32(&intValue, forKey:500))
     XCTAssertEqual(intValue, Int32(400))
-    XCTAssertTrue(msg.mapInt32Int32.valueForKey(501, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Int32.getInt32(&intValue, forKey:501))
     XCTAssertEqual(intValue, Int32(401))
     XCTAssertEqual(msg.mapStringString.count, Int(2))
     XCTAssertEqual(msg.mapStringString.objectForKey("bar") as? String, "foo")
     XCTAssertEqual(msg.mapStringString.objectForKey("xyz") as? String, "abc")
     XCTAssertEqual(msg.mapInt32Enum.count, UInt(2))
-    XCTAssertTrue(msg.mapInt32Enum.valueForKey(600, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Enum.getEnum(&intValue, forKey:600))
     XCTAssertEqual(intValue, Message2_Enum.Bar.rawValue)
-    XCTAssertTrue(msg.mapInt32Enum.valueForKey(601, value:&intValue))
+    XCTAssertTrue(msg.mapInt32Enum.getEnum(&intValue, forKey:601))
     XCTAssertEqual(intValue, Message3_Enum.GPBUnrecognizedEnumeratorValue.rawValue)
-    XCTAssertTrue(msg.mapInt32Enum.valueForKey(601, rawValue:&intValue))
+    XCTAssertTrue(msg.mapInt32Enum.getRawValue(&intValue, forKey:601))
     XCTAssertEqual(intValue, 666)
 
     // Clearing a string with nil.
@@ -439,8 +439,8 @@ class GPBBridgeTests: XCTestCase {
     msg.optionalGroup.a = 102
     msg.repeatedStringArray.addObject("abc")
     msg.repeatedStringArray.addObject("def")
-    msg.mapInt32Int32.setValue(200, forKey:300)
-    msg.mapInt32Int32.setValue(201, forKey:201)
+    msg.mapInt32Int32.setInt32(200, forKey:300)
+    msg.mapInt32Int32.setInt32(201, forKey:201)
     msg.mapStringString.setObject("foo", forKey:"bar")
     msg.mapStringString.setObject("abc", forKey:"xyz")
 

--- a/objectivec/Tests/GPBTestUtilities.m
+++ b/objectivec/Tests/GPBTestUtilities.m
@@ -1089,19 +1089,19 @@ const uint32_t kGPBDefaultRepeatCount = 2;
 
 - (void)setAllMapFields:(TestMap *)message numEntries:(uint32_t)count {
   for (uint32_t i = 0; i < count; i++) {
-    [message.mapInt32Int32 setValue:(i + 1) forKey:100 + i * 100];
-    [message.mapInt64Int64 setValue:(i + 1) forKey:101 + i * 100];
-    [message.mapUint32Uint32 setValue:(i + 1) forKey:102 + i * 100];
-    [message.mapUint64Uint64 setValue:(i + 1) forKey:103 + i * 100];
-    [message.mapSint32Sint32 setValue:(i + 1) forKey:104 + i * 100];
-    [message.mapSint64Sint64 setValue:(i + 1) forKey:105 + i * 100];
-    [message.mapFixed32Fixed32 setValue:(i + 1) forKey:106 + i * 100];
-    [message.mapFixed64Fixed64 setValue:(i + 1) forKey:107 + i * 100];
-    [message.mapSfixed32Sfixed32 setValue:(i + 1) forKey:108 + i * 100];
-    [message.mapSfixed64Sfixed64 setValue:(i + 1) forKey:109 + i * 100];
-    [message.mapInt32Float setValue:(i + 1) forKey:110 + i * 100];
-    [message.mapInt32Double setValue:(i + 1) forKey:111 + i * 100];
-    [message.mapBoolBool setValue:((i % 2) == 1) forKey:((i % 2) == 0)];
+    [message.mapInt32Int32 setInt32:(i + 1) forKey:100 + i * 100];
+    [message.mapInt64Int64 setInt64:(i + 1) forKey:101 + i * 100];
+    [message.mapUint32Uint32 setUInt32:(i + 1) forKey:102 + i * 100];
+    [message.mapUint64Uint64 setUInt64:(i + 1) forKey:103 + i * 100];
+    [message.mapSint32Sint32 setInt32:(i + 1) forKey:104 + i * 100];
+    [message.mapSint64Sint64 setInt64:(i + 1) forKey:105 + i * 100];
+    [message.mapFixed32Fixed32 setUInt32:(i + 1) forKey:106 + i * 100];
+    [message.mapFixed64Fixed64 setUInt64:(i + 1) forKey:107 + i * 100];
+    [message.mapSfixed32Sfixed32 setInt32:(i + 1) forKey:108 + i * 100];
+    [message.mapSfixed64Sfixed64 setInt64:(i + 1) forKey:109 + i * 100];
+    [message.mapInt32Float setFloat:(i + 1) forKey:110 + i * 100];
+    [message.mapInt32Double setDouble:(i + 1) forKey:111 + i * 100];
+    [message.mapBoolBool setBool:((i % 2) == 1) forKey:((i % 2) == 0)];
 
     NSString *keyStr = [[NSString alloc] initWithFormat:@"%d", 112 + i * 100];
     NSString *dataStr = [[NSString alloc] initWithFormat:@"%d", i + 1];
@@ -1114,8 +1114,8 @@ const uint32_t kGPBDefaultRepeatCount = 2;
     [data release];
 
     [message.mapInt32Enum
-        setValue:(i % 2) ? MapEnum_MapEnumBar : MapEnum_MapEnumBaz
-          forKey:114 + i * 100];
+        setEnum:(i % 2) ? MapEnum_MapEnumBar : MapEnum_MapEnumBaz
+         forKey:114 + i * 100];
 
     ForeignMessage *subMsg = [[ForeignMessage alloc] init];
     subMsg.c = i + 1;


### PR DESCRIPTION
Note: Breaking API change on the Dictionary classes.

The numeric value classes were using "Value" in the naming, but this silently
collided with the KVC category on NSObject; meaning KVC code could break up a
keypath and call these selectors with the wrong types leading to crashes (even
though the code all would compile cleanly).

- Rename the methods to use the "type" instead of literal "Value".
- Update all the impls and tests.
- Enable the warning that will catch issues like this in the future.

Fixes https://github.com/google/protobuf/issues/1616