### PR TITLE
close opened file descriptors properly

### DIFF
--- a/src/google/protobuf/testing/file.cc
+++ b/src/google/protobuf/testing/file.cc
@@ -91,6 +91,7 @@ bool File::WriteStringToFile(const string& contents, const string& name) {
 
   if (fwrite(contents.data(), 1, contents.size(), file) != contents.size()) {
     GOOGLE_LOG(ERROR) << "fwrite(" << name << "): " << strerror(errno);
+    fclose(file);
     return false;
   }
 


### PR DESCRIPTION
[src/google/protobuf/testing/file.cc:95]: (error) Resource leak: file

Found by https://github.com/bryongloden/cppcheck