### PR TITLE
Use latest maven-compiler-plugin (2.6.0)

### DIFF
--- a/java/compatibility_tests/v2.5.0/protos/pom.xml
+++ b/java/compatibility_tests/v2.5.0/protos/pom.xml
@@ -28,7 +28,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.6.0</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -92,11 +92,34 @@
 
       <!-- Add the generated sources to the build -->
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <generatedSourcesDirectory>${generated.sources.dir}</generatedSourcesDirectory>
-          <generatedTestSourcesDirectory>${generated.testsources.dir}</generatedTestSourcesDirectory>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.sources.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-generated-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.testsources.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- OSGI bundle configuration -->

--- a/java/lite/pom.xml
+++ b/java/lite/pom.xml
@@ -76,10 +76,38 @@
 
       <!-- Only compile a subset of the files -->
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.sources.lite.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-generated-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.testsources.lite.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <generatedSourcesDirectory>${generated.sources.lite.dir}</generatedSourcesDirectory>
-          <generatedTestSourcesDirectory>${generated.testsources.lite.dir}</generatedTestSourcesDirectory>
           <includes>
             <include>**/AbstractMessageLite.java</include>
             <include>**/AbstractParser.java</include>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -94,7 +94,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.6.0</version>
           <configuration>
             <source>1.6</source>
             <target>1.6</target>

--- a/java/util/pom.xml
+++ b/java/util/pom.xml
@@ -79,12 +79,24 @@
         </executions>
       </plugin>
 
+      <!-- Add the generated test sources to the build -->
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- Add the generated test sources to the build -->
-          <generatedTestSourcesDirectory>${generated.testsources.dir}</generatedTestSourcesDirectory>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-generated-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${generated.testsources.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Configure the OSGI bundle -->


### PR DESCRIPTION
* Uses build-helper-maven-plugin to add generated sources to the classpath
* Fixes an issue building with newer versions of the maven-compiler-plugin
  (See https://issues.apache.org/jira/browse/MCOMPILER-240)

This aids downstream packagers, for which only newer versions of the maven-compiler-plugin are available. See the issue on the [Fedora Mailing List][1].

[1]: https://lists.fedoraproject.org/archives/list/java-devel@lists.fedoraproject.org/message/HDGYGFB3MGFVURS3CHOWCP2N6VIPMTEF/