### PR TITLE
Add JsonParseOptions to ignore unknown fields

### DIFF
--- a/src/google/protobuf/util/internal/proto_writer.cc
+++ b/src/google/protobuf/util/internal/proto_writer.cc
@@ -71,6 +71,7 @@ ProtoWriter::ProtoWriter(TypeResolver* type_resolver,
       adapter_(&buffer_),
       stream_(new CodedOutputStream(&adapter_)),
       listener_(listener),
+      ignore_unknown_fields_(false),
       invalid_depth_(0),
       tracker_(new ObjectLocationTracker()) {}
 
@@ -88,6 +89,7 @@ ProtoWriter::ProtoWriter(const TypeInfo* typeinfo,
       adapter_(&buffer_),
       stream_(new CodedOutputStream(&adapter_)),
       listener_(listener),
+      ignore_unknown_fields_(false),
       invalid_depth_(0),
       tracker_(new ObjectLocationTracker()) {}
 
@@ -692,7 +694,9 @@ const google::protobuf::Field* ProtoWriter::Lookup(
   }
   const google::protobuf::Field* field =
       typeinfo_->FindField(&e->type(), unnormalized_name);
-  if (field == NULL) InvalidName(unnormalized_name, "Cannot find field.");
+  if (field == NULL && !ignore_unknown_fields_) {
+    InvalidName(unnormalized_name, "Cannot find field.");
+  }
   return field;
 }
 

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -142,6 +142,10 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
 
   const TypeInfo* typeinfo() { return typeinfo_; }
 
+  void set_ignore_unknown_fields(bool ignore_unknown_fields) {
+    ignore_unknown_fields_ = ignore_unknown_fields;
+  }
+
  protected:
   class LIBPROTOBUF_EXPORT ProtoElement : public BaseElement, public LocationTrackerInterface {
    public:
@@ -240,7 +244,8 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
 
   // Lookup the field in the current element. Looks in the base descriptor
   // and in any extension. This will report an error if the field cannot be
-  // found or if multiple matching extensions are found.
+  // found when ignore_unknown_names_ is false or if multiple matching
+  // extensions are found.
   const google::protobuf::Field* Lookup(StringPiece name);
 
   // Lookup the field type in the type descriptor. Returns NULL if the type
@@ -292,6 +297,9 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
 
   // Indicates whether we finished writing root message completely.
   bool done_;
+
+  // If true, don't report unknown field names to the listener.
+  bool ignore_unknown_fields_;
 
   // Variable for internal state processing:
   // element_    : the current element.

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -63,7 +63,9 @@ ProtoStreamObjectWriter::ProtoStreamObjectWriter(
     : ProtoWriter(type_resolver, type, output, listener),
       master_type_(type),
       current_(NULL),
-      options_(options) {}
+      options_(options) {
+  set_ignore_unknown_fields(options_.ignore_unknown_fields);
+}
 
 ProtoStreamObjectWriter::ProtoStreamObjectWriter(
     const TypeInfo* typeinfo, const google::protobuf::Type& type,

--- a/src/google/protobuf/util/internal/protostream_objectwriter.h
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.h
@@ -83,7 +83,12 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
     // preserve integer precision.
     bool struct_integers_as_strings;
 
-    Options() : struct_integers_as_strings(false) {}
+    // Not treat unknown fields as an error. If there is an unknown fields,
+    // just ignore it and continue to process the rest.
+    bool ignore_unknown_fields;
+
+    Options()
+        : struct_integers_as_strings(false), ignore_unknown_fields(false) {}
 
     // Default instance of Options with all options set to defaults.
     static const Options& Defaults() {

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -44,7 +44,14 @@ class ZeroCopyOutputStream;
 }  // namespace io
 namespace util {
 
-struct JsonOptions {
+struct JsonParseOptions {
+  // Whether to ignore unknown JSON fields during parsing
+  bool ignore_unknown_fields;
+
+  JsonParseOptions() : ignore_unknown_fields(false) {}
+};
+
+struct JsonPrintOptions {
   // Whether to add spaces, line breaks and indentation to make the JSON output
   // easy to read.
   bool add_whitespace;
@@ -54,10 +61,13 @@ struct JsonOptions {
   // behavior and print primitive fields regardless of their values.
   bool always_print_primitive_fields;
 
-  JsonOptions() : add_whitespace(false),
-                  always_print_primitive_fields(false) {
+  JsonPrintOptions() : add_whitespace(false),
+                       always_print_primitive_fields(false) {
   }
 };
+
+// DEPRECATED. Use JsonPrintOptions instead.
+typedef JsonPrintOptions JsonOptions;
 
 // Converts protobuf binary data to JSON.
 // The conversion will fail if:
@@ -70,14 +80,14 @@ util::Status BinaryToJsonStream(
     const string& type_url,
     io::ZeroCopyInputStream* binary_input,
     io::ZeroCopyOutputStream* json_output,
-    const JsonOptions& options);
+    const JsonPrintOptions& options);
 
 inline util::Status BinaryToJsonStream(
     TypeResolver* resolver, const string& type_url,
     io::ZeroCopyInputStream* binary_input,
     io::ZeroCopyOutputStream* json_output) {
   return BinaryToJsonStream(resolver, type_url, binary_input, json_output,
-                            JsonOptions());
+                            JsonPrintOptions());
 }
 
 LIBPROTOBUF_EXPORT util::Status BinaryToJsonString(
@@ -85,14 +95,14 @@ LIBPROTOBUF_EXPORT util::Status BinaryToJsonString(
     const string& type_url,
     const string& binary_input,
     string* json_output,
-    const JsonOptions& options);
+    const JsonPrintOptions& options);
 
 inline util::Status BinaryToJsonString(TypeResolver* resolver,
                                          const string& type_url,
                                          const string& binary_input,
                                          string* json_output) {
   return BinaryToJsonString(resolver, type_url, binary_input, json_output,
-                            JsonOptions());
+                            JsonPrintOptions());
 }
 
 // Converts JSON data to protobuf binary format.
@@ -100,18 +110,37 @@ inline util::Status BinaryToJsonString(TypeResolver* resolver,
 //   1. TypeResolver fails to resolve a type.
 //   2. input is not valid JSON format, or conflicts with the type
 //      information returned by TypeResolver.
-//   3. input has unknown fields.
 util::Status JsonToBinaryStream(
     TypeResolver* resolver,
     const string& type_url,
     io::ZeroCopyInputStream* json_input,
-    io::ZeroCopyOutputStream* binary_output);
+    io::ZeroCopyOutputStream* binary_output,
+    const JsonParseOptions& options);
+
+inline util::Status JsonToBinaryStream(
+    TypeResolver* resolver,
+    const string& type_url,
+    io::ZeroCopyInputStream* json_input,
+    io::ZeroCopyOutputStream* binary_output) {
+  return JsonToBinaryStream(resolver, type_url, json_input, binary_output,
+                            JsonParseOptions());
+}
 
 LIBPROTOBUF_EXPORT util::Status JsonToBinaryString(
     TypeResolver* resolver,
     const string& type_url,
     const string& json_input,
-    string* binary_output);
+    string* binary_output,
+    const JsonParseOptions& options);
+
+inline util::Status JsonToBinaryString(
+    TypeResolver* resolver,
+    const string& type_url,
+    const string& json_input,
+    string* binary_output) {
+  return JsonToBinaryString(resolver, type_url, json_input, binary_output,
+                            JsonParseOptions());
+}
 
 namespace internal {
 // Internal helper class. Put in the header so we can write unit-tests for it.


### PR DESCRIPTION
- add JsonParseOptions for JsonToBinaryString allow unknown fields
- rename current JsonOptions to JsonPrintOptions