### PR TITLE
Restore New*Callback into google::protobuf namespace …

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -2956,7 +2956,7 @@ GenerateMergeFromCodedStream(io::Printer* printer) {
     // on the CodedOutputStream.
     printer->Print(
       "  ::google::protobuf::io::LazyStringOutputStream unknown_fields_string(\n"
-      "      ::google::protobuf::internal::NewPermanentCallback(\n"
+      "      ::google::protobuf::NewPermanentCallback(\n"
       "          &MutableUnknownFieldsFor$classname$, this));\n"
       "  ::google::protobuf::io::CodedOutputStream unknown_fields_stream(\n"
       "      &unknown_fields_string, false);\n",

--- a/src/google/protobuf/compiler/cpp/cpp_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_unittest.cc
@@ -1252,7 +1252,7 @@ class GeneratedServiceTest : public testing::Test {
       foo_(descriptor_->FindMethodByName("Foo")),
       bar_(descriptor_->FindMethodByName("Bar")),
       stub_(&mock_channel_),
-      done_(::google::protobuf::internal::NewPermanentCallback(&DoNothing)) {}
+      done_(NewPermanentCallback(&DoNothing)) {}
 
   virtual void SetUp() {
     ASSERT_TRUE(foo_ != NULL);

--- a/src/google/protobuf/stubs/callback.h
+++ b/src/google/protobuf/stubs/callback.h
@@ -381,6 +381,8 @@ class MethodResultCallback_5_2 : public ResultCallback2<R, A1, A2> {
   typename remove_reference<P5>::type p5_;
 };
 
+}  // namespace internal
+
 // See Closure.
 inline Closure* NewCallback(void (*function)()) {
   return new internal::FunctionClosure0(function, true);
@@ -532,8 +534,6 @@ inline ResultCallback2<R, A1, A2>* NewPermanentCallback(
                                                 A2>(object, function, false, p1,
                                                     p2, p3, p4, p5);
 }
-
-}  // namespace internal
 
 // A function which does nothing.  Useful for creating no-op callbacks, e.g.:
 //   Closure* nothing = NewCallback(&DoNothing);

--- a/src/google/protobuf/stubs/common_unittest.cc
+++ b/src/google/protobuf/stubs/common_unittest.cc
@@ -41,8 +41,6 @@
 
 namespace google {
 namespace protobuf {
-using internal::NewCallback;
-using internal::NewPermanentCallback;
 namespace {
 
 // TODO(kenton):  More tests.

--- a/src/google/protobuf/stubs/once_unittest.cc
+++ b/src/google/protobuf/stubs/once_unittest.cc
@@ -43,7 +43,6 @@
 
 namespace google {
 namespace protobuf {
-using internal::NewCallback;
 namespace {
 
 class OnceInitTest : public testing::Test {
@@ -128,11 +127,11 @@ class OnceInitTest : public testing::Test {
   };
 
   TestThread* RunInitOnceInNewThread() {
-    return new TestThread(internal::NewCallback(this, &OnceInitTest::InitOnce));
+    return new TestThread(NewCallback(this, &OnceInitTest::InitOnce));
   }
   TestThread* RunInitRecursiveOnceInNewThread() {
     return new TestThread(
-        internal::NewCallback(this, &OnceInitTest::InitRecursiveOnce));
+        NewCallback(this, &OnceInitTest::InitRecursiveOnce));
   }
 
   enum State {

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -907,7 +907,7 @@ Status ProtoStreamObjectWriter::RenderFieldMask(ProtoStreamObjectWriter* ow,
 // conversions as much as possible. Because ToSnakeCase sometimes returns the
 // wrong value.
   google::protobuf::scoped_ptr<ResultCallback1<util::Status, StringPiece> > callback(
-      ::google::protobuf::internal::NewPermanentCallback(&RenderOneFieldPath, ow));
+      NewPermanentCallback(&RenderOneFieldPath, ow));
   return DecodeCompactFieldMaskPaths(data.str(), callback.get());
 }
 

--- a/src/google/protobuf/util/message_differencer.cc
+++ b/src/google/protobuf/util/message_differencer.cc
@@ -1389,8 +1389,7 @@ bool MessageDifferencer::MatchRepeatedFieldIndices(
       // doesn't necessarily imply Compare(b, c). Therefore a naive greedy
       // algorithm will fail to find a maximum matching.
       // Here we use the argumenting path algorithm.
-      MaximumMatcher::NodeMatchCallback* callback =
-          ::google::protobuf::internal::NewPermanentCallback(
+      MaximumMatcher::NodeMatchCallback* callback = NewPermanentCallback(
               this, &MessageDifferencer::IsMatch,
               repeated_field, key_comparator,
               &message1, &message2, parent_fields);


### PR DESCRIPTION
… since these are used by the service stubs code

Fixes #1966