### PR TITLE
Fixes traivs cpp build.

### DIFF
--- a/src/google/protobuf/stubs/int128.cc
+++ b/src/google/protobuf/stubs/int128.cc
@@ -145,15 +145,15 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
   std::streamsize div_base_log;
   switch (flags & std::ios::basefield) {
     case std::ios::hex:
-      div = GOOGLE_ULONGLONG(0x1000000000000000);  // 16^15
+      div = static_cast<uint64>(GOOGLE_ULONGLONG(0x1000000000000000));  // 16^15
       div_base_log = 15;
       break;
     case std::ios::oct:
-      div = GOOGLE_ULONGLONG(01000000000000000000000);  // 8^21
+      div = static_cast<uint64>(GOOGLE_ULONGLONG(01000000000000000000000));  // 8^21
       div_base_log = 21;
       break;
     default:  // std::ios::dec
-      div = GOOGLE_ULONGLONG(10000000000000000000);  // 10^19
+      div = static_cast<uint64>(GOOGLE_ULONGLONG(10000000000000000000));  // 10^19
       div_base_log = 19;
       break;
   }

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -132,8 +132,8 @@ typedef uint64_t uint64;
 #define GOOGLE_LL_FORMAT "I64"  // As in printf("%I64d", ...)
 #else
 // By long long, we actually mean int64.
-#define GOOGLE_LONGLONG(x) INT64_C(x)
-#define GOOGLE_ULONGLONG(x) UINT64_C(x)
+#define GOOGLE_LONGLONG(x) x##LL
+#define GOOGLE_ULONGLONG(x) x##ULL
 // Used to format real long long integers.
 #define GOOGLE_LL_FORMAT "ll"  // As in "%lld". Note that "q" is poor form also.
 #endif


### PR DESCRIPTION
Remove the use of INT64_C/UINT64_C and add static_cast when necessary.

@pherl to review.

Turns out static_cast is not needed when assigning a xxULL value to int64_t in most places as the compiler is smart enough to figure out a GOOGLE_ULONGLONG(xxx) value actually can fit into a int64_t type.