### PR TITLE
Properly camel-case file-level extensions for JSPB

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -3050,7 +3050,8 @@ void Generator::GenerateFile(const GeneratorOptions& options,
   // This will ensure that the file-level object will be declared to hold
   // the extensions.
   for (int i = 0; i < file->extension_count(); i++) {
-    provided.insert(file->extension(i)->full_name());
+    provided.insert(GetPath(options, file) + "." +
+                    JSObjectFieldName(options, file->extension(i)));
   }
 
   FindProvidesForFile(options, printer, file, &provided);


### PR DESCRIPTION
The current JSPB generator does not camel-case file-level extension
names where they appear in goog.exportSymbol(...), resulting in a
mismatch between the goog.exportSymbol() line and the actual code. This
only affects JSPB when it is used with an import style other than
Closure.

Here is a diff of the generated code from js/test2.proto before and
after this change:
--- js/test2_pb.js	2016-07-01 11:28:32.263643143 -0700
+++ js/test2_pb.js-new	2016-07-01 11:28:05.391294428 -0700
@@ -9,10 +9,10 @@
 var goog = jspb;
 var global = Function('return this')();

-goog.exportSymbol('jspb.test.floating_msg_field', null, global);
-goog.exportSymbol('jspb.test.floating_str_field', null, global);
 goog.exportSymbol('proto.jspb.test.ExtensionMessage', null, global);
 goog.exportSymbol('proto.jspb.test.TestExtensionsMessage', null, global);
+goog.exportSymbol('proto.jspb.test.floatingMsgField', null, global);
+goog.exportSymbol('proto.jspb.test.floatingStrField', null, global);

 /**
  * Generated by JsPbCodeGenerator.