### PR TITLE
JavaScript: Make implicit defaults consistent with explicit defaults in toObject

### DIFF
--- a/js/message_test.js
+++ b/js/message_test.js
@@ -145,11 +145,7 @@ describe('Message test suite', function() {
         undefined, undefined, undefined, undefined]);
     var result = foo.toObject();
     assertObjectEquals({
-      aString: undefined,
-      anOutOfOrderBool: undefined,
-      aNestedMessage: {
-        anInt: undefined
-      },
+      aNestedMessage: {},
       // Note: JsPb converts undefined repeated fields to empty arrays.
       aRepeatedMessageList: [],
       aRepeatedStringList: []
@@ -184,14 +180,7 @@ describe('Message test suite', function() {
     var response = new proto.jspb.test.DefaultValues();
 
     // Test toObject
-    var expectedObject = {
-      stringField: defaultString,
-      boolField: true,
-      intField: 11,
-      enumField: 13,
-      emptyField: '',
-      bytesField: 'bW9v'
-    };
+    var expectedObject = {};
     assertObjectEquals(expectedObject, response.toObject());
 
 
@@ -722,12 +711,7 @@ describe('Message test suite', function() {
     assertObjectEquals({id: 'g1', someBoolList: [true, false]},
         groups[0].toObject());
     assertObjectEquals({
-      repeatedGroupList: [{id: 'g1', someBoolList: [true, false]}],
-      requiredGroup: {id: undefined},
-      optionalGroup: undefined,
-      requiredSimple: {aRepeatedStringList: [], aString: undefined},
-      optionalSimple: undefined,
-      id: undefined
+      repeatedGroupList: [{id: 'g1', someBoolList: [true, false]}]
     }, group.toObject());
     var group1 = new proto.jspb.test.TestGroup1();
     group1.setGroup(someGroup);


### PR DESCRIPTION
This was originally part of #1447, but it was decided to postpone this part. The relevant parts of the description of the previous PR follow.

Currently, the JS implementation treats proto2 fields with specified defaults differently from fields without specified defaults in `toObject`.

Consider the following message definition:

``` proto
message Test {
  optional string foo = 1;
  optional string bar = 2 [default = ""];
}
```

If both `foo` and `bar` are unset, `toObject()` returns `{ foo: undefined, bar: "" }`.

However, `foo` and `bar` should be equivalent when unset per the [spec](https://developers.google.com/protocol-buffers/docs/proto#optional) (which would be consistent with the other implementations). I propose to unify their behavior in the following way:

If both `foo` and `bar` are unset, `toObject()` returns `{}`. This is for two reasons: 1) putting the default value in the object would cause loss of presence information; 2) properties with `undefined` values don't carry any useful information and just add noise to the object.
