### PR TITLE
Fix for maps_test.js in JavaScript.

### DIFF
--- a/js/maps_test.js
+++ b/js/maps_test.js
@@ -30,10 +30,14 @@
 
 goog.require('goog.testing.asserts');
 goog.require('goog.userAgent');
+
+// CommonJS-LoadFromFile: testbinary_pb proto.jspb.test
 goog.require('proto.jspb.test.MapValueEnum');
 goog.require('proto.jspb.test.MapValueMessage');
-goog.require('proto.jspb.test.MapValueMessageNoBinary');
 goog.require('proto.jspb.test.TestMapFields');
+
+// CommonJS-LoadFromFile: test_pb proto.jspb.test
+goog.require('proto.jspb.test.MapValueMessageNoBinary');
 goog.require('proto.jspb.test.TestMapFieldsNoBinary');
 
 /**
@@ -258,64 +262,6 @@ function makeTests(msgInfo, submessageCtor, suffix) {
     });
   }
 
-
-  /**
-   * Tests serialization and deserialization in JSPB format.
-   */
-  it('testJSPBFormat' + suffix, function() {
-    var msg = new msgInfo.constructor();
-    fillMapFields(msg);
-    var serialized = msg.serialize();
-    var decoded = msgInfo.deserialize(serialized);
-    checkMapFields(decoded);
-  });
-
-  /**
-   * Tests serialization and deserialization in JSPB format, when there is
-   * a submessage that also contains map entries.  This tests recursive
-   * sync.
-   */
-  it('testJSPBFormatNested' + suffix, function() {
-    var submsg = new msgInfo.constructor();
-    var mapValue = new msgInfo.constructor();
-    var msg = new msgInfo.constructor();
-
-    msg.getMapStringTestmapfieldsMap().set('test', mapValue);
-    msg.setTestMapFields(submsg);
-
-    fillMapFields(submsg);
-    fillMapFields(msg);
-    fillMapFields(mapValue);
-
-    var serialized = msg.serialize();
-
-    var decoded = msgInfo.deserialize(serialized);
-    checkMapFields(decoded);
-
-    var decodedSubmsg = decoded.getTestMapFields();
-    assertNotNull(decodedSubmsg);
-    checkMapFields(decodedSubmsg);
-
-    var decodedMapValue = decoded.getMapStringTestmapfieldsMap().get('test');
-    assertNotNull(decodedMapValue);
-    checkMapFields(decodedMapValue);
-  });
-
-  /**
-   * Tests toObject()/fromObject().
-   */
-  it('testToFromObject' + suffix, function() {
-    var msg = new msgInfo.constructor();
-    fillMapFields(msg);
-    var obj = msg.toObject();
-    var decoded = msgInfo.fromObject(obj);
-    checkMapFields(decoded);
-    obj = msgInfo.deserialize(msg.serialize()).toObject();
-    decoded = msgInfo.fromObject(obj);
-    checkMapFields(decoded);
-  });
-
-
   /**
    * Exercises the lazy map<->underlying array sync.
    */
@@ -346,14 +292,10 @@ function makeTests(msgInfo, submessageCtor, suffix) {
 describe('mapsTest', function() {
   makeTests({
     constructor: proto.jspb.test.TestMapFields,
-    fromObject: proto.jspb.test.TestMapFields.fromObject,
-    deserialize: proto.jspb.test.TestMapFields.deserialize,
     deserializeBinary: proto.jspb.test.TestMapFields.deserializeBinary
   }, proto.jspb.test.MapValueMessage, "_Binary");
   makeTests({
     constructor: proto.jspb.test.TestMapFieldsNoBinary,
-    fromObject: proto.jspb.test.TestMapFieldsNoBinary.fromObject,
-    deserialize: proto.jspb.test.TestMapFieldsNoBinary.deserialize,
     deserializeBinary: null
   }, proto.jspb.test.MapValueMessageNoBinary, "_NoBinary");
 });

--- a/js/test.proto
+++ b/js/test.proto
@@ -234,3 +234,29 @@ message TestEndsWithBytes {
   optional bytes data = 2;
 }
 
+message TestMapFieldsNoBinary {
+  map<string, string> map_string_string = 1;
+  map<string, int32> map_string_int32 = 2;
+  map<string, int64> map_string_int64 = 3;
+  map<string, bool> map_string_bool = 4;
+  map<string, double> map_string_double = 5;
+  map<string, MapValueEnumNoBinary> map_string_enum = 6;
+  map<string, MapValueMessageNoBinary> map_string_msg = 7;
+
+  map<int32, string> map_int32_string = 8;
+  map<int64, string> map_int64_string = 9;
+  map<bool, string> map_bool_string = 10;
+
+  optional TestMapFieldsNoBinary test_map_fields = 11;
+  map<string, TestMapFieldsNoBinary> map_string_testmapfields = 12;
+}
+
+enum MapValueEnumNoBinary {
+  MAP_VALUE_FOO_NOBINARY = 0;
+  MAP_VALUE_BAR_NOBINARY = 1;
+  MAP_VALUE_BAZ_NOBINARY = 2;
+}
+
+message MapValueMessageNoBinary {
+  optional int32 foo = 1;
+}


### PR DESCRIPTION
Had to strip out some JSPB-format test code,
but also added some .proto test messages that
had been improperly stripped out.