### PR TITLE
Add a proto_lang_toolchain() for cc_proto_library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -749,3 +749,10 @@ internal_protobuf_py_tests(
     ],
     deps = [":python_tests"],
 )
+
+proto_lang_toolchain(
+  name = "cc_toolchain",
+  runtime = ":protobuf",
+  command_line = "--cpp_out=$(OUT)",
+  visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Bazel's built-in cc_proto_library rule uses a proto_lang_toolchain to learn how to invoke proto-compiler.
To use Bazel's cc_proto_library, add the following to your project's WORKSPACE file:

local_repository(
  name = "com_google_protobuf_cc",
  path = "/path/to/protobuf-distribution/"
)