### PR TITLE
Add an Erlang project, gpb, to third_party.md

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -36,6 +36,7 @@ These are projects we know about implementing Protocol Buffers for other program
 * Erlang: http://piqi.org/
 * Erlang: https://code.google.com/p/protoc-gen-erl/
 * Erlang: https://github.com/basho/erlang_protobuffs
+* Erlang: https://github.com/tomas-abrahamsson/gpb
 * Go: https://github.com/golang/protobuf (Google-official implementation)
 * Go: http://code.google.com/p/goprotobuf/
 * Go: https://github.com/akunspy/gopbuf


### PR DESCRIPTION
I have yet another Erlang binding to the protocol buffers.

I noticed the name, gpb, clashes with that used in the Objective C binding. I'm sorry about that. I was not aware of that when I started work on my Erlang project long ago, but since it is different languages, I don't think there's any confusion.
