### PR TITLE
Conformance Tests for Null Timestamp and Duration JSON Values

### DIFF
--- a/conformance/conformance_test.cc
+++ b/conformance/conformance_test.cc
@@ -1771,6 +1771,10 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
       R"({"repeatedDuration": ["1.5s", "-1.5s"]})",
       "repeated_duration: {seconds: 1 nanos: 500000000}"
       "repeated_duration: {seconds: -1 nanos: -500000000}");
+  RunValidJsonTest(
+      "DurationNull", REQUIRED,
+      R"({"optionalDuration": null})",
+      "");
 
   ExpectParseFailureForJson(
       "DurationMissingS", REQUIRED,
@@ -1840,6 +1844,10 @@ bool ConformanceTestSuite::RunSuite(ConformanceTestRunner* runner,
       "TimestampWithNegativeOffset", REQUIRED,
       R"({"optionalTimestamp": "1969-12-31T16:00:00-08:00"})",
       "optional_timestamp: {seconds: 0}");
+  RunValidJsonTest(
+      "TimestampNull", REQUIRED,
+      R"({"optionalTimestamp": null})",
+      "");
 
   ExpectParseFailureForJson(
       "TimestampJsonInputTooSmall", REQUIRED,


### PR DESCRIPTION
I opened an issue in the `Go` protobuf repo yesterday: https://github.com/golang/protobuf/issues/253 which showed an issue parsing a `null` JSON value for a `Timestamp` type.

According to the [official documentation](https://developers.google.com/protocol-buffers/docs/proto3#json), `null` values in `json` will be treated as zero values:

> If a value is missing in the JSON-encoded data or if its value is null, it will be interpreted as the appropriate default value when parsed into a protocol buffer. If a field has the default value in the protocol buffer, it will be omitted in the JSON-encoded data by default to save space. An implementation may provide options to emit fields with default values in the JSON-encoded output.