### PR TITLE
Fix jenkins tests.

### DIFF
--- a/conformance/failure_list_csharp.txt
+++ b/conformance/failure_list_csharp.txt
@@ -1,2 +1,6 @@
 Recommended.JsonInput.FieldNameWithDoubleUnderscores.JsonOutput
+Recommended.JsonInput.FieldNameWithDoubleUnderscores.ProtobufOutput
+Recommended.JsonInput.FieldNameWithDoubleUnderscores.Validator
+Required.JsonInput.FieldNameInLowerCamelCase.Validator
 Required.JsonInput.FieldNameInSnakeCase.JsonOutput
+Required.JsonInput.FieldNameInSnakeCase.ProtobufOutput

--- a/jenkins/docker/Dockerfile
+++ b/jenkins/docker/Dockerfile
@@ -132,7 +132,7 @@ ENV MVN mvn --batch-mode
 RUN cd /tmp && \
   git clone https://github.com/google/protobuf.git && \
   cd protobuf && \
-  git reset 734930f9197b7bc97c3c794c7a949fee2a08c280 && \
+  git reset bf379715c93b581eeb078cec1f0dd8a7d79df431 && \
   ./autogen.sh && \
   ./configure && \
   make -j4 && \


### PR DESCRIPTION
1. Listed failing csharp conformance tests.
2. Updated the maven cache in the Docker image.