### PR TITLE
Bring C#'s ToPascalCase method in line with C++.

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonFormatterTest.cs
@@ -230,6 +230,12 @@ namespace Google.Protobuf
         [TestCase("foo_bar", "fooBar")]
         [TestCase("bananaBanana", "bananaBanana")]
         [TestCase("BANANABanana", "bananaBanana")]
+        [TestCase("simple", "simple")]
+        [TestCase("ACTION_AND_ADVENTURE", "actionAndAdventure")]
+        [TestCase("action_and_adventure", "actionAndAdventure")]
+        [TestCase("kFoo", "kFoo")]
+        [TestCase("HTTPServer", "httpServer")]
+        [TestCase("CLIENT", "client")]
         public void ToCamelCase(string original, string expected)
         {
             Assert.AreEqual(expected, JsonFormatter.ToCamelCase(original));

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -274,7 +274,6 @@ namespace Google.Protobuf
         }
 
         // Converted from src/google/protobuf/util/internal/utility.cc ToCamelCase
-        // TODO: Use the new field in FieldDescriptor.
         internal static string ToCamelCase(string input)
         {
             bool capitalizeNext = false;
@@ -305,6 +304,7 @@ namespace Google.Protobuf
                         (!wasCap || (i + 1 < input.Length && char.IsLower(input[i + 1]))))
                     {
                         firstWord = false;
+                        result.Append(input[i]);
                     }
                     else
                     {
@@ -320,8 +320,16 @@ namespace Google.Protobuf
                         result.Append(char.ToUpperInvariant(input[i]));
                         continue;
                     }
+                    else
+                    {
+                        result.Append(input[i]);
+                        continue;
+                    }
                 }
-                result.Append(input[i]);
+                else
+                {
+                    result.Append(char.ToLowerInvariant(input[i]));
+                }
             }
             return result.ToString();
         }


### PR DESCRIPTION
I'd been hoping this would get our JSON conformance test failures down, but it doesn't.
At least we're now consistent with the C++ code.

This code is called in two cases:

- If we have a proto descriptor that doesn't have the json_name field for some reason
- When formatting a field mask

It's important that this is consistent with other platforms; I hadn't noticed when the C++ code it was ported from changed.

