### PR TITLE
MessageOptions should handle both proto2 and google.protobuf package names.

### DIFF
--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -1024,8 +1024,11 @@ bool ProtoStreamObjectSource::IsMap(
   // TODO(xiaofeng): Unify option names.
   return field.kind() == google::protobuf::Field_Kind_TYPE_MESSAGE &&
          (GetBoolOptionOrDefault(field_type->options(),
-                                 "google.protobuf.MessageOptions.map_entry", false) ||
-          GetBoolOptionOrDefault(field_type->options(), "map_entry", false));
+                                 "google.protobuf.MessageOptions.map_entry",
+                                 false) ||
+          GetBoolOptionOrDefault(field_type->options(), "map_entry", false) ||
+          GetBoolOptionOrDefault(field_type->options(),
+                                 "proto2.MessageOptions.map_entry", false));
 }
 
 std::pair<int64, int32> ProtoStreamObjectSource::ReadSecondsAndNanos(
@@ -1119,3 +1122,4 @@ const string FormatNanos(uint32 nanos) {
 }  // namespace util
 }  // namespace protobuf
 }  // namespace google
+

--- a/src/google/protobuf/util/internal/protostream_objectwriter.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.cc
@@ -1240,8 +1240,11 @@ bool ProtoStreamObjectWriter::IsMap(const google::protobuf::Field& field) {
 
   // TODO(xiaofeng): Unify option names.
   return GetBoolOptionOrDefault(field_type->options(),
-                                "google.protobuf.MessageOptions.map_entry", false) ||
-         GetBoolOptionOrDefault(field_type->options(), "map_entry", false);
+                                "google.protobuf.MessageOptions.map_entry",
+                                false) ||
+         GetBoolOptionOrDefault(field_type->options(), "map_entry", false) ||
+         GetBoolOptionOrDefault(field_type->options(),
+                                "proto2.MessageOptions.map_entry", false);
 }
 
 bool ProtoStreamObjectWriter::IsAny(const google::protobuf::Field& field) {
@@ -1266,3 +1269,4 @@ bool ProtoStreamObjectWriter::IsStructListValue(
 }  // namespace util
 }  // namespace protobuf
 }  // namespace google
+

--- a/src/google/protobuf/util/internal/utility.cc
+++ b/src/google/protobuf/util/internal/utility.cc
@@ -356,15 +356,23 @@ bool IsValidBoolString(const string& bool_string) {
 
 bool IsMap(const google::protobuf::Field& field,
            const google::protobuf::Type& type) {
-  return (field.cardinality() ==
-              google::protobuf::Field_Cardinality_CARDINALITY_REPEATED &&
-          GetBoolOptionOrDefault(type.options(),
-                                 "google.protobuf.MessageOptions.map_entry", false));
+  return (
+      field.cardinality() ==
+          google::protobuf::Field_Cardinality_CARDINALITY_REPEATED &&
+      (GetBoolOptionOrDefault(
+           type.options(), "google.protobuf.MessageOptions.map_entry", false) ||
+       GetBoolOptionOrDefault(type.options(), "proto2.MessageOptions.map_entry",
+                              false)));
 }
 
 bool IsMessageSetWireFormat(const google::protobuf::Type& type) {
-  return GetBoolOptionOrDefault(
-      type.options(), "google.protobuf.MessageOptions.message_set_wire_format", false);
+  return (
+      GetBoolOptionOrDefault(
+          type.options(),
+          "google.protobuf.MessageOptions.message_set_wire_format", false) ||
+      GetBoolOptionOrDefault(type.options(),
+                             "proto2.MessageOptions.message_set_wire_format",
+                             false));
 }
 
 string DoubleAsString(double value) {
@@ -404,3 +412,4 @@ bool SafeStrToFloat(StringPiece str, float* value) {
 }  // namespace util
 }  // namespace protobuf
 }  // namespace google
+


### PR DESCRIPTION
This is done so that the same utility code can be used irrespective of whether MessageOptions belong to package name 'proto2' or 'google.protobuf'.