### PR TITLE
Fix csharp/src/Google.Protobuf.Test/project.json

### DIFF
--- a/csharp/src/Google.Protobuf.Test/project.json
+++ b/csharp/src/Google.Protobuf.Test/project.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "Google.Protobuf": { "target": "project" },
     "NUnit": "3.4.0",
-    "dotnet-test-nunit": "3.4.0-alpha-2",
+    "dotnet-test-nunit": "3.4.0-alpha-2"
   },
 
   "testRunner": "nunit",


### PR DESCRIPTION
This change fixes the following Chromium presubmit error:

  third_party/protobuf/csharp/src/Google.Protobuf.Test/project.json could
  not be parsed: Expecting property name: line 25 column 3 (char 482)