### PR TITLE
PHP: fix ZTS tsrm_ls errors

### DIFF
--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -192,7 +192,7 @@ static HashTable *repeated_field_get_gc(zval *object, zval ***table,
 // C RepeatedField Utilities
 // -----------------------------------------------------------------------------
 
-void *repeated_field_index_native(RepeatedField *intern, int index) {
+void *repeated_field_index_native(RepeatedField *intern, int index TSRMLS_DC) {
   HashTable *ht = HASH_OF(intern->array);
   void *value;
 

--- a/php/ext/google/protobuf/array.c
+++ b/php/ext/google/protobuf/array.c
@@ -160,7 +160,8 @@ static void repeated_field_write_dimension(zval *object, zval *offset,
   unsigned char memory[NATIVE_SLOT_MAX_SIZE];
   memset(memory, 0, NATIVE_SLOT_MAX_SIZE);
 
-  if (!native_slot_set(intern->type, intern->msg_ce, memory, value)) {
+  if (!native_slot_set(intern->type, intern->msg_ce, memory, value
+		       TSRMLS_CC)) {
     return;
   }
 

--- a/php/ext/google/protobuf/encode_decode.c
+++ b/php/ext/google/protobuf/encode_decode.c
@@ -199,11 +199,11 @@ static void *startseq_handler(void* closure, const void* hd) {
 // Handlers that append primitive values to a repeated field.
 #define DEFINE_APPEND_HANDLER(type, ctype)                             \
   static bool append##type##_handler(void* closure, const void* hd,    \
-                                     ctype val) {                      \
+                                     ctype val TSRMLS_DC) {            \
     zval* array = (zval*)closure;                                      \
     RepeatedField* intern =                                            \
         (RepeatedField*)zend_object_store_get_object(array TSRMLS_CC); \
-    repeated_field_push_native(intern, &val);                          \
+    repeated_field_push_native(intern, &val TSRMLS_CC);                \
     return true;                                                       \
   }
 
@@ -218,7 +218,7 @@ DEFINE_APPEND_HANDLER(double, double)
 // Appends a string to a repeated field.
 static void* appendstr_handler(void *closure,
                                const void *hd,
-                               size_t size_hint) {
+                               size_t size_hint TSRMLS_DC) {
   zval* array = (zval*)closure;
   RepeatedField* intern =
       (RepeatedField*)zend_object_store_get_object(array TSRMLS_CC);
@@ -234,7 +234,7 @@ static void* appendstr_handler(void *closure,
 // Appends a 'bytes' string to a repeated field.
 static void* appendbytes_handler(void *closure,
                                  const void *hd,
-                                 size_t size_hint) {
+                                 size_t size_hint TSRMLS_DC) {
   zval* array = (zval*)closure;
   RepeatedField* intern =
       (RepeatedField*)zend_object_store_get_object(array TSRMLS_CC);
@@ -296,7 +296,7 @@ static size_t stringdata_handler(void* closure, const void* hd,
 }
 
 // Appends a submessage to a repeated field.
-static void *appendsubmsg_handler(void *closure, const void *hd) {
+static void *appendsubmsg_handler(void *closure, const void *hd TSRMLS_DC) {
   zval* array = (zval*)closure;
   RepeatedField* intern =
       (RepeatedField*)zend_object_store_get_object(array TSRMLS_CC);
@@ -319,7 +319,7 @@ static void *appendsubmsg_handler(void *closure, const void *hd) {
 }
 
 // Sets a non-repeated submessage field in a message.
-static void *submsg_handler(void *closure, const void *hd) {
+static void *submsg_handler(void *closure, const void *hd TSRMLS_DC) {
   MessageHeader* msg = closure;
   const submsg_handlerdata_t* submsgdata = hd;
   zval* subdesc_php = get_def_obj((void*)submsgdata->md);
@@ -423,7 +423,8 @@ static void map_slot_key(upb_fieldtype_t type, const void* from, char** keyval,
   }
 }
 
-static void map_slot_value(upb_fieldtype_t type, const void* from, upb_value* v) {
+static void map_slot_value(upb_fieldtype_t type, const void* from,
+			   upb_value* v) {
   size_t len;
   void* to = upb_value_memory(v);
 #ifndef NDEBUG
@@ -464,7 +465,8 @@ static void *startmapentry_handler(void *closure, const void *hd) {
 
 // Handler to end a map entry: inserts the value defined during the message into
 // the map. This is the 'endmsg' handler on the map entry msgdef.
-static bool endmap_handler(void *closure, const void *hd, upb_status* s) {
+static bool endmap_handler(void *closure, const void *hd, upb_status* s
+			   TSRMLS_DC) {
   map_parse_frame_t* frame = closure;
   const map_handlerdata_t* mapdata = hd;
 
@@ -574,7 +576,7 @@ static void *oneofbytes_handler(void *closure,
 
 // Handler for a submessage field in a oneof.
 static void *oneofsubmsg_handler(void *closure,
-                                 const void *hd) {
+                                 const void *hd TSRMLS_DC) {
   MessageHeader* msg = closure;
   const oneof_handlerdata_t *oneofdata = hd;
   uint32_t oldcase = DEREF(msg, oneofdata->case_ofs, uint32_t);
@@ -771,7 +773,8 @@ static void add_handlers_for_oneof_field(upb_handlers *h,
   upb_handlerattr_uninit(&attr);
 }
 
-static void add_handlers_for_message(const void *closure, upb_handlers *h) {
+static void add_handlers_for_message(const void *closure, upb_handlers *h
+				     TSRMLS_DC) {
   const upb_msgdef* msgdef = upb_handlers_msgdef(h);
   Descriptor* desc = (Descriptor*)zend_object_store_get_object(
       get_def_obj((void*)msgdef) TSRMLS_CC);
@@ -860,7 +863,7 @@ static const upb_pbdecodermethod *msgdef_decodermethod(Descriptor* desc) {
 // -----------------------------------------------------------------------------
 
 static void putmsg(zval* msg, const Descriptor* desc, upb_sink* sink,
-                   int depth);
+                   int depth TSRMLS_DC);
 
 static void putstr(zval* str, const upb_fielddef* f, upb_sink* sink);
 
@@ -868,11 +871,12 @@ static void putrawstr(const char* str, int len, const upb_fielddef* f,
                       upb_sink* sink);
 
 static void putsubmsg(zval* submsg, const upb_fielddef* f, upb_sink* sink,
-                      int depth);
+                      int depth TSRMLS_DC);
 
 static void putarray(zval* array, const upb_fielddef* f, upb_sink* sink,
-                     int depth);
-static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink, int depth);
+                     int depth TSRMLS_DC);
+static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink, int depth
+		   TSRMLS_DC);
 
 static upb_selector_t getsel(const upb_fielddef* f, upb_handlertype_t type) {
   upb_selector_t ret;
@@ -882,7 +886,7 @@ static upb_selector_t getsel(const upb_fielddef* f, upb_handlertype_t type) {
 }
 
 static void put_optional_value(void* memory, int len, const upb_fielddef* f,
-                               int depth, upb_sink* sink) {
+                               int depth, upb_sink* sink TSRMLS_DC) {
   assert(upb_fielddef_label(f) == UPB_LABEL_OPTIONAL);
 
   switch (upb_fielddef_type(f)) {
@@ -911,7 +915,7 @@ static void put_optional_value(void* memory, int len, const upb_fielddef* f,
       break;
     case UPB_TYPE_MESSAGE: {
       zval* submsg = *(zval**)memory;
-      putsubmsg(submsg, f, sink, depth);
+      putsubmsg(submsg, f, sink, depth TSRMLS_CC);
       break;
     }
     default:
@@ -943,7 +947,7 @@ static int raw_value_len(void* memory, int len, const upb_fielddef* f) {
 }
 
 static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink,
-                   int depth) {
+                   int depth TSRMLS_DC) {
   Map* self;
   upb_sink subsink;
   const upb_fielddef* key_field;
@@ -970,13 +974,13 @@ static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink,
 
     // Serialize key.
     const char *key = map_iter_key(&it, &len);
-    put_optional_value(key, len, key_field, depth + 1, &entry_sink);
+    put_optional_value(key, len, key_field, depth + 1, &entry_sink TSRMLS_CC);
 
     // Serialize value.
     upb_value value = map_iter_value(&it, &len);
     put_optional_value(raw_value(upb_value_memory(&value), value_field),
                        raw_value_len(upb_value_memory(&value), len, value_field),
-                       value_field, depth + 1, &entry_sink);
+                       value_field, depth + 1, &entry_sink TSRMLS_CC);
 
     upb_sink_endmsg(&entry_sink, &status);
     upb_sink_endsubmsg(&subsink, getsel(f, UPB_HANDLER_ENDSUBMSG));
@@ -986,7 +990,7 @@ static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink,
 }
 
 static void putmsg(zval* msg_php, const Descriptor* desc, upb_sink* sink,
-                   int depth) {
+                   int depth TSRMLS_DC) {
   upb_msg_field_iter i;
   upb_status status;
 
@@ -1023,12 +1027,12 @@ static void putmsg(zval* msg_php, const Descriptor* desc, upb_sink* sink,
     if (is_map_field(f)) {
       zval* map = *DEREF(msg, offset, zval**);
       if (map != NULL) {
-        putmap(map, f, sink, depth);
+        putmap(map, f, sink, depth TSRMLS_CC);
       }
     } else if (upb_fielddef_isseq(f)) {
       zval* array = *DEREF(msg, offset, zval**);
       if (array != NULL) {
-        putarray(array, f, sink, depth);
+        putarray(array, f, sink, depth TSRMLS_CC);
       }
     } else if (upb_fielddef_isstring(f)) {
       zval* str = *DEREF(msg, offset, zval**);
@@ -1036,7 +1040,7 @@ static void putmsg(zval* msg_php, const Descriptor* desc, upb_sink* sink,
         putstr(str, f, sink);
       }
     } else if (upb_fielddef_issubmsg(f)) {
-      putsubmsg(*DEREF(msg, offset, zval**), f, sink, depth);
+      putsubmsg(*DEREF(msg, offset, zval**), f, sink, depth TSRMLS_CC);
     } else {
       upb_selector_t sel = getsel(f, upb_handlers_getprimitivehandlertype(f));
 
@@ -1113,7 +1117,7 @@ static void putrawstr(const char* str, int len, const upb_fielddef* f,
 }
 
 static void putsubmsg(zval* submsg, const upb_fielddef* f, upb_sink* sink,
-                      int depth) {
+                      int depth TSRMLS_DC) {
   upb_sink subsink;
 
   if (Z_TYPE_P(submsg) == IS_NULL) return;
@@ -1123,12 +1127,12 @@ static void putsubmsg(zval* submsg, const upb_fielddef* f, upb_sink* sink,
       (Descriptor*)zend_object_store_get_object(php_descriptor TSRMLS_CC);
 
   upb_sink_startsubmsg(sink, getsel(f, UPB_HANDLER_STARTSUBMSG), &subsink);
-  putmsg(submsg, subdesc, &subsink, depth + 1);
+  putmsg(submsg, subdesc, &subsink, depth + 1 TSRMLS_CC);
   upb_sink_endsubmsg(sink, getsel(f, UPB_HANDLER_ENDSUBMSG));
 }
 
 static void putarray(zval* array, const upb_fielddef* f, upb_sink* sink,
-                     int depth) {
+                     int depth TSRMLS_DC) {
   upb_sink subsink;
   upb_fieldtype_t type = upb_fielddef_type(f);
   upb_selector_t sel = 0;
@@ -1147,7 +1151,7 @@ static void putarray(zval* array, const upb_fielddef* f, upb_sink* sink,
   }
 
   for (i = 0; i < size; i++) {
-    void* memory = repeated_field_index_native(intern, i);
+    void* memory = repeated_field_index_native(intern, i TSRMLS_CC);
     switch (type) {
 #define T(upbtypeconst, upbtype, ctype)                      \
   case upbtypeconst:                                         \
@@ -1168,7 +1172,7 @@ static void putarray(zval* array, const upb_fielddef* f, upb_sink* sink,
         putstr(*((zval**)memory), f, &subsink);
         break;
       case UPB_TYPE_MESSAGE:
-        putsubmsg(*((zval**)memory), f, &subsink, depth);
+        putsubmsg(*((zval**)memory), f, &subsink, depth TSRMLS_CC);
         break;
 
 #undef T
@@ -1206,7 +1210,7 @@ PHP_METHOD(Message, encode) {
     stackenv_init(&se, "Error occurred during encoding: %s");
     encoder = upb_pb_encoder_create(&se.env, serialize_handlers, &sink.sink);
 
-    putmsg(getThis(), desc, upb_pb_encoder_input(encoder), 0);
+    putmsg(getThis(), desc, upb_pb_encoder_input(encoder), 0 TSRMLS_CC);
 
     RETVAL_STRINGL(sink.ptr, sink.len, 1);
 

--- a/php/ext/google/protobuf/encode_decode.c
+++ b/php/ext/google/protobuf/encode_decode.c
@@ -964,7 +964,7 @@ static void putmap(zval* map, const upb_fielddef* f, upb_sink* sink,
   key_field = map_field_key(f);
   value_field = map_field_value(f);
 
-  for (map_begin(map, &it); !map_done(&it); map_next(&it)) {
+  for (map_begin(map, &it TSRMLS_CC); !map_done(&it); map_next(&it)) {
     upb_status status;
 
     upb_sink entry_sink;

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -96,7 +96,7 @@ static void message_set_property(zval* object, zval* member, zval* value,
     zend_error(E_USER_ERROR, "Unknown field: %s", Z_STRVAL_P(member));
   }
 
-  layout_set(self->descriptor->layout, self, field, value);
+  layout_set(self->descriptor->layout, self, field, value TSRMLS_CC);
 }
 
 static zval* message_get_property(zval* object, zval* member, int type,

--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -177,7 +177,8 @@ static zend_object_value message_create(zend_class_entry* ce TSRMLS_DC) {
 
   zend_object_std_init(&msg->std, ce TSRMLS_CC);
   object_properties_init(&msg->std, ce);
-  layout_init(desc->layout, message_data(msg), msg->std.properties_table);
+  layout_init(desc->layout, message_data(msg), msg->std.properties_table
+	      TSRMLS_CC);
 
   return_value.handle = zend_objects_store_put(
       msg, (zend_objects_store_dtor_t)zend_objects_destroy_object, message_free,

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -233,11 +233,12 @@ struct MessageHeader {
 };
 
 MessageLayout* create_layout(const upb_msgdef* msgdef);
-void layout_init(MessageLayout* layout, void* storage, zval** properties_table);
+void layout_init(MessageLayout* layout, void* storage, zval** properties_table
+		 TSRMLS_DC);
 zval* layout_get(MessageLayout* layout, const void* storage,
                  const upb_fielddef* field, zval** cache TSRMLS_DC);
 void layout_set(MessageLayout* layout, MessageHeader* header,
-                const upb_fielddef* field, zval* val);
+                const upb_fielddef* field, zval* val TSRMLS_DC);
 void free_layout(MessageLayout* layout);
 
 PHP_METHOD(Message, readOneof);
@@ -293,7 +294,7 @@ PHP_METHOD(Util, checkRepeatedField);
 
 size_t native_slot_size(upb_fieldtype_t type);
 bool native_slot_set(upb_fieldtype_t type, const zend_class_entry* klass,
-                     void* memory, zval* value);
+                     void* memory, zval* value TSRMLS_DC);
 void native_slot_init(upb_fieldtype_t type, void* memory, zval** cache);
 // For each property, in order to avoid conversion between the zval object and
 // the actual data type during parsing/serialization, the containing message
@@ -325,7 +326,7 @@ typedef struct {
   upb_strtable_iter it;
 } MapIter;
 
-void map_begin(zval* self, MapIter* iter);
+void map_begin(zval* self, MapIter* iter TSRMLS_DC);
 void map_next(MapIter* iter);
 bool map_done(MapIter* iter);
 const char* map_iter_key(MapIter* iter, int* len);
@@ -377,10 +378,10 @@ void repeated_field_create_with_type(zend_class_entry* ce,
                                      zval** repeated_field TSRMLS_DC);
 // Return the element at the index position from the repeated field. There is
 // not restriction on the type of stored elements.
-void *repeated_field_index_native(RepeatedField *intern, int index);
+void *repeated_field_index_native(RepeatedField *intern, int index TSRMLS_DC);
 // Add the element to the end of the repeated field. There is not restriction on
 // the type of stored elements.
-void repeated_field_push_native(RepeatedField *intern, void *value);
+void repeated_field_push_native(RepeatedField *intern, void *value TSRMLS_DC);
 
 PHP_METHOD(RepeatedField, __construct);
 PHP_METHOD(RepeatedField, append);
@@ -411,7 +412,7 @@ typedef struct {
 // -----------------------------------------------------------------------------
 
 upb_fieldtype_t to_fieldtype(upb_descriptortype_t type);
-const zend_class_entry *field_type_class(const upb_fielddef *field);
+const zend_class_entry *field_type_class(const upb_fielddef *field TSRMLS_DC);
 
 // -----------------------------------------------------------------------------
 // Utilities.


### PR DESCRIPTION
Fixes #2186 

To reproduce:
 - compile PHP from source with `./configure --enable-maintainer-zts`
 - then compile the protobuf extension