### PR TITLE
Speed up JSON parsing.

### DIFF
--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -172,12 +172,15 @@ namespace internal {
 class LIBPROTOBUF_EXPORT ZeroCopyStreamByteSink : public strings::ByteSink {
  public:
   explicit ZeroCopyStreamByteSink(io::ZeroCopyOutputStream* stream)
-      : stream_(stream) {}
+      : stream_(stream), buffer_size_(0) {}
+  ~ZeroCopyStreamByteSink();
 
   virtual void Append(const char* bytes, size_t len);
 
  private:
   io::ZeroCopyOutputStream* stream_;
+  void* buffer_;
+  int buffer_size_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ZeroCopyStreamByteSink);
 };


### PR DESCRIPTION
It turns out calling StringOutputStream::Next()/BackUp() repeatedly is
very costly in opensource protobuf because it keeps resize() the string
back and forth. The current JSON conversion API suffers this problem and
leads to ridiculously long parsing time:
https://github.com/google/protobuf/issues/2305#issuecomment-257785492

This change fixes the problem but caching the buffer of Next() and avoid
calling BackUp() as much as possible.