### PR TITLE
Reduce test length to avoid stack overflow on VS.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,16 +20,16 @@ environment:
 test: off
 
 install:
-  - ps: Start-FileDownload https://github.com/google/googlemock/archive/release-1.7.0.zip
+  - curl -L -o release-1.7.0.zip https://github.com/google/googlemock/archive/release-1.7.0.zip
   - 7z x release-1.7.0.zip
   - del /Q release-1.7.0.zip
   - rename googlemock-release-1.7.0 gmock
-  - ps: Start-FileDownload https://github.com/google/googletest/archive/release-1.7.0.zip
+  - curl -L -o release-1.7.0.zip "https://github.com/google/googletest/archive/release-1.7.0.zip"
   - 7z x release-1.7.0.zip
   - del /Q release-1.7.0.zip
   - rename googletest-release-1.7.0 gtest
   - move gtest gmock
-  - ps: Start-FileDownload https://go.microsoft.com/fwlink/?LinkID=809122 -FileName dotnetsdk.exe
+  - curl -L -o dotnetsdk.exe "https://go.microsoft.com/fwlink/?LinkID=809122"
   - dotnetsdk.exe /install /quiet /norestart
 
 before_build:

--- a/src/google/protobuf/util/internal/json_stream_parser_test.cc
+++ b/src/google/protobuf/util/internal/json_stream_parser_test.cc
@@ -318,15 +318,15 @@ TEST_F(JsonStreamParserTest, ObjectKeyTypes) {
 // - array containing array, object, values (true, false, null, num, string)
 TEST_F(JsonStreamParserTest, ArrayValues) {
   StringPiece str =
-      "[true, false, null, 'a string', \"another string\", [22, -127, 45.3, "
+      "[true, false, null, 'a', \"an\", [22, -127, 45.3, "
       "-1056.4, 11779497823553162765], {'key': true}]";
   for (int i = 0; i <= str.length(); ++i) {
     ow_.StartList("")
         ->RenderBool("", true)
         ->RenderBool("", false)
         ->RenderNull("")
-        ->RenderString("", "a string")
-        ->RenderString("", "another string")
+        ->RenderString("", "a")
+        ->RenderString("", "an")
         ->StartList("")
         ->RenderUint64("", 22)
         ->RenderInt64("", -127)


### PR DESCRIPTION
It seems gmock is chaining all expectations in a nested structure and adding too many expectations will cause stack overflow when the gmock object is destructed. This pull request makes the test case shorter but still have the same test coverage.

It fixes JsonStreamParserTest.ArrayValues on Visual Studio and also fixes most other failing test cases caused by a corrupted stack.