### PR TITLE
Use 64-bit protoc binaries in compatibility tests.

### DIFF
--- a/java/compatibility_tests/v2.5.0/test.sh
+++ b/java/compatibility_tests/v2.5.0/test.sh
@@ -21,23 +21,23 @@ case "$1" in
     ;;
   2.6.1)
     OLD_VERSION=2.6.1
-    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/2.6.1-build2/protoc-2.6.1-build2-linux-x86_32.exe
+    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/2.6.1-build2/protoc-2.6.1-build2-linux-x86_64.exe
     ;;
   3.0.0-beta-1)
     OLD_VERSION=3.0.0-beta-1
-    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-1/protoc-3.0.0-beta-1-linux-x86_32.exe
+    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-1/protoc-3.0.0-beta-1-linux-x86_64.exe
     ;;
   3.0.0-beta-2)
     OLD_VERSION=3.0.0-beta-2
-    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-2/protoc-3.0.0-beta-2-linux-x86_32.exe
+    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-2/protoc-3.0.0-beta-2-linux-x86_64.exe
     ;;
   3.0.0-beta-3)
     OLD_VERSION=3.0.0-beta-3
-    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-3/protoc-3.0.0-beta-3-linux-x86_32.exe
+    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-3/protoc-3.0.0-beta-3-linux-x86_64.exe
     ;;
   3.0.0-beta-4)
     OLD_VERSION=3.0.0-beta-4
-    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_32.exe
+    OLD_VERSION_PROTOC=http://repo1.maven.org/maven2/com/google/protobuf/protoc/3.0.0-beta-4/protoc-3.0.0-beta-4-linux-x86_64.exe
     ;;
   *)
     echo "[ERROR]: Unknown version number: $1"


### PR DESCRIPTION
Turns out travis by default doesn't have the needed dependencies to run a 32-bit
binary.