### PR TITLE
Update autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,7 +9,7 @@ set -e
 if [ ! -z "$@" ]; then
   for argument in "$@"; do
     case $argument in
-	  # make curl silent
+    # make curl silent
       "-s")
         curlopts="-s"
         ;;
@@ -29,7 +29,7 @@ fi
 
 # Check that gmock is present.  Usually it is already there since the
 # directory is set up as an SVN external.
-if test ! -e gmock; then
+if test ! -e gmock -o   && ! -e googlemock-release-1.7.0; then
   echo "Google Mock not present.  Fetching gmock-1.7.0 from the web..."
   curl $curlopts -L -O https://github.com/google/googlemock/archive/release-1.7.0.zip
   unzip -q release-1.7.0.zip


### PR DESCRIPTION
For the people who had installed gmock before had gmock named as googlemock-release-1.7.0 because they didn't rename it. Hence if now they have it they won't have to download gmock.zip again.
