### PR TITLE
Restore jenkins files.

### DIFF
--- a/jenkins/build_and_run_docker.sh
+++ b/jenkins/build_and_run_docker.sh
@@ -33,6 +33,7 @@ docker run \
   "$@" \
   -e CCACHE_DIR=$CCACHE_DIR \
   -e EXTERNAL_GIT_ROOT="/var/local/jenkins/protobuf" \
+  -e TEST_SET="$TEST_SET" \
   -e THIS_IS_REALLY_NEEDED='see https://github.com/docker/docker/issues/14203 for why docker is awful' \
   -v "$git_root:/var/local/jenkins/protobuf:ro" \
   -v $CCACHE_DIR:$CCACHE_DIR \

--- a/jenkins/buildcmds/pull_request.sh
+++ b/jenkins/buildcmds/pull_request.sh
@@ -12,4 +12,5 @@
 export DOCKERFILE_DIR=jenkins/docker
 export DOCKER_RUN_SCRIPT=jenkins/pull_request_in_docker.sh
 export OUTPUT_DIR=testoutput
+export TEST_SET="csharp java_jdk7 javanano_jdk7 java_oracle7 javanano_oracle7 python python_cpp ruby_all javascript golang php_all"
 ./jenkins/build_and_run_docker.sh

--- a/jenkins/docker/Dockerfile
+++ b/jenkins/docker/Dockerfile
@@ -14,25 +14,29 @@ RUN echo 'deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main' > /
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DB82666C
 
 # Apt source for Oracle Java.
-run echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' > /etc/apt/sources.list.d/webupd8team-java-trusty.list && \
+RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main' > /etc/apt/sources.list.d/webupd8team-java-trusty.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && \
   echo "oracle-java7-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 
 # Apt source for Mono
-run echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \
+RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \
   echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
+# Apt source for php
+RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main" | tee /etc/apt/sources.list.d/various-php.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F4FCBB07
+
 # Install dotnet SDK based on https://www.microsoft.com/net/core#debian
 # (Ubuntu instructions need apt to support https)
-RUN apt-get update && apt-get install -y curl libunwind8 gettext && \
-  curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130 && \
+RUN apt-get update && apt-get install -y --force-yes curl libunwind8 gettext && \
+  curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130 &&  \
   mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet && \
   ln -s /opt/dotnet/dotnet /usr/local/bin
 
 # Install dependencies.  We start with the basic ones require to build protoc
 # and the C++ build
-RUN apt-get update && apt-get install -y \
+RUN apt-get clean && apt-get update && apt-get install -y --force-yes \
   autoconf \
   autotools-dev \
   build-essential \
@@ -71,6 +75,21 @@ RUN apt-get update && apt-get install -y \
   python3.4-dev \
   # -- For Ruby --
   ruby \
+  # -- For C++ benchmarks --
+  cmake \
+  # -- For PHP --
+  php5.5     \
+  php5.5-dev \
+  php5.5-xml \
+  php5.6     \
+  php5.6-dev \
+  php5.6-xml \
+  php7.0     \
+  php7.0-dev \
+  php7.0-xml \
+  phpunit    \
+  valgrind   \
+  libxml2-dev \
   && apt-get clean
 
 ##################
@@ -116,11 +135,40 @@ RUN cd /tmp && \
   git reset bf379715c93b581eeb078cec1f0dd8a7d79df431 && \
   ./autogen.sh && \
   ./configure && \
-  make -j6 && \
+  make -j4 && \
   cd java && \
   $MVN install dependency:go-offline -Dmaven.repo.local=$MAVEN_REPO && \
   cd ../javanano && \
   $MVN install dependency:go-offline -Dmaven.repo.local=$MAVEN_REPO
+
+##################
+# PHP dependencies.
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php composer-setup.php
+RUN mv composer.phar /usr/bin/composer
+RUN php -r "unlink('composer-setup.php');"
+RUN cd /tmp && \
+  cd protobuf && \
+  ln -sfn /usr/bin/php5.5 /usr/bin/php && \
+  ln -sfn /usr/bin/php-config5.5 /usr/bin/php-config && \
+  ln -sfn /usr/bin/phpize5.5 /usr/bin/phpize && \
+  composer install && \
+  mv vendor /usr/local/vendor-5.5 && \
+  ln -sfn /usr/bin/php5.6 /usr/bin/php && \
+  ln -sfn /usr/bin/php-config5.6 /usr/bin/php-config && \
+  ln -sfn /usr/bin/phpize5.6 /usr/bin/phpize && \
+  composer install && \
+  mv vendor /usr/local/vendor-5.6 && \
+  ln -sfn /usr/bin/php7.0 /usr/bin/php && \
+  ln -sfn /usr/bin/php-config7.0 /usr/bin/php-config && \
+  ln -sfn /usr/bin/phpize7.0 /usr/bin/phpize && \
+  composer install && \
+  mv vendor /usr/local/vendor-7.0
+RUN wget http://am1.php.net/get/php-5.5.38.tar.bz2/from/this/mirror
+RUN mv mirror php-5.5.38.tar.bz2
+RUN tar -xvf php-5.5.38.tar.bz2
+RUN cd php-5.5.38 && ./configure --enable-maintainer-zts --prefix=/usr/local/php-5.5-zts && \
+    make && make install
 
 ##################
 # Go dependencies.
@@ -130,7 +178,7 @@ RUN apt-get install -y  \
 
 ##################
 # Javascript dependencies.
-Run apt-get install -y \
+RUN apt-get install -y \
   # -- For javascript -- \
   npm
 

--- a/jenkins/pull_request_in_docker.sh
+++ b/jenkins/pull_request_in_docker.sh
@@ -45,19 +45,11 @@ TIME_CMD="/usr/bin/time -f %e -o $LOG_OUTPUT_DIR/1/cpp/build_time"
 
 $TIME_CMD $TEST_SCRIPT cpp > >(tee $CPP_STDOUT) 2> >(tee $CPP_STDERR >&2)
 
-# Other tests are run in parallel.
+# Other tests are run in parallel. TEST_SET is defined in
+# buildcmds/pull_request{_32}.sh
 
 parallel --results $LOG_OUTPUT_DIR --joblog $OUTPUT_DIR/joblog $TEST_SCRIPT ::: \
-  csharp \
-  java_jdk7 \
-  javanano_jdk7 \
-  java_oracle7 \
-  javanano_oracle7 \
-  python \
-  python_cpp \
-  ruby_all \
-  javascript \
-  golang \
+  $TEST_SET \
   || true  # Process test results even if tests fail.
 
 cat $OUTPUT_DIR/joblog


### PR DESCRIPTION
The last up-integration from github to google3 was made at commit
e28286fa05d8327fd6c5aa70cfb3be558f0932b8 but somehow the change in
that commit is not actually in the up-integration CL and as a result
that change was reverted by the down-integration. Restoring them
should make the jenkins tests running again.

Tried to rerun the up-integration script with both repos pined to the old versions but this time the jenkins changes showed up correct in the CL. Not sure where I made the mistake...