### PR TITLE
Cherrypick: Use public methods to fetch oneofs in generated code.

### DIFF
--- a/objectivec/google/protobuf/Struct.pbobjc.m
+++ b/objectivec/google/protobuf/Struct.pbobjc.m
@@ -237,7 +237,7 @@ void SetGPBValue_NullValue_RawValue(GPBValue *message, int32_t value) {
 
 void GPBValue_ClearKindOneOfCase(GPBValue *message) {
   GPBDescriptor *descriptor = [message descriptor];
-  GPBOneofDescriptor *oneof = descriptor->oneofs_[0];
+  GPBOneofDescriptor *oneof = [descriptor.oneofs objectAtIndex:0];
   GPBMaybeClearOneof(message, oneof, -1, 0);
 }
 #pragma mark - GPBListValue

--- a/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc
@@ -119,7 +119,7 @@ void OneofGenerator::GenerateClearFunctionImplementation(io::Printer* printer) {
       variables_,
       "void $owning_message_class$_Clear$capitalized_name$OneOfCase($owning_message_class$ *message) {\n"
       "  GPBDescriptor *descriptor = [message descriptor];\n"
-      "  GPBOneofDescriptor *oneof = descriptor->oneofs_[$raw_index$];\n"
+      "  GPBOneofDescriptor *oneof = [descriptor.oneofs objectAtIndex:$raw_index$];\n"
       "  GPBMaybeClearOneof(message, oneof, $index$, 0);\n"
       "}\n");
 }


### PR DESCRIPTION
When building into frameworks, the generated code doesn't always have direct
access to the proto internals.  Instead of opening up the access, just use the
public method to fetch the correct oneof.

Fixes https://github.com/google/protobuf/issues/1789