### PR TITLE
generic atomicops: Use strong compare_exchange

### DIFF
--- a/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+++ b/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
@@ -38,7 +38,7 @@ namespace internal {
 inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
                                          Atomic32 old_value,
                                          Atomic32 new_value) {
-  __atomic_compare_exchange_n(ptr, &old_value, new_value, true,
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
                               __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   return old_value;
 }
@@ -61,7 +61,7 @@ inline Atomic32 Barrier_AtomicIncrement(volatile Atomic32* ptr,
 inline Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
                                        Atomic32 old_value,
                                        Atomic32 new_value) {
-  __atomic_compare_exchange_n(ptr, &old_value, new_value, true,
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
                               __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
   return old_value;
 }
@@ -69,7 +69,7 @@ inline Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
 inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
                                        Atomic32 old_value,
                                        Atomic32 new_value) {
-  __atomic_compare_exchange_n(ptr, &old_value, new_value, true,
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
                               __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
   return old_value;
 }
@@ -115,7 +115,7 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
 inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
                                        Atomic64 old_value,
                                        Atomic64 new_value) {
-  __atomic_compare_exchange_n(ptr, &old_value, new_value, true,
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
                               __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
   return old_value;
 }
@@ -123,7 +123,7 @@ inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
 inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
                                          Atomic64 old_value,
                                          Atomic64 new_value) {
-  __atomic_compare_exchange_n(ptr, &old_value, new_value, true,
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
                               __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   return old_value;
 }


### PR DESCRIPTION
Weak compare-and-exchange are allowed to fail spuriously, so we have
to use the strong variation here.
