### PR TITLE
Disable test if EXPECT_DEATH is not available.

### DIFF
--- a/src/google/protobuf/stubs/stringpiece_unittest.cc
+++ b/src/google/protobuf/stubs/stringpiece_unittest.cc
@@ -784,9 +784,11 @@ TEST(FindOneCharTest, EdgeCases) {
 }
 
 #ifndef NDEBUG
+#ifdef PROTOBUF_HAS_DEATH_TEST
 TEST(NonNegativeLenTest, NonNegativeLen) {
   EXPECT_DEATH(StringPiece("xyz", -1), "len >= 0");
 }
+#endif  // PROTOBUF_HAS_DEATH_TEST
 #endif  // ndef DEBUG
 
 }  // namespace


### PR DESCRIPTION
All other tests using `EXPECT_DEATH()` are guarded by the same `#ifdef`.

See also: #2003