### PR TITLE
 Added optimisation to RepeatedField<T>.Add(IEnumerabl<T> values)

### DIFF
--- a/csharp/src/Google.Protobuf.Test/packages.config
+++ b/csharp/src/Google.Protobuf.Test/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" userInstalled="true" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" userInstalled="true" />
-</packages>

--- a/csharp/src/Google.Protobuf.Test/packages.config
+++ b/csharp/src/Google.Protobuf.Test/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" userInstalled="true" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" userInstalled="true" />
+</packages>

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -320,10 +320,20 @@ namespace Google.Protobuf.Collections
             {
                 throw new ArgumentNullException("values");
             }
-            // TODO: Check for ICollection and get the Count, to optimize?
-            foreach (T item in values)
+
+            ICollection collection = values as ICollection;
+            if (collection != null)
             {
-                Add(item);
+                this.EnsureSize(this.count + collection.Count);
+                collection.CopyTo(this.array, this.count);
+                this.count += collection.Count;
+            }
+            else
+            {
+                foreach (T item in values)
+                {
+                    Add(item);
+                }
             }
         }
 


### PR DESCRIPTION
Code now checks for Icollection and makes use of ICollection.CopyTo. This would increase performance when adding llarge sequence.

Also added constructors. One constructors with capacity. This constructor shall be used whenever we know the capacity that we'll require thus avoiding wasting of memory.

Generally speaking, this code seems mostly borrowed from System.Collections.Generic.List<T> why not refactor RepeatedField to be just a kind of wrapper around List<T> ?