### PR TITLE
Update repo in Bazel build files to use googletest instead of the deprecated gMock

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,15 +1,15 @@
-new_http_archive(
-    name = "gmock_archive",
-    url = "https://googlemock.googlecode.com/files/gmock-1.7.0.zip",
-    sha256 = "26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b",
+new_git_repository(
+    name = "googletest",
     build_file = "gmock.BUILD",
+    remote = "https://github.com/google/googletest",
+    tag = "release-1.8.0",
 )
 
 new_http_archive(
     name = "six_archive",
-    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
-    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
     build_file = "six.BUILD",
+    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
 )
 
 bind(
@@ -19,12 +19,12 @@ bind(
 
 bind(
     name = "gtest",
-    actual = "@gmock_archive//:gtest",
+    actual = "@googletest//:gtest",
 )
 
 bind(
     name = "gtest_main",
-    actual = "@gmock_archive//:gtest_main",
+    actual = "@googletest//:gtest_main",
 )
 
 bind(
@@ -33,8 +33,8 @@ bind(
 )
 
 maven_jar(
-  name = "guava_maven",
-  artifact = "com.google.guava:guava:18.0",
+    name = "guava_maven",
+    artifact = "com.google.guava:guava:18.0",
 )
 
 bind(
@@ -43,8 +43,8 @@ bind(
 )
 
 maven_jar(
-  name = "gson_maven",
-  artifact = "com.google.code.gson:gson:2.3",
+    name = "gson_maven",
+    artifact = "com.google.code.gson:gson:2.3",
 )
 
 bind(

--- a/gmock.BUILD
+++ b/gmock.BUILD
@@ -1,19 +1,19 @@
 cc_library(
     name = "gtest",
     srcs = [
-        "gmock-1.7.0/gtest/src/gtest-all.cc",
-        "gmock-1.7.0/src/gmock-all.cc",
+        "googletest/src/gtest-all.cc",
+        "googlemock/src/gmock-all.cc",
     ],
     hdrs = glob([
-        "gmock-1.7.0/**/*.h",
-        "gmock-1.7.0/gtest/src/*.cc",
-        "gmock-1.7.0/src/*.cc",
+        "**/*.h",
+        "googletest/src/*.cc",
+        "googlemock/src/*.cc",
     ]),
     includes = [
-        "gmock-1.7.0",
-        "gmock-1.7.0/gtest",
-        "gmock-1.7.0/gtest/include",
-        "gmock-1.7.0/include",
+        "googlemock",
+        "googletest",
+        "googletest/include",
+        "googlemock/include",
     ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
@@ -21,7 +21,7 @@ cc_library(
 
 cc_library(
     name = "gtest_main",
-    srcs = ["gmock-1.7.0/src/gmock_main.cc"],
+    srcs = ["googlemock/src/gmock_main.cc"],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
     deps = [":gtest"],


### PR DESCRIPTION
As far as I can tell, the Bazel build for protobufs is currently broken due to a dependency on a decommissioned project (https://googlemock.googlecode.com). This change uses GoogleTest directly from github instead.