### PR TITLE
Change CodedInputStream#DEFAULT_SIZE_LIMIT from 64MB to kint32max (0x7FFFFFF)

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -885,7 +885,8 @@ public final class CodedInputStream {
   private int sizeLimit = DEFAULT_SIZE_LIMIT;
 
   private static final int DEFAULT_RECURSION_LIMIT = 100;
-  private static final int DEFAULT_SIZE_LIMIT = 64 << 20;  // 64MB
+  // Integer.MAX_VALUE == ./src/google/protobuf/stubs/port.h:static const int32 kint32max = 0x7FFFFFFF;
+  private static final int DEFAULT_SIZE_LIMIT = Integer.MAX_VALUE;
   private static final int BUFFER_SIZE = 4096;
 
   private CodedInputStream(


### PR DESCRIPTION
Fix for "parseDelimitedFrom behavior has changed between pb2.5 and 3.1 #2228"

Seems a bit tough adding a test for something so primitive.
