### PR TITLE
Use global namespace to avoid ambiguity.

### DIFF
--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -46,7 +46,7 @@
 #include <google/protobuf/wire_format_lite_inl.h>
 #include <google/protobuf/stubs/strutil.h>
 
-using namespace std;
+using namespace ::std;
 
 namespace {
 // Helper methods to test parsing merge behavior.

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -217,7 +217,7 @@ class FatalException : public std::exception {
 
 // This is at the end of the file instead of the beginning to work around a bug
 // in some versions of MSVC.
-using namespace std;  // Don't do this at home, kids.
+using namespace ::std;  // Don't do this at home, kids.
 
 }  // namespace protobuf
 }  // namespace google


### PR DESCRIPTION
This aligns with other codes in ProtoBuf, for example:

```
::std::pair<bool, const uint8*>
const ::std::string& Any::type_url()
```
