### PR TITLE
Adds a new import-mapping option to the js_generator.

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -33,6 +33,7 @@
 #ifndef GOOGLE_PROTOBUF_COMPILER_JS_GENERATOR_H__
 #define GOOGLE_PROTOBUF_COMPILER_JS_GENERATOR_H__
 
+#include <map>
 #include <string>
 #include <set>
 
@@ -69,6 +70,13 @@ struct GeneratorOptions {
   bool error_on_name_conflict;
   // Enable binary-format support?
   bool binary;
+  // The following option is only relevant for commonjs and
+  // potentially applicable es6 when that is implemented.  Parse an
+  // option like 'Mexample/foo.proto=bar'.  The corresponding
+  // require() statement will then become "require('bar')" rather than
+  // "require('example/foo_pb.js')".
+  map<string, string>* import_map;
+
   // What style of imports should be used.
   enum ImportStyle {
     IMPORT_CLOSURE,    // goog.require()
@@ -85,6 +93,7 @@ struct GeneratorOptions {
         library(""),
         error_on_name_conflict(false),
         binary(false),
+        import_map(new map<string, string>),
         import_style(IMPORT_CLOSURE) {}
 
   bool ParseFromOptions(


### PR DESCRIPTION
This option is directly modeled after protoc-gen-go's ImportMap
'Mfoo=bar' option, adapted for use in a commonjs context.  It enables
the caller to provide override values for 'require()' statements in
generated code.  For example,
'--js_out=Mexample/foo.proto=example-foo:outdir/ would generate
`require('example-foo')` instead of `require('./example/foo_js.pb')`.
Multiple 'M' options are allowed.

The main use case is to permit the use of module-names rather than
filenames for required files, allowing users to use the more flexible
module loading schemes in lieu of hardcoded filenames.

It also fixes #1745 and provides a workaround for #1746.
