### PR TITLE
Use git clean before installing via bundler

### DIFF
--- a/ruby/travis-test.sh
+++ b/ruby/travis-test.sh
@@ -10,12 +10,14 @@ test_version() {
     bash --login -c \
       "rvm install $version && rvm use $version && rvm get head && \
        which ruby && \
+       git clean -f && \
        gem install bundler && bundle && \
        rake test"
   else
     bash --login -c \
       "rvm install $version && rvm use $version && \
        which ruby && \
+       git clean -f && \
        gem install bundler && bundle && \
        rake test &&
        cd ../conformance && make test_ruby"


### PR DESCRIPTION
Should fix problems in Jenkins introduce by #2199 not seen in Travis due to the use of `./test.sh ruby_all` which runs every platform in the same directory