### PR TITLE
total_bytes_limit_ with size when size is bigger 64MB

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -1349,6 +1349,8 @@ inline CodedInputStream::CodedInputStream(const uint8* buffer, int size)
     extension_factory_(NULL) {
   // Note that setting current_limit_ == size is important to prevent some
   // code paths from trying to access input_ and segfaulting.
+  if(total_bytes_limit_ < size)
+  	  total_bytes_limit_ = size;
 }
 
 inline bool CodedInputStream::IsFlat() const {


### PR DESCRIPTION
Can't parse GraphDef from the given flat array that size is bigger than
64MB.
