### PR TITLE
Speed up ObjC Generation with large dependency trees

### DIFF
--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -63,29 +63,16 @@ class FileGenerator {
 
   const string& RootClassName() const { return root_class_name_; }
 
-  bool IsPublicDependency() const { return is_public_dep_; }
-
- protected:
-  void SetIsPublicDependency(bool is_public_dep) {
-    is_public_dep_ = is_public_dep;
-  }
-
  private:
   const FileDescriptor* file_;
   string root_class_name_;
 
-  // Access this field through the DependencyGenerators accessor call below.
-  // Do not reference it directly.
-  vector<FileGenerator*> dependency_generators_;
-
   vector<EnumGenerator*> enum_generators_;
   vector<MessageGenerator*> message_generators_;
   vector<ExtensionGenerator*> extension_generators_;
-  bool is_public_dep_;
 
   const Options options_;
 
-  const vector<FileGenerator*>& DependencyGenerators();
   void PrintFileRuntimePreamble(
       io::Printer* printer, const string& header_to_import) const;
 


### PR DESCRIPTION
Don't create FileGenerators for each dep. FileGenerators will deeply create all
the message, enum, and field generators; but those aren't needed when doing
the imports for dependencies. Instead directly generate the imports off the
FileDescriptors so no extra objects are created. The only other use was when
chaining together the *Roots for the file extension registry, but that also
can be generate off the name of the FileDescriptor directly.