### PR TITLE
Add support for GNU/Hurd which doesn't define PATH_MAX.

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -51,6 +51,9 @@
 #include <ctype.h>
 
 #include <limits.h> //For PATH_MAX
+#if defined(__GNU__)
+#define PATH_MAX 4096
+#endif
 
 #include <memory>
 #ifndef _SHARED_PTR_H


### PR DESCRIPTION
Using `sysconf` is a better solution as documented in the [GNU/Hurd porting guidelines](https://www.gnu.org/software/hurd/hurd/porting/guidelines.html#PATH_MAX_tt_MAX_PATH_tt_MAXPATHL):
> `PATH_MAX`, `MAX_PATH`, `MAXPATHLEN`, `_POSIX_PATH_MAX`
> 
> http://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
> 
> Every unconditionalized use of `PATH_MAX`, `MAX_PATH` or `MAXPATHLEN` is a POSIX incompatibility. If there is no upper limit on the length of a path (as its the case for GNU), this symbol is not defined in any header file. Instead, you need to either use a different implementation that does not rely on the length of a string or use `sysconf()` to query the length at runtime. If `sysconf()` returns -1, you have to use `realloc()` to allocate the needed memory dynamically. Usually it is thus simpler to just use dynamic allocation. Sometimes the amount is actually known. Else, a geometrically growing loop can be used: for instance, see [Alioth patch](http://alioth.debian.org/tracker/download.php/30628/410472/303735/1575/cpulimit-path-max-fix.patch) or [Pulseaudio patch](http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-pulse;att=1;bug=522100). Note that in some cases there are GNU extensions that just work fine: when the `__GLIBC__` macro is defined, `getcwd()` calls can be just replaced by `get_current_dir_name()` calls.
> 
> Note: constants such as `_POSIX_PATH_MAX` are only the minimum required value for a potential corresponding `PATH_MAX` macro. They are not a replacement for `PATH_MAX`, just the minimum value that one can assume.
> 
> Note 2: Yes, some POSIX functions such as `realpath()` actually assume that `PATH_MAX` is defined. This is a bug of the POSIX standard, which got fixed in the latest revisions, in which one can simply pass `NULL` to get a dynamically allocated buffer.

See also: #2000