### PR TITLE
Bazel build: fix gmock remote repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,8 @@
 new_http_archive(
   name = "gmock_archive",
-  url = "https://googlemock.googlecode.com/files/gmock-1.7.0.zip",
-  sha256 = "26fcbb5925b74ad5fc8c26b0495dfc96353f4d553492eb97e85a8a6d2f43095b",
+  url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
+  sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
+  strip_prefix = "googletest-release-1.8.0",
   build_file = "gmock.BUILD",
 )
 

--- a/gmock.BUILD
+++ b/gmock.BUILD
@@ -1,19 +1,19 @@
 cc_library(
     name = "gtest",
     srcs = [
-        "gmock-1.7.0/gtest/src/gtest-all.cc",
-        "gmock-1.7.0/src/gmock-all.cc",
+        "googletest/src/gtest-all.cc",
+        "googlemock/src/gmock-all.cc",
     ],
     hdrs = glob([
-        "gmock-1.7.0/**/*.h",
-        "gmock-1.7.0/gtest/src/*.cc",
-        "gmock-1.7.0/src/*.cc",
+        "googletest/**/*.h",
+        "googletest/src/*.cc",
+        "googlemock/src/*.cc",
     ]),
     includes = [
-        "gmock-1.7.0",
-        "gmock-1.7.0/gtest",
-        "gmock-1.7.0/gtest/include",
-        "gmock-1.7.0/include",
+        "googlemock",
+        "googletest",
+        "googletest/include",
+        "googlemock/include",
     ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
@@ -21,7 +21,7 @@ cc_library(
 
 cc_library(
     name = "gtest_main",
-    srcs = ["gmock-1.7.0/src/gmock_main.cc"],
+    srcs = ["googlemock/src/gmock_main.cc"],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
     deps = [":gtest"],


### PR DESCRIPTION
With googlecode deprecation, the old url was no longer existing.

Tested with bazel test //... on a mac machine.