### PR TITLE
Added alias getFieldProto3 as used by older generated code.

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -755,6 +755,18 @@ jspb.Message.getFieldWithDefault = function(msg, fieldNumber, defaultValue) {
 
 
 /**
+ * Alias for getFieldWithDefault used by older generated code.
+ * @template T
+ * @param {!jspb.Message} msg A jspb proto.
+ * @param {number} fieldNumber The field number.
+ * @param {T} defaultValue The default value.
+ * @return {T} The field's value.
+ * @protected
+ */
+jspb.Message.getFieldProto3 = jspb.Message.getFieldWithDefault;
+
+
+/**
  * Gets the value of a map field, lazily creating the map container if
  * necessary.
  *


### PR DESCRIPTION
Un-breaks users who have old generated code and upgrade
to the 3.1.0 release.

CC/review: @murgatroid99, @nicolasnoble.

I wasn't able to test this against old generated code. If you have any tests that would exercise this case, let me know. Otherwise I'll try to create an artificial test for it.