### PR TITLE
Add ability to parse to and from Python native dictionary

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -97,6 +97,9 @@ class JsonFormatBase(unittest.TestCase):
     json_format.Parse(json_format.MessageToJson(message),
                       parsed_message)
     self.assertEqual(message, parsed_message)
+    json_format.ParseDict(json_format.MessageToJson(message, as_str=False),
+                          parsed_message)
+    self.assertEqual(message, parsed_message)
 
   def CheckError(self, text, error_message):
     message = json_format_proto3_pb2.TestMessage()


### PR DESCRIPTION
Hello maintainers, I would like to add the ability for the Python module's [`json_format`](https://github.com/google/protobuf/blob/master/python/google/protobuf/json_format.py#L89) to work directly with native Python `dict`. I have found it necessary at times to go from a `protobuf` instance object directly to a `dict`. Currently, serialization to and from a `JSON` string is supported. Meaning that if I have a `protobuf` and want a `dict`, the conversion function transforms the `protobuf` privately into a `dict`, and then calls `json.dumps` on that `dict` resulting in a `str`, the end user then has to `json.loads` that `str` back to a `dict`:

```
protobuf - > dict -> str -> dict
```

I want to make the portion where we call `json.dumps` optional for users who would like a native Python dictionary. The logic works similarly on the inverse, when going from a Python `dict` to a `protobuf` on parse, the user is required to serialize their `dict` with `json.dumps` before calling the Parse function, which then immediately `json.loads` the dict back into memory:

```
dict -> str -> dict -> protobuf
```

My pull request adds this functionality to the [`json_format`](https://github.com/google/protobuf/blob/master/python/google/protobuf/json_format.py#L89) file and updates the unit tests to account for the changes specified.
