### PR TITLE
Fix python_cpp test on Mac

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -12,7 +12,7 @@ setenv =
 commands =
     python setup.py -q build_py
     python: python setup.py -q build
-    cpp: python setup.py -q build --cpp_implementation --warnings_as_errors
+    cpp: python setup.py -q build --cpp_implementation --warnings_as_errors --compile_static_extension
     python: python setup.py -q test -q
     cpp: python setup.py -q test -q --cpp_implementation
     python: python setup.py -q test_conformance

--- a/tests.sh
+++ b/tests.sh
@@ -28,7 +28,8 @@ internal_build_cpp() {
   fi
 
   ./autogen.sh
-  ./configure
+  ./configure CXXFLAGS="-fPIC"  # -fPIC is needed for python cpp test.
+                                # See python/setup.py for more details
   make -j2
 }
 


### PR DESCRIPTION
Link staticly when building extension, so that the extension doesn't require installing protobuf library.