### PR TITLE
Remove missing static analyzer warning.

### DIFF
--- a/src/google/protobuf/map_field.cc
+++ b/src/google/protobuf/map_field.cc
@@ -94,7 +94,7 @@ int MapFieldBase::SpaceUsedExcludingSelfNoLock() const {
 
 void MapFieldBase::InitMetadataOnce() const {
   GOOGLE_CHECK(entry_descriptor_ != NULL);
-  GOOGLE_CHECK(assign_descriptor_callback_ != NULL);
+  assert(assign_descriptor_callback_ != NULL);
   (*assign_descriptor_callback_)();
 }
 


### PR DESCRIPTION
Is there any real problem in switching GOOGLE_CHECK for assert?
