### PR TITLE
Allow the JsonFormat.Parser to ignore unknown fields.

### DIFF
--- a/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
+++ b/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java
@@ -224,7 +224,7 @@ public class JsonFormat {
    * Creates a {@link Parser} with default configuration.
    */
   public static Parser parser() {
-    return new Parser(TypeRegistry.getEmptyTypeRegistry());
+    return new Parser(TypeRegistry.getEmptyTypeRegistry(), false);
   }
 
   /**
@@ -232,9 +232,11 @@ public class JsonFormat {
    */
   public static class Parser {
     private final TypeRegistry registry;
+    private final boolean ignoreUnknownFields;
 
-    private Parser(TypeRegistry registry) {
+    private Parser(TypeRegistry registry, boolean ignoreUnknownFields) {
       this.registry = registry;
+      this.ignoreUnknownFields = ignoreUnknownFields;
     }
 
     /**
@@ -247,7 +249,16 @@ public class JsonFormat {
       if (this.registry != TypeRegistry.getEmptyTypeRegistry()) {
         throw new IllegalArgumentException("Only one registry is allowed.");
       }
-      return new Parser(registry);
+      return new Parser(registry, this.ignoreUnknownFields);
+    }
+
+    /**
+     * Creates a new {@link Parser} configured to not throw an exception
+     * when an unknown field is encountered. The new Parser clones all other
+     * configurations from this Parser.
+     */
+    public Parser ignoreUnknownFields() {
+      return new Parser(this.registry, true);
     }
 
     /**
@@ -259,7 +270,7 @@ public class JsonFormat {
     public void merge(String json, Message.Builder builder) throws InvalidProtocolBufferException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry).merge(json, builder);
+      new ParserImpl(registry, ignoreUnknownFields).merge(json, builder);
     }
 
     /**
@@ -272,7 +283,7 @@ public class JsonFormat {
     public void merge(Reader json, Message.Builder builder) throws IOException {
       // TODO(xiaofeng): Investigate the allocation overhead and optimize for
       // mobile.
-      new ParserImpl(registry).merge(json, builder);
+      new ParserImpl(registry, ignoreUnknownFields).merge(json, builder);
     }
   }
 
@@ -1024,9 +1035,11 @@ public class JsonFormat {
   private static class ParserImpl {
     private final TypeRegistry registry;
     private final JsonParser jsonParser;
+    private final boolean ignoreUnknownFields;
 
-    ParserImpl(TypeRegistry registry) {
+    ParserImpl(TypeRegistry registry, boolean ignoreUnknownFields) {
       this.registry = registry;
+      this.ignoreUnknownFields = ignoreUnknownFields;
       this.jsonParser = new JsonParser();
     }
 
@@ -1191,6 +1204,9 @@ public class JsonFormat {
         }
         FieldDescriptor field = fieldNameMap.get(entry.getKey());
         if (field == null) {
+          if (ignoreUnknownFields) {
+            continue;
+          }
           throw new InvalidProtocolBufferException(
               "Cannot find field: "
                   + entry.getKey()

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -1030,6 +1030,22 @@ public class JsonFormatTest extends TestCase {
     }
   }
 
+  public void testParserUnknownFields() throws Exception {
+    try {
+      TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+      String json = "{\n" + "  \"unknownField\": \"XXX\"\n" + "}";
+      JsonFormat.parser().merge(json, builder);
+      fail("Exception is expected.");
+    } catch (InvalidProtocolBufferException e) {
+      // Expected.
+    }
+  }
+  public void testParserIgnoreUnknownFields() throws Exception {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    String json = "{\n" + "  \"unknownField\": \"XXX\"\n" + "}";
+    JsonFormat.parser().ignoreUnknownFields().merge(json, builder);
+  }
+
   public void testCustomJsonName() throws Exception {
     TestCustomJsonName message = TestCustomJsonName.newBuilder().setValue(12345).build();
     assertEquals("{\n" + "  \"@value\": 12345\n" + "}", JsonFormat.printer().print(message));


### PR DESCRIPTION
The default behaviour of throwing an exception remains.