### PR TITLE
Place Python extensions correctly in Bazel build.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -577,7 +577,7 @@ py_library(
 )
 
 cc_binary(
-    name = "internal/_api_implementation.so",
+    name = "python/google/protobuf/internal/_api_implementation.so",
     srcs = ["python/google/protobuf/internal/api_implementation.cc"],
     copts = COPTS + [
         "-DPYTHON_PROTO2_CPP_IMPL_V2",
@@ -591,7 +591,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "pyext/_message.so",
+    name = "python/google/protobuf/pyext/_message.so",
     srcs = glob([
         "python/google/protobuf/pyext/*.cc",
         "python/google/protobuf/pyext/*.h",
@@ -653,8 +653,8 @@ py_proto_library(
     data = select({
         "//conditions:default": [],
         ":use_fast_cpp_protos": [
-            ":internal/_api_implementation.so",
-            ":pyext/_message.so",
+            ":python/google/protobuf/internal/_api_implementation.so",
+            ":python/google/protobuf/pyext/_message.so",
         ],
     }),
     default_runtime = "",

--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -1905,7 +1905,11 @@ static PyObject* CopyFrom(CMessage* self, PyObject* arg) {
 // get OOM errors. The protobuf APIs do not provide any tools for processing
 // protobufs in chunks.  If you have protos this big you should break them up if
 // it is at all convenient to do so.
+#ifdef PROTOBUF_PYTHON_ALLOW_OVERSIZE_PROTOS
+static bool allow_oversize_protos = true;
+#else
 static bool allow_oversize_protos = false;
+#endif
 
 // Provide a method in the module to set allow_oversize_protos to a boolean
 // value. This method returns the newly value of allow_oversize_protos.


### PR DESCRIPTION
Currently google/protobuf/pyext/_message.so and google/protobuf/internal/_api_implementation.so do not end up in the correct place in the Bazel build (i.e. they don't live with all the other Python files at google/protobuf/...), so they are never loaded as intended.