### PR TITLE
Use /usr/bin/python instead of /usr/bin/python2.4

### DIFF
--- a/python/mox.py
+++ b/python/mox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.4
+#!/usr/bin/python
 #
 # Copyright 2008 Google Inc.
 #

--- a/python/stubout.py
+++ b/python/stubout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.4
+#!/usr/bin/python
 #
 # Copyright 2008 Google Inc.
 #


### PR DESCRIPTION
Using `/usr/bin/env python` like `python/setup.py` is an option too.

Fixes: #1999 
