### PR TITLE
Add more tests to jenkins.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ env:
   - CONFIG=objectivec_cocoapods_integration
   - CONFIG=python
   - CONFIG=python_cpp
-  - CONFIG=ruby19
-  - CONFIG=ruby20
   - CONFIG=ruby21
   - CONFIG=ruby22
   - CONFIG=jruby

--- a/jenkins/docker/Dockerfile
+++ b/jenkins/docker/Dockerfile
@@ -87,7 +87,6 @@ RUN wget www.nuget.org/NuGet.exe -O /usr/local/bin/nuget.exe
 RUN pip install pip --upgrade
 RUN pip install virtualenv tox yattag
 
-
 ##################
 # Ruby dependencies
 
@@ -95,12 +94,12 @@ RUN pip install virtualenv tox yattag
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
-# Install Ruby 2.1
+# Install Ruby 2.1, Ruby 2.2 and JRuby 1.7
 RUN /bin/bash -l -c "rvm install ruby-2.1"
-RUN /bin/bash -l -c "rvm use --default ruby-2.1"
+RUN /bin/bash -l -c "rvm install ruby-2.2"
+RUN /bin/bash -l -c "rvm install jruby-1.7"
 RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.1' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 
 ##################
@@ -118,10 +117,27 @@ RUN cd /tmp && \
   ./configure && \
   make -j6 && \
   cd java && \
-  $MVN install dependency:go-offline -Dmaven.repo.local=$MAVEN_REPO -P lite && \
   $MVN install dependency:go-offline -Dmaven.repo.local=$MAVEN_REPO && \
   cd ../javanano && \
   $MVN install dependency:go-offline -Dmaven.repo.local=$MAVEN_REPO
+
+##################
+# Go dependencies.
+RUN apt-get install -y  \
+  # -- For go -- \
+  golang
+
+##################
+# Javascript dependencies.
+Run apt-get install -y \
+  # -- For javascript -- \
+  npm
+
+# On Debian/Ubuntu, nodejs binary is named 'nodejs' because the name 'node'
+# is taken by another legacy binary. We don't have that legacy binary and
+# npm expects the binary to be named 'node', so we just create a symbol
+# link here.
+RUN ln -s `which nodejs` /usr/bin/node
 
 ##################
 # Prepare ccache

--- a/jenkins/pull_request_in_docker.sh
+++ b/jenkins/pull_request_in_docker.sh
@@ -55,7 +55,9 @@ parallel --results $LOG_OUTPUT_DIR --joblog $OUTPUT_DIR/joblog $TEST_SCRIPT ::: 
   javanano_oracle7 \
   python \
   python_cpp \
-  ruby21 \
+  ruby_all \
+  javascript \
+  golang \
   || true  # Process test results even if tests fail.
 
 cat $OUTPUT_DIR/joblog

--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -5,7 +5,7 @@ set -e
 
 test_version() {
   version=$1
-  if [ "$version" == "jruby" ] ; then
+  if [ "$version" == "jruby-1.7" ] ; then
     # No conformance tests yet -- JRuby is too broken to run them.
     bash --login -c \
       "rvm install $version && rvm use $version && \

--- a/tests.sh
+++ b/tests.sh
@@ -113,10 +113,12 @@ build_golang() {
   export PATH="`pwd`/src:$PATH"
 
   # Install Go and the Go protobuf compiler plugin.
-  sudo apt-get update -qq
-  sudo apt-get install -qq golang
+  on_travis sudo apt-get update -qq
+  on_travis sudo apt-get install -qq golang
+
   export GOPATH="$HOME/gocode"
   mkdir -p "$GOPATH/src/github.com/google"
+  rm -f "$GOPATH/src/github.com/google/protobuf"
   ln -s "`pwd`" "$GOPATH/src/github.com/google/protobuf"
   export PATH="$GOPATH/bin:$PATH"
   go get github.com/golang/protobuf/protoc-gen-go
@@ -296,14 +298,6 @@ build_python_cpp() {
   cd ..
 }
 
-build_ruby19() {
-  internal_build_cpp  # For conformance tests.
-  cd ruby && bash travis-test.sh ruby-1.9 && cd ..
-}
-build_ruby20() {
-  internal_build_cpp  # For conformance tests.
-  cd ruby && bash travis-test.sh ruby-2.0 && cd ..
-}
 build_ruby21() {
   internal_build_cpp  # For conformance tests.
   cd ruby && bash travis-test.sh ruby-2.1 && cd ..
@@ -314,7 +308,14 @@ build_ruby22() {
 }
 build_jruby() {
   internal_build_cpp  # For conformance tests.
-  cd ruby && bash travis-test.sh jruby && cd ..
+  # TODO(xiaofeng): Upgrade to jruby-9.x. There are some broken jests to be
+  # fixed.
+  cd ruby && bash travis-test.sh jruby-1.7 && cd ..
+}
+build_ruby_all() {
+  build_ruby21
+  build_ruby22
+  build_jruby
 }
 
 build_javascript() {
@@ -348,11 +349,10 @@ Usage: $0 { cpp |
             objectivec_cocoapods_integration |
             python |
             python_cpp |
-            ruby19 |
-            ruby20 |
             ruby21 |
             ruby22 |
-            jruby }
+            jruby |
+            ruby_all)
 "
   exit 1
 fi


### PR DESCRIPTION
1. Added ruby22 and jruby tests to jenkins.
2. Added javascript tests to jenkins.
3. Added golang tests to jenkins.
4. Removed ruby19/ruby20 tests from travis. Support for ruby 2.0 has
   ended since 2016/02/24.
   https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
