### PR TITLE
Rm check on dependency in the C# reflection API

### DIFF
--- a/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/FileDescriptor.cs
@@ -251,17 +251,6 @@ namespace Google.Protobuf.Reflection
                     "Dependencies passed to FileDescriptor.BuildFrom() don't match " +
                     "those listed in the FileDescriptorProto.");
             }
-            for (int i = 0; i < proto.Dependency.Count; i++)
-            {
-                if (dependencies[i].Name != proto.Dependency[i])
-                {
-                    throw new DescriptorValidationException(
-                        result,
-                        "Dependencies passed to FileDescriptor.BuildFrom() don't match " +
-                        "those listed in the FileDescriptorProto. Expected: " +
-                        proto.Dependency[i] + " but was: " + dependencies[i].Name);
-                }
-            }
 
             result.CrossLink();
             return result;


### PR DESCRIPTION
This check adds a few constraints on the way to build a project when we have
a proto file which imports another one. In particular, on projects which
build both C# and Java, it's easy to end up with exceptions like

    Expected: included.proto but was src/main/protobuf/included.proto

A user may work around this issue, but it may add unnecessary constraints
on the layout of the project.

According to https://github.com/google/protobuf/commit/f3504cf3b1d456a843e8242fdee9ba0bf2991dc1#diff-ecb0b909ed572381a1c8d1994f09a948R309
it has already been considered to get rid of this check, for
similar considerations, and because it doesn't exist in the Java code