### PR TITLE
Change CodedInputStream#DEFAULT_SIZE_LIMIT from 64MB to

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -60,7 +60,8 @@ import java.util.List;
 public abstract class CodedInputStream {
   private static final int DEFAULT_BUFFER_SIZE = 4096;
   private static final int DEFAULT_RECURSION_LIMIT = 100;
-  private static final int DEFAULT_SIZE_LIMIT = 64 << 20; // 64MB
+  // Integer.MAX_VALUE == 0x7FFFFFF == INT_MAX from limits.h
+  private static final int DEFAULT_SIZE_LIMIT = Integer.MAX_VALUE;
 
   /** Visible for subclasses. See setRecursionLimit() */
   int recursionDepth;
@@ -2762,9 +2763,9 @@ public abstract class CodedInputStream {
         throw InvalidProtocolBufferException.negativeSize();
       }
 
-      // Verify that the message size so far has not exceeded sizeLimit.
+      // Integer-overflow-conscious check that the message size so far has not exceeded sizeLimit.
       int currentMessageSize = totalBytesRetired + pos + size;
-      if (currentMessageSize > sizeLimit) {
+      if (currentMessageSize - sizeLimit > 0) {
         throw InvalidProtocolBufferException.sizeLimitExceeded();
       }
 


### PR DESCRIPTION
Integer.MAX_SIZE (0x7FFFFFF) #2228

M java/core/src/main/java/com/google/protobuf/CodedInputStream.java
 Set DEFAULT_SIZE_LIMIT to Integer.MAX_SIZE (Was 64MB). This is how it was
 in pre-2.7.0 pb. Changed size check to an overflow-conscious test (as it
 is later in tryRefillBuffer (making sizeLimit a long was to disruptive).

M java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java
 Add two tests that echo tests recently added over in c++ to test parse
 of message sizes that are approach and are beyond the size limit.