### PR TITLE
Bump the version in prep for the 3.0.2 tag being cut

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -5,7 +5,7 @@
 # dependent projects use the :git notation to refer to the library.
 Pod::Spec.new do |s|
   s.name     = 'Protobuf'
-  s.version  = '3.0.0'
+  s.version  = '3.0.2'
   s.summary  = 'Protocol Buffers v.3 runtime library for Objective-C.'
   s.homepage = 'https://github.com/google/protobuf'
   s.license  = 'New BSD'
@@ -36,5 +36,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '7.1'
   s.osx.deployment_target = '10.9'
+  s.watchos.deployment_target = '2.0'
   s.requires_arc = false
 end


### PR DESCRIPTION
Also pull the watchos support info from master.