### PR TITLE
update the OSGi metadata for the javanano package

### DIFF
--- a/javanano/pom.xml
+++ b/javanano/pom.xml
@@ -164,8 +164,8 @@
         <configuration>
           <instructions>
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
-            <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
-            <Export-Package>com.google.protobuf;version=3.0.0-alpha-7</Export-Package>
+            <Bundle-SymbolicName>com.google.protobuf.nano</Bundle-SymbolicName>
+            <Export-Package>com.google.protobuf.nano;version=3.0.0-alpha-7</Export-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
the javanano OSGi metadata was referencing the wrong package for exporting classes in an OSGi environment