### PR TITLE
Change StringOutputStream's interface for better performance.

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -133,9 +133,7 @@ class LIBPROTOBUF_EXPORT StringOutputStream : public ZeroCopyOutputStream {
  public:
   // Create a StringOutputStream which appends bytes to the given string.
   // The string remains property of the caller, but it is mutated in arbitrary
-  // ways and MUST NOT be accessed in any way until you're done with the
-  // stream. Either be sure there's no further usage, or (safest) destroy the
-  // stream before using the contents.
+  // ways and MUST NOT be accessed in any way until the stream is destructed.
   //
   // Hint:  If you call target->reserve(n) before creating the stream,
   //   the first call to Next() will return at least n bytes of buffer
@@ -155,6 +153,7 @@ class LIBPROTOBUF_EXPORT StringOutputStream : public ZeroCopyOutputStream {
   static const int kMinimumSize = 16;
 
   string* target_;
+  int64 byte_count_; // number of bytes written till now
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(StringOutputStream);
 };

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -331,7 +331,7 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
   // stream_  : wrapper for writing tags and other encodings in wire format.
   strings::ByteSink* output_;
   string buffer_;
-  google::protobuf::io::StringOutputStream adapter_;
+  google::protobuf::scoped_ptr<google::protobuf::io::StringOutputStream> adapter_;
   google::protobuf::scoped_ptr<google::protobuf::io::CodedOutputStream> stream_;
 
   // Variables for error tracking and reporting:


### PR DESCRIPTION
This fixes major performance issue with JsonStringToMessage(). Current version
of StringOutputStream is really slow outside Google. This is because
STLStringResizeUninitialized() is un-optimized (it has to zero out the
re-sized bytes). And STLStringResizeUninitialized() is invoked
repeatedly everytime a token is written.