### PR TITLE
Added explicit cast to avoid size warning on Win64.

### DIFF
--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -244,7 +244,7 @@ class LIBPROTOBUF_EXPORT MessageLite {
   //
   // ByteSize() is generally linear in the number of fields defined for the
   // proto.
-  virtual int ByteSize() const { return ByteSizeLong(); }
+  virtual int ByteSize() const { return static_cast<int>(ByteSizeLong()); }
   virtual size_t ByteSizeLong() const;
 
   // Serializes the message without recomputing the size.  The message must


### PR DESCRIPTION
The message_lite.h file is a public file that gets pulled in by the public protobuf interface, Visual Studio 2015 projects with the flag /WX ([Threat Warnings as Errors](https://msdn.microsoft.com/en-us/library/thxezb7y.aspx)) fail compilation because of the warning generated by this line.

While a boundary check should be in place regardless of platform, the intent of the code is obvious, all this change does is silence the warning.