### PR TITLE
Get value from text format name in GPBEnumDescriptor

### DIFF
--- a/objectivec/GPBDescriptor.h
+++ b/objectivec/GPBDescriptor.h
@@ -123,6 +123,7 @@ typedef NS_ENUM(uint8_t, GPBFieldType) {
 - (BOOL)getValue:(nullable int32_t *)outValue forEnumName:(NSString *)name;
 
 - (nullable NSString *)textFormatNameForValue:(int32_t)number;
+- (BOOL)getValue:(nullable int32_t *)outValue forEnumTextFormatName:(NSString *)textFormatName;
 
 @end
 

--- a/objectivec/GPBDescriptor.m
+++ b/objectivec/GPBDescriptor.m
@@ -745,6 +745,23 @@ uint32_t GPBFieldAlternateTag(GPBFieldDescriptor *self) {
   return NO;
 }
 
+- (BOOL)getValue:(int32_t *)outValue forEnumTextFormatName:(NSString *)textFormatName;
+{
+    if (nameOffsets_ == NULL) [self calcValueNameOffsets];
+
+    for (uint32_t i = 0; i < valueCount_; ++i) {
+        int32_t value = values_[i];
+        NSString *valueTextFormatName = [self textFormatNameForValue:value];
+        if ([valueTextFormatName isEqual:textFormatName]) {
+            if (outValue) {
+                *outValue = value;
+            }
+            return YES;
+        }
+    }
+    return NO;
+}
+
 - (NSString *)textFormatNameForValue:(int32_t)number {
   if (nameOffsets_ == NULL) [self calcValueNameOffsets];
 

--- a/objectivec/Tests/GPBDescriptorTests.m
+++ b/objectivec/Tests/GPBDescriptorTests.m
@@ -125,6 +125,12 @@
       [descriptor getValue:&value forEnumName:@"TestAllTypes_NestedEnum_Baz"]);
   XCTAssertEqual(value, TestAllTypes_NestedEnum_Baz);
 
+  // TextFormat
+  enumName = [descriptor textFormatNameForValue:1];
+  XCTAssertNotNil(enumName);
+  XCTAssertTrue([descriptor getValue:&value forEnumTextFormatName:@"FOO"]);
+  XCTAssertEqual(value, TestAllTypes_NestedEnum_Foo);
+
   // Bad values
   enumName = [descriptor enumNameForValue:0];
   XCTAssertNil(enumName);
@@ -134,6 +140,8 @@
                           forEnumName:@"TestAllTypes_NestedEnum_Unknown"]);
   XCTAssertFalse([descriptor getValue:NULL
                           forEnumName:@"TestAllTypes_NestedEnum_Unknown"]);
+  XCTAssertFalse([descriptor getValue:NULL forEnumTextFormatName:@"Unknown"]);
+  XCTAssertFalse([descriptor getValue:&value forEnumTextFormatName:@"Unknown"]);
 }
 
 - (void)testEnumValueValidator {


### PR DESCRIPTION
/cc @thomasvl @efirestone

Given code generated with C++

```c++
enum EnumType {
  OPTION_1 = 1,
  OPTION_2 = 2,
  OPTION_3 = 3
};
```
Using objc generator and using a prefix `PBTesting`:
```objc
typedef GPB_ENUM(PBTestingEnumType) {
  PBTestingEnumType_Option1 = 1,
  PBTestingEnumType_Option2 = 2,
  PBTestingEnumType_Option3 = 3,
};
```

The best way for us to get a value is to use text format since that has not changed between our transition from C++ generator to ObjC generator. This change adds a method to pull a value using text format instead.