### PR TITLE
Fix Visual Studio compile issues.

### DIFF
--- a/src/google/protobuf/any.pb.cc
+++ b/src/google/protobuf/any.pb.cc
@@ -71,7 +71,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fany_2eproto() {
-  Any::default_instance_.Shutdown();
+  Any_default_instance_.Shutdown();
   delete Any_reflection_;
 }
 
@@ -79,8 +79,8 @@ void protobuf_InitDefaults_google_2fprotobuf_2fany_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::internal::GetEmptyString();
-  Any::default_instance_.DefaultConstruct();
-  Any::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Any_default_instance_.DefaultConstruct();
+  Any_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fany_2eproto_once_);
@@ -196,7 +196,7 @@ const Any& Any::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Any> Any::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Any> Any_default_instance_;
 
 Any* Any::New(::google::protobuf::Arena* arena) const {
   Any* n = new Any;
@@ -510,6 +510,9 @@ void Any::set_allocated_value(::std::string* value) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Any.value)
 }
 
+inline const Any* Any::internal_default_instance() {
+  return &Any_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/any.pb.h
+++ b/src/google/protobuf/any.pb.h
@@ -58,9 +58,7 @@ class LIBPROTOBUF_EXPORT Any : public ::google::protobuf::Message /* @@protoc_in
   static const ::google::protobuf::Descriptor* descriptor();
   static const Any& default_instance();
 
-  static inline const Any* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Any* internal_default_instance();
 
   // implements Any -----------------------------------------------
 
@@ -154,8 +152,9 @@ class LIBPROTOBUF_EXPORT Any : public ::google::protobuf::Message /* @@protoc_in
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fany_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Any> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Any> Any_default_instance_;
+
 // ===================================================================
 
 
@@ -252,6 +251,9 @@ inline void Any::set_allocated_value(::std::string* value) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Any.value)
 }
 
+inline const Any* Any::internal_default_instance() {
+  return &Any_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -121,11 +121,11 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fapi_2eproto() {
-  Api::default_instance_.Shutdown();
+  Api_default_instance_.Shutdown();
   delete Api_reflection_;
-  Method::default_instance_.Shutdown();
+  Method_default_instance_.Shutdown();
   delete Method_reflection_;
-  Mixin::default_instance_.Shutdown();
+  Mixin_default_instance_.Shutdown();
   delete Mixin_reflection_;
 }
 
@@ -135,14 +135,14 @@ void protobuf_InitDefaults_google_2fprotobuf_2fapi_2eproto_impl() {
   ::google::protobuf::protobuf_InitDefaults_google_2fprotobuf_2fsource_5fcontext_2eproto();
   ::google::protobuf::protobuf_InitDefaults_google_2fprotobuf_2ftype_2eproto();
   ::google::protobuf::internal::GetEmptyString();
-  Api::default_instance_.DefaultConstruct();
+  Api_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Method::default_instance_.DefaultConstruct();
+  Method_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Mixin::default_instance_.DefaultConstruct();
-  Api::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Method::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Mixin::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Mixin_default_instance_.DefaultConstruct();
+  Api_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Method_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Mixin_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fapi_2eproto_once_);
@@ -250,7 +250,7 @@ Api::~Api() {
 void Api::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   version_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &Api_default_instance_.get()) {
     delete source_context_;
   }
 }
@@ -270,7 +270,7 @@ const Api& Api::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Api> Api::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Api> Api_default_instance_;
 
 Api* Api::New(::google::protobuf::Arena* arena) const {
   Api* n = new Api;
@@ -948,6 +948,9 @@ void Api::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Api.syntax)
 }
 
+inline const Api* Api::internal_default_instance() {
+  return &Api_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1015,7 +1018,7 @@ const Method& Method::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Method> Method::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Method> Method_default_instance_;
 
 Method* Method::New(::google::protobuf::Arena* arena) const {
   Method* n = new Method;
@@ -1679,6 +1682,9 @@ void Method::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Method.syntax)
 }
 
+inline const Method* Method::internal_default_instance() {
+  return &Method_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1737,7 +1743,7 @@ const Mixin& Mixin::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Mixin> Mixin::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Mixin> Mixin_default_instance_;
 
 Mixin* Mixin::New(::google::protobuf::Arena* arena) const {
   Mixin* n = new Mixin;
@@ -2063,6 +2069,9 @@ void Mixin::set_allocated_root(::std::string* root) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Mixin.root)
 }
 
+inline const Mixin* Mixin::internal_default_instance() {
+  return &Mixin_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/api.pb.h
+++ b/src/google/protobuf/api.pb.h
@@ -61,9 +61,7 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   static const ::google::protobuf::Descriptor* descriptor();
   static const Api& default_instance();
 
-  static inline const Api* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Api* internal_default_instance();
 
   void Swap(Api* other);
 
@@ -202,8 +200,9 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fapi_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Api> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Api> Api_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Method) */ {
@@ -221,9 +220,7 @@ class LIBPROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc
   static const ::google::protobuf::Descriptor* descriptor();
   static const Method& default_instance();
 
-  static inline const Method* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Method* internal_default_instance();
 
   void Swap(Method* other);
 
@@ -352,8 +349,9 @@ class LIBPROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fapi_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Method> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Method> Method_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Mixin : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Mixin) */ {
@@ -371,9 +369,7 @@ class LIBPROTOBUF_EXPORT Mixin : public ::google::protobuf::Message /* @@protoc_
   static const ::google::protobuf::Descriptor* descriptor();
   static const Mixin& default_instance();
 
-  static inline const Mixin* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Mixin* internal_default_instance();
 
   void Swap(Mixin* other);
 
@@ -456,8 +452,9 @@ class LIBPROTOBUF_EXPORT Mixin : public ::google::protobuf::Message /* @@protoc_
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fapi_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Mixin> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Mixin> Mixin_default_instance_;
+
 // ===================================================================
 
 
@@ -697,6 +694,9 @@ inline void Api::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Api.syntax)
 }
 
+inline const Api* Api::internal_default_instance() {
+  return &Api_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Method
@@ -905,6 +905,9 @@ inline void Method::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Method.syntax)
 }
 
+inline const Method* Method::internal_default_instance() {
+  return &Method_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Mixin
@@ -997,6 +1000,9 @@ inline void Mixin::set_allocated_root(::std::string* root) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Mixin.root)
 }
 
+inline const Mixin* Mixin::internal_default_instance() {
+  return &Mixin_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1179,14 +1179,12 @@ CommandLineInterface::InterpretArgument(const string& name,
     if (direct_dependencies_explicitly_set_) {
       std::cerr << name << " may only be passed once. To specify multiple "
                            "direct dependencies, pass them all as a single "
-                           "parameter separated by '"
-                << kPathSeparator << "'." << std::endl;
+                           "parameter separated by ':'." << std::endl;
       return PARSE_ARGUMENT_FAIL;
     }
 
     direct_dependencies_explicitly_set_ = true;
-    vector<string> direct = Split(
-        value, kPathSeparator, true);
+    vector<string> direct = Split(value, ":", true);
     GOOGLE_DCHECK(direct_dependencies_.empty());
     direct_dependencies_.insert(direct.begin(), direct.end());
 

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -114,11 +114,11 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fcompiler_2fplugin_2eproto() {
-  CodeGeneratorRequest::default_instance_.Shutdown();
+  CodeGeneratorRequest_default_instance_.Shutdown();
   delete CodeGeneratorRequest_reflection_;
-  CodeGeneratorResponse::default_instance_.Shutdown();
+  CodeGeneratorResponse_default_instance_.Shutdown();
   delete CodeGeneratorResponse_reflection_;
-  CodeGeneratorResponse_File::default_instance_.Shutdown();
+  CodeGeneratorResponse_File_default_instance_.Shutdown();
   delete CodeGeneratorResponse_File_reflection_;
 }
 
@@ -127,14 +127,14 @@ void protobuf_InitDefaults_google_2fprotobuf_2fcompiler_2fplugin_2eproto_impl() 
 
   ::google::protobuf::protobuf_InitDefaults_google_2fprotobuf_2fdescriptor_2eproto();
   ::google::protobuf::internal::GetEmptyString();
-  CodeGeneratorRequest::default_instance_.DefaultConstruct();
+  CodeGeneratorRequest_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  CodeGeneratorResponse::default_instance_.DefaultConstruct();
+  CodeGeneratorResponse_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  CodeGeneratorResponse_File::default_instance_.DefaultConstruct();
-  CodeGeneratorRequest::default_instance_.get_mutable()->InitAsDefaultInstance();
-  CodeGeneratorResponse::default_instance_.get_mutable()->InitAsDefaultInstance();
-  CodeGeneratorResponse_File::default_instance_.get_mutable()->InitAsDefaultInstance();
+  CodeGeneratorResponse_File_default_instance_.DefaultConstruct();
+  CodeGeneratorRequest_default_instance_.get_mutable()->InitAsDefaultInstance();
+  CodeGeneratorResponse_default_instance_.get_mutable()->InitAsDefaultInstance();
+  CodeGeneratorResponse_File_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fcompiler_2fplugin_2eproto_once_);
@@ -242,7 +242,7 @@ const CodeGeneratorRequest& CodeGeneratorRequest::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorRequest> CodeGeneratorRequest::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorRequest> CodeGeneratorRequest_default_instance_;
 
 CodeGeneratorRequest* CodeGeneratorRequest::New(::google::protobuf::Arena* arena) const {
   CodeGeneratorRequest* n = new CodeGeneratorRequest;
@@ -691,6 +691,9 @@ CodeGeneratorRequest::proto_file() const {
   return proto_file_;
 }
 
+inline const CodeGeneratorRequest* CodeGeneratorRequest::internal_default_instance() {
+  return &CodeGeneratorRequest_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -752,7 +755,7 @@ const CodeGeneratorResponse_File& CodeGeneratorResponse_File::default_instance()
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse_File> CodeGeneratorResponse_File::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse_File> CodeGeneratorResponse_File_default_instance_;
 
 CodeGeneratorResponse_File* CodeGeneratorResponse_File::New(::google::protobuf::Arena* arena) const {
   CodeGeneratorResponse_File* n = new CodeGeneratorResponse_File;
@@ -1128,7 +1131,7 @@ const CodeGeneratorResponse& CodeGeneratorResponse::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse> CodeGeneratorResponse::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse> CodeGeneratorResponse_default_instance_;
 
 CodeGeneratorResponse* CodeGeneratorResponse::New(::google::protobuf::Arena* arena) const {
   CodeGeneratorResponse* n = new CodeGeneratorResponse;
@@ -1548,6 +1551,9 @@ void CodeGeneratorResponse_File::set_allocated_content(::std::string* content) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.compiler.CodeGeneratorResponse.File.content)
 }
 
+inline const CodeGeneratorResponse_File* CodeGeneratorResponse_File::internal_default_instance() {
+  return &CodeGeneratorResponse_File_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // CodeGeneratorResponse
@@ -1636,6 +1642,9 @@ CodeGeneratorResponse::file() const {
   return file_;
 }
 
+inline const CodeGeneratorResponse* CodeGeneratorResponse::internal_default_instance() {
+  return &CodeGeneratorResponse_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -69,9 +69,7 @@ class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message
   static const ::google::protobuf::Descriptor* descriptor();
   static const CodeGeneratorRequest& default_instance();
 
-  static inline const CodeGeneratorRequest* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const CodeGeneratorRequest* internal_default_instance();
 
   void Swap(CodeGeneratorRequest* other);
 
@@ -176,8 +174,9 @@ class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fcompiler_2fplugin_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorRequest> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorRequest> CodeGeneratorRequest_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse.File) */ {
@@ -203,9 +202,7 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::M
   static const ::google::protobuf::Descriptor* descriptor();
   static const CodeGeneratorResponse_File& default_instance();
 
-  static inline const CodeGeneratorResponse_File* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const CodeGeneratorResponse_File* internal_default_instance();
 
   void Swap(CodeGeneratorResponse_File* other);
 
@@ -310,8 +307,9 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::M
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fcompiler_2fplugin_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse_File> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse_File> CodeGeneratorResponse_File_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse) */ {
@@ -337,9 +335,7 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Messag
   static const ::google::protobuf::Descriptor* descriptor();
   static const CodeGeneratorResponse& default_instance();
 
-  static inline const CodeGeneratorResponse* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const CodeGeneratorResponse* internal_default_instance();
 
   void Swap(CodeGeneratorResponse* other);
 
@@ -429,8 +425,9 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Messag
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fcompiler_2fplugin_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<CodeGeneratorResponse> CodeGeneratorResponse_default_instance_;
+
 // ===================================================================
 
 
@@ -578,6 +575,9 @@ CodeGeneratorRequest::proto_file() const {
   return proto_file_;
 }
 
+inline const CodeGeneratorRequest* CodeGeneratorRequest::internal_default_instance() {
+  return &CodeGeneratorRequest_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // CodeGeneratorResponse_File
@@ -744,6 +744,9 @@ inline void CodeGeneratorResponse_File::set_allocated_content(::std::string* con
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.compiler.CodeGeneratorResponse.File.content)
 }
 
+inline const CodeGeneratorResponse_File* CodeGeneratorResponse_File::internal_default_instance() {
+  return &CodeGeneratorResponse_File_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // CodeGeneratorResponse
@@ -832,6 +835,9 @@ CodeGeneratorResponse::file() const {
   return file_;
 }
 
+inline const CodeGeneratorResponse* CodeGeneratorResponse::internal_default_instance() {
+  return &CodeGeneratorResponse_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -622,124 +622,124 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto() {
-  FileDescriptorSet::default_instance_.Shutdown();
+  FileDescriptorSet_default_instance_.Shutdown();
   delete FileDescriptorSet_reflection_;
-  FileDescriptorProto::default_instance_.Shutdown();
+  FileDescriptorProto_default_instance_.Shutdown();
   delete FileDescriptorProto_reflection_;
-  DescriptorProto::default_instance_.Shutdown();
+  DescriptorProto_default_instance_.Shutdown();
   delete DescriptorProto_reflection_;
-  DescriptorProto_ExtensionRange::default_instance_.Shutdown();
+  DescriptorProto_ExtensionRange_default_instance_.Shutdown();
   delete DescriptorProto_ExtensionRange_reflection_;
-  DescriptorProto_ReservedRange::default_instance_.Shutdown();
+  DescriptorProto_ReservedRange_default_instance_.Shutdown();
   delete DescriptorProto_ReservedRange_reflection_;
-  FieldDescriptorProto::default_instance_.Shutdown();
+  FieldDescriptorProto_default_instance_.Shutdown();
   delete FieldDescriptorProto_reflection_;
-  OneofDescriptorProto::default_instance_.Shutdown();
+  OneofDescriptorProto_default_instance_.Shutdown();
   delete OneofDescriptorProto_reflection_;
-  EnumDescriptorProto::default_instance_.Shutdown();
+  EnumDescriptorProto_default_instance_.Shutdown();
   delete EnumDescriptorProto_reflection_;
-  EnumValueDescriptorProto::default_instance_.Shutdown();
+  EnumValueDescriptorProto_default_instance_.Shutdown();
   delete EnumValueDescriptorProto_reflection_;
-  ServiceDescriptorProto::default_instance_.Shutdown();
+  ServiceDescriptorProto_default_instance_.Shutdown();
   delete ServiceDescriptorProto_reflection_;
-  MethodDescriptorProto::default_instance_.Shutdown();
+  MethodDescriptorProto_default_instance_.Shutdown();
   delete MethodDescriptorProto_reflection_;
-  FileOptions::default_instance_.Shutdown();
+  FileOptions_default_instance_.Shutdown();
   delete FileOptions_reflection_;
-  MessageOptions::default_instance_.Shutdown();
+  MessageOptions_default_instance_.Shutdown();
   delete MessageOptions_reflection_;
-  FieldOptions::default_instance_.Shutdown();
+  FieldOptions_default_instance_.Shutdown();
   delete FieldOptions_reflection_;
-  OneofOptions::default_instance_.Shutdown();
+  OneofOptions_default_instance_.Shutdown();
   delete OneofOptions_reflection_;
-  EnumOptions::default_instance_.Shutdown();
+  EnumOptions_default_instance_.Shutdown();
   delete EnumOptions_reflection_;
-  EnumValueOptions::default_instance_.Shutdown();
+  EnumValueOptions_default_instance_.Shutdown();
   delete EnumValueOptions_reflection_;
-  ServiceOptions::default_instance_.Shutdown();
+  ServiceOptions_default_instance_.Shutdown();
   delete ServiceOptions_reflection_;
-  MethodOptions::default_instance_.Shutdown();
+  MethodOptions_default_instance_.Shutdown();
   delete MethodOptions_reflection_;
-  UninterpretedOption::default_instance_.Shutdown();
+  UninterpretedOption_default_instance_.Shutdown();
   delete UninterpretedOption_reflection_;
-  UninterpretedOption_NamePart::default_instance_.Shutdown();
+  UninterpretedOption_NamePart_default_instance_.Shutdown();
   delete UninterpretedOption_NamePart_reflection_;
-  SourceCodeInfo::default_instance_.Shutdown();
+  SourceCodeInfo_default_instance_.Shutdown();
   delete SourceCodeInfo_reflection_;
-  SourceCodeInfo_Location::default_instance_.Shutdown();
+  SourceCodeInfo_Location_default_instance_.Shutdown();
   delete SourceCodeInfo_Location_reflection_;
-  GeneratedCodeInfo::default_instance_.Shutdown();
+  GeneratedCodeInfo_default_instance_.Shutdown();
   delete GeneratedCodeInfo_reflection_;
-  GeneratedCodeInfo_Annotation::default_instance_.Shutdown();
+  GeneratedCodeInfo_Annotation_default_instance_.Shutdown();
   delete GeneratedCodeInfo_Annotation_reflection_;
 }
 
 void protobuf_InitDefaults_google_2fprotobuf_2fdescriptor_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  FileDescriptorSet::default_instance_.DefaultConstruct();
+  FileDescriptorSet_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  FileDescriptorProto::default_instance_.DefaultConstruct();
+  FileDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  DescriptorProto::default_instance_.DefaultConstruct();
-  DescriptorProto_ExtensionRange::default_instance_.DefaultConstruct();
-  DescriptorProto_ReservedRange::default_instance_.DefaultConstruct();
+  DescriptorProto_default_instance_.DefaultConstruct();
+  DescriptorProto_ExtensionRange_default_instance_.DefaultConstruct();
+  DescriptorProto_ReservedRange_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  FieldDescriptorProto::default_instance_.DefaultConstruct();
+  FieldDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  OneofDescriptorProto::default_instance_.DefaultConstruct();
+  OneofDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  EnumDescriptorProto::default_instance_.DefaultConstruct();
+  EnumDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  EnumValueDescriptorProto::default_instance_.DefaultConstruct();
+  EnumValueDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  ServiceDescriptorProto::default_instance_.DefaultConstruct();
+  ServiceDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  MethodDescriptorProto::default_instance_.DefaultConstruct();
+  MethodDescriptorProto_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  FileOptions::default_instance_.DefaultConstruct();
-  MessageOptions::default_instance_.DefaultConstruct();
-  FieldOptions::default_instance_.DefaultConstruct();
-  OneofOptions::default_instance_.DefaultConstruct();
-  EnumOptions::default_instance_.DefaultConstruct();
-  EnumValueOptions::default_instance_.DefaultConstruct();
-  ServiceOptions::default_instance_.DefaultConstruct();
-  MethodOptions::default_instance_.DefaultConstruct();
+  FileOptions_default_instance_.DefaultConstruct();
+  MessageOptions_default_instance_.DefaultConstruct();
+  FieldOptions_default_instance_.DefaultConstruct();
+  OneofOptions_default_instance_.DefaultConstruct();
+  EnumOptions_default_instance_.DefaultConstruct();
+  EnumValueOptions_default_instance_.DefaultConstruct();
+  ServiceOptions_default_instance_.DefaultConstruct();
+  MethodOptions_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  UninterpretedOption::default_instance_.DefaultConstruct();
+  UninterpretedOption_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  UninterpretedOption_NamePart::default_instance_.DefaultConstruct();
-  SourceCodeInfo::default_instance_.DefaultConstruct();
+  UninterpretedOption_NamePart_default_instance_.DefaultConstruct();
+  SourceCodeInfo_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  SourceCodeInfo_Location::default_instance_.DefaultConstruct();
-  GeneratedCodeInfo::default_instance_.DefaultConstruct();
+  SourceCodeInfo_Location_default_instance_.DefaultConstruct();
+  GeneratedCodeInfo_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  GeneratedCodeInfo_Annotation::default_instance_.DefaultConstruct();
-  FileDescriptorSet::default_instance_.get_mutable()->InitAsDefaultInstance();
-  FileDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  DescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  DescriptorProto_ExtensionRange::default_instance_.get_mutable()->InitAsDefaultInstance();
-  DescriptorProto_ReservedRange::default_instance_.get_mutable()->InitAsDefaultInstance();
-  FieldDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  OneofDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  EnumDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  EnumValueDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  ServiceDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  MethodDescriptorProto::default_instance_.get_mutable()->InitAsDefaultInstance();
-  FileOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  MessageOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  FieldOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  OneofOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  EnumOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  EnumValueOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  ServiceOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  MethodOptions::default_instance_.get_mutable()->InitAsDefaultInstance();
-  UninterpretedOption::default_instance_.get_mutable()->InitAsDefaultInstance();
-  UninterpretedOption_NamePart::default_instance_.get_mutable()->InitAsDefaultInstance();
-  SourceCodeInfo::default_instance_.get_mutable()->InitAsDefaultInstance();
-  SourceCodeInfo_Location::default_instance_.get_mutable()->InitAsDefaultInstance();
-  GeneratedCodeInfo::default_instance_.get_mutable()->InitAsDefaultInstance();
-  GeneratedCodeInfo_Annotation::default_instance_.get_mutable()->InitAsDefaultInstance();
+  GeneratedCodeInfo_Annotation_default_instance_.DefaultConstruct();
+  FileDescriptorSet_default_instance_.get_mutable()->InitAsDefaultInstance();
+  FileDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  DescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  DescriptorProto_ExtensionRange_default_instance_.get_mutable()->InitAsDefaultInstance();
+  DescriptorProto_ReservedRange_default_instance_.get_mutable()->InitAsDefaultInstance();
+  FieldDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  OneofDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  EnumDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  EnumValueDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  ServiceDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  MethodDescriptorProto_default_instance_.get_mutable()->InitAsDefaultInstance();
+  FileOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  MessageOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  FieldOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  OneofOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  EnumOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  EnumValueOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  ServiceOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  MethodOptions_default_instance_.get_mutable()->InitAsDefaultInstance();
+  UninterpretedOption_default_instance_.get_mutable()->InitAsDefaultInstance();
+  UninterpretedOption_NamePart_default_instance_.get_mutable()->InitAsDefaultInstance();
+  SourceCodeInfo_default_instance_.get_mutable()->InitAsDefaultInstance();
+  SourceCodeInfo_Location_default_instance_.get_mutable()->InitAsDefaultInstance();
+  GeneratedCodeInfo_default_instance_.get_mutable()->InitAsDefaultInstance();
+  GeneratedCodeInfo_Annotation_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fdescriptor_2eproto_once_);
@@ -963,7 +963,7 @@ const FileDescriptorSet& FileDescriptorSet::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorSet> FileDescriptorSet::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorSet> FileDescriptorSet_default_instance_;
 
 FileDescriptorSet* FileDescriptorSet::New(::google::protobuf::Arena* arena) const {
   FileDescriptorSet* n = new FileDescriptorSet;
@@ -1197,6 +1197,9 @@ FileDescriptorSet::file() const {
   return file_;
 }
 
+inline const FileDescriptorSet* FileDescriptorSet::internal_default_instance() {
+  return &FileDescriptorSet_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1256,7 +1259,7 @@ void FileDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   package_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   syntax_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &FileDescriptorProto_default_instance_.get()) {
     delete options_;
     delete source_code_info_;
   }
@@ -1277,7 +1280,7 @@ const FileDescriptorProto& FileDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorProto> FileDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorProto> FileDescriptorProto_default_instance_;
 
 FileDescriptorProto* FileDescriptorProto::New(::google::protobuf::Arena* arena) const {
   FileDescriptorProto* n = new FileDescriptorProto;
@@ -2498,6 +2501,9 @@ void FileDescriptorProto::set_allocated_syntax(::std::string* syntax) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.FileDescriptorProto.syntax)
 }
 
+inline const FileDescriptorProto* FileDescriptorProto::internal_default_instance() {
+  return &FileDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2554,7 +2560,7 @@ const DescriptorProto_ExtensionRange& DescriptorProto_ExtensionRange::default_in
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ExtensionRange> DescriptorProto_ExtensionRange::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ExtensionRange> DescriptorProto_ExtensionRange_default_instance_;
 
 DescriptorProto_ExtensionRange* DescriptorProto_ExtensionRange::New(::google::protobuf::Arena* arena) const {
   DescriptorProto_ExtensionRange* n = new DescriptorProto_ExtensionRange;
@@ -2862,7 +2868,7 @@ const DescriptorProto_ReservedRange& DescriptorProto_ReservedRange::default_inst
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ReservedRange> DescriptorProto_ReservedRange::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ReservedRange> DescriptorProto_ReservedRange_default_instance_;
 
 DescriptorProto_ReservedRange* DescriptorProto_ReservedRange::New(::google::protobuf::Arena* arena) const {
   DescriptorProto_ReservedRange* n = new DescriptorProto_ReservedRange;
@@ -3164,7 +3170,7 @@ DescriptorProto::~DescriptorProto() {
 
 void DescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &DescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -3184,7 +3190,7 @@ const DescriptorProto& DescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto> DescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto> DescriptorProto_default_instance_;
 
 DescriptorProto* DescriptorProto::New(::google::protobuf::Arena* arena) const {
   DescriptorProto* n = new DescriptorProto;
@@ -3851,6 +3857,9 @@ void DescriptorProto_ExtensionRange::set_end(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.DescriptorProto.ExtensionRange.end)
 }
 
+inline const DescriptorProto_ExtensionRange* DescriptorProto_ExtensionRange::internal_default_instance() {
+  return &DescriptorProto_ExtensionRange_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // DescriptorProto_ReservedRange
@@ -3903,6 +3912,9 @@ void DescriptorProto_ReservedRange::set_end(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.DescriptorProto.ReservedRange.end)
 }
 
+inline const DescriptorProto_ReservedRange* DescriptorProto_ReservedRange::internal_default_instance() {
+  return &DescriptorProto_ReservedRange_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // DescriptorProto
@@ -4271,6 +4283,9 @@ DescriptorProto::mutable_reserved_name() {
   return &reserved_name_;
 }
 
+inline const DescriptorProto* DescriptorProto::internal_default_instance() {
+  return &DescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -4409,7 +4424,7 @@ void FieldDescriptorProto::SharedDtor() {
   extendee_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   default_value_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   json_name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &FieldDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -4429,7 +4444,7 @@ const FieldDescriptorProto& FieldDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FieldDescriptorProto> FieldDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FieldDescriptorProto> FieldDescriptorProto_default_instance_;
 
 FieldDescriptorProto* FieldDescriptorProto::New(::google::protobuf::Arena* arena) const {
   FieldDescriptorProto* n = new FieldDescriptorProto;
@@ -5500,6 +5515,9 @@ void FieldDescriptorProto::set_allocated_options(::google::protobuf::FieldOption
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.FieldDescriptorProto.options)
 }
 
+inline const FieldDescriptorProto* FieldDescriptorProto::internal_default_instance() {
+  return &FieldDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -5542,7 +5560,7 @@ OneofDescriptorProto::~OneofDescriptorProto() {
 
 void OneofDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &OneofDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -5562,7 +5580,7 @@ const OneofDescriptorProto& OneofDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<OneofDescriptorProto> OneofDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<OneofDescriptorProto> OneofDescriptorProto_default_instance_;
 
 OneofDescriptorProto* OneofDescriptorProto::New(::google::protobuf::Arena* arena) const {
   OneofDescriptorProto* n = new OneofDescriptorProto;
@@ -5922,6 +5940,9 @@ void OneofDescriptorProto::set_allocated_options(::google::protobuf::OneofOption
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.OneofDescriptorProto.options)
 }
 
+inline const OneofDescriptorProto* OneofDescriptorProto::internal_default_instance() {
+  return &OneofDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -5965,7 +5986,7 @@ EnumDescriptorProto::~EnumDescriptorProto() {
 
 void EnumDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &EnumDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -5985,7 +6006,7 @@ const EnumDescriptorProto& EnumDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<EnumDescriptorProto> EnumDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<EnumDescriptorProto> EnumDescriptorProto_default_instance_;
 
 EnumDescriptorProto* EnumDescriptorProto::New(::google::protobuf::Arena* arena) const {
   EnumDescriptorProto* n = new EnumDescriptorProto;
@@ -6420,6 +6441,9 @@ void EnumDescriptorProto::set_allocated_options(::google::protobuf::EnumOptions*
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.EnumDescriptorProto.options)
 }
 
+inline const EnumDescriptorProto* EnumDescriptorProto::internal_default_instance() {
+  return &EnumDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -6464,7 +6488,7 @@ EnumValueDescriptorProto::~EnumValueDescriptorProto() {
 
 void EnumValueDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &EnumValueDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -6484,7 +6508,7 @@ const EnumValueDescriptorProto& EnumValueDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<EnumValueDescriptorProto> EnumValueDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<EnumValueDescriptorProto> EnumValueDescriptorProto_default_instance_;
 
 EnumValueDescriptorProto* EnumValueDescriptorProto::New(::google::protobuf::Arena* arena) const {
   EnumValueDescriptorProto* n = new EnumValueDescriptorProto;
@@ -6905,6 +6929,9 @@ void EnumValueDescriptorProto::set_allocated_options(::google::protobuf::EnumVal
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.EnumValueDescriptorProto.options)
 }
 
+inline const EnumValueDescriptorProto* EnumValueDescriptorProto::internal_default_instance() {
+  return &EnumValueDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -6948,7 +6975,7 @@ ServiceDescriptorProto::~ServiceDescriptorProto() {
 
 void ServiceDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &ServiceDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -6968,7 +6995,7 @@ const ServiceDescriptorProto& ServiceDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<ServiceDescriptorProto> ServiceDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<ServiceDescriptorProto> ServiceDescriptorProto_default_instance_;
 
 ServiceDescriptorProto* ServiceDescriptorProto::New(::google::protobuf::Arena* arena) const {
   ServiceDescriptorProto* n = new ServiceDescriptorProto;
@@ -7403,6 +7430,9 @@ void ServiceDescriptorProto::set_allocated_options(::google::protobuf::ServiceOp
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.ServiceDescriptorProto.options)
 }
 
+inline const ServiceDescriptorProto* ServiceDescriptorProto::internal_default_instance() {
+  return &ServiceDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -7455,7 +7485,7 @@ void MethodDescriptorProto::SharedDtor() {
   name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   input_type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   output_type_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (this != &default_instance_.get()) {
+  if (this != &MethodDescriptorProto_default_instance_.get()) {
     delete options_;
   }
 }
@@ -7475,7 +7505,7 @@ const MethodDescriptorProto& MethodDescriptorProto::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<MethodDescriptorProto> MethodDescriptorProto::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<MethodDescriptorProto> MethodDescriptorProto_default_instance_;
 
 MethodDescriptorProto* MethodDescriptorProto::New(::google::protobuf::Arena* arena) const {
   MethodDescriptorProto* n = new MethodDescriptorProto;
@@ -8186,6 +8216,9 @@ void MethodDescriptorProto::set_server_streaming(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.MethodDescriptorProto.server_streaming)
 }
 
+inline const MethodDescriptorProto* MethodDescriptorProto::internal_default_instance() {
+  return &MethodDescriptorProto_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -8289,7 +8322,7 @@ const FileOptions& FileOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FileOptions> FileOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FileOptions> FileOptions_default_instance_;
 
 FileOptions* FileOptions::New(::google::protobuf::Arena* arena) const {
   FileOptions* n = new FileOptions;
@@ -9646,6 +9679,9 @@ FileOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const FileOptions* FileOptions::internal_default_instance() {
+  return &FileOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -9705,7 +9741,7 @@ const MessageOptions& MessageOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<MessageOptions> MessageOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<MessageOptions> MessageOptions_default_instance_;
 
 MessageOptions* MessageOptions::New(::google::protobuf::Arena* arena) const {
   MessageOptions* n = new MessageOptions;
@@ -10218,6 +10254,9 @@ MessageOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const MessageOptions* MessageOptions::internal_default_instance() {
+  return &MessageOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -10325,7 +10364,7 @@ const FieldOptions& FieldOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FieldOptions> FieldOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FieldOptions> FieldOptions_default_instance_;
 
 FieldOptions* FieldOptions::New(::google::protobuf::Arena* arena) const {
   FieldOptions* n = new FieldOptions;
@@ -10972,6 +11011,9 @@ FieldOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const FieldOptions* FieldOptions::internal_default_instance() {
+  return &FieldOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -11025,7 +11067,7 @@ const OneofOptions& OneofOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<OneofOptions> OneofOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<OneofOptions> OneofOptions_default_instance_;
 
 OneofOptions* OneofOptions::New(::google::protobuf::Arena* arena) const {
   OneofOptions* n = new OneofOptions;
@@ -11281,6 +11323,9 @@ OneofOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const OneofOptions* OneofOptions::internal_default_instance() {
+  return &OneofOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -11338,7 +11383,7 @@ const EnumOptions& EnumOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<EnumOptions> EnumOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<EnumOptions> EnumOptions_default_instance_;
 
 EnumOptions* EnumOptions::New(::google::protobuf::Arena* arena) const {
   EnumOptions* n = new EnumOptions;
@@ -11735,6 +11780,9 @@ EnumOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const EnumOptions* EnumOptions::internal_default_instance() {
+  return &EnumOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -11790,7 +11838,7 @@ const EnumValueOptions& EnumValueOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<EnumValueOptions> EnumValueOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<EnumValueOptions> EnumValueOptions_default_instance_;
 
 EnumValueOptions* EnumValueOptions::New(::google::protobuf::Arena* arena) const {
   EnumValueOptions* n = new EnumValueOptions;
@@ -12107,6 +12155,9 @@ EnumValueOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const EnumValueOptions* EnumValueOptions::internal_default_instance() {
+  return &EnumValueOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -12162,7 +12213,7 @@ const ServiceOptions& ServiceOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<ServiceOptions> ServiceOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<ServiceOptions> ServiceOptions_default_instance_;
 
 ServiceOptions* ServiceOptions::New(::google::protobuf::Arena* arena) const {
   ServiceOptions* n = new ServiceOptions;
@@ -12479,6 +12530,9 @@ ServiceOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const ServiceOptions* ServiceOptions::internal_default_instance() {
+  return &ServiceOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -12534,7 +12588,7 @@ const MethodOptions& MethodOptions::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<MethodOptions> MethodOptions::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<MethodOptions> MethodOptions_default_instance_;
 
 MethodOptions* MethodOptions::New(::google::protobuf::Arena* arena) const {
   MethodOptions* n = new MethodOptions;
@@ -12851,6 +12905,9 @@ MethodOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const MethodOptions* MethodOptions::internal_default_instance() {
+  return &MethodOptions_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -12908,7 +12965,7 @@ const UninterpretedOption_NamePart& UninterpretedOption_NamePart::default_instan
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption_NamePart> UninterpretedOption_NamePart::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption_NamePart> UninterpretedOption_NamePart_default_instance_;
 
 UninterpretedOption_NamePart* UninterpretedOption_NamePart::New(::google::protobuf::Arena* arena) const {
   UninterpretedOption_NamePart* n = new UninterpretedOption_NamePart;
@@ -13241,7 +13298,7 @@ const UninterpretedOption& UninterpretedOption::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption> UninterpretedOption::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption> UninterpretedOption_default_instance_;
 
 UninterpretedOption* UninterpretedOption::New(::google::protobuf::Arena* arena) const {
   UninterpretedOption* n = new UninterpretedOption;
@@ -13803,6 +13860,9 @@ void UninterpretedOption_NamePart::set_is_extension(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UninterpretedOption.NamePart.is_extension)
 }
 
+inline const UninterpretedOption_NamePart* UninterpretedOption_NamePart::internal_default_instance() {
+  return &UninterpretedOption_NamePart_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // UninterpretedOption
@@ -14071,6 +14131,9 @@ void UninterpretedOption::set_allocated_aggregate_value(::std::string* aggregate
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.UninterpretedOption.aggregate_value)
 }
 
+inline const UninterpretedOption* UninterpretedOption::internal_default_instance() {
+  return &UninterpretedOption_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -14132,7 +14195,7 @@ const SourceCodeInfo_Location& SourceCodeInfo_Location::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo_Location> SourceCodeInfo_Location::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo_Location> SourceCodeInfo_Location_default_instance_;
 
 SourceCodeInfo_Location* SourceCodeInfo_Location::New(::google::protobuf::Arena* arena) const {
   SourceCodeInfo_Location* n = new SourceCodeInfo_Location;
@@ -14630,7 +14693,7 @@ const SourceCodeInfo& SourceCodeInfo::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo> SourceCodeInfo::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo> SourceCodeInfo_default_instance_;
 
 SourceCodeInfo* SourceCodeInfo::New(::google::protobuf::Arena* arena) const {
   SourceCodeInfo* n = new SourceCodeInfo;
@@ -15056,6 +15119,9 @@ SourceCodeInfo_Location::mutable_leading_detached_comments() {
   return &leading_detached_comments_;
 }
 
+inline const SourceCodeInfo_Location* SourceCodeInfo_Location::internal_default_instance() {
+  return &SourceCodeInfo_Location_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // SourceCodeInfo
@@ -15090,6 +15156,9 @@ SourceCodeInfo::location() const {
   return location_;
 }
 
+inline const SourceCodeInfo* SourceCodeInfo::internal_default_instance() {
+  return &SourceCodeInfo_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -15150,7 +15219,7 @@ const GeneratedCodeInfo_Annotation& GeneratedCodeInfo_Annotation::default_instan
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo_Annotation> GeneratedCodeInfo_Annotation::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo_Annotation> GeneratedCodeInfo_Annotation_default_instance_;
 
 GeneratedCodeInfo_Annotation* GeneratedCodeInfo_Annotation::New(::google::protobuf::Arena* arena) const {
   GeneratedCodeInfo_Annotation* n = new GeneratedCodeInfo_Annotation;
@@ -15574,7 +15643,7 @@ const GeneratedCodeInfo& GeneratedCodeInfo::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo> GeneratedCodeInfo::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo> GeneratedCodeInfo_default_instance_;
 
 GeneratedCodeInfo* GeneratedCodeInfo::New(::google::protobuf::Arena* arena) const {
   GeneratedCodeInfo* n = new GeneratedCodeInfo;
@@ -15909,6 +15978,9 @@ void GeneratedCodeInfo_Annotation::set_end(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.GeneratedCodeInfo.Annotation.end)
 }
 
+inline const GeneratedCodeInfo_Annotation* GeneratedCodeInfo_Annotation::internal_default_instance() {
+  return &GeneratedCodeInfo_Annotation_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // GeneratedCodeInfo
@@ -15943,6 +16015,9 @@ GeneratedCodeInfo::annotation() const {
   return annotation_;
 }
 
+inline const GeneratedCodeInfo* GeneratedCodeInfo::internal_default_instance() {
+  return &GeneratedCodeInfo_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -205,9 +205,7 @@ class LIBPROTOBUF_EXPORT FileDescriptorSet : public ::google::protobuf::Message 
   static const ::google::protobuf::Descriptor* descriptor();
   static const FileDescriptorSet& default_instance();
 
-  static inline const FileDescriptorSet* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FileDescriptorSet* internal_default_instance();
 
   void Swap(FileDescriptorSet* other);
 
@@ -280,8 +278,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorSet : public ::google::protobuf::Message 
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorSet> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorSet> FileDescriptorSet_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FileDescriptorProto) */ {
@@ -307,9 +306,7 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   static const ::google::protobuf::Descriptor* descriptor();
   static const FileDescriptorProto& default_instance();
 
-  static inline const FileDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FileDescriptorProto* internal_default_instance();
 
   void Swap(FileDescriptorProto* other);
 
@@ -533,8 +530,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FileDescriptorProto> FileDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT DescriptorProto_ExtensionRange : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto.ExtensionRange) */ {
@@ -560,9 +558,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto_ExtensionRange : public ::google::proto
   static const ::google::protobuf::Descriptor* descriptor();
   static const DescriptorProto_ExtensionRange& default_instance();
 
-  static inline const DescriptorProto_ExtensionRange* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const DescriptorProto_ExtensionRange* internal_default_instance();
 
   void Swap(DescriptorProto_ExtensionRange* other);
 
@@ -642,8 +638,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto_ExtensionRange : public ::google::proto
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ExtensionRange> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ExtensionRange> DescriptorProto_ExtensionRange_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT DescriptorProto_ReservedRange : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto.ReservedRange) */ {
@@ -669,9 +666,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto_ReservedRange : public ::google::protob
   static const ::google::protobuf::Descriptor* descriptor();
   static const DescriptorProto_ReservedRange& default_instance();
 
-  static inline const DescriptorProto_ReservedRange* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const DescriptorProto_ReservedRange* internal_default_instance();
 
   void Swap(DescriptorProto_ReservedRange* other);
 
@@ -751,8 +746,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto_ReservedRange : public ::google::protob
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ReservedRange> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto_ReservedRange> DescriptorProto_ReservedRange_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.DescriptorProto) */ {
@@ -778,9 +774,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   static const ::google::protobuf::Descriptor* descriptor();
   static const DescriptorProto& default_instance();
 
-  static inline const DescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const DescriptorProto* internal_default_instance();
 
   void Swap(DescriptorProto* other);
 
@@ -978,8 +972,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<DescriptorProto> DescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT FieldDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FieldDescriptorProto) */ {
@@ -1005,9 +1000,7 @@ class LIBPROTOBUF_EXPORT FieldDescriptorProto : public ::google::protobuf::Messa
   static const ::google::protobuf::Descriptor* descriptor();
   static const FieldDescriptorProto& default_instance();
 
-  static inline const FieldDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FieldDescriptorProto* internal_default_instance();
 
   void Swap(FieldDescriptorProto* other);
 
@@ -1280,8 +1273,9 @@ class LIBPROTOBUF_EXPORT FieldDescriptorProto : public ::google::protobuf::Messa
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FieldDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FieldDescriptorProto> FieldDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT OneofDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.OneofDescriptorProto) */ {
@@ -1307,9 +1301,7 @@ class LIBPROTOBUF_EXPORT OneofDescriptorProto : public ::google::protobuf::Messa
   static const ::google::protobuf::Descriptor* descriptor();
   static const OneofDescriptorProto& default_instance();
 
-  static inline const OneofDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const OneofDescriptorProto* internal_default_instance();
 
   void Swap(OneofDescriptorProto* other);
 
@@ -1396,8 +1388,9 @@ class LIBPROTOBUF_EXPORT OneofDescriptorProto : public ::google::protobuf::Messa
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<OneofDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<OneofDescriptorProto> OneofDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumDescriptorProto) */ {
@@ -1423,9 +1416,7 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   static const ::google::protobuf::Descriptor* descriptor();
   static const EnumDescriptorProto& default_instance();
 
-  static inline const EnumDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const EnumDescriptorProto* internal_default_instance();
 
   void Swap(EnumDescriptorProto* other);
 
@@ -1525,8 +1516,9 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<EnumDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<EnumDescriptorProto> EnumDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT EnumValueDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValueDescriptorProto) */ {
@@ -1552,9 +1544,7 @@ class LIBPROTOBUF_EXPORT EnumValueDescriptorProto : public ::google::protobuf::M
   static const ::google::protobuf::Descriptor* descriptor();
   static const EnumValueDescriptorProto& default_instance();
 
-  static inline const EnumValueDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const EnumValueDescriptorProto* internal_default_instance();
 
   void Swap(EnumValueDescriptorProto* other);
 
@@ -1651,8 +1641,9 @@ class LIBPROTOBUF_EXPORT EnumValueDescriptorProto : public ::google::protobuf::M
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<EnumValueDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<EnumValueDescriptorProto> EnumValueDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ServiceDescriptorProto) */ {
@@ -1678,9 +1669,7 @@ class LIBPROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Mes
   static const ::google::protobuf::Descriptor* descriptor();
   static const ServiceDescriptorProto& default_instance();
 
-  static inline const ServiceDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const ServiceDescriptorProto* internal_default_instance();
 
   void Swap(ServiceDescriptorProto* other);
 
@@ -1780,8 +1769,9 @@ class LIBPROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Mes
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<ServiceDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<ServiceDescriptorProto> ServiceDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT MethodDescriptorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MethodDescriptorProto) */ {
@@ -1807,9 +1797,7 @@ class LIBPROTOBUF_EXPORT MethodDescriptorProto : public ::google::protobuf::Mess
   static const ::google::protobuf::Descriptor* descriptor();
   static const MethodDescriptorProto& default_instance();
 
-  static inline const MethodDescriptorProto* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const MethodDescriptorProto* internal_default_instance();
 
   void Swap(MethodDescriptorProto* other);
 
@@ -1946,8 +1934,9 @@ class LIBPROTOBUF_EXPORT MethodDescriptorProto : public ::google::protobuf::Mess
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<MethodDescriptorProto> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<MethodDescriptorProto> MethodDescriptorProto_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT FileOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FileOptions) */ {
@@ -1973,9 +1962,7 @@ class LIBPROTOBUF_EXPORT FileOptions : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const FileOptions& default_instance();
 
-  static inline const FileOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FileOptions* internal_default_instance();
 
   void Swap(FileOptions* other);
 
@@ -2244,8 +2231,9 @@ class LIBPROTOBUF_EXPORT FileOptions : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FileOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FileOptions> FileOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT MessageOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MessageOptions) */ {
@@ -2271,9 +2259,7 @@ class LIBPROTOBUF_EXPORT MessageOptions : public ::google::protobuf::Message /* 
   static const ::google::protobuf::Descriptor* descriptor();
   static const MessageOptions& default_instance();
 
-  static inline const MessageOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const MessageOptions* internal_default_instance();
 
   void Swap(MessageOptions* other);
 
@@ -2389,8 +2375,9 @@ class LIBPROTOBUF_EXPORT MessageOptions : public ::google::protobuf::Message /* 
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<MessageOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<MessageOptions> MessageOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT FieldOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FieldOptions) */ {
@@ -2416,9 +2403,7 @@ class LIBPROTOBUF_EXPORT FieldOptions : public ::google::protobuf::Message /* @@
   static const ::google::protobuf::Descriptor* descriptor();
   static const FieldOptions& default_instance();
 
-  static inline const FieldOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FieldOptions* internal_default_instance();
 
   void Swap(FieldOptions* other);
 
@@ -2610,8 +2595,9 @@ class LIBPROTOBUF_EXPORT FieldOptions : public ::google::protobuf::Message /* @@
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FieldOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FieldOptions> FieldOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT OneofOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.OneofOptions) */ {
@@ -2637,9 +2623,7 @@ class LIBPROTOBUF_EXPORT OneofOptions : public ::google::protobuf::Message /* @@
   static const ::google::protobuf::Descriptor* descriptor();
   static const OneofOptions& default_instance();
 
-  static inline const OneofOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const OneofOptions* internal_default_instance();
 
   void Swap(OneofOptions* other);
 
@@ -2715,8 +2699,9 @@ class LIBPROTOBUF_EXPORT OneofOptions : public ::google::protobuf::Message /* @@
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<OneofOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<OneofOptions> OneofOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT EnumOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumOptions) */ {
@@ -2742,9 +2727,7 @@ class LIBPROTOBUF_EXPORT EnumOptions : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const EnumOptions& default_instance();
 
-  static inline const EnumOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const EnumOptions* internal_default_instance();
 
   void Swap(EnumOptions* other);
 
@@ -2840,8 +2823,9 @@ class LIBPROTOBUF_EXPORT EnumOptions : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<EnumOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<EnumOptions> EnumOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT EnumValueOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValueOptions) */ {
@@ -2867,9 +2851,7 @@ class LIBPROTOBUF_EXPORT EnumValueOptions : public ::google::protobuf::Message /
   static const ::google::protobuf::Descriptor* descriptor();
   static const EnumValueOptions& default_instance();
 
-  static inline const EnumValueOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const EnumValueOptions* internal_default_instance();
 
   void Swap(EnumValueOptions* other);
 
@@ -2955,8 +2937,9 @@ class LIBPROTOBUF_EXPORT EnumValueOptions : public ::google::protobuf::Message /
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<EnumValueOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<EnumValueOptions> EnumValueOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT ServiceOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ServiceOptions) */ {
@@ -2982,9 +2965,7 @@ class LIBPROTOBUF_EXPORT ServiceOptions : public ::google::protobuf::Message /* 
   static const ::google::protobuf::Descriptor* descriptor();
   static const ServiceOptions& default_instance();
 
-  static inline const ServiceOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const ServiceOptions* internal_default_instance();
 
   void Swap(ServiceOptions* other);
 
@@ -3070,8 +3051,9 @@ class LIBPROTOBUF_EXPORT ServiceOptions : public ::google::protobuf::Message /* 
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<ServiceOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<ServiceOptions> ServiceOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT MethodOptions : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.MethodOptions) */ {
@@ -3097,9 +3079,7 @@ class LIBPROTOBUF_EXPORT MethodOptions : public ::google::protobuf::Message /* @
   static const ::google::protobuf::Descriptor* descriptor();
   static const MethodOptions& default_instance();
 
-  static inline const MethodOptions* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const MethodOptions* internal_default_instance();
 
   void Swap(MethodOptions* other);
 
@@ -3185,8 +3165,9 @@ class LIBPROTOBUF_EXPORT MethodOptions : public ::google::protobuf::Message /* @
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<MethodOptions> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<MethodOptions> MethodOptions_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT UninterpretedOption_NamePart : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UninterpretedOption.NamePart) */ {
@@ -3212,9 +3193,7 @@ class LIBPROTOBUF_EXPORT UninterpretedOption_NamePart : public ::google::protobu
   static const ::google::protobuf::Descriptor* descriptor();
   static const UninterpretedOption_NamePart& default_instance();
 
-  static inline const UninterpretedOption_NamePart* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const UninterpretedOption_NamePart* internal_default_instance();
 
   void Swap(UninterpretedOption_NamePart* other);
 
@@ -3302,8 +3281,9 @@ class LIBPROTOBUF_EXPORT UninterpretedOption_NamePart : public ::google::protobu
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption_NamePart> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption_NamePart> UninterpretedOption_NamePart_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT UninterpretedOption : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UninterpretedOption) */ {
@@ -3329,9 +3309,7 @@ class LIBPROTOBUF_EXPORT UninterpretedOption : public ::google::protobuf::Messag
   static const ::google::protobuf::Descriptor* descriptor();
   static const UninterpretedOption& default_instance();
 
-  static inline const UninterpretedOption* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const UninterpretedOption* internal_default_instance();
 
   void Swap(UninterpretedOption* other);
 
@@ -3481,8 +3459,9 @@ class LIBPROTOBUF_EXPORT UninterpretedOption : public ::google::protobuf::Messag
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<UninterpretedOption> UninterpretedOption_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.SourceCodeInfo.Location) */ {
@@ -3508,9 +3487,7 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Me
   static const ::google::protobuf::Descriptor* descriptor();
   static const SourceCodeInfo_Location& default_instance();
 
-  static inline const SourceCodeInfo_Location* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const SourceCodeInfo_Location* internal_default_instance();
 
   void Swap(SourceCodeInfo_Location* other);
 
@@ -3645,8 +3622,9 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Me
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo_Location> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo_Location> SourceCodeInfo_Location_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT SourceCodeInfo : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.SourceCodeInfo) */ {
@@ -3672,9 +3650,7 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo : public ::google::protobuf::Message /* 
   static const ::google::protobuf::Descriptor* descriptor();
   static const SourceCodeInfo& default_instance();
 
-  static inline const SourceCodeInfo* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const SourceCodeInfo* internal_default_instance();
 
   void Swap(SourceCodeInfo* other);
 
@@ -3749,8 +3725,9 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo : public ::google::protobuf::Message /* 
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<SourceCodeInfo> SourceCodeInfo_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT GeneratedCodeInfo_Annotation : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.GeneratedCodeInfo.Annotation) */ {
@@ -3776,9 +3753,7 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo_Annotation : public ::google::protobu
   static const ::google::protobuf::Descriptor* descriptor();
   static const GeneratedCodeInfo_Annotation& default_instance();
 
-  static inline const GeneratedCodeInfo_Annotation* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const GeneratedCodeInfo_Annotation* internal_default_instance();
 
   void Swap(GeneratedCodeInfo_Annotation* other);
 
@@ -3887,8 +3862,9 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo_Annotation : public ::google::protobu
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo_Annotation> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo_Annotation> GeneratedCodeInfo_Annotation_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT GeneratedCodeInfo : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.GeneratedCodeInfo) */ {
@@ -3914,9 +3890,7 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo : public ::google::protobuf::Message 
   static const ::google::protobuf::Descriptor* descriptor();
   static const GeneratedCodeInfo& default_instance();
 
-  static inline const GeneratedCodeInfo* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const GeneratedCodeInfo* internal_default_instance();
 
   void Swap(GeneratedCodeInfo* other);
 
@@ -3991,8 +3965,9 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo : public ::google::protobuf::Message 
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fdescriptor_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<GeneratedCodeInfo> GeneratedCodeInfo_default_instance_;
+
 // ===================================================================
 
 
@@ -4031,6 +4006,9 @@ FileDescriptorSet::file() const {
   return file_;
 }
 
+inline const FileDescriptorSet* FileDescriptorSet::internal_default_instance() {
+  return &FileDescriptorSet_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // FileDescriptorProto
@@ -4522,6 +4500,9 @@ inline void FileDescriptorProto::set_allocated_syntax(::std::string* syntax) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.FileDescriptorProto.syntax)
 }
 
+inline const FileDescriptorProto* FileDescriptorProto::internal_default_instance() {
+  return &FileDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // DescriptorProto_ExtensionRange
@@ -4574,6 +4555,9 @@ inline void DescriptorProto_ExtensionRange::set_end(::google::protobuf::int32 va
   // @@protoc_insertion_point(field_set:google.protobuf.DescriptorProto.ExtensionRange.end)
 }
 
+inline const DescriptorProto_ExtensionRange* DescriptorProto_ExtensionRange::internal_default_instance() {
+  return &DescriptorProto_ExtensionRange_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // DescriptorProto_ReservedRange
@@ -4626,6 +4610,9 @@ inline void DescriptorProto_ReservedRange::set_end(::google::protobuf::int32 val
   // @@protoc_insertion_point(field_set:google.protobuf.DescriptorProto.ReservedRange.end)
 }
 
+inline const DescriptorProto_ReservedRange* DescriptorProto_ReservedRange::internal_default_instance() {
+  return &DescriptorProto_ReservedRange_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // DescriptorProto
@@ -4994,6 +4981,9 @@ DescriptorProto::mutable_reserved_name() {
   return &reserved_name_;
 }
 
+inline const DescriptorProto* DescriptorProto::internal_default_instance() {
+  return &DescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // FieldDescriptorProto
@@ -5411,6 +5401,9 @@ inline void FieldDescriptorProto::set_allocated_options(::google::protobuf::Fiel
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.FieldDescriptorProto.options)
 }
 
+inline const FieldDescriptorProto* FieldDescriptorProto::internal_default_instance() {
+  return &FieldDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // OneofDescriptorProto
@@ -5514,6 +5507,9 @@ inline void OneofDescriptorProto::set_allocated_options(::google::protobuf::Oneo
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.OneofDescriptorProto.options)
 }
 
+inline const OneofDescriptorProto* OneofDescriptorProto::internal_default_instance() {
+  return &OneofDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // EnumDescriptorProto
@@ -5647,6 +5643,9 @@ inline void EnumDescriptorProto::set_allocated_options(::google::protobuf::EnumO
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.EnumDescriptorProto.options)
 }
 
+inline const EnumDescriptorProto* EnumDescriptorProto::internal_default_instance() {
+  return &EnumDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // EnumValueDescriptorProto
@@ -5774,6 +5773,9 @@ inline void EnumValueDescriptorProto::set_allocated_options(::google::protobuf::
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.EnumValueDescriptorProto.options)
 }
 
+inline const EnumValueDescriptorProto* EnumValueDescriptorProto::internal_default_instance() {
+  return &EnumValueDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // ServiceDescriptorProto
@@ -5907,6 +5909,9 @@ inline void ServiceDescriptorProto::set_allocated_options(::google::protobuf::Se
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.ServiceDescriptorProto.options)
 }
 
+inline const ServiceDescriptorProto* ServiceDescriptorProto::internal_default_instance() {
+  return &ServiceDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // MethodDescriptorProto
@@ -6166,6 +6171,9 @@ inline void MethodDescriptorProto::set_server_streaming(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.MethodDescriptorProto.server_streaming)
 }
 
+inline const MethodDescriptorProto* MethodDescriptorProto::internal_default_instance() {
+  return &MethodDescriptorProto_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // FileOptions
@@ -6687,6 +6695,9 @@ FileOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const FileOptions* FileOptions::internal_default_instance() {
+  return &FileOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // MessageOptions
@@ -6817,6 +6828,9 @@ MessageOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const MessageOptions* MessageOptions::internal_default_instance() {
+  return &MessageOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // FieldOptions
@@ -6997,6 +7011,9 @@ FieldOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const FieldOptions* FieldOptions::internal_default_instance() {
+  return &FieldOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // OneofOptions
@@ -7031,6 +7048,9 @@ OneofOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const OneofOptions* OneofOptions::internal_default_instance() {
+  return &OneofOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // EnumOptions
@@ -7113,6 +7133,9 @@ EnumOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const EnumOptions* EnumOptions::internal_default_instance() {
+  return &EnumOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // EnumValueOptions
@@ -7171,6 +7194,9 @@ EnumValueOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const EnumValueOptions* EnumValueOptions::internal_default_instance() {
+  return &EnumValueOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // ServiceOptions
@@ -7229,6 +7255,9 @@ ServiceOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const ServiceOptions* ServiceOptions::internal_default_instance() {
+  return &ServiceOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // MethodOptions
@@ -7287,6 +7316,9 @@ MethodOptions::uninterpreted_option() const {
   return uninterpreted_option_;
 }
 
+inline const MethodOptions* MethodOptions::internal_default_instance() {
+  return &MethodOptions_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // UninterpretedOption_NamePart
@@ -7369,6 +7401,9 @@ inline void UninterpretedOption_NamePart::set_is_extension(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UninterpretedOption.NamePart.is_extension)
 }
 
+inline const UninterpretedOption_NamePart* UninterpretedOption_NamePart::internal_default_instance() {
+  return &UninterpretedOption_NamePart_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // UninterpretedOption
@@ -7637,6 +7672,9 @@ inline void UninterpretedOption::set_allocated_aggregate_value(::std::string* ag
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.UninterpretedOption.aggregate_value)
 }
 
+inline const UninterpretedOption* UninterpretedOption::internal_default_instance() {
+  return &UninterpretedOption_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // SourceCodeInfo_Location
@@ -7864,6 +7902,9 @@ SourceCodeInfo_Location::mutable_leading_detached_comments() {
   return &leading_detached_comments_;
 }
 
+inline const SourceCodeInfo_Location* SourceCodeInfo_Location::internal_default_instance() {
+  return &SourceCodeInfo_Location_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // SourceCodeInfo
@@ -7898,6 +7939,9 @@ SourceCodeInfo::location() const {
   return location_;
 }
 
+inline const SourceCodeInfo* SourceCodeInfo::internal_default_instance() {
+  return &SourceCodeInfo_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // GeneratedCodeInfo_Annotation
@@ -8034,6 +8078,9 @@ inline void GeneratedCodeInfo_Annotation::set_end(::google::protobuf::int32 valu
   // @@protoc_insertion_point(field_set:google.protobuf.GeneratedCodeInfo.Annotation.end)
 }
 
+inline const GeneratedCodeInfo_Annotation* GeneratedCodeInfo_Annotation::internal_default_instance() {
+  return &GeneratedCodeInfo_Annotation_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // GeneratedCodeInfo
@@ -8068,6 +8115,9 @@ GeneratedCodeInfo::annotation() const {
   return annotation_;
 }
 
+inline const GeneratedCodeInfo* GeneratedCodeInfo::internal_default_instance() {
+  return &GeneratedCodeInfo_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 

--- a/src/google/protobuf/duration.pb.cc
+++ b/src/google/protobuf/duration.pb.cc
@@ -71,15 +71,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fduration_2eproto() {
-  Duration::default_instance_.Shutdown();
+  Duration_default_instance_.Shutdown();
   delete Duration_reflection_;
 }
 
 void protobuf_InitDefaults_google_2fprotobuf_2fduration_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  Duration::default_instance_.DefaultConstruct();
-  Duration::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Duration_default_instance_.DefaultConstruct();
+  Duration_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fduration_2eproto_once_);
@@ -200,7 +200,7 @@ const Duration& Duration::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Duration> Duration::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Duration> Duration_default_instance_;
 
 Duration* Duration::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Duration>(arena);
@@ -465,6 +465,9 @@ void Duration::set_nanos(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Duration.nanos)
 }
 
+inline const Duration* Duration::internal_default_instance() {
+  return &Duration_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/duration.pb.h
+++ b/src/google/protobuf/duration.pb.h
@@ -61,9 +61,7 @@ class LIBPROTOBUF_EXPORT Duration : public ::google::protobuf::Message /* @@prot
   static const ::google::protobuf::Descriptor* descriptor();
   static const Duration& default_instance();
 
-  static inline const Duration* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Duration* internal_default_instance();
 
   void UnsafeArenaSwap(Duration* other);
   void Swap(Duration* other);
@@ -145,8 +143,9 @@ class LIBPROTOBUF_EXPORT Duration : public ::google::protobuf::Message /* @@prot
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fduration_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Duration> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Duration> Duration_default_instance_;
+
 // ===================================================================
 
 
@@ -183,6 +182,9 @@ inline void Duration::set_nanos(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Duration.nanos)
 }
 
+inline const Duration* Duration::internal_default_instance() {
+  return &Duration_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/empty.pb.cc
+++ b/src/google/protobuf/empty.pb.cc
@@ -69,15 +69,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fempty_2eproto() {
-  Empty::default_instance_.Shutdown();
+  Empty_default_instance_.Shutdown();
   delete Empty_reflection_;
 }
 
 void protobuf_InitDefaults_google_2fprotobuf_2fempty_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  Empty::default_instance_.DefaultConstruct();
-  Empty::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Empty_default_instance_.DefaultConstruct();
+  Empty_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fempty_2eproto_once_);
@@ -193,7 +193,7 @@ const Empty& Empty::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Empty> Empty::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Empty> Empty_default_instance_;
 
 Empty* Empty::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Empty>(arena);
@@ -333,6 +333,9 @@ void Empty::InternalSwap(Empty* other) {
 #if PROTOBUF_INLINE_NOT_IN_HEADERS
 // Empty
 
+inline const Empty* Empty::internal_default_instance() {
+  return &Empty_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/empty.pb.h
+++ b/src/google/protobuf/empty.pb.h
@@ -61,9 +61,7 @@ class LIBPROTOBUF_EXPORT Empty : public ::google::protobuf::Message /* @@protoc_
   static const ::google::protobuf::Descriptor* descriptor();
   static const Empty& default_instance();
 
-  static inline const Empty* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Empty* internal_default_instance();
 
   void UnsafeArenaSwap(Empty* other);
   void Swap(Empty* other);
@@ -131,8 +129,9 @@ class LIBPROTOBUF_EXPORT Empty : public ::google::protobuf::Message /* @@protoc_
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fempty_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Empty> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Empty> Empty_default_instance_;
+
 // ===================================================================
 
 
@@ -141,6 +140,9 @@ class LIBPROTOBUF_EXPORT Empty : public ::google::protobuf::Message /* @@protoc_
 #if !PROTOBUF_INLINE_NOT_IN_HEADERS
 // Empty
 
+inline const Empty* Empty::internal_default_instance() {
+  return &Empty_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -70,7 +70,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2ffield_5fmask_2eproto() {
-  FieldMask::default_instance_.Shutdown();
+  FieldMask_default_instance_.Shutdown();
   delete FieldMask_reflection_;
 }
 
@@ -78,8 +78,8 @@ void protobuf_InitDefaults_google_2fprotobuf_2ffield_5fmask_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::internal::GetEmptyString();
-  FieldMask::default_instance_.DefaultConstruct();
-  FieldMask::default_instance_.get_mutable()->InitAsDefaultInstance();
+  FieldMask_default_instance_.DefaultConstruct();
+  FieldMask_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2ffield_5fmask_2eproto_once_);
@@ -175,7 +175,7 @@ const FieldMask& FieldMask::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FieldMask> FieldMask::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FieldMask> FieldMask_default_instance_;
 
 FieldMask* FieldMask::New(::google::protobuf::Arena* arena) const {
   FieldMask* n = new FieldMask;
@@ -417,6 +417,9 @@ FieldMask::mutable_paths() {
   return &paths_;
 }
 
+inline const FieldMask* FieldMask::internal_default_instance() {
+  return &FieldMask_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/field_mask.pb.h
+++ b/src/google/protobuf/field_mask.pb.h
@@ -57,9 +57,7 @@ class LIBPROTOBUF_EXPORT FieldMask : public ::google::protobuf::Message /* @@pro
   static const ::google::protobuf::Descriptor* descriptor();
   static const FieldMask& default_instance();
 
-  static inline const FieldMask* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FieldMask* internal_default_instance();
 
   void Swap(FieldMask* other);
 
@@ -135,8 +133,9 @@ class LIBPROTOBUF_EXPORT FieldMask : public ::google::protobuf::Message /* @@pro
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ffield_5fmask_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FieldMask> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FieldMask> FieldMask_default_instance_;
+
 // ===================================================================
 
 
@@ -200,6 +199,9 @@ FieldMask::mutable_paths() {
   return &paths_;
 }
 
+inline const FieldMask* FieldMask::internal_default_instance() {
+  return &FieldMask_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/source_context.pb.cc
+++ b/src/google/protobuf/source_context.pb.cc
@@ -70,7 +70,7 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fsource_5fcontext_2eproto() {
-  SourceContext::default_instance_.Shutdown();
+  SourceContext_default_instance_.Shutdown();
   delete SourceContext_reflection_;
 }
 
@@ -78,8 +78,8 @@ void protobuf_InitDefaults_google_2fprotobuf_2fsource_5fcontext_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::internal::GetEmptyString();
-  SourceContext::default_instance_.DefaultConstruct();
-  SourceContext::default_instance_.get_mutable()->InitAsDefaultInstance();
+  SourceContext_default_instance_.DefaultConstruct();
+  SourceContext_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fsource_5fcontext_2eproto_once_);
@@ -177,7 +177,7 @@ const SourceContext& SourceContext::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<SourceContext> SourceContext::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<SourceContext> SourceContext_default_instance_;
 
 SourceContext* SourceContext::New(::google::protobuf::Arena* arena) const {
   SourceContext* n = new SourceContext;
@@ -408,6 +408,9 @@ void SourceContext::set_allocated_file_name(::std::string* file_name) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.SourceContext.file_name)
 }
 
+inline const SourceContext* SourceContext::internal_default_instance() {
+  return &SourceContext_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/source_context.pb.h
+++ b/src/google/protobuf/source_context.pb.h
@@ -57,9 +57,7 @@ class LIBPROTOBUF_EXPORT SourceContext : public ::google::protobuf::Message /* @
   static const ::google::protobuf::Descriptor* descriptor();
   static const SourceContext& default_instance();
 
-  static inline const SourceContext* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const SourceContext* internal_default_instance();
 
   void Swap(SourceContext* other);
 
@@ -130,8 +128,9 @@ class LIBPROTOBUF_EXPORT SourceContext : public ::google::protobuf::Message /* @
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fsource_5fcontext_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<SourceContext> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<SourceContext> SourceContext_default_instance_;
+
 // ===================================================================
 
 
@@ -184,6 +183,9 @@ inline void SourceContext::set_allocated_file_name(::std::string* file_name) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.SourceContext.file_name)
 }
 
+inline const SourceContext* SourceContext::internal_default_instance() {
+  return &SourceContext_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -137,12 +137,12 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fstruct_2eproto() {
-  Struct::default_instance_.Shutdown();
+  Struct_default_instance_.Shutdown();
   delete Struct_reflection_;
-  Value::default_instance_.Shutdown();
+  Value_default_instance_.Shutdown();
   delete Value_default_oneof_instance_;
   delete Value_reflection_;
-  ListValue::default_instance_.Shutdown();
+  ListValue_default_instance_.Shutdown();
   delete ListValue_reflection_;
 }
 
@@ -150,14 +150,14 @@ void protobuf_InitDefaults_google_2fprotobuf_2fstruct_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::internal::GetEmptyString();
-  Struct::default_instance_.DefaultConstruct();
+  Struct_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Value::default_instance_.DefaultConstruct();
+  Value_default_instance_.DefaultConstruct();
   Value_default_oneof_instance_ = new ValueOneofInstance();
-  ListValue::default_instance_.DefaultConstruct();
-  Struct::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Value::default_instance_.get_mutable()->InitAsDefaultInstance();
-  ListValue::default_instance_.get_mutable()->InitAsDefaultInstance();
+  ListValue_default_instance_.DefaultConstruct();
+  Struct_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Value_default_instance_.get_mutable()->InitAsDefaultInstance();
+  ListValue_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fstruct_2eproto_once_);
@@ -304,7 +304,7 @@ const Struct& Struct::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Struct> Struct::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Struct> Struct_default_instance_;
 
 Struct* Struct::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Struct>(arena);
@@ -630,6 +630,9 @@ Struct::mutable_fields() {
   return fields_.MutableMap();
 }
 
+inline const Struct* Struct::internal_default_instance() {
+  return &Struct_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -721,7 +724,7 @@ const Value& Value::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Value> Value::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Value> Value_default_instance_;
 
 Value* Value::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Value>(arena);
@@ -1527,6 +1530,9 @@ void Value::clear_has_kind() {
 Value::KindCase Value::kind_case() const {
   return Value::KindCase(_oneof_case_[0]);
 }
+inline const Value* Value::internal_default_instance() {
+  return &Value_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1602,7 +1608,7 @@ const ListValue& ListValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<ListValue> ListValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<ListValue> ListValue_default_instance_;
 
 ListValue* ListValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<ListValue>(arena);
@@ -1820,6 +1826,9 @@ ListValue::values() const {
   return values_;
 }
 
+inline const ListValue* ListValue::internal_default_instance() {
+  return &ListValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/struct.pb.h
+++ b/src/google/protobuf/struct.pb.h
@@ -86,9 +86,7 @@ class LIBPROTOBUF_EXPORT Struct : public ::google::protobuf::Message /* @@protoc
   static const ::google::protobuf::Descriptor* descriptor();
   static const Struct& default_instance();
 
-  static inline const Struct* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Struct* internal_default_instance();
 
   void UnsafeArenaSwap(Struct* other);
   void Swap(Struct* other);
@@ -177,8 +175,9 @@ class LIBPROTOBUF_EXPORT Struct : public ::google::protobuf::Message /* @@protoc
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fstruct_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Struct> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Struct> Struct_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Value) */ {
@@ -210,9 +209,7 @@ class LIBPROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_
     KIND_NOT_SET = 0,
   };
 
-  static inline const Value* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Value* internal_default_instance();
 
   void UnsafeArenaSwap(Value* other);
   void Swap(Value* other);
@@ -382,8 +379,9 @@ class LIBPROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fstruct_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Value> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Value> Value_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT ListValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.ListValue) */ {
@@ -405,9 +403,7 @@ class LIBPROTOBUF_EXPORT ListValue : public ::google::protobuf::Message /* @@pro
   static const ::google::protobuf::Descriptor* descriptor();
   static const ListValue& default_instance();
 
-  static inline const ListValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const ListValue* internal_default_instance();
 
   void UnsafeArenaSwap(ListValue* other);
   void Swap(ListValue* other);
@@ -488,8 +484,9 @@ class LIBPROTOBUF_EXPORT ListValue : public ::google::protobuf::Message /* @@pro
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fstruct_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<ListValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<ListValue> ListValue_default_instance_;
+
 // ===================================================================
 
 
@@ -516,6 +513,9 @@ Struct::mutable_fields() {
   return fields_.MutableMap();
 }
 
+inline const Struct* Struct::internal_default_instance() {
+  return &Struct_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Value
@@ -901,6 +901,9 @@ inline void Value::clear_has_kind() {
 inline Value::KindCase Value::kind_case() const {
   return Value::KindCase(_oneof_case_[0]);
 }
+inline const Value* Value::internal_default_instance() {
+  return &Value_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // ListValue
@@ -935,6 +938,9 @@ ListValue::values() const {
   return values_;
 }
 
+inline const ListValue* ListValue::internal_default_instance() {
+  return &ListValue_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 

--- a/src/google/protobuf/timestamp.pb.cc
+++ b/src/google/protobuf/timestamp.pb.cc
@@ -71,15 +71,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2ftimestamp_2eproto() {
-  Timestamp::default_instance_.Shutdown();
+  Timestamp_default_instance_.Shutdown();
   delete Timestamp_reflection_;
 }
 
 void protobuf_InitDefaults_google_2fprotobuf_2ftimestamp_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  Timestamp::default_instance_.DefaultConstruct();
-  Timestamp::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Timestamp_default_instance_.DefaultConstruct();
+  Timestamp_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2ftimestamp_2eproto_once_);
@@ -200,7 +200,7 @@ const Timestamp& Timestamp::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Timestamp> Timestamp::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Timestamp> Timestamp_default_instance_;
 
 Timestamp* Timestamp::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Timestamp>(arena);
@@ -465,6 +465,9 @@ void Timestamp::set_nanos(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Timestamp.nanos)
 }
 
+inline const Timestamp* Timestamp::internal_default_instance() {
+  return &Timestamp_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/timestamp.pb.h
+++ b/src/google/protobuf/timestamp.pb.h
@@ -61,9 +61,7 @@ class LIBPROTOBUF_EXPORT Timestamp : public ::google::protobuf::Message /* @@pro
   static const ::google::protobuf::Descriptor* descriptor();
   static const Timestamp& default_instance();
 
-  static inline const Timestamp* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Timestamp* internal_default_instance();
 
   void UnsafeArenaSwap(Timestamp* other);
   void Swap(Timestamp* other);
@@ -145,8 +143,9 @@ class LIBPROTOBUF_EXPORT Timestamp : public ::google::protobuf::Message /* @@pro
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftimestamp_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Timestamp> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Timestamp> Timestamp_default_instance_;
+
 // ===================================================================
 
 
@@ -183,6 +182,9 @@ inline void Timestamp::set_nanos(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Timestamp.nanos)
 }
 
+inline const Timestamp* Timestamp::internal_default_instance() {
+  return &Timestamp_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -173,15 +173,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto() {
-  Type::default_instance_.Shutdown();
+  Type_default_instance_.Shutdown();
   delete Type_reflection_;
-  Field::default_instance_.Shutdown();
+  Field_default_instance_.Shutdown();
   delete Field_reflection_;
-  Enum::default_instance_.Shutdown();
+  Enum_default_instance_.Shutdown();
   delete Enum_reflection_;
-  EnumValue::default_instance_.Shutdown();
+  EnumValue_default_instance_.Shutdown();
   delete EnumValue_reflection_;
-  Option::default_instance_.Shutdown();
+  Option_default_instance_.Shutdown();
   delete Option_reflection_;
 }
 
@@ -191,20 +191,20 @@ void protobuf_InitDefaults_google_2fprotobuf_2ftype_2eproto_impl() {
   ::google::protobuf::protobuf_InitDefaults_google_2fprotobuf_2fany_2eproto();
   ::google::protobuf::protobuf_InitDefaults_google_2fprotobuf_2fsource_5fcontext_2eproto();
   ::google::protobuf::internal::GetEmptyString();
-  Type::default_instance_.DefaultConstruct();
+  Type_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Field::default_instance_.DefaultConstruct();
+  Field_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Enum::default_instance_.DefaultConstruct();
+  Enum_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  EnumValue::default_instance_.DefaultConstruct();
+  EnumValue_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  Option::default_instance_.DefaultConstruct();
-  Type::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Field::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Enum::default_instance_.get_mutable()->InitAsDefaultInstance();
-  EnumValue::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Option::default_instance_.get_mutable()->InitAsDefaultInstance();
+  Option_default_instance_.DefaultConstruct();
+  Type_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Field_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Enum_default_instance_.get_mutable()->InitAsDefaultInstance();
+  EnumValue_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Option_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2ftype_2eproto_once_);
@@ -395,7 +395,7 @@ void Type::SharedDtor() {
   }
 
   name_.Destroy(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), arena);
-  if (this != &default_instance_.get()) {
+  if (this != &Type_default_instance_.get()) {
     delete source_context_;
   }
 }
@@ -421,7 +421,7 @@ const Type& Type::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Type> Type::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Type> Type_default_instance_;
 
 Type* Type::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Type>(arena);
@@ -1077,6 +1077,9 @@ void Type::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Type.syntax)
 }
 
+inline const Type* Type::internal_default_instance() {
+  return &Type_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1251,7 +1254,7 @@ const Field& Field::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Field> Field::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Field> Field_default_instance_;
 
 Field* Field::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Field>(arena);
@@ -2206,6 +2209,9 @@ void Field::unsafe_arena_set_allocated_default_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Field.default_value)
 }
 
+inline const Field* Field::internal_default_instance() {
+  return &Field_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2302,7 +2308,7 @@ void Enum::SharedDtor() {
   }
 
   name_.Destroy(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), arena);
-  if (this != &default_instance_.get()) {
+  if (this != &Enum_default_instance_.get()) {
     delete source_context_;
   }
 }
@@ -2328,7 +2334,7 @@ const Enum& Enum::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Enum> Enum::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Enum> Enum_default_instance_;
 
 Enum* Enum::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Enum>(arena);
@@ -2878,6 +2884,9 @@ void Enum::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Enum.syntax)
 }
 
+inline const Enum* Enum::internal_default_instance() {
+  return &Enum_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2958,7 +2967,7 @@ const EnumValue& EnumValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<EnumValue> EnumValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<EnumValue> EnumValue_default_instance_;
 
 EnumValue* EnumValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<EnumValue>(arena);
@@ -3343,6 +3352,9 @@ EnumValue::options() const {
   return options_;
 }
 
+inline const EnumValue* EnumValue::internal_default_instance() {
+  return &EnumValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -3433,7 +3445,7 @@ void Option::SharedDtor() {
   }
 
   name_.Destroy(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), arena);
-  if (this != &default_instance_.get()) {
+  if (this != &Option_default_instance_.get()) {
     delete value_;
   }
 }
@@ -3459,7 +3471,7 @@ const Option& Option::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Option> Option::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Option> Option_default_instance_;
 
 Option* Option::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Option>(arena);
@@ -3809,6 +3821,9 @@ const ::google::protobuf::Any& Option::value() const {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Option.value)
 }
 
+inline const Option* Option::internal_default_instance() {
+  return &Option_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -150,9 +150,7 @@ class LIBPROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_i
   static const ::google::protobuf::Descriptor* descriptor();
   static const Type& default_instance();
 
-  static inline const Type* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Type* internal_default_instance();
 
   void UnsafeArenaSwap(Type* other);
   void Swap(Type* other);
@@ -302,8 +300,9 @@ class LIBPROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_i
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Type> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Type> Type_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Field) */ {
@@ -325,9 +324,7 @@ class LIBPROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_
   static const ::google::protobuf::Descriptor* descriptor();
   static const Field& default_instance();
 
-  static inline const Field* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Field* internal_default_instance();
 
   void UnsafeArenaSwap(Field* other);
   void Swap(Field* other);
@@ -593,8 +590,9 @@ class LIBPROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Field> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Field> Field_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Enum) */ {
@@ -616,9 +614,7 @@ class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_i
   static const ::google::protobuf::Descriptor* descriptor();
   static const Enum& default_instance();
 
-  static inline const Enum* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Enum* internal_default_instance();
 
   void UnsafeArenaSwap(Enum* other);
   void Swap(Enum* other);
@@ -751,8 +747,9 @@ class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_i
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Enum> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Enum> Enum_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.EnumValue) */ {
@@ -774,9 +771,7 @@ class LIBPROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@pro
   static const ::google::protobuf::Descriptor* descriptor();
   static const EnumValue& default_instance();
 
-  static inline const EnumValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const EnumValue* internal_default_instance();
 
   void UnsafeArenaSwap(EnumValue* other);
   void Swap(EnumValue* other);
@@ -879,8 +874,9 @@ class LIBPROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@pro
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<EnumValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<EnumValue> EnumValue_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Option) */ {
@@ -902,9 +898,7 @@ class LIBPROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc
   static const ::google::protobuf::Descriptor* descriptor();
   static const Option& default_instance();
 
-  static inline const Option* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Option* internal_default_instance();
 
   void UnsafeArenaSwap(Option* other);
   void Swap(Option* other);
@@ -1004,8 +998,9 @@ class LIBPROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc
   friend void protobuf_ShutdownFile_google_2fprotobuf_2ftype_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Option> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Option> Option_default_instance_;
+
 // ===================================================================
 
 
@@ -1260,6 +1255,9 @@ inline void Type::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Type.syntax)
 }
 
+inline const Type* Type::internal_default_instance() {
+  return &Type_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Field
@@ -1628,6 +1626,9 @@ inline void Field::unsafe_arena_set_allocated_default_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Field.default_value)
 }
 
+inline const Field* Field::internal_default_instance() {
+  return &Field_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Enum
@@ -1823,6 +1824,9 @@ inline void Enum::set_syntax(::google::protobuf::Syntax value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Enum.syntax)
 }
 
+inline const Enum* Enum::internal_default_instance() {
+  return &Enum_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // EnumValue
@@ -1937,6 +1941,9 @@ EnumValue::options() const {
   return options_;
 }
 
+inline const EnumValue* EnumValue::internal_default_instance() {
+  return &EnumValue_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Option
@@ -2058,6 +2065,9 @@ inline  void Option::set_allocated_value(::google::protobuf::Any* value) {
   // @@protoc_insertion_point(field_set_allocated:google.protobuf.Option.value)
 }
 
+inline const Option* Option::internal_default_instance() {
+  return &Option_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 

--- a/src/google/protobuf/util/field_mask_util.cc
+++ b/src/google/protobuf/util/field_mask_util.cc
@@ -456,11 +456,12 @@ void FieldMaskTree::TrimMessage(const Node* node, Message* message) {
   const int32 field_count = descriptor->field_count();
   for (int index = 0; index < field_count; ++index) {
     const FieldDescriptor* field = descriptor->field(index);
-    if (!ContainsKey(node->children, field->name())) {
+    map<string, Node*>::const_iterator it = node->children.find(field->name());
+    if (it == node->children.end()) {
       reflection->ClearField(message, field);
     } else {
       if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
-        Node* child = node->children.at(field->name());
+        Node* child = it->second;
         if (!child->children.empty()) {
           TrimMessage(child, reflection->MutableMessage(message, field));
         }

--- a/src/google/protobuf/util/time_util.cc
+++ b/src/google/protobuf/util/time_util.cc
@@ -143,11 +143,13 @@ int64 RoundTowardZero(int64 value, int64 divider) {
 }  // namespace
 
 // Actually define these static const integers. Required by C++ standard (but
-// omitting them may still work with some compilers).
+// some compilers don't like it).
+#ifndef _MSC_VER
 const int64 TimeUtil::kTimestampMinSeconds;
 const int64 TimeUtil::kTimestampMaxSeconds;
 const int64 TimeUtil::kDurationMaxSeconds;
 const int64 TimeUtil::kDurationMinSeconds;
+#endif  // !_MSC_VER
 
 string TimeUtil::ToString(const Timestamp& timestamp) {
   return FormatTime(timestamp.seconds(), timestamp.nanos());

--- a/src/google/protobuf/wrappers.pb.cc
+++ b/src/google/protobuf/wrappers.pb.cc
@@ -222,49 +222,49 @@ void protobuf_RegisterTypes(const ::std::string&) {
 }  // namespace
 
 void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto() {
-  DoubleValue::default_instance_.Shutdown();
+  DoubleValue_default_instance_.Shutdown();
   delete DoubleValue_reflection_;
-  FloatValue::default_instance_.Shutdown();
+  FloatValue_default_instance_.Shutdown();
   delete FloatValue_reflection_;
-  Int64Value::default_instance_.Shutdown();
+  Int64Value_default_instance_.Shutdown();
   delete Int64Value_reflection_;
-  UInt64Value::default_instance_.Shutdown();
+  UInt64Value_default_instance_.Shutdown();
   delete UInt64Value_reflection_;
-  Int32Value::default_instance_.Shutdown();
+  Int32Value_default_instance_.Shutdown();
   delete Int32Value_reflection_;
-  UInt32Value::default_instance_.Shutdown();
+  UInt32Value_default_instance_.Shutdown();
   delete UInt32Value_reflection_;
-  BoolValue::default_instance_.Shutdown();
+  BoolValue_default_instance_.Shutdown();
   delete BoolValue_reflection_;
-  StringValue::default_instance_.Shutdown();
+  StringValue_default_instance_.Shutdown();
   delete StringValue_reflection_;
-  BytesValue::default_instance_.Shutdown();
+  BytesValue_default_instance_.Shutdown();
   delete BytesValue_reflection_;
 }
 
 void protobuf_InitDefaults_google_2fprotobuf_2fwrappers_2eproto_impl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  DoubleValue::default_instance_.DefaultConstruct();
-  FloatValue::default_instance_.DefaultConstruct();
-  Int64Value::default_instance_.DefaultConstruct();
-  UInt64Value::default_instance_.DefaultConstruct();
-  Int32Value::default_instance_.DefaultConstruct();
-  UInt32Value::default_instance_.DefaultConstruct();
-  BoolValue::default_instance_.DefaultConstruct();
+  DoubleValue_default_instance_.DefaultConstruct();
+  FloatValue_default_instance_.DefaultConstruct();
+  Int64Value_default_instance_.DefaultConstruct();
+  UInt64Value_default_instance_.DefaultConstruct();
+  Int32Value_default_instance_.DefaultConstruct();
+  UInt32Value_default_instance_.DefaultConstruct();
+  BoolValue_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  StringValue::default_instance_.DefaultConstruct();
+  StringValue_default_instance_.DefaultConstruct();
   ::google::protobuf::internal::GetEmptyString();
-  BytesValue::default_instance_.DefaultConstruct();
-  DoubleValue::default_instance_.get_mutable()->InitAsDefaultInstance();
-  FloatValue::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Int64Value::default_instance_.get_mutable()->InitAsDefaultInstance();
-  UInt64Value::default_instance_.get_mutable()->InitAsDefaultInstance();
-  Int32Value::default_instance_.get_mutable()->InitAsDefaultInstance();
-  UInt32Value::default_instance_.get_mutable()->InitAsDefaultInstance();
-  BoolValue::default_instance_.get_mutable()->InitAsDefaultInstance();
-  StringValue::default_instance_.get_mutable()->InitAsDefaultInstance();
-  BytesValue::default_instance_.get_mutable()->InitAsDefaultInstance();
+  BytesValue_default_instance_.DefaultConstruct();
+  DoubleValue_default_instance_.get_mutable()->InitAsDefaultInstance();
+  FloatValue_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Int64Value_default_instance_.get_mutable()->InitAsDefaultInstance();
+  UInt64Value_default_instance_.get_mutable()->InitAsDefaultInstance();
+  Int32Value_default_instance_.get_mutable()->InitAsDefaultInstance();
+  UInt32Value_default_instance_.get_mutable()->InitAsDefaultInstance();
+  BoolValue_default_instance_.get_mutable()->InitAsDefaultInstance();
+  StringValue_default_instance_.get_mutable()->InitAsDefaultInstance();
+  BytesValue_default_instance_.get_mutable()->InitAsDefaultInstance();
 }
 
 GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_InitDefaults_google_2fprotobuf_2fwrappers_2eproto_once_);
@@ -389,7 +389,7 @@ const DoubleValue& DoubleValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<DoubleValue> DoubleValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<DoubleValue> DoubleValue_default_instance_;
 
 DoubleValue* DoubleValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<DoubleValue>(arena);
@@ -582,6 +582,9 @@ void DoubleValue::set_value(double value) {
   // @@protoc_insertion_point(field_set:google.protobuf.DoubleValue.value)
 }
 
+inline const DoubleValue* DoubleValue::internal_default_instance() {
+  return &DoubleValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -657,7 +660,7 @@ const FloatValue& FloatValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<FloatValue> FloatValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<FloatValue> FloatValue_default_instance_;
 
 FloatValue* FloatValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<FloatValue>(arena);
@@ -850,6 +853,9 @@ void FloatValue::set_value(float value) {
   // @@protoc_insertion_point(field_set:google.protobuf.FloatValue.value)
 }
 
+inline const FloatValue* FloatValue::internal_default_instance() {
+  return &FloatValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -925,7 +931,7 @@ const Int64Value& Int64Value::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Int64Value> Int64Value::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Int64Value> Int64Value_default_instance_;
 
 Int64Value* Int64Value::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Int64Value>(arena);
@@ -1120,6 +1126,9 @@ void Int64Value::set_value(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Int64Value.value)
 }
 
+inline const Int64Value* Int64Value::internal_default_instance() {
+  return &Int64Value_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1195,7 +1204,7 @@ const UInt64Value& UInt64Value::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<UInt64Value> UInt64Value::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<UInt64Value> UInt64Value_default_instance_;
 
 UInt64Value* UInt64Value::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<UInt64Value>(arena);
@@ -1390,6 +1399,9 @@ void UInt64Value::set_value(::google::protobuf::uint64 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UInt64Value.value)
 }
 
+inline const UInt64Value* UInt64Value::internal_default_instance() {
+  return &UInt64Value_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1465,7 +1477,7 @@ const Int32Value& Int32Value::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<Int32Value> Int32Value::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<Int32Value> Int32Value_default_instance_;
 
 Int32Value* Int32Value::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<Int32Value>(arena);
@@ -1660,6 +1672,9 @@ void Int32Value::set_value(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Int32Value.value)
 }
 
+inline const Int32Value* Int32Value::internal_default_instance() {
+  return &Int32Value_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -1735,7 +1750,7 @@ const UInt32Value& UInt32Value::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<UInt32Value> UInt32Value::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<UInt32Value> UInt32Value_default_instance_;
 
 UInt32Value* UInt32Value::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<UInt32Value>(arena);
@@ -1930,6 +1945,9 @@ void UInt32Value::set_value(::google::protobuf::uint32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UInt32Value.value)
 }
 
+inline const UInt32Value* UInt32Value::internal_default_instance() {
+  return &UInt32Value_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2005,7 +2023,7 @@ const BoolValue& BoolValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<BoolValue> BoolValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<BoolValue> BoolValue_default_instance_;
 
 BoolValue* BoolValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<BoolValue>(arena);
@@ -2198,6 +2216,9 @@ void BoolValue::set_value(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.BoolValue.value)
 }
 
+inline const BoolValue* BoolValue::internal_default_instance() {
+  return &BoolValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2274,7 +2295,7 @@ const StringValue& StringValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<StringValue> StringValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<StringValue> StringValue_default_instance_;
 
 StringValue* StringValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<StringValue>(arena);
@@ -2534,6 +2555,9 @@ void StringValue::unsafe_arena_set_allocated_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.StringValue.value)
 }
 
+inline const StringValue* StringValue::internal_default_instance() {
+  return &StringValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // ===================================================================
@@ -2610,7 +2634,7 @@ const BytesValue& BytesValue::default_instance() {
   return *internal_default_instance();
 }
 
-::google::protobuf::internal::ExplicitlyConstructed<BytesValue> BytesValue::default_instance_;
+::google::protobuf::internal::ExplicitlyConstructed<BytesValue> BytesValue_default_instance_;
 
 BytesValue* BytesValue::New(::google::protobuf::Arena* arena) const {
   return ::google::protobuf::Arena::CreateMessage<BytesValue>(arena);
@@ -2858,6 +2882,9 @@ void BytesValue::unsafe_arena_set_allocated_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.BytesValue.value)
 }
 
+inline const BytesValue* BytesValue::internal_default_instance() {
+  return &BytesValue_default_instance_.get();
+}
 #endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
 
 // @@protoc_insertion_point(namespace_scope)

--- a/src/google/protobuf/wrappers.pb.h
+++ b/src/google/protobuf/wrappers.pb.h
@@ -69,9 +69,7 @@ class LIBPROTOBUF_EXPORT DoubleValue : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const DoubleValue& default_instance();
 
-  static inline const DoubleValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const DoubleValue* internal_default_instance();
 
   void UnsafeArenaSwap(DoubleValue* other);
   void Swap(DoubleValue* other);
@@ -146,8 +144,9 @@ class LIBPROTOBUF_EXPORT DoubleValue : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<DoubleValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<DoubleValue> DoubleValue_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT FloatValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.FloatValue) */ {
@@ -169,9 +168,7 @@ class LIBPROTOBUF_EXPORT FloatValue : public ::google::protobuf::Message /* @@pr
   static const ::google::protobuf::Descriptor* descriptor();
   static const FloatValue& default_instance();
 
-  static inline const FloatValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const FloatValue* internal_default_instance();
 
   void UnsafeArenaSwap(FloatValue* other);
   void Swap(FloatValue* other);
@@ -246,8 +243,9 @@ class LIBPROTOBUF_EXPORT FloatValue : public ::google::protobuf::Message /* @@pr
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<FloatValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<FloatValue> FloatValue_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Int64Value : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Int64Value) */ {
@@ -269,9 +267,7 @@ class LIBPROTOBUF_EXPORT Int64Value : public ::google::protobuf::Message /* @@pr
   static const ::google::protobuf::Descriptor* descriptor();
   static const Int64Value& default_instance();
 
-  static inline const Int64Value* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Int64Value* internal_default_instance();
 
   void UnsafeArenaSwap(Int64Value* other);
   void Swap(Int64Value* other);
@@ -346,8 +342,9 @@ class LIBPROTOBUF_EXPORT Int64Value : public ::google::protobuf::Message /* @@pr
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Int64Value> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Int64Value> Int64Value_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT UInt64Value : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UInt64Value) */ {
@@ -369,9 +366,7 @@ class LIBPROTOBUF_EXPORT UInt64Value : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const UInt64Value& default_instance();
 
-  static inline const UInt64Value* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const UInt64Value* internal_default_instance();
 
   void UnsafeArenaSwap(UInt64Value* other);
   void Swap(UInt64Value* other);
@@ -446,8 +441,9 @@ class LIBPROTOBUF_EXPORT UInt64Value : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<UInt64Value> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<UInt64Value> UInt64Value_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT Int32Value : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.Int32Value) */ {
@@ -469,9 +465,7 @@ class LIBPROTOBUF_EXPORT Int32Value : public ::google::protobuf::Message /* @@pr
   static const ::google::protobuf::Descriptor* descriptor();
   static const Int32Value& default_instance();
 
-  static inline const Int32Value* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const Int32Value* internal_default_instance();
 
   void UnsafeArenaSwap(Int32Value* other);
   void Swap(Int32Value* other);
@@ -546,8 +540,9 @@ class LIBPROTOBUF_EXPORT Int32Value : public ::google::protobuf::Message /* @@pr
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<Int32Value> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<Int32Value> Int32Value_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT UInt32Value : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.UInt32Value) */ {
@@ -569,9 +564,7 @@ class LIBPROTOBUF_EXPORT UInt32Value : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const UInt32Value& default_instance();
 
-  static inline const UInt32Value* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const UInt32Value* internal_default_instance();
 
   void UnsafeArenaSwap(UInt32Value* other);
   void Swap(UInt32Value* other);
@@ -646,8 +639,9 @@ class LIBPROTOBUF_EXPORT UInt32Value : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<UInt32Value> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<UInt32Value> UInt32Value_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT BoolValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.BoolValue) */ {
@@ -669,9 +663,7 @@ class LIBPROTOBUF_EXPORT BoolValue : public ::google::protobuf::Message /* @@pro
   static const ::google::protobuf::Descriptor* descriptor();
   static const BoolValue& default_instance();
 
-  static inline const BoolValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const BoolValue* internal_default_instance();
 
   void UnsafeArenaSwap(BoolValue* other);
   void Swap(BoolValue* other);
@@ -746,8 +738,9 @@ class LIBPROTOBUF_EXPORT BoolValue : public ::google::protobuf::Message /* @@pro
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<BoolValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<BoolValue> BoolValue_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT StringValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.StringValue) */ {
@@ -769,9 +762,7 @@ class LIBPROTOBUF_EXPORT StringValue : public ::google::protobuf::Message /* @@p
   static const ::google::protobuf::Descriptor* descriptor();
   static const StringValue& default_instance();
 
-  static inline const StringValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const StringValue* internal_default_instance();
 
   void UnsafeArenaSwap(StringValue* other);
   void Swap(StringValue* other);
@@ -854,8 +845,9 @@ class LIBPROTOBUF_EXPORT StringValue : public ::google::protobuf::Message /* @@p
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<StringValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<StringValue> StringValue_default_instance_;
+
 // -------------------------------------------------------------------
 
 class LIBPROTOBUF_EXPORT BytesValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.BytesValue) */ {
@@ -877,9 +869,7 @@ class LIBPROTOBUF_EXPORT BytesValue : public ::google::protobuf::Message /* @@pr
   static const ::google::protobuf::Descriptor* descriptor();
   static const BytesValue& default_instance();
 
-  static inline const BytesValue* internal_default_instance() {
-    return &default_instance_.get();
-  }
+  static const BytesValue* internal_default_instance();
 
   void UnsafeArenaSwap(BytesValue* other);
   void Swap(BytesValue* other);
@@ -962,8 +952,9 @@ class LIBPROTOBUF_EXPORT BytesValue : public ::google::protobuf::Message /* @@pr
   friend void protobuf_ShutdownFile_google_2fprotobuf_2fwrappers_2eproto();
 
   void InitAsDefaultInstance();
-  static ::google::protobuf::internal::ExplicitlyConstructed<BytesValue> default_instance_;
 };
+extern ::google::protobuf::internal::ExplicitlyConstructed<BytesValue> BytesValue_default_instance_;
+
 // ===================================================================
 
 
@@ -986,6 +977,9 @@ inline void DoubleValue::set_value(double value) {
   // @@protoc_insertion_point(field_set:google.protobuf.DoubleValue.value)
 }
 
+inline const DoubleValue* DoubleValue::internal_default_instance() {
+  return &DoubleValue_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // FloatValue
@@ -1004,6 +998,9 @@ inline void FloatValue::set_value(float value) {
   // @@protoc_insertion_point(field_set:google.protobuf.FloatValue.value)
 }
 
+inline const FloatValue* FloatValue::internal_default_instance() {
+  return &FloatValue_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Int64Value
@@ -1022,6 +1019,9 @@ inline void Int64Value::set_value(::google::protobuf::int64 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Int64Value.value)
 }
 
+inline const Int64Value* Int64Value::internal_default_instance() {
+  return &Int64Value_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // UInt64Value
@@ -1040,6 +1040,9 @@ inline void UInt64Value::set_value(::google::protobuf::uint64 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UInt64Value.value)
 }
 
+inline const UInt64Value* UInt64Value::internal_default_instance() {
+  return &UInt64Value_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // Int32Value
@@ -1058,6 +1061,9 @@ inline void Int32Value::set_value(::google::protobuf::int32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.Int32Value.value)
 }
 
+inline const Int32Value* Int32Value::internal_default_instance() {
+  return &Int32Value_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // UInt32Value
@@ -1076,6 +1082,9 @@ inline void UInt32Value::set_value(::google::protobuf::uint32 value) {
   // @@protoc_insertion_point(field_set:google.protobuf.UInt32Value.value)
 }
 
+inline const UInt32Value* UInt32Value::internal_default_instance() {
+  return &UInt32Value_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // BoolValue
@@ -1094,6 +1103,9 @@ inline void BoolValue::set_value(bool value) {
   // @@protoc_insertion_point(field_set:google.protobuf.BoolValue.value)
 }
 
+inline const BoolValue* BoolValue::internal_default_instance() {
+  return &BoolValue_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // StringValue
@@ -1164,6 +1176,9 @@ inline void StringValue::unsafe_arena_set_allocated_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.StringValue.value)
 }
 
+inline const StringValue* StringValue::internal_default_instance() {
+  return &StringValue_default_instance_.get();
+}
 // -------------------------------------------------------------------
 
 // BytesValue
@@ -1234,6 +1249,9 @@ inline void BytesValue::unsafe_arena_set_allocated_value(
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.BytesValue.value)
 }
 
+inline const BytesValue* BytesValue::internal_default_instance() {
+  return &BytesValue_default_instance_.get();
+}
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
 // -------------------------------------------------------------------
 


### PR DESCRIPTION
Visual Studio refuses to compile this:
```cpp
template<typename T>
class ExplicitlyConstructed {
  char data[sizeof(T)];
};
class Any {
  static ExplicitlyConstructed<Any> default_instance;
};
```
and complains about the default_instance line that it's "use of undefined type Any":
https://ci.appveyor.com/project/protobuf/protobuf/build/1.0.2673/job/nrdf4tb9dau0sck5

This pull request moves the default_instance out so VC++ can be happy about it:
```cpp
class Any {
};
ExplicitlyConstructed<Any> Any_default_instance;
```

Also included other small fixes.