### PR TITLE
#2356 : fix ExceptionInInitializerError on IBM J9

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/MapFieldLite.java
+++ b/java/core/src/main/java/com/google/protobuf/MapFieldLite.java
@@ -58,7 +58,7 @@ public final class MapFieldLite<K, V> extends LinkedHashMap<K, V> {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private static final MapFieldLite EMPTY_MAP_FIELD = new MapFieldLite(Collections.emptyMap());
+  private static final MapFieldLite EMPTY_MAP_FIELD = new MapFieldLite();
   static {
     EMPTY_MAP_FIELD.makeImmutable();
   }


### PR DESCRIPTION
this patch fixs #2356

when static field `EMPTY_MAP_FIELD` in `MapFieldLite` is initilized on IBM J9, `putAll` which is overrided and calls `ensureMutable` is called in its super class `LinkedHashMap`, that causes `UnsupportedOperationException` is thrown as `isMutable` is false at that time. 

`LinkedHashMap` in Oracle JDK doesn't call `putAll`, so it's OK.

code below comes from JD of `java.util.LinkedHashMap` in `java.util.jar` of IBM J9
```
  public LinkedHashMap(Map<? extends K, ? extends V> paramMap)
  {
    this.accessOrder = false;
    this.head = null;
    this.tail = null;
    putAll(paramMap);
  }
```
IBM J9 version info:
```
$ java -version
java version "1.6.0"
Java(TM) SE Runtime Environment (build pap3260sr9fp1-20110208_03(SR9 FP1))
IBM J9 VM (build 2.4, JRE 1.6.0 IBM J9 2.4 AIX ppc-32 jvmap3260sr9-20110203_74623 (JIT enabled, AOT enabled)
J9VM - 20110203_074623
JIT  - r9_20101028_17488ifx3
GC   - 20101027_AA)
JCL  - 20110203_01
```