### PR TITLE
Fix some failing travis tests.

### DIFF
--- a/objectivec/google/protobuf/Any.pbobjc.h
+++ b/objectivec/google/protobuf/Any.pbobjc.h
@@ -71,6 +71,16 @@ typedef GPB_ENUM(GPBAny_FieldNumber) {
 ///       foo = any.unpack(Foo.class);
 ///     }
 ///
+///  Example 3: Pack and unpack a message in Python.
+///
+///     foo = Foo(...)
+///     any = Any()
+///     any.Pack(foo)
+///     ...
+///     if any.Is(Foo.DESCRIPTOR):
+///       any.Unpack(foo)
+///       ...
+///
 /// The pack methods provided by protobuf library will by default use
 /// 'type.googleapis.com/full.type.name' as the type URL and the unpack
 /// methods only use the fully qualified type name after the last '/'
@@ -110,10 +120,10 @@ typedef GPB_ENUM(GPBAny_FieldNumber) {
 /// A URL/resource name whose content describes the type of the
 /// serialized protocol buffer message.
 ///
-/// For URLs which use the schema `http`, `https`, or no schema, the
+/// For URLs which use the scheme `http`, `https`, or no scheme, the
 /// following restrictions and interpretations apply:
 ///
-/// * If no schema is provided, `https` is assumed.
+/// * If no scheme is provided, `https` is assumed.
 /// * The last segment of the URL's path must represent the fully
 ///   qualified name of the type (as in `path/google.protobuf.Duration`).
 ///   The name should be in a canonical form (e.g., leading "." is
@@ -126,7 +136,7 @@ typedef GPB_ENUM(GPBAny_FieldNumber) {
 ///   on changes to types. (Use versioned type names to manage
 ///   breaking changes.)
 ///
-/// Schemas other than `http`, `https` (or the empty schema) might be
+/// Schemes other than `http`, `https` (or the empty scheme) might be
 /// used with implementation specific semantics.
 @property(nonatomic, readwrite, copy, null_resettable) NSString *typeURL;
 

--- a/objectivec/google/protobuf/FieldMask.pbobjc.h
+++ b/objectivec/google/protobuf/FieldMask.pbobjc.h
@@ -113,6 +113,58 @@ typedef GPB_ENUM(GPBFieldMask_FieldNumber) {
 /// describe the updated values, the API ignores the values of all
 /// fields not covered by the mask.
 ///
+/// If a repeated field is specified for an update operation, the existing
+/// repeated values in the target resource will be overwritten by the new values.
+/// Note that a repeated field is only allowed in the last position of a field
+/// mask.
+///
+/// If a sub-message is specified in the last position of the field mask for an
+/// update operation, then the existing sub-message in the target resource is
+/// overwritten. Given the target message:
+///
+///     f {
+///       b {
+///         d : 1
+///         x : 2
+///       }
+///       c : 1
+///     }
+///
+/// And an update message:
+///
+///     f {
+///       b {
+///         d : 10
+///       }
+///     }
+///
+/// then if the field mask is:
+///
+///  paths: "f.b"
+///
+/// then the result will be:
+///
+///     f {
+///       b {
+///         d : 10
+///       }
+///       c : 1
+///     }
+///
+/// However, if the update mask was:
+///
+///  paths: "f.b.d"
+///
+/// then the result would be:
+///
+///     f {
+///       b {
+///         d : 10
+///         x : 2
+///       }
+///       c : 1
+///     }
+///
 /// In order to reset a field's value to the default, the field must
 /// be in the mask and set to the default value in the provided resource.
 /// Hence, in order to reset all fields of a resource, provide a default

--- a/objectivec/google/protobuf/SourceContext.pbobjc.h
+++ b/objectivec/google/protobuf/SourceContext.pbobjc.h
@@ -50,7 +50,7 @@ typedef GPB_ENUM(GPBSourceContext_FieldNumber) {
 @interface GPBSourceContext : GPBMessage
 
 /// The path-qualified name of the .proto file that contained the associated
-/// protobuf element.  For example: `"google/protobuf/source.proto"`.
+/// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
 @property(nonatomic, readwrite, copy, null_resettable) NSString *fileName;
 
 @end

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -375,6 +375,7 @@ libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/java/java_message_builder_lite.h    \
   google/protobuf/compiler/java/java_name_resolver.cc          \
   google/protobuf/compiler/java/java_name_resolver.h           \
+  google/protobuf/compiler/java/java_options.h                 \
   google/protobuf/compiler/java/java_primitive_field.cc        \
   google/protobuf/compiler/java/java_primitive_field.h         \
   google/protobuf/compiler/java/java_primitive_field_lite.cc   \


### PR DESCRIPTION
Travis caught up last night and revealed some broken tests:
https://travis-ci.org/google/protobuf/builds/141462983

This change fixes the cppdist test and the objectivec test.
1. Add missing header file to Makefile.am.
2. Re-generate objectivec generated code for well-known types.
