### PR TITLE
[PERF]Improved performance of RepeatedField deserialization

### DIFF
--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -101,10 +101,11 @@ namespace Google.Protobuf.Collections
                 int length = input.ReadLength();
                 if (length > 0)
                 {
+                    EnsureSize(count + length);
                     int oldLimit = input.PushLimit(length);
                     while (!input.ReachedLimit)
                     {
-                        Add(reader(input));
+                        array[count++] = reader(input);
                     }
                     input.PopLimit(oldLimit);
                 }


### PR DESCRIPTION
Because in case of packed encoding we know the number of records we can resize array only once instead of log(count) times.

This has major impact on another perf work I intend to do (Allowing use of structs instead of classes - in that case array of struct reallocation is way more costly).
