### PR TITLE
Fix up ignores and conformance generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ src/protoc
 src/unittest_proto_middleman
 
 # Generated test scaffolding
+src/no_warning_test.cc
+src/no-warning-test
 src/protobuf*-test
 src/test_plugin
 src/testzip.*
@@ -108,7 +110,7 @@ conformance/conformance.pb.cc
 conformance/conformance.pb.h
 conformance/Conformance.pbobjc.h
 conformance/Conformance.pbobjc.m
-conformance/conformance.rb
+conformance/conformance_pb.rb
 conformance/google/
 conformance/javac_middleman
 conformance/lite/

--- a/conformance/Makefile.am
+++ b/conformance/Makefile.am
@@ -20,7 +20,7 @@ other_language_protoc_outputs =                                \
   conformance_pb2.py                                           \
   Conformance.pbobjc.h                                         \
   Conformance.pbobjc.m                                         \
-  conformance.rb                                               \
+  conformance_pb.rb                                            \
   com/google/protobuf/Any.java                                 \
   com/google/protobuf/AnyOrBuilder.java                        \
   com/google/protobuf/AnyProto.java                            \


### PR DESCRIPTION
- Update ruby conformance generation for rename of generated files that seems
  to have happened.
- Update gitignores for the above and for the no-warnings-test.