### PR TITLE
Fix unused parameter warnings in arena_free

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -83,6 +83,7 @@ inline void arena_free(void* object, size_t size) {
 #if defined(__GXX_DELETE_WITH_SIZE__) || defined(__cpp_sized_deallocation)
   ::operator delete(object, size);
 #else
+  (void)size;
   ::operator delete(object);
 #endif
 }


### PR DESCRIPTION
The size parameter is only used in cases where the compiler supports
sized delete, so when that's not available we need to specifically cast
it to void to prevent a warning.