### PR TITLE
Remove arbitrary "proto." namespace prefix for generated js

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -202,7 +202,7 @@ string GetPath(const GeneratorOptions& options,
   if (!options.namespace_prefix.empty()) {
     return options.namespace_prefix;
   } else if (!file->package().empty()) {
-    return "proto." + file->package();
+    return file->package();
   } else {
     return "proto";
   }


### PR DESCRIPTION
There is likely more that can be done to rectify this issue, but this was a simple fix to make package names match more or less what one would expect in the other generated languages such as C++.  There is a related issue in that passing a namespace_prefix overrides all generated namespaces, so that cross-namespace proto imports result in invalid generated code if the parameter is present.
