### PR TITLE
Remove redundant symbol

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -281,7 +281,7 @@ class RepeatedField {
       Element* e = &rep->elements[0];
       Element* limit = &rep->elements[size];
       for (; e < limit; e++) {
-        e->Element::~Element();
+        e->~Element();
       }
       if (rep->arena == NULL) {
         delete[] reinterpret_cast<char*>(rep);


### PR DESCRIPTION
Hello,

My organization is trying to begin using protobufs.  This PR is for a compilation issue that appears to be a bug in MSVC.  We include a header file (foo.h) that contains the lines:

class Element;
typedef class Element Element;

We are not at liberty to change this file and find a compilation error at the line which this PR changes.   The compiler error is as follows:

> Protobuf\3.0.0.b4\cpp\include\google/protobuf/repeated_field.h(284): error C2027: use of undefined type 'Element'
> 1>          path\to\foo.h(630) : see declaration of 'Element'
> 1>          Protobuf\3.0.0.b4\cpp\include\google/protobuf/repeated_field.h(279) : while compiling class template member function 'void google::protobuf::RepeatedField<Element>::InternalDeallocate(google::protobuf::RepeatedField<Element>::Rep *,int)'
> 1>          with
> 1>          [
> 1>              Element=google::protobuf::int32
> 1>          ]
> 1>          Protobuf\3.0.0.b4\cpp\include\google/protobuf/repeated_field.h(1298) : see reference to function template instantiation 'void google::protobuf::RepeatedField<Element>::InternalDeallocate(google::protobuf::RepeatedField<Element>::Rep *,int)' being compiled
> 1>          with
> 1>          [
> 1>              Element=google::protobuf::int32
> 1>          ]
> 1>          caerep.property.pb.h(128) : see reference to class template instantiation 'google::protobuf::RepeatedField<Element>' being compiled
> 1>          with
> 1>          [
> 1>              Element=google::protobuf::int32
> 1>          ]
> 1>Protobuf\3.0.0.b4\cpp\include\google/protobuf/repeated_field.h(284): error C2273: 'function-style cast' : illegal as right side of '->' operator
