### PR TITLE
JavaScript: Use strings for 64-bit ints to preserve precision

### DIFF
--- a/js/binary/proto_test.js
+++ b/js/binary/proto_test.js
@@ -107,7 +107,7 @@ function fillAllFields(msg) {
   msg.setOptionalInt32(-42);
   // can be exactly represented by JS number (64-bit double, i.e., 52-bit
   // mantissa).
-  msg.setOptionalInt64('-9223372032559808512');
+  msg.setOptionalInt64(-0x7fffffff00000000);
   msg.setOptionalUint32(0x80000000);
   msg.setOptionalUint64('17293822569102704640');
   msg.setOptionalSint32(-100);
@@ -199,7 +199,7 @@ function bytesCompare(arr, expected) {
  */
 function checkAllFields(original, copy) {
   assertEquals(copy.getOptionalInt32(), -42);
-  assertEquals(copy.getOptionalInt64(), '-9223372032559808512');
+  assertEquals(copy.getOptionalInt64(), -0x7fffffff00000000);
   assertEquals(copy.getOptionalUint32(), 0x80000000);
   assertEquals(copy.getOptionalUint64(), '17293822569102704640');
   assertEquals(copy.getOptionalSint32(), -100);

--- a/js/binary/proto_test.js
+++ b/js/binary/proto_test.js
@@ -107,15 +107,15 @@ function fillAllFields(msg) {
   msg.setOptionalInt32(-42);
   // can be exactly represented by JS number (64-bit double, i.e., 52-bit
   // mantissa).
-  msg.setOptionalInt64(-0x7fffffff00000000);
+  msg.setOptionalInt64('-9223372032559808512');
   msg.setOptionalUint32(0x80000000);
-  msg.setOptionalUint64(0xf000000000000000);
+  msg.setOptionalUint64('17293822569102704640');
   msg.setOptionalSint32(-100);
-  msg.setOptionalSint64(-0x8000000000000000);
+  msg.setOptionalSint64(-0x8000000000000000 + '');
   msg.setOptionalFixed32(1234);
-  msg.setOptionalFixed64(0x1234567800000000);
+  msg.setOptionalFixed64('1311768464867721216');
   msg.setOptionalSfixed32(-1234);
-  msg.setOptionalSfixed64(-0x1234567800000000);
+  msg.setOptionalSfixed64('-1311768464867721216');
   msg.setOptionalFloat(1.5);
   msg.setOptionalDouble(-1.5);
   msg.setOptionalBool(true);
@@ -131,15 +131,15 @@ function fillAllFields(msg) {
 
 
   msg.setRepeatedInt32List([-42]);
-  msg.setRepeatedInt64List([-0x7fffffff00000000]);
+  msg.setRepeatedInt64List(['-9223372032559808512']);
   msg.setRepeatedUint32List([0x80000000]);
-  msg.setRepeatedUint64List([0xf000000000000000]);
+  msg.setRepeatedUint64List(['17293822569102704640']);
   msg.setRepeatedSint32List([-100]);
-  msg.setRepeatedSint64List([-0x8000000000000000]);
+  msg.setRepeatedSint64List([-0x8000000000000000 + '']);
   msg.setRepeatedFixed32List([1234]);
-  msg.setRepeatedFixed64List([0x1234567800000000]);
+  msg.setRepeatedFixed64List(['1311768464867721216']);
   msg.setRepeatedSfixed32List([-1234]);
-  msg.setRepeatedSfixed64List([-0x1234567800000000]);
+  msg.setRepeatedSfixed64List(['-1311768464867721216']);
   msg.setRepeatedFloatList([1.5]);
   msg.setRepeatedDoubleList([-1.5]);
   msg.setRepeatedBoolList([true]);
@@ -153,15 +153,15 @@ function fillAllFields(msg) {
   msg.setRepeatedForeignEnumList([proto.jspb.test.ForeignEnum.FOREIGN_FOO]);
 
   msg.setPackedRepeatedInt32List([-42]);
-  msg.setPackedRepeatedInt64List([-0x7fffffff00000000]);
+  msg.setPackedRepeatedInt64List(['-9223372032559808512']);
   msg.setPackedRepeatedUint32List([0x80000000]);
-  msg.setPackedRepeatedUint64List([0xf000000000000000]);
+  msg.setPackedRepeatedUint64List(['17293822569102704640']);
   msg.setPackedRepeatedSint32List([-100]);
-  msg.setPackedRepeatedSint64List([-0x8000000000000000]);
+  msg.setPackedRepeatedSint64List([-0x8000000000000000 + '']);
   msg.setPackedRepeatedFixed32List([1234]);
-  msg.setPackedRepeatedFixed64List([0x1234567800000000]);
+  msg.setPackedRepeatedFixed64List(['1311768464867721216']);
   msg.setPackedRepeatedSfixed32List([-1234]);
-  msg.setPackedRepeatedSfixed64List([-0x1234567800000000]);
+  msg.setPackedRepeatedSfixed64List(['-1311768464867721216']);
   msg.setPackedRepeatedFloatList([1.5]);
   msg.setPackedRepeatedDoubleList([-1.5]);
   msg.setPackedRepeatedBoolList([true]);
@@ -199,15 +199,15 @@ function bytesCompare(arr, expected) {
  */
 function checkAllFields(original, copy) {
   assertEquals(copy.getOptionalInt32(), -42);
-  assertEquals(copy.getOptionalInt64(), -0x7fffffff00000000);
+  assertEquals(copy.getOptionalInt64(), '-9223372032559808512');
   assertEquals(copy.getOptionalUint32(), 0x80000000);
-  assertEquals(copy.getOptionalUint64(), 0xf000000000000000);
+  assertEquals(copy.getOptionalUint64(), '17293822569102704640');
   assertEquals(copy.getOptionalSint32(), -100);
-  assertEquals(copy.getOptionalSint64(), -0x8000000000000000);
+  assertEquals(copy.getOptionalSint64(), -0x8000000000000000 + '');
   assertEquals(copy.getOptionalFixed32(), 1234);
-  assertEquals(copy.getOptionalFixed64(), 0x1234567800000000);
+  assertEquals(copy.getOptionalFixed64(), '1311768464867721216');
   assertEquals(copy.getOptionalSfixed32(), -1234);
-  assertEquals(copy.getOptionalSfixed64(), -0x1234567800000000);
+  assertEquals(copy.getOptionalSfixed64(), '-1311768464867721216');
   assertEquals(copy.getOptionalFloat(), 1.5);
   assertEquals(copy.getOptionalDouble(), -1.5);
   assertEquals(copy.getOptionalBool(), true);
@@ -228,15 +228,15 @@ function checkAllFields(original, copy) {
       proto.jspb.test.TestAllTypes.OneofFieldCase.ONEOF_STRING);
 
   assertElementsEquals(copy.getRepeatedInt32List(), [-42]);
-  assertElementsEquals(copy.getRepeatedInt64List(), [-0x7fffffff00000000]);
+  assertElementsEquals(copy.getRepeatedInt64List(), ['-9223372032559808512']);
   assertElementsEquals(copy.getRepeatedUint32List(), [0x80000000]);
-  assertElementsEquals(copy.getRepeatedUint64List(), [0xf000000000000000]);
+  assertElementsEquals(copy.getRepeatedUint64List(), ['17293822569102704640']);
   assertElementsEquals(copy.getRepeatedSint32List(), [-100]);
-  assertElementsEquals(copy.getRepeatedSint64List(), [-0x8000000000000000]);
+  assertElementsEquals(copy.getRepeatedSint64List(), [-0x8000000000000000 + '']);
   assertElementsEquals(copy.getRepeatedFixed32List(), [1234]);
-  assertElementsEquals(copy.getRepeatedFixed64List(), [0x1234567800000000]);
+  assertElementsEquals(copy.getRepeatedFixed64List(), ['1311768464867721216']);
   assertElementsEquals(copy.getRepeatedSfixed32List(), [-1234]);
-  assertElementsEquals(copy.getRepeatedSfixed64List(), [-0x1234567800000000]);
+  assertElementsEquals(copy.getRepeatedSfixed64List(), ['-1311768464867721216']);
   assertElementsEquals(copy.getRepeatedFloatList(), [1.5]);
   assertElementsEquals(copy.getRepeatedDoubleList(), [-1.5]);
   assertElementsEquals(copy.getRepeatedBoolList(), [true]);
@@ -256,19 +256,19 @@ function checkAllFields(original, copy) {
 
   assertElementsEquals(copy.getPackedRepeatedInt32List(), [-42]);
   assertElementsEquals(copy.getPackedRepeatedInt64List(),
-      [-0x7fffffff00000000]);
+      ['-9223372032559808512']);
   assertElementsEquals(copy.getPackedRepeatedUint32List(), [0x80000000]);
   assertElementsEquals(copy.getPackedRepeatedUint64List(),
-      [0xf000000000000000]);
+      ['17293822569102704640']);
   assertElementsEquals(copy.getPackedRepeatedSint32List(), [-100]);
   assertElementsEquals(copy.getPackedRepeatedSint64List(),
-      [-0x8000000000000000]);
+      [-0x8000000000000000 + '']);
   assertElementsEquals(copy.getPackedRepeatedFixed32List(), [1234]);
   assertElementsEquals(copy.getPackedRepeatedFixed64List(),
-      [0x1234567800000000]);
+      ['1311768464867721216']);
   assertElementsEquals(copy.getPackedRepeatedSfixed32List(), [-1234]);
   assertElementsEquals(copy.getPackedRepeatedSfixed64List(),
-      [-0x1234567800000000]);
+      ['-1311768464867721216']);
   assertElementsEquals(copy.getPackedRepeatedFloatList(), [1.5]);
   assertElementsEquals(copy.getPackedRepeatedDoubleList(), [-1.5]);
 
@@ -285,23 +285,23 @@ function checkAllFields(original, copy) {
 function checkExtensions(msg) {
   assertEquals(-42,
       msg.getExtension(proto.jspb.test.extendOptionalInt32));
-  assertEquals(-0x7fffffff00000000,
+  assertEquals('-9223372032559808512',
       msg.getExtension(proto.jspb.test.extendOptionalInt64));
   assertEquals(0x80000000,
       msg.getExtension(proto.jspb.test.extendOptionalUint32));
-  assertEquals(0xf000000000000000,
+  assertEquals('17293822569102704640',
       msg.getExtension(proto.jspb.test.extendOptionalUint64));
   assertEquals(-100,
       msg.getExtension(proto.jspb.test.extendOptionalSint32));
-  assertEquals(-0x8000000000000000,
+  assertEquals(-0x8000000000000000 + '',
       msg.getExtension(proto.jspb.test.extendOptionalSint64));
   assertEquals(1234,
       msg.getExtension(proto.jspb.test.extendOptionalFixed32));
-  assertEquals(0x1234567800000000,
+  assertEquals('1311768464867721216',
       msg.getExtension(proto.jspb.test.extendOptionalFixed64));
   assertEquals(-1234,
       msg.getExtension(proto.jspb.test.extendOptionalSfixed32));
-  assertEquals(-0x1234567800000000,
+  assertEquals('-1311768464867721216',
       msg.getExtension(proto.jspb.test.extendOptionalSfixed64));
   assertEquals(1.5,
       msg.getExtension(proto.jspb.test.extendOptionalFloat));
@@ -324,31 +324,31 @@ function checkExtensions(msg) {
       [-42]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedInt64List),
-      [-0x7fffffff00000000]);
+      ['-9223372032559808512']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedUint32List),
       [0x80000000]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedUint64List),
-      [0xf000000000000000]);
+      ['17293822569102704640']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedSint32List),
       [-100]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedSint64List),
-      [-0x8000000000000000]);
+      [-0x8000000000000000 + '']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedFixed32List),
       [1234]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedFixed64List),
-      [0x1234567800000000]);
+      ['1311768464867721216']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedSfixed32List),
       [-1234]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedSfixed64List),
-      [-0x1234567800000000]);
+      ['-1311768464867721216']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendRepeatedFloatList),
       [1.5]);
@@ -379,31 +379,31 @@ function checkExtensions(msg) {
       [-42]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedInt64List),
-      [-0x7fffffff00000000]);
+      ['-9223372032559808512']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedUint32List),
       [0x80000000]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedUint64List),
-      [0xf000000000000000]);
+      ['17293822569102704640']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedSint32List),
       [-100]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedSint64List),
-      [-0x8000000000000000]);
+      [-0x8000000000000000 + '']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedFixed32List),
       [1234]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedFixed64List),
-      [0x1234567800000000]);
+      ['1311768464867721216']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedSfixed32List),
       [-1234]);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedSfixed64List),
-      [-0x1234567800000000]);
+      ['-1311768464867721216']);
   assertElementsEquals(
       msg.getExtension(proto.jspb.test.extendPackedRepeatedFloatList),
       [1.5]);
@@ -515,23 +515,23 @@ describe('protoBinaryTest', function() {
     msg.setExtension(
         proto.jspb.test.extendOptionalInt32, -42);
     msg.setExtension(
-        proto.jspb.test.extendOptionalInt64, -0x7fffffff00000000);
+        proto.jspb.test.extendOptionalInt64, '-9223372032559808512');
     msg.setExtension(
         proto.jspb.test.extendOptionalUint32, 0x80000000);
     msg.setExtension(
-        proto.jspb.test.extendOptionalUint64, 0xf000000000000000);
+        proto.jspb.test.extendOptionalUint64, '17293822569102704640');
     msg.setExtension(
         proto.jspb.test.extendOptionalSint32, -100);
     msg.setExtension(
-        proto.jspb.test.extendOptionalSint64, -0x8000000000000000);
+        proto.jspb.test.extendOptionalSint64, -0x8000000000000000 + '');
     msg.setExtension(
         proto.jspb.test.extendOptionalFixed32, 1234);
     msg.setExtension(
-        proto.jspb.test.extendOptionalFixed64, 0x1234567800000000);
+        proto.jspb.test.extendOptionalFixed64, '1311768464867721216');
     msg.setExtension(
         proto.jspb.test.extendOptionalSfixed32, -1234);
     msg.setExtension(
-        proto.jspb.test.extendOptionalSfixed64, -0x1234567800000000);
+        proto.jspb.test.extendOptionalSfixed64, '-1311768464867721216');
     msg.setExtension(
         proto.jspb.test.extendOptionalFloat, 1.5);
     msg.setExtension(
@@ -553,23 +553,23 @@ describe('protoBinaryTest', function() {
     msg.setExtension(
         proto.jspb.test.extendRepeatedInt32List, [-42]);
     msg.setExtension(
-        proto.jspb.test.extendRepeatedInt64List, [-0x7fffffff00000000]);
+        proto.jspb.test.extendRepeatedInt64List, ['-9223372032559808512']);
     msg.setExtension(
         proto.jspb.test.extendRepeatedUint32List, [0x80000000]);
     msg.setExtension(
-        proto.jspb.test.extendRepeatedUint64List, [0xf000000000000000]);
+        proto.jspb.test.extendRepeatedUint64List, ['17293822569102704640']);
     msg.setExtension(
         proto.jspb.test.extendRepeatedSint32List, [-100]);
     msg.setExtension(
-        proto.jspb.test.extendRepeatedSint64List, [-0x8000000000000000]);
+        proto.jspb.test.extendRepeatedSint64List, [-0x8000000000000000 + '']);
     msg.setExtension(
         proto.jspb.test.extendRepeatedFixed32List, [1234]);
     msg.setExtension(
-        proto.jspb.test.extendRepeatedFixed64List, [0x1234567800000000]);
+        proto.jspb.test.extendRepeatedFixed64List, ['1311768464867721216']);
     msg.setExtension(
         proto.jspb.test.extendRepeatedSfixed32List, [-1234]);
     msg.setExtension(
-        proto.jspb.test.extendRepeatedSfixed64List, [-0x1234567800000000]);
+        proto.jspb.test.extendRepeatedSfixed64List, ['-1311768464867721216']);
     msg.setExtension(
         proto.jspb.test.extendRepeatedFloatList, [1.5]);
     msg.setExtension(
@@ -590,24 +590,24 @@ describe('protoBinaryTest', function() {
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedInt32List, [-42]);
     msg.setExtension(
-        proto.jspb.test.extendPackedRepeatedInt64List, [-0x7fffffff00000000]);
+        proto.jspb.test.extendPackedRepeatedInt64List, ['-9223372032559808512']);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedUint32List, [0x80000000]);
     msg.setExtension(
-        proto.jspb.test.extendPackedRepeatedUint64List, [0xf000000000000000]);
+        proto.jspb.test.extendPackedRepeatedUint64List, ['17293822569102704640']);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedSint32List, [-100]);
     msg.setExtension(
-        proto.jspb.test.extendPackedRepeatedSint64List, [-0x8000000000000000]);
+        proto.jspb.test.extendPackedRepeatedSint64List, [-0x8000000000000000 + '']);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedFixed32List, [1234]);
     msg.setExtension(
-        proto.jspb.test.extendPackedRepeatedFixed64List, [0x1234567800000000]);
+        proto.jspb.test.extendPackedRepeatedFixed64List, ['1311768464867721216']);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedSfixed32List, [-1234]);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedSfixed64List,
-        [-0x1234567800000000]);
+        ['-1311768464867721216']);
     msg.setExtension(
         proto.jspb.test.extendPackedRepeatedFloatList, [1.5]);
     msg.setExtension(

--- a/js/maps_test.js
+++ b/js/maps_test.js
@@ -86,7 +86,7 @@ function makeTests(msgInfo, submessageCtor, suffix) {
   var fillMapFields = function(msg) {
     msg.getMapStringStringMap().set('asdf', 'jkl;').set('key 2', 'hello world');
     msg.getMapStringInt32Map().set('a', 1).set('b', -2);
-    msg.getMapStringInt64Map().set('c', 0x100000000).set('d', 0x200000000);
+    msg.getMapStringInt64Map().set('c', '4294967296').set('d', '8589934592');
     msg.getMapStringBoolMap().set('e', true).set('f', false);
     msg.getMapStringDoubleMap().set('g', 3.14159).set('h', 2.71828);
     msg.getMapStringEnumMap()
@@ -98,7 +98,7 @@ function makeTests(msgInfo, submessageCtor, suffix) {
     msg.getMapStringMsgMap().get('k').setFoo(42);
     msg.getMapStringMsgMap().get('l').setFoo(84);
     msg.getMapInt32StringMap().set(-1, 'a').set(42, 'b');
-    msg.getMapInt64StringMap().set(0x123456789abc, 'c').set(0xcba987654321, 'd');
+    msg.getMapInt64StringMap().set('20015998343868', 'c').set('223928981472033', 'd');
     msg.getMapBoolStringMap().set(false, 'e').set(true, 'f');
   };
 
@@ -116,8 +116,8 @@ function makeTests(msgInfo, submessageCtor, suffix) {
           ['b', -2]
     ]);
     checkMapEquals(msg.getMapStringInt64Map(), [
-          ['c', 0x100000000],
-          ['d', 0x200000000]
+          ['c', '4294967296'],
+          ['d', '8589934592']
     ]);
     checkMapEquals(msg.getMapStringBoolMap(), [
           ['e', true],
@@ -136,8 +136,8 @@ function makeTests(msgInfo, submessageCtor, suffix) {
           [42, 'b']
     ]);
     checkMapEquals(msg.getMapInt64StringMap(), [
-          [0x123456789abc, 'c'],
-          [0xcba987654321, 'd']
+          ['20015998343868', 'c'],
+          ['223928981472033', 'd']
     ]);
     checkMapEquals(msg.getMapBoolStringMap(), [
           [false, 'e'],

--- a/js/proto3_test.js
+++ b/js/proto3_test.js
@@ -133,15 +133,15 @@ describe('proto3Test', function() {
     var msg = new proto.jspb.test.TestProto3();
 
     msg.setOptionalInt32(-42);
-    msg.setOptionalInt64(-0x7fffffff00000000);
+    msg.setOptionalInt64('-9223372032559808512');
     msg.setOptionalUint32(0x80000000);
-    msg.setOptionalUint64(0xf000000000000000);
+    msg.setOptionalUint64('17293822569102704640');
     msg.setOptionalSint32(-100);
-    msg.setOptionalSint64(-0x8000000000000000);
+    msg.setOptionalSint64(-0x8000000000000000 + '');
     msg.setOptionalFixed32(1234);
-    msg.setOptionalFixed64(0x1234567800000000);
+    msg.setOptionalFixed64('1311768464867721216');
     msg.setOptionalSfixed32(-1234);
-    msg.setOptionalSfixed64(-0x1234567800000000);
+    msg.setOptionalSfixed64('-1311768464867721216');
     msg.setOptionalFloat(1.5);
     msg.setOptionalDouble(-1.5);
     msg.setOptionalBool(true);
@@ -153,15 +153,15 @@ describe('proto3Test', function() {
     msg.setOptionalForeignEnum(proto.jspb.test.Proto3Enum.PROTO3_BAR);
 
     msg.setRepeatedInt32List([-42]);
-    msg.setRepeatedInt64List([-0x7fffffff00000000]);
+    msg.setRepeatedInt64List(['-9223372032559808512']);
     msg.setRepeatedUint32List([0x80000000]);
-    msg.setRepeatedUint64List([0xf000000000000000]);
+    msg.setRepeatedUint64List(['17293822569102704640']);
     msg.setRepeatedSint32List([-100]);
-    msg.setRepeatedSint64List([-0x8000000000000000]);
+    msg.setRepeatedSint64List([-0x8000000000000000 + '']);
     msg.setRepeatedFixed32List([1234]);
-    msg.setRepeatedFixed64List([0x1234567800000000]);
+    msg.setRepeatedFixed64List(['1311768464867721216']);
     msg.setRepeatedSfixed32List([-1234]);
-    msg.setRepeatedSfixed64List([-0x1234567800000000]);
+    msg.setRepeatedSfixed64List(['-1311768464867721216']);
     msg.setRepeatedFloatList([1.5]);
     msg.setRepeatedDoubleList([-1.5]);
     msg.setRepeatedBoolList([true]);
@@ -178,15 +178,15 @@ describe('proto3Test', function() {
     msg = proto.jspb.test.TestProto3.deserializeBinary(serialized);
 
     assertEquals(msg.getOptionalInt32(), -42);
-    assertEquals(msg.getOptionalInt64(), -0x7fffffff00000000);
+    assertEquals(msg.getOptionalInt64(), '-9223372032559808512');
     assertEquals(msg.getOptionalUint32(), 0x80000000);
-    assertEquals(msg.getOptionalUint64(), 0xf000000000000000);
+    assertEquals(msg.getOptionalUint64(), '17293822569102704640');
     assertEquals(msg.getOptionalSint32(), -100);
-    assertEquals(msg.getOptionalSint64(), -0x8000000000000000);
+    assertEquals(msg.getOptionalSint64(), -0x8000000000000000 + '');
     assertEquals(msg.getOptionalFixed32(), 1234);
-    assertEquals(msg.getOptionalFixed64(), 0x1234567800000000);
+    assertEquals(msg.getOptionalFixed64(), '1311768464867721216');
     assertEquals(msg.getOptionalSfixed32(), -1234);
-    assertEquals(msg.getOptionalSfixed64(), -0x1234567800000000);
+    assertEquals(msg.getOptionalSfixed64(), '-1311768464867721216');
     assertEquals(msg.getOptionalFloat(), 1.5);
     assertEquals(msg.getOptionalDouble(), -1.5);
     assertEquals(msg.getOptionalBool(), true);
@@ -197,15 +197,15 @@ describe('proto3Test', function() {
         proto.jspb.test.Proto3Enum.PROTO3_BAR);
 
     assertElementsEquals(msg.getRepeatedInt32List(), [-42]);
-    assertElementsEquals(msg.getRepeatedInt64List(), [-0x7fffffff00000000]);
+    assertElementsEquals(msg.getRepeatedInt64List(), ['-9223372032559808512']);
     assertElementsEquals(msg.getRepeatedUint32List(), [0x80000000]);
-    assertElementsEquals(msg.getRepeatedUint64List(), [0xf000000000000000]);
+    assertElementsEquals(msg.getRepeatedUint64List(), ['17293822569102704640']);
     assertElementsEquals(msg.getRepeatedSint32List(), [-100]);
-    assertElementsEquals(msg.getRepeatedSint64List(), [-0x8000000000000000]);
+    assertElementsEquals(msg.getRepeatedSint64List(), [-0x8000000000000000 + '']);
     assertElementsEquals(msg.getRepeatedFixed32List(), [1234]);
-    assertElementsEquals(msg.getRepeatedFixed64List(), [0x1234567800000000]);
+    assertElementsEquals(msg.getRepeatedFixed64List(), ['1311768464867721216']);
     assertElementsEquals(msg.getRepeatedSfixed32List(), [-1234]);
-    assertElementsEquals(msg.getRepeatedSfixed64List(), [-0x1234567800000000]);
+    assertElementsEquals(msg.getRepeatedSfixed64List(), ['-1311768464867721216']);
     assertElementsEquals(msg.getRepeatedFloatList(), [1.5]);
     assertElementsEquals(msg.getRepeatedDoubleList(), [-1.5]);
     assertElementsEquals(msg.getRepeatedBoolList(), [true]);

--- a/js/testbinary.proto
+++ b/js/testbinary.proto
@@ -40,7 +40,7 @@ package jspb.test;
 // properly.
 message TestAllTypes {
   optional    int32 optional_int32    =  1;
-  optional    int64 optional_int64    =  2;
+  optional    int64 optional_int64    =  2 [jstype=JS_NUMBER];
   optional   uint32 optional_uint32   =  3;
   optional   uint64 optional_uint64   =  4;
   optional   sint32 optional_sint32   =  5;

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -1064,7 +1064,8 @@ string JSBinaryReaderMethodType(const FieldDescriptor* field) {
   return name;
 }
 
-string JSBinaryReadWriteMethodName(const FieldDescriptor* field,
+string JSBinaryReadWriteMethodName(const GeneratorOptions& options,
+                                   const FieldDescriptor* field,
                                    bool is_writer) {
   string name = JSBinaryReaderMethodType(field);
   if (field->is_packed()) {
@@ -1072,9 +1073,11 @@ string JSBinaryReadWriteMethodName(const FieldDescriptor* field,
   } else if (is_writer && field->is_repeated()) {
     name = "Repeated" + name;
   }
-  if (field->options().jstype() != FieldOptions_JSType_JS_NUMBER) {
-    if (field->cpp_type() == FieldDescriptor::CPPTYPE_INT64 ||
-        field->cpp_type() == FieldDescriptor::CPPTYPE_UINT64) {
+  if (field->cpp_type() == FieldDescriptor::CPPTYPE_INT64 ||
+      field->cpp_type() == FieldDescriptor::CPPTYPE_UINT64) {
+    if (field->options().jstype() == FieldOptions_JSType_JS_STRING ||
+        field->options().jstype() == FieldOptions_JSType_JS_NORMAL &&
+        options.int64_default_type == GeneratorOptions::kInt64String) {
       name += "String";
     }
   }
@@ -1084,13 +1087,13 @@ string JSBinaryReadWriteMethodName(const FieldDescriptor* field,
 string JSBinaryReaderMethodName(const GeneratorOptions& options,
                                 const FieldDescriptor* field) {
   return "jspb.BinaryReader.prototype.read" +
-         JSBinaryReadWriteMethodName(field, /* is_writer = */ false);
+         JSBinaryReadWriteMethodName(options, field, /* is_writer = */ false);
 }
 
 string JSBinaryWriterMethodName(const GeneratorOptions& options,
                                 const FieldDescriptor* field) {
   return "jspb.BinaryWriter.prototype.write" +
-         JSBinaryReadWriteMethodName(field, /* is_writer = */ true);
+         JSBinaryReadWriteMethodName(options, field, /* is_writer = */ true);
 }
 
 string JSReturnClause(const FieldDescriptor* desc) {
@@ -2898,7 +2901,7 @@ void Generator::GenerateClassDeserializeBinaryField(
                                              /* singular_if_not_packed */ true,
                                              BYTES_U8),
           "reader",
-          JSBinaryReadWriteMethodName(field, /* is_writer = */ false));
+          JSBinaryReadWriteMethodName(options, field, /* is_writer = */ false));
     }
 
     if (field->is_repeated() && !field->is_packed()) {
@@ -3059,7 +3062,9 @@ void Generator::GenerateClassSerializeBinaryField(
         "    writer.write$method$(\n"
         "      $index$,\n"
         "      f",
-        "method", JSBinaryReadWriteMethodName(field, /* is_writer = */ true),
+        "method", JSBinaryReadWriteMethodName(options,
+                                              field,
+                                              /* is_writer = */ true),
         "index", SimpleItoa(field->number()));
 
     if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE &&
@@ -3228,6 +3233,12 @@ bool GeneratorOptions::ParseFromOptions(
       } else {
         *error = "Unknown import style " + options[i].second + ", expected " +
                  "one of: closure, commonjs, browser, es6.";
+      }
+    } else if (options[i].first == "int64_default_type") {
+      if (options[i].second == "number") {
+        int64_default_type = kInt64Number;
+      } else if (options[i].second == "string") {
+        int64_default_type = kInt64String;
       }
     } else if (options[i].first == "extension") {
       extension = options[i].second;

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -1072,6 +1072,10 @@ string JSBinaryReadWriteMethodName(const FieldDescriptor* field,
   } else if (is_writer && field->is_repeated()) {
     name = "Repeated" + name;
   }
+  if (field->cpp_type() == FieldDescriptor::CPPTYPE_INT64 ||
+      field->cpp_type() == FieldDescriptor::CPPTYPE_UINT64) {
+    name += "String";
+  }
   return name;
 }
 

--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -1072,9 +1072,11 @@ string JSBinaryReadWriteMethodName(const FieldDescriptor* field,
   } else if (is_writer && field->is_repeated()) {
     name = "Repeated" + name;
   }
-  if (field->cpp_type() == FieldDescriptor::CPPTYPE_INT64 ||
-      field->cpp_type() == FieldDescriptor::CPPTYPE_UINT64) {
-    name += "String";
+  if (field->options().jstype() != FieldOptions_JSType_JS_NUMBER) {
+    if (field->cpp_type() == FieldDescriptor::CPPTYPE_INT64 ||
+        field->cpp_type() == FieldDescriptor::CPPTYPE_UINT64) {
+      name += "String";
+    }
   }
   return name;
 }

--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -68,12 +68,18 @@ struct GeneratorOptions {
     kImportBrowser,   // no import statements
     kImportEs6,       // import { member } from ''
   } import_style;
+  // Type to use for int64s by default.
+  enum Int64DefaultType {
+    kInt64Number,
+    kInt64String,
+  } int64_default_type;
 
   GeneratorOptions()
       : output_dir("."),
         namespace_prefix(""),
         binary(false),
         import_style(kImportClosure),
+        int64_default_type(kInt64Number),
         add_require_for_enums(false),
         testonly(false),
         library(""),


### PR DESCRIPTION
Currently the following happens:

``` js
C:\Users\Nikolai\Downloads\protobuf\js>node
> var u = require('./testbinary_pb')
undefined
> var t = new u.TestAllTypes();
undefined
> t.setOptionalSfixed64('76561197988007571')
undefined
> var bytes = t.serializeBinary()

> var t2 = u.TestAllTypes.deserializeBinary(bytes)

> t2.getOptionalSfixed64()
76561197988007570
>
```

This fixes it by representing 64-bit ints as decimal strings:

``` js
$ node
> var u = require('./testbinary_pb')
undefined
> var t = new u.TestAllTypes();
undefined
> t.setOptionalSfixed64('76561197988007571')
undefined
> var bytes = t.serializeBinary()

> var t2 = u.TestAllTypes.deserializeBinary(bytes)

> t2.getOptionalSfixed64()
'76561197988007571'
>
```
