### PR TITLE
Fix compiler warnings when running :protobuf_test

### DIFF
--- a/src/google/protobuf/compiler/mock_code_generator.cc
+++ b/src/google/protobuf/compiler/mock_code_generator.cc
@@ -61,7 +61,7 @@ namespace compiler {
 // comma-separated string.
 string CommaSeparatedList(const vector<const FileDescriptor*> all_files) {
   vector<string> names;
-  for (int i = 0; i < all_files.size(); i++) {
+  for (size_t i = 0; i < all_files.size(); i++) {
     names.push_back(all_files[i]->name());
   }
   return Join(names, ",");
@@ -97,7 +97,7 @@ void MockCodeGenerator::ExpectGenerated(
   while (!lines.empty() && lines.back().empty()) {
     lines.pop_back();
   }
-  for (int i = 0; i < lines.size(); i++) {
+  for (size_t i = 0; i < lines.size(); i++) {
     lines[i] += "\n";
   }
 
@@ -114,7 +114,7 @@ void MockCodeGenerator::ExpectGenerated(
   EXPECT_EQ(kFirstInsertionPoint, lines[1 + insertion_list.size()]);
   EXPECT_EQ(kSecondInsertionPoint, lines[2 + insertion_list.size() * 2]);
 
-  for (int i = 0; i < insertion_list.size(); i++) {
+  for (size_t i = 0; i < insertion_list.size(); i++) {
     EXPECT_EQ(GetOutputFileContent(insertion_list[i], "first_insert",
                                    file, file, first_message_name),
               lines[1 + i]);
@@ -170,7 +170,7 @@ bool MockCodeGenerator::Generate(
     SplitStringUsing(StripPrefixString(parameter, "insert="),
                      ",", &insert_into);
 
-    for (int i = 0; i < insert_into.size(); i++) {
+    for (size_t i = 0; i < insert_into.size(); i++) {
       {
         google::protobuf::scoped_ptr<io::ZeroCopyOutputStream> output(context->OpenForInsert(
             GetOutputFileName(insert_into[i], file), kFirstInsertionPointName));


### PR DESCRIPTION
When running >bazel test :protobuf_test a few compiler warnings came up.  They were centered around the usage of "int" as the loop counter where the value should have been a size_t.