### PR TITLE
Fix gcc warning when using map

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -1285,7 +1285,7 @@ class Map {
     // Return a power of two no less than max(kMinTableSize, n).
     // Assumes either n < kMinTableSize or n is a power of two.
     size_type TableSize(size_type n) {
-      return n < kMinTableSize ? kMinTableSize : n;
+      return n < static_cast<size_type>(kMinTableSize) ? static_cast<size_type>(kMinTableSize) : n;
     }
 
     // Use alloc_ to allocate an array of n objects of type U.

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -1285,7 +1285,9 @@ class Map {
     // Return a power of two no less than max(kMinTableSize, n).
     // Assumes either n < kMinTableSize or n is a power of two.
     size_type TableSize(size_type n) {
-      return n < static_cast<size_type>(kMinTableSize) ? static_cast<size_type>(kMinTableSize) : n;
+      return n < static_cast<size_type>(kMinTableSize)
+                 ? static_cast<size_type>(kMinTableSize)
+                 : n;
     }
 
     // Use alloc_ to allocate an array of n objects of type U.


### PR DESCRIPTION
Fix for Issue #2211: Addressing GCC warning on enumeral/non-enumeral in conditional expression.
