### PR TITLE
JavaScript: Add protoc option to preserve field names in toObject

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -68,12 +68,15 @@ struct GeneratorOptions {
     kImportBrowser,   // no import statements
     kImportEs6,       // import { member } from ''
   } import_style;
+  // Preserve field names in toObject?
+  bool preserve_proto_fieldnames;
 
   GeneratorOptions()
       : output_dir("."),
         namespace_prefix(""),
         binary(false),
         import_style(kImportClosure),
+        preserve_proto_fieldnames(false),
         add_require_for_enums(false),
         testonly(false),
         library(""),


### PR DESCRIPTION
Currently, `toObject` returns an object with field names converted to camelCase. However, in some cases the original field names are preferable. This adds a `protoc` option `preserve_proto_fieldnames` that keeps them as-is, and also doesn't append "List" or "Map".

I'll add tests if/when I get a go-ahead on the general idea (and perhaps some suggestion on how the test should work).
