### PR TITLE
Fixes the parsing of the proto-framework map file.

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -223,7 +223,7 @@ bool ImportWriter::ProtoFrameworkCollector::ConsumeLine(
       offset = proto_file_list.length();
     }
 
-    StringPiece proto_file(proto_file_list, start, offset);
+    StringPiece proto_file(proto_file_list, start, offset - start);
     StringPieceTrimWhitespace(&proto_file);
     if (proto_file.size() != 0) {
       map<string, string>::iterator existing_entry =

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -1306,7 +1306,8 @@ bool Parser::Finish() {
     return true;
   }
   // Force a newline onto the end to finish parsing.
-  p_ = StringPiece(leftover_ + "\n");
+  leftover_ += "\n";
+  p_ = StringPiece(leftover_);
   if (!ParseLoop()) {
     return false;
   }


### PR DESCRIPTION
 - Fixes memory issue where the pointer to the StringPiece would be allocated on the stack, and would mangle the output.
 - Fixes length of the file name when parsing the comma separated files.