### PR TITLE
Fix instances of classes implementing `__eq__` but not `__hash__`

### DIFF
--- a/python/google/protobuf/internal/containers.py
+++ b/python/google/protobuf/internal/containers.py
@@ -337,6 +337,8 @@ class RepeatedScalarFieldContainer(BaseContainer):
     # We are presumably comparing against some other sequence type.
     return other == self._values
 
+  __hash__ = None
+
 collections.MutableSequence.register(BaseContainer)
 
 
@@ -429,6 +431,8 @@ class RepeatedCompositeFieldContainer(BaseContainer):
       raise TypeError('Can only compare repeated composite fields against '
                       'other repeated composite fields.')
     return self._values == other._values
+
+  __hash__ = None
 
 
 class ScalarMap(MutableMapping):


### PR DESCRIPTION
I've been working through looking at adopting Python 3, and I've been utilizing the -3 flag to help idenitfy issues with Python 3.

Here's a quick write up I did last week:

https://gist.github.com/rowillia/c0feed97c1863b2d8e5a3ed73712df65

The -3 flagged a few issues in protobuf worth fixing, namely around eq shadowing hash in PY3.

Fixing these issues will help make the -3 flag less noisey for folks running protobuf in production.
