### PR TITLE
Fix to typo/oversight in reflection tests

### DIFF
--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -636,7 +636,7 @@ class ReflectionTest(unittest.TestCase):
     if struct.calcsize('L') == 4:
       # Python only has signed ints, so 32-bit python can't fit an uint32
       # in an int.
-      TestGetAndDeserialize('optional_uint32', 1 << 31, long)
+      TestGetAndDeserialize('optional_uint32', 1 << 31, integer_64)
     else:
       # 64-bit python can fit uint32 inside an int
       TestGetAndDeserialize('optional_uint32', 1 << 31, int)


### PR DESCRIPTION
Fixed small typo/oversight in reflection tests affecting python 3 only