### PR TITLE
issue-2108 [protoc/Java] Excessive copying on buildPartial()

### DIFF
--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -292,11 +292,15 @@ GenerateBuildingCode(io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_->file())) {
     printer->Print(variables_,
       "if ($get_has_field_bit_from_local$) {\n"
+      "  result.$name$_ = $name$_;\n"
       "  $set_has_field_bit_to_local$;\n"
+      "} else {\n"
+      "  result.$name$_ = $default_number$;\n"
       "}\n");
+  } else {
+    printer->Print(variables_,
+      "result.$name$_ = $name$_;\n");
   }
-  printer->Print(variables_,
-    "result.$name$_ = $name$_;\n");
 }
 
 void ImmutableEnumFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_lazy_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_lazy_message_field.cc
@@ -233,12 +233,9 @@ void ImmutableLazyMessageFieldGenerator::
 GenerateBuildingCode(io::Printer* printer) const {
   printer->Print(variables_,
       "if ($get_has_field_bit_from_local$) {\n"
+      "  result.$name$_.set($name$_);\n"
       "  $set_has_field_bit_to_local$;\n"
       "}\n");
-
-  printer->Print(variables_,
-      "result.$name$_.set(\n"
-      "    $name$_);\n");
 }
 
 void ImmutableLazyMessageFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -251,7 +251,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   bool support_field_presence = SupportFieldPresence(descriptor_->file());
 
   printer->Print(variables_,
-    "private $type$ $name$_ = null;\n");
+    "private $type$ $name$_;\n");
 
   printer->Print(variables_,
       // If this builder is non-null, it is used and the other fields are
@@ -434,15 +434,20 @@ void ImmutableMessageFieldGenerator::
 GenerateBuildingCode(io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_->file())) {
     printer->Print(variables_,
-        "if ($get_has_field_bit_from_local$) {\n"
-        "  $set_has_field_bit_to_local$;\n"
-        "}\n");
+      "if ($get_has_field_bit_from_local$) {\n");
+    printer->Indent();
+    PrintNestedBuilderCondition(printer,
+      "result.$name$_ = $name$_;\n",
+      "result.$name$_ = $name$Builder_.build();\n");
+    printer->Outdent();
+    printer->Print(variables_,
+      "  $set_has_field_bit_to_local$;\n"
+      "}\n");
+  } else {
+    PrintNestedBuilderCondition(printer,
+      "result.$name$_ = $name$_;\n",
+      "result.$name$_ = $name$Builder_.build();\n");
   }
-
-  PrintNestedBuilderCondition(printer,
-    "result.$name$_ = $name$_;\n",
-
-    "result.$name$_ = $name$Builder_.build();\n");
 }
 
 void ImmutableMessageFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -257,7 +257,9 @@ GenerateFieldBuilderInitializationCode(io::Printer* printer)  const {
 
 void ImmutablePrimitiveFieldGenerator::
 GenerateInitializationCode(io::Printer* printer) const {
-  printer->Print(variables_, "$name$_ = $default$;\n");
+  if (!IsDefaultValueJavaDefault(descriptor_)) {
+    printer->Print(variables_, "$name$_ = $default$;\n");
+  }
 }
 
 void ImmutablePrimitiveFieldGenerator::
@@ -287,11 +289,21 @@ GenerateBuildingCode(io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_->file())) {
     printer->Print(variables_,
       "if ($get_has_field_bit_from_local$) {\n"
-      "  $set_has_field_bit_to_local$;\n"
-      "}\n");
+      "  result.$name$_ = $name$_;\n"
+      "  $set_has_field_bit_to_local$;\n");
+    if (IsDefaultValueJavaDefault(descriptor_)) {
+      printer->Print(variables_,
+        "}\n");
+    } else {
+      printer->Print(variables_,
+        "} else {\n"
+        "  result.$name$_ = $default$;\n"
+        "}\n");
+    }
+  } else {
+    printer->Print(variables_,
+      "result.$name$_ = $name$_;\n");
   }
-  printer->Print(variables_,
-    "result.$name$_ = $name$_;\n");
 }
 
 void ImmutablePrimitiveFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -395,11 +395,15 @@ GenerateBuildingCode(io::Printer* printer) const {
   if (SupportFieldPresence(descriptor_->file())) {
     printer->Print(variables_,
       "if ($get_has_field_bit_from_local$) {\n"
+      "  result.$name$_ = $name$_;\n"
       "  $set_has_field_bit_to_local$;\n"
+      "} else {\n"
+      "  result.$name$_ = $default$;\n"
       "}\n");
+  } else {
+    printer->Print(variables_,
+      "result.$name$_ = $name$_;\n");
   }
-  printer->Print(variables_,
-    "result.$name$_ = $name$_;\n");
 }
 
 void ImmutableStringFieldGenerator::


### PR DESCRIPTION
Pull request for issue-2108: https://github.com/google/protobuf/issues/2108

The build() method call time is too high if a bean has too many fields and only some of these fields are set. 

The reason of that because filed copying are outside bit check condition which differs from merge() method which is reverse for build().

I see no any reason why someone really wants uninitialized fields to be copied on build()
