### PR TITLE
Add canonical Bazel workspace name.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "google_protobuf")
+
 new_http_archive(
     name = "gmock_archive",
     url = "https://googlemock.googlecode.com/files/gmock-1.7.0.zip",


### PR DESCRIPTION
c.f. google/protobuf#1767

I didn't run buildifier on this because it produced a bunch of (ordering) diffs in other rules, and I wanted to keep this constrained.
