### PR TITLE
define no_threadlocal on OpenBSD

### DIFF
--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -114,11 +114,11 @@ GOOGLE_PROTOBUF_PLATFORM_ERROR
 
 #undef GOOGLE_PROTOBUF_PLATFORM_ERROR
 
-#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE)
+#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE) || defined(__OpenBSD__)
 // Android ndk does not support the __thread keyword very well yet. Here
 // we use pthread_key_create()/pthread_getspecific()/... methods for
 // TLS support on android.
-// iOS also does not support the __thread keyword.
+// iOS and OpenBSD also do not support the __thread keyword.
 #define GOOGLE_PROTOBUF_NO_THREADLOCAL
 #endif
 


### PR DESCRIPTION
OpenBSD like IOS and the android NDK does not support thread local storage.
this defines it in platform macros.