### PR TITLE
More Ruby-eqsue interface

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -178,6 +178,45 @@ VALUE Message_method_missing(int argc, VALUE* argv, VALUE _self) {
   }
 }
 
+VALUE Message_respond_to_missing(int argc, VALUE* argv, VALUE _self) {
+  MessageHeader* self;
+  VALUE method_name, method_str;
+  char* name;
+  size_t name_len;
+  bool setter;
+  const upb_oneofdef* o;
+  const upb_fielddef* f;
+
+  TypedData_Get_Struct(_self, MessageHeader, &Message_type, self);
+  if (argc < 1) {
+    rb_raise(rb_eArgError, "Expected method name as first argument.");
+  }
+  method_name = argv[0];
+  if (!SYMBOL_P(method_name)) {
+    rb_raise(rb_eArgError, "Expected symbol as method name.");
+  }
+  method_str = rb_id2str(SYM2ID(method_name));
+  name = RSTRING_PTR(method_str);
+  name_len = RSTRING_LEN(method_str);
+  setter = false;
+
+  // Setters have names that end in '='.
+  if (name[name_len - 1] == '=') {
+    setter = true;
+    name_len--;
+  }
+
+  // See if this name corresponds to either a oneof or field in this message.
+  if (!upb_msgdef_lookupname(self->descriptor->msgdef, name, name_len, &f,
+                             &o)) {
+    return rb_call_super(argc, argv);
+  }
+  if (o != NULL) {
+    return setter ? Qfalse : Qtrue;
+  }
+  return Qtrue;
+}
+
 int Message_initialize_kwarg(VALUE key, VALUE val, VALUE _self) {
   MessageHeader* self;
   VALUE method_str;
@@ -303,6 +342,9 @@ VALUE Message_deep_copy(VALUE _self) {
  * field is of a primitive type).
  */
 VALUE Message_eq(VALUE _self, VALUE _other) {
+  if (TYPE(_self) != TYPE(_other)) {
+    return Qfalse;
+  }
   MessageHeader* self;
   MessageHeader* other;
   TypedData_Get_Struct(_self, MessageHeader, &Message_type, self);
@@ -459,6 +501,8 @@ VALUE build_class_from_descriptor(Descriptor* desc) {
 
   rb_define_method(klass, "method_missing",
                    Message_method_missing, -1);
+  rb_define_method(klass, "respond_to_missing?",
+                   Message_respond_to_missing, -1);
   rb_define_method(klass, "initialize", Message_initialize, -1);
   rb_define_method(klass, "dup", Message_dup, 0);
   // Also define #clone so that we don't inherit Object#clone.

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -342,11 +342,11 @@ VALUE Message_deep_copy(VALUE _self) {
  * field is of a primitive type).
  */
 VALUE Message_eq(VALUE _self, VALUE _other) {
+  MessageHeader* self;
+  MessageHeader* other;
   if (TYPE(_self) != TYPE(_other)) {
     return Qfalse;
   }
-  MessageHeader* self;
-  MessageHeader* other;
   TypedData_Get_Struct(_self, MessageHeader, &Message_type, self);
   TypedData_Get_Struct(_other, MessageHeader, &Message_type, other);
 

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -1189,7 +1189,7 @@ module BasicTest
     def test_respond_to
       msg = MapMessage.new
       assert msg.respond_to?(:map_string_int32)
-      assert_false msg.respond_to?(:map_string_int32)
+      assert_false msg.respond_to?(:bacon)
     end
   end
 end

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -1181,5 +1181,15 @@ module BasicTest
       m2 = MapMessage.decode_json(MapMessage.encode_json(m))
       assert m == m2
     end
+
+    def test_comparison_with_arbitrary_object
+      assert_false MapMessage.new == nil
+    end
+
+    def test_respond_to
+      msg = MapMessage.new
+      assert msg.respond_to?(:map_string_int32)
+      assert_false msg.respond_to?(:map_string_int32)
+    end
   end
 end


### PR DESCRIPTION
There are two changes in this PR.

First change implements `respond_to_missing?` which is expected by a ton of Ruby APIs, and is a [good thing](https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding) to do. The implementation shares a ton of code with `method_missing` and I briefly thought about factoring it out to a shared function but I decided against it since it would create an abstraction that is hard to follow.

Second change makes `==` a bit more lenient. The comparison will now return `false` instead of failing if a message is compared to something with a different type. This is how Ruby APIs generally work:

```
$ irb
irb(main):001:0> Time.now == nil
=> false
irb(main):002:0> 7 == nil
=> false
irb(main):003:0> 7 == "7"
=> false
irb(main):004:0> Time.now == "bacon"
=> false
```