### PR TITLE
ObjC support for GenerateAll().

### DIFF
--- a/objectivec/DevTools/compile_testing_protos.sh
+++ b/objectivec/DevTools/compile_testing_protos.sh
@@ -99,26 +99,26 @@ CORE_PROTO_FILES+=(
   src/google/protobuf/descriptor.proto
 )
 
-compile_proto() {
+compile_protos() {
   src/protoc                                   \
     --objc_out="${OUTPUT_DIR}/google/protobuf" \
     --proto_path=src/google/protobuf/          \
     --proto_path=src                           \
-    $*
+    "$@"
 }
 
+# Note: there is overlap in package.Message names between some of the test
+# files, so they can't be generated all at once. This works because the overlap
+# isn't linked into a single binary.
 for a_proto in "${CORE_PROTO_FILES[@]}" ; do
-  compile_proto "${a_proto}"
+  compile_protos "${a_proto}"
 done
 
-OBJC_PROTO_FILES=(
-  objectivec/Tests/unittest_cycle.proto
-  objectivec/Tests/unittest_runtime_proto2.proto
-  objectivec/Tests/unittest_runtime_proto3.proto
-  objectivec/Tests/unittest_objc.proto
+# Objective C specific testing protos.
+compile_protos \
+  --proto_path="objectivec/Tests" \
+  objectivec/Tests/unittest_cycle.proto \
+  objectivec/Tests/unittest_runtime_proto2.proto \
+  objectivec/Tests/unittest_runtime_proto3.proto \
+  objectivec/Tests/unittest_objc.proto \
   objectivec/Tests/unittest_objc_startup.proto
-)
-
-for a_proto in "${OBJC_PROTO_FILES[@]}" ; do
-  compile_proto --proto_path="objectivec/Tests" "${a_proto}"
-done

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.h
@@ -47,8 +47,15 @@ class LIBPROTOC_EXPORT ObjectiveCGenerator : public CodeGenerator {
   ~ObjectiveCGenerator();
 
   // implements CodeGenerator ----------------------------------------
-  bool Generate(const FileDescriptor* file, const string& parameter,
-                OutputDirectory* output_directory, string* error) const;
+  bool HasGenerateAll() const;
+  bool Generate(const FileDescriptor* file,
+                const string& parameter,
+                GeneratorContext* context,
+                string* error) const;
+  bool GenerateAll(const vector<const FileDescriptor*>& files,
+                   const string& parameter,
+                   GeneratorContext* context,
+                   string* error) const;
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ObjectiveCGenerator);

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -185,12 +185,12 @@ string ProtobufFrameworkImportSymbol(const string& framework_name);
 // Checks if the file is one of the proto's bundled with the library.
 bool IsProtobufLibraryBundledProtoFile(const FileDescriptor* file);
 
-// Checks the prefix for a given file and outputs any warnings needed, if
-// there are flat out errors, then out_error is filled in and the result is
-// false.
-bool ValidateObjCClassPrefix(const FileDescriptor* file,
-                             const Options& generation_options,
-                             string* out_error);
+// Checks the prefix for the given files and outputs any warnings as needed. If
+// there are flat out errors, then out_error is filled in with the first error
+// and the result is false.
+bool ValidateObjCClassPrefixes(const vector<const FileDescriptor*>& files,
+                               const Options& generation_options,
+                               string* out_error);
 
 // Generate decode data needed for ObjC's GPBDecodeTextFormatName() to transform
 // the input into the expected output.


### PR DESCRIPTION
- Expect calls on GenerateAll() and not Generate().
- Parse the prefix validation file once, and then check all the files.