### PR TITLE
Declare all inputs of protoc action

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -62,6 +62,7 @@ def _proto_gen_impl(ctx):
   if ctx.attr.gen_py:
     args += ["--python_out=" + ctx.var["GENDIR"] + "/" + gen_dir]
 
+  inputs = srcs + deps
   if ctx.executable.plugin:
     plugin = ctx.executable.plugin
     lang = ctx.attr.plugin_language
@@ -75,10 +76,11 @@ def _proto_gen_impl(ctx):
       outdir = ",".join(ctx.attr.plugin_options) + ":" + outdir
     args += ["--plugin=protoc-gen-%s=%s" % (lang, plugin.path)]
     args += ["--%s_out=%s" % (lang, outdir)]
+    inputs += [plugin]
 
   if args:
     ctx.action(
-        inputs=srcs + deps,
+        inputs=inputs,
         outputs=ctx.outputs.outs,
         arguments=args + import_flags + [s.path for s in srcs],
         executable=ctx.executable.protoc,


### PR DESCRIPTION
ctx.executable.plugin must be in the inputs of protoc's action when using a plugin, otherwise the action will fail.

This bug has been hidden by a bug in Bazel: for every ctx.action, Bazel used to automatically add the runfiles of all executable inputs of the RULE instead of using the inputs of the specific ACTION. Consequently, we could get away with underspecifying the inputs of the action.

Fixes bazelbuild/bazel/issues/1929