### PR TITLE
Support hash computation for protobuf messages.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -163,6 +163,7 @@ cc_library(
         "src/google/protobuf/util/internal/utility.cc",
         "src/google/protobuf/util/json_util.cc",
         "src/google/protobuf/util/message_differencer.cc",
+        "src/google/protobuf/util/message_hasher.cc",
         "src/google/protobuf/util/time_util.cc",
         "src/google/protobuf/util/type_resolver_util.cc",
         "src/google/protobuf/wire_format.cc",

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -48,6 +48,7 @@ set(libprotobuf_files
   ${protobuf_source_dir}/src/google/protobuf/util/internal/utility.cc
   ${protobuf_source_dir}/src/google/protobuf/util/json_util.cc
   ${protobuf_source_dir}/src/google/protobuf/util/message_differencer.cc
+  ${protobuf_source_dir}/src/google/protobuf/util/message_hasher.cc
   ${protobuf_source_dir}/src/google/protobuf/util/time_util.cc
   ${protobuf_source_dir}/src/google/protobuf/util/type_resolver_util.cc
   ${protobuf_source_dir}/src/google/protobuf/wire_format.cc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -296,6 +296,7 @@ libprotobuf_la_SOURCES =                                       \
   google/protobuf/util/internal/utility.h                      \
   google/protobuf/util/json_util.cc                            \
   google/protobuf/util/message_differencer.cc                  \
+  google/protobuf/util/message_hasher.cc                       \
   google/protobuf/util/time_util.cc                            \
   google/protobuf/util/type_resolver_util.cc
 

--- a/src/google/protobuf/util/message_hasher.cc
+++ b/src/google/protobuf/util/message_hasher.cc
@@ -1,0 +1,103 @@
+#include <google/protobuf/util/message_hasher.h>
+
+GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_START
+
+// service declarations
+
+template<typename T>
+size_t stdhashfunc(const T& t) {
+  return std::hash<T>()(t);
+}
+
+using ::google::protobuf::Message;
+using ::google::protobuf::Reflection;
+using ::google::protobuf::FieldDescriptor;
+
+inline size_t HashForSimpleType(const Message& message, const Reflection& reflection, const FieldDescriptor& field, int index = -1);
+inline size_t HashForRepeatedType(const Message& message, const Reflection& reflection, const FieldDescriptor& field);
+inline size_t HashForMessageType(const Message& message);
+
+size_t hash<::google::protobuf::Message>::operator()(const ::google::protobuf::Message& m) const {
+  return HashForMessageType(m);
+}
+
+
+// implementation
+
+inline size_t HashForMessageType(const Message& message) {
+  size_t hash = 1;
+  const Reflection *reflection = message.GetReflection();
+  std::vector<const FieldDescriptor*> fields;
+  reflection->ListFields(message, &fields);
+  for (int i = 0; i < fields.size(); ++i) {
+    const FieldDescriptor *field = fields[i];
+    if (field->is_repeated()) {
+      hash ^= HashForRepeatedType(message, *reflection, *field);
+    }
+    else if (field->type() == FieldDescriptor::TYPE_MESSAGE) {
+      if (reflection->HasField(message, field)) {
+        hash ^= HashForMessageType(*reflection->MutableMessage(const_cast<Message*>(&message), field));
+      }
+    }
+    else {
+      hash ^= HashForSimpleType(message, *reflection, *field);
+    }
+  }
+  return hash;
+}
+
+
+// NOTICE:
+// As far as we keep "hash ^= X" operations in this method, it will support protobuf map<k,v> type, because it is 
+// similar to "repeated message { key, value }".
+inline size_t HashForRepeatedType(const Message& message, const Reflection& reflection, const FieldDescriptor& field) {
+  size_t hash = 1;
+  int size = reflection.FieldSize(message, &field);
+  for (int i = 0; i < size; ++i) {
+    if (field.type() == FieldDescriptor::TYPE_MESSAGE)
+      hash ^= HashForMessageType(*reflection.MutableRepeatedMessage(const_cast<Message*>(&message), &field, i));
+    else
+      hash ^= HashForSimpleType(message, reflection, field, i);
+  }
+  return hash;
+}
+
+inline size_t HashForSimpleType(const Message& message, const Reflection& reflection, const FieldDescriptor& field, int index) {
+  assert(!field.is_repeated() || index < reflection.FieldSize(message, &field));
+  assert(reflection.HasField(message, &field));
+  switch (field.cpp_type()) {
+#define OUTPUT_FIELD(CPPTYPE, METHOD)                            \
+    case FieldDescriptor::CPPTYPE_##CPPTYPE:                     \
+      return stdhashfunc(field.is_repeated()                     \
+        ? reflection.GetRepeated##METHOD(message, &field, index) \
+        : reflection.Get##METHOD(message, &field));              \
+
+    OUTPUT_FIELD(INT32, Int32)
+    OUTPUT_FIELD(INT64, Int64)
+    OUTPUT_FIELD(UINT32, UInt32)
+    OUTPUT_FIELD(UINT64, UInt64)
+    OUTPUT_FIELD(FLOAT, Float)
+    OUTPUT_FIELD(DOUBLE, Double)
+    OUTPUT_FIELD(BOOL, Bool)
+
+#undef OUTPUT_FIELD
+
+    case FieldDescriptor::CPPTYPE_STRING: {
+      std::string scratch;
+      return stdhashfunc(field.is_repeated()
+        ? reflection.GetRepeatedStringReference(message, &field, index, &scratch)
+        : reflection.GetStringReference(message, &field, &scratch));
+    }
+
+    case FieldDescriptor::CPPTYPE_ENUM:
+      return stdhashfunc(field.is_repeated()
+        ? reflection.GetRepeatedEnumValue(message, &field, index)
+        : reflection.GetEnumValue(message, &field));
+  
+    default:
+      assert(false);
+      return 1;
+  }
+}
+
+GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_END

--- a/src/google/protobuf/util/message_hasher.h
+++ b/src/google/protobuf/util/message_hasher.h
@@ -1,0 +1,14 @@
+#include <google/protobuf/message.h>
+#include <google/protobuf/stubs/hash.h>
+
+GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_START
+
+// Computes hash of the message.
+// Algorithm iterates all message fields for hash computation. It is more
+// fast and convinient to use google::protobuf::hash<your_message_type> instead.
+template<>
+struct hash<::google::protobuf::Message> {
+  size_t operator()(const ::google::protobuf::Message& m) const;
+};
+
+GOOGLE_PROTOBUF_HASH_NAMESPACE_DECLARATION_END


### PR DESCRIPTION
This pull request relates to following issue: https://github.com/google/protobuf/issues/2066

It adds hash computation support for `::google::protobuf::Message` class and for all generated classes for messages in C++ code.

This pull request is **a draft** because I need advise or help about how to
1) write tests for added code (unfortunately, I'm not familiar with google test framework and have not written much tests in my life),
2) change or regenerate .pb.h files within protobuf repository according changes in these files' generator.

And of course I need a code review.

@xfxyjwf 
We can move discussion from issue ticket here, if you want.
And sorry for the delay. Life is hard sometimes.
