### PR TITLE
Add link to Elm protobuf plugin

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -32,6 +32,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * Delphi: http://sourceforge.net/projects/protobuf-delphi/
 * Delphi: http://fundementals.sourceforge.net/dl.html
 * Elixir: https://github.com/jeremyong/exprotoc
+* Elm: https://github.com/tiziano88/elm-protobuf
 * Erlang: http://github.com/ngerakines/erlang_protobuffs/tree/master
 * Erlang: http://piqi.org/
 * Erlang: https://code.google.com/p/protoc-gen-erl/


### PR DESCRIPTION
The plugin is still work in progress, but at least if someone is looking for something that works in Elm they will be able to find it and contribute to it rather than starting from scratch.
