### PR TITLE
Fixed references to foreign nested messages with CommonJS-style imports

### DIFF
--- a/js/message_test.js
+++ b/js/message_test.js
@@ -1040,4 +1040,18 @@ describe('Message test suite', function() {
     assertNan(message.getDefaultDoubleField());
   });
 
+  // Verify that we can successfully use a field referring to a nested message
+  // from a different .proto file.
+  it('testForeignNestedMessage', function() {
+    var msg = new proto.jspb.test.ForeignNestedFieldMessage();
+    var nested = new proto.jspb.test.Deeply.Nested.Message();
+    nested.setCount(5);
+    msg.setDeeplyNestedMessage(nested);
+
+    // After a serialization-deserialization round trip we should get back the
+    // same data we started with.
+    var serialized = msg.serializeBinary();
+    var deserialized = proto.jspb.test.ForeignNestedFieldMessage.deserializeBinary(serialized);
+    assertEquals(5, deserialized.getDeeplyNestedMessage().getCount());
+  });
 });

--- a/js/test.proto
+++ b/js/test.proto
@@ -260,3 +260,11 @@ enum MapValueEnumNoBinary {
 message MapValueMessageNoBinary {
   optional int32 foo = 1;
 }
+
+message Deeply {
+  message Nested {
+    message Message {
+      optional int32 count = 1;
+    }
+  }
+}

--- a/js/test2.proto
+++ b/js/test2.proto
@@ -35,6 +35,8 @@ option java_multiple_files = true;
 
 package jspb.test;
 
+import "test.proto";
+
 message TestExtensionsMessage {
   optional int32 intfield = 1;
   extensions 100 to max;
@@ -51,4 +53,8 @@ message ExtensionMessage {
 extend TestExtensionsMessage {
   optional ExtensionMessage floating_msg_field = 101;
   optional string floating_str_field = 102;
+}
+
+message ForeignNestedFieldMessage {
+  optional Deeply.Nested.Message deeply_nested_message = 1;
 }


### PR DESCRIPTION
A bug was causing generated JSPB code with CommonJS-style imports to
refer incorrectly to nested messages from other .proto files. The
generated code would have things like "test_pb.InnerMessage" instead of
"test_pb.OuterMessage.InnerMessage". This commit fixes the problem by
correctly taking into account any message nesting.