### PR TITLE
Update C# build to use netstandard1.0.

### DIFF
--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -1,24 +1,19 @@
-#
-# 	Untracked directories
-#
-src/AddressBook/bin
-src/AddressBook/obj
-src/Google.Protobuf/bin/
-src/Google.Protobuf/obj/
-src/Google.Protobuf.Conformance/bin/
-src/Google.Protobuf.Conformance/obj/
-src/Google.Protobuf.Test/bin/
-src/Google.Protobuf.Test/obj/
-src/Google.Protobuf.JsonDump/bin/
-src/Google.Protobuf.JsonDump/obj/
-mono/bin
-mono/tmp
+# Package management
+project.lock.json
+.vs
+
+# Output directories
+bin
+obj
+tmp
+
+# Miscellaneous files
+# (possibly out of date...)
+
 mono/protoc
 build_output
 build_temp
 build/msbuild*.log
-lib/Microsoft.Silverlight.Testing
-lib/NUnit
 
 #
 # 	Untracked files

--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -1,6 +1,9 @@
 # Package management
 project.lock.json
 .vs
+*.nuget.targets
+*.nuget.props
+
 
 # Output directories
 bin

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -11,11 +11,12 @@
     <RootNamespace>Google.Protobuf</RootNamespace>
     <AssemblyName>Google.Protobuf</AssemblyName>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -67,11 +68,6 @@
     <AssemblyOriginatorKeyFile>..\..\keys\Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="ByteArray.cs" />
     <Compile Include="ByteString.cs" />
@@ -147,17 +143,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Google.Protobuf.nuspec" />
-    <None Include="packages.config" />
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\packages\NuSpec.ReferenceGenerator.1.4.1\build\portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\NuSpec.ReferenceGenerator.targets" Condition="Exists('..\packages\NuSpec.ReferenceGenerator.1.4.1\build\portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\NuSpec.ReferenceGenerator.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NuSpec.ReferenceGenerator.1.4.1\build\portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\NuSpec.ReferenceGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuSpec.ReferenceGenerator.1.4.1\build\portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\NuSpec.ReferenceGenerator.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuget.targets
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuget.targets
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
-    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
-  </PropertyGroup>
-  <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\2.0.0-beta-bld14\build\netstandard1.0\NuSpec.ReferenceGenerator.targets" Condition="Exists('$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\2.0.0-beta-bld14\build\netstandard1.0\NuSpec.ReferenceGenerator.targets')" />
-  </ImportGroup>
-</Project>

--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuget.targets
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuget.targets
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup>
+    <Import Project="$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\2.0.0-beta-bld14\build\netstandard1.0\NuSpec.ReferenceGenerator.targets" Condition="Exists('$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\2.0.0-beta-bld14\build\netstandard1.0\NuSpec.ReferenceGenerator.targets')" />
+  </ImportGroup>
+</Project>

--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
@@ -24,7 +24,7 @@
       <group targetFramework="monotouch" />
       <group targetFramework="monoandroid" />
       <!-- Dependencies for newer, more granular platforms (.NET Core etc) -->
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.0">
         <dependency id="System.Collections" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.0" />
         <dependency id="System.Globalization" version="4.0.0" />
@@ -43,12 +43,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin/ReleaseSigned/Google.Protobuf.dll" target="lib/portable-net45+netcore45+wpa81+wp8" />
-    <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/portable-net45+netcore45+wpa81+wp8" />
-    <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/portable-net45+netcore45+wpa81+wp8" />
-    <file src="bin/ReleaseSigned/Google.Protobuf.dll" target="lib/dotnet" />
-    <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/dotnet" />
-    <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/dotnet" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.dll" target="lib/netstandard1.0" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.pdb" target="lib/netstandard1.0" />
+    <file src="bin/ReleaseSigned/Google.Protobuf.xml" target="lib/netstandard1.0" />
     <file src="**\*.cs" target="src" />
   </files>
 </package>

--- a/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.nuspec
@@ -25,20 +25,20 @@
       <group targetFramework="monoandroid" />
       <!-- Dependencies for newer, more granular platforms (.NET Core etc) -->
       <group targetFramework="netstandard1.0">
-        <dependency id="System.Collections" version="4.0.0" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.0" />
-        <dependency id="System.Globalization" version="4.0.0" />
-        <dependency id="System.IO" version="4.0.0" />
-        <dependency id="System.Linq" version="4.0.0" />
-        <dependency id="System.Linq.Expressions" version="4.0.0" />
-        <dependency id="System.ObjectModel" version="4.0.0" />
-        <dependency id="System.Reflection" version="4.0.0" />
-        <dependency id="System.Reflection.Extensions" version="4.0.0" />
-        <dependency id="System.Runtime" version="4.0.0" />
-        <dependency id="System.Runtime.Extensions" version="4.0.0" />
-        <dependency id="System.Text.Encoding" version="4.0.0" />
-        <dependency id="System.Text.RegularExpressions" version="4.0.0" />
-        <dependency id="System.Threading" version="4.0.0" />
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.IO" version="4.1.0" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.1.0" />
+        <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.Encoding" version="4.0.11" />
+        <dependency id="System.Text.RegularExpressions" version="4.1.0" />
+        <dependency id="System.Threading" version="4.0.11" />
       </group>
     </dependencies>
   </metadata>

--- a/csharp/src/Google.Protobuf/packages.config
+++ b/csharp/src/Google.Protobuf/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NuSpec.ReferenceGenerator" version="1.4.1" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
-</packages>

--- a/csharp/src/Google.Protobuf/project.json
+++ b/csharp/src/Google.Protobuf/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0",
+    "NuSpec.ReferenceGenerator": { "type": "build", "version": "1.4.2" }
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/csharp/src/Google.Protobuf/project.json
+++ b/csharp/src/Google.Protobuf/project.json
@@ -1,9 +1,8 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.0",
-    "NuSpec.ReferenceGenerator": { "type": "build", "version": "1.4.2" }
+    "NuSpec.ReferenceGenerator": { "type": "build", "version": "2.0.0-beta-bld14" }
   },
   "frameworks": {
     "netstandard1.0": {}


### PR DESCRIPTION
This should now be portable everywhere (after a nuget update, at least).

Fixes issue #966.

// cc @onovotny for extra review if possible :)