### PR TITLE
Use require_relative in Ruby for imported definitions

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -429,7 +429,7 @@ bool MaybeEmitDependency(const FileDescriptor* import,
     return true;
   } else {
     printer->Print(
-      "require '$name$'\n", "name", GetRequireName(import->name()));
+      "require_relative '$name$'\n", "name", GetRequireName(import->name()));
     return true;
   }
 }


### PR DESCRIPTION
A 'require' won't work because the file is not on the $LOADPATH.

For example, with these definitions in a.proto and b.proto:
syntax = "proto3";
import "b.proto";
message A {
	repeated B b = 1;
}

syntax = "proto3";
message B {
	string text = 1;
}

When did "load 'a_pb.rb'" I used to get:
a_pb.rb:6:in `require': cannot load such file -- b_pb (LoadError)