### PR TITLE
Update TextFormat to handle unknown Enum values

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/TextFormat.java
+++ b/java/core/src/main/java/com/google/protobuf/TextFormat.java
@@ -34,6 +34,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -442,7 +443,11 @@ public final class TextFormat {
           break;
 
         case ENUM:
-          generator.print(((EnumValueDescriptor) value).getName());
+          if (((EnumValueDescriptor) value).getIndex() == -1) {
+            generator.print(String.valueOf(((EnumValueDescriptor) value).getNumber()));
+          } else {
+            generator.print(((EnumValueDescriptor) value).getName());
+          }
           break;
 
         case MESSAGE:
@@ -1679,7 +1684,11 @@ public final class TextFormat {
 
             if (tokenizer.lookingAtInteger()) {
               final int number = tokenizer.consumeInt32();
-              value = enumType.findValueByNumber(number);
+              if (enumType.getFile().supportsUnknownEnumValue()) {
+                value = enumType.findValueByNumberCreatingIfUnknown(number);
+              } else {
+                value = enumType.findValueByNumber(number);
+              }
               if (value == null) {
                 throw tokenizer.parseExceptionPreviousToken(
                   "Enum type \"" + enumType.getFullName()

--- a/java/core/src/test/java/com/google/protobuf/UnknownEnumValueTest.java
+++ b/java/core/src/test/java/com/google/protobuf/UnknownEnumValueTest.java
@@ -229,7 +229,7 @@ public class UnknownEnumValueTest extends TestCase {
     assertFalse(message.equals(differentMessage));
   }
   
-  public void testUnknownEnumValuesInTextFormat() {
+  public void testUnknownEnumValuesInTextFormat() throws ParseException {
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     builder.setOptionalNestedEnumValue(4321);
     builder.addRepeatedNestedEnumValue(5432);
@@ -239,17 +239,26 @@ public class UnknownEnumValueTest extends TestCase {
     // We can print a message with unknown enum values.
     String textData = TextFormat.printToString(message);
     assertEquals(
-        "optional_nested_enum: UNKNOWN_ENUM_VALUE_NestedEnum_4321\n"
-        + "repeated_nested_enum: UNKNOWN_ENUM_VALUE_NestedEnum_5432\n"
-        + "packed_nested_enum: UNKNOWN_ENUM_VALUE_NestedEnum_6543\n", textData);
+        "optional_nested_enum: 4321\n"
+        + "repeated_nested_enum: 5432\n"
+        + "packed_nested_enum: 6543\n", textData);
     
     // Parsing unknown enum values will fail just like parsing other kinds of
     // unknown fields.
-    try {
-      TextFormat.merge(textData, builder);
-      fail();
-    } catch (ParseException e) {
-      // expected.
-    }
+    
+    builder = TestAllTypes.newBuilder();
+    TextFormat.merge(textData, builder);
+    message = builder.build();
+    
+    assertEquals(4321, message.getOptionalNestedEnumValue());
+    assertEquals(5432, message.getRepeatedNestedEnumValue(0));
+    assertEquals(5432, message.getRepeatedNestedEnumValueList().get(0).intValue());
+    assertEquals(6543, message.getPackedNestedEnumValue(0));
+    // Returns UNRECOGNIZED if an enum type is requested.
+    assertEquals(TestAllTypes.NestedEnum.UNRECOGNIZED, message.getOptionalNestedEnum());
+    assertEquals(TestAllTypes.NestedEnum.UNRECOGNIZED, message.getRepeatedNestedEnum(0));
+    assertEquals(TestAllTypes.NestedEnum.UNRECOGNIZED, message.getRepeatedNestedEnumList().get(0));
+    assertEquals(TestAllTypes.NestedEnum.UNRECOGNIZED, message.getPackedNestedEnum(0));
+    
   }
 }


### PR DESCRIPTION
Currently `TextFormat.java` (and presumably the equivalent implementation in other languages) does not handle unknown enum values at all well.  When printed they produce a string value `UNKNOWN_ENUM_VALUE_NestedEnum_XXXX` which cannot then be parsed again.  So a perfectly valid proto3 message with an unknown enum value cannot be round tripped to a string a back again using `TextFormat`.

I have updated the java `TextFormat` implementation to instead handle unknown Enum values in precisely the same way as they are handled by the `JsonFormat` implementation i.e. they are printed as simple number values and parsed successfully back to unknown Enum values for proto3 messages.
