### PR TITLE
JavaScript: support using Uint8Array in toObject

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -2162,8 +2162,11 @@ void Generator::GenerateClassFieldToObject(const GeneratorOptions& options,
     }
   } else if (field->type() == FieldDescriptor::TYPE_BYTES) {
     // For bytes fields we want to always return the B64 data.
+    // Unless it's proto2 and the user explicitly wants binary.
+    auto mode = field->file()->syntax() == FileDescriptor::SYNTAX_PROTO2 &&
+                options.binary ? BytesMode::BYTES_U8 : BytesMode::BYTES_B64;
     printer->Print("msg.get$getter$()",
-                   "getter", JSGetterName(options, field, BYTES_B64));
+                   "getter", JSGetterName(options, field, mode));
   } else {
     bool use_default = field->has_default_value();
 


### PR DESCRIPTION
Currently, `toObject` always outputs `bytes` fields as base64-encoded strings. This is understandable for proto3, which has a canonical JSON mapping, but isn't necessary for proto2. I propose using `Uint8Array` for `bytes` fields in proto2 when binary support is enabled.

My usecase is described [here](https://github.com/google/protobuf/issues/1591#issuecomment-239203004). In short: I want a way to convert Protobuf messages to plain JS objects without having to hard-code fields for each message I use. `toObject` works for me for the most part (pending #1951 and #1922), but I would prefer not to have to decode base64 back into a `Buffer` or `Uint8Array`.

Consider this a feature request with proof-of-concept implementation attached.
