### PR TITLE
Remove unnecessary reflection call

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Compatibility/TypeExtensionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Compatibility/TypeExtensionsTest.cs
@@ -34,6 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+#if !DOTNET35
 namespace Google.Protobuf.Compatibility
 {
     public class TypeExtensionsTest
@@ -50,24 +51,6 @@ namespace Google.Protobuf.Compatibility
         {
         }
 
-        [Test]
-        [TestCase(typeof(int), true)]
-        [TestCase(typeof(int?), true)]
-        [TestCase(typeof(Nullable<>), true)]
-        [TestCase(typeof(WireFormat.WireType), true)]
-        [TestCase(typeof(string), false)]
-        [TestCase(typeof(object), false)]
-        [TestCase(typeof(Enum), false)]
-        [TestCase(typeof(ValueType), false)]
-        [TestCase(typeof(TypeExtensionsTest), false)]
-        [TestCase(typeof(Action), false)]
-        [TestCase(typeof(Action<>), false)]
-        [TestCase(typeof(IDisposable), false)]
-        public void IsValueType(Type type, bool expected)
-        {
-            Assert.AreEqual(expected, TypeExtensions.IsValueType(type));
-        }
-#if !DOTNET35
         [Test]
         [TestCase(typeof(object), typeof(string), true)]
         [TestCase(typeof(object), typeof(int), true)]
@@ -129,6 +112,6 @@ namespace Google.Protobuf.Compatibility
         {
             Assert.Throws<AmbiguousMatchException>(() => TypeExtensions.GetMethod(type, name));
         }
-#endif
     }
 }
+#endif

--- a/csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs
+++ b/csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs
@@ -33,6 +33,7 @@
 using System;
 using System.Reflection;
 
+#if !DOTNET35
 namespace Google.Protobuf.Compatibility
 {
     /// <summary>
@@ -45,20 +46,6 @@ namespace Google.Protobuf.Compatibility
     /// </summary>
     internal static class TypeExtensions
     {
-        /// <summary>
-        /// Returns true if the target type is a value type, including a nullable value type or an enum, or false
-        /// if it's a reference type (class, delegate, interface - including System.ValueType and System.Enum).
-        /// </summary>
-#if DOTNET35
-        internal static bool IsValueType(this Type target) {
-            return target.IsValueType;
-        }
-#else
-        internal static bool IsValueType(this Type target)
-        {
-            return target.GetTypeInfo().IsValueType;
-        }
-
         /// <summary>
         /// See https://msdn.microsoft.com/en-us/library/system.type.isassignablefrom
         /// </summary>
@@ -114,6 +101,6 @@ namespace Google.Protobuf.Compatibility
             }
             return null;
         }
-#endif
     }
 }
+#endif

--- a/csharp/src/Google.Protobuf/FieldCodec.cs
+++ b/csharp/src/Google.Protobuf/FieldCodec.cs
@@ -347,7 +347,8 @@ namespace Google.Protobuf
     public sealed class FieldCodec<T>
     {
         private static readonly T DefaultDefault;
-        private static readonly bool TypeSupportsPacking = typeof(T).IsValueType() && Nullable.GetUnderlyingType(typeof(T)) == null;
+        // Only non-nullable value types support packing. This is the simplest way of detecting that.
+        private static readonly bool TypeSupportsPacking = default(T) != null;
 
         static FieldCodec()
         {


### PR DESCRIPTION
This is the only call to TypeExtensions.IsValueType, so we can remove
that method, making the whole type conditionally compiled out for .NET 3.5