### PR TITLE
Fix #2071 replacing /bin/sh with bash when generates descriptor

### DIFF
--- a/generate_descriptor_proto.sh
+++ b/generate_descriptor_proto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Run this script to regenerate descriptor.pb.{h,cc} after the protocol
 # compiler changes.  Since these files are compiled into the protocol compiler


### PR DESCRIPTION
On Ubuntu `/bin/sh` is `dash` by default, this can cause `generate_descriptor_proto.sh` fail to execute.