### PR TITLE
Fix go_package for descriptor.proto

### DIFF
--- a/src/google/protobuf/descriptor.proto
+++ b/src/google/protobuf/descriptor.proto
@@ -40,7 +40,7 @@
 syntax = "proto2";
 
 package google.protobuf;
-option go_package = "descriptor";
+option go_package = "github.com/golang/protobuf/protoc-gen-go/descriptor";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.Protobuf.Reflection";


### PR DESCRIPTION
To avoid `cannot find package "google/protobuf"` error