### PR TITLE
Fixed issue in cmake; bool equality can't be tested with EQUAL

### DIFF
--- a/cmake/protobuf-config-version.cmake.in
+++ b/cmake/protobuf-config-version.cmake.in
@@ -37,7 +37,7 @@ endif()
 # Check and save build options used to create this package
 macro(_check_and_save_build_option OPTION VALUE)
   if(DEFINED ${PACKAGE_FIND_NAME}_${OPTION} AND
-    NOT ${PACKAGE_FIND_NAME}_${OPTION} EQUAL VALUE)
+    NOT "${${PACKAGE_FIND_NAME}_${OPTION}} STREQUAL "${VALUE}")
     set(PACKAGE_VERSION_UNSUITABLE TRUE)
   endif()
   set(${PACKAGE_FIND_NAME}_${OPTION} ${VALUE})

--- a/cmake/protobuf-config-version.cmake.in
+++ b/cmake/protobuf-config-version.cmake.in
@@ -37,7 +37,7 @@ endif()
 # Check and save build options used to create this package
 macro(_check_and_save_build_option OPTION VALUE)
   if(DEFINED ${PACKAGE_FIND_NAME}_${OPTION} AND
-    NOT "${${PACKAGE_FIND_NAME}_${OPTION}} STREQUAL "${VALUE}")
+    NOT "${${PACKAGE_FIND_NAME}_${OPTION}}" STREQUAL "${VALUE}")
     set(PACKAGE_VERSION_UNSUITABLE TRUE)
   endif()
   set(${PACKAGE_FIND_NAME}_${OPTION} ${VALUE})


### PR DESCRIPTION
The current cmake package configuration relies on compatibility checks with booleans using EQUAL. As far as I can tell, CMAKE doesn't do the intuitive thing when comparing booleans with EQUAL expressions; something like:

```
SET(TESTA ON)
SET(TESTB ON)

IF(TESTA EQUAL TESTB)
     message("Equal is true")
ENDIF()

IF("${TESTA}" STREQUAL "${TESTB}")
     message("Strequal is true")
ENDIF()
```

will only print the latter message. The change submitted just treats them like strings and it works as expected.

This seems to break any usages of find_package against the current version of protobuf; I suspect the reason no one has noticed is that until most distros have packages from v3 or higher, most people are just including it via add_subdirectory or the like. 
