### PR TITLE
C++: Fix use with GOOGLE_PROTOBUF_NO_STATIC_INITIALIZER

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -722,7 +722,7 @@ void FileGenerator::GenerateBuildDescriptors(io::Printer* printer) {
       "adddescriptorsname", GlobalAddDescriptorsName(file_->name()));
 
   if (!StaticInitializersForced(file_, options_)) {
-    printer->Print("#ifdef GOOGLE_PROTOBUF_NO_STATIC_INITIALIZER\n");
+    printer->Print("#ifndef GOOGLE_PROTOBUF_NO_STATIC_INITIALIZER\n");
   }
   printer->Print(
       // With static initializers.


### PR DESCRIPTION
Behavior of define GOOGLE_PROTOBUF_NO_STATIC_INITIALIZER has been
altered between 337a028 and cc8ca5b for C++.

See github issue #2385 for further details.