### PR TITLE
Add https://metacpan.org/pod/Google::ProtocolBuffers::Dynamic

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -63,6 +63,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * OCaml: http://piqi.org/
 * Perl: http://groups.google.com/group/protobuf-perl
 * Perl: http://search.cpan.org/perldoc?Google::ProtocolBuffers
+* Perl: https://metacpan.org/pod/Google::ProtocolBuffers::Dynamic
 * Perl/XS: http://code.google.com/p/protobuf-perlxs/
 * PHP: http://code.google.com/p/pb4php/
 * PHP: https://github.com/allegro/php-protobuf/


### PR DESCRIPTION
Uses Google's C++ library for .proto parsing and uPB for protobuf
encoding/decoding; it supports both proto2 and proto3 syntax and
encoding/decoding is more than 10 times faster than pure-Perl
Google::ProtocolBuffers.