### PR TITLE
Fix bazel build of //:protoc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -304,6 +304,7 @@ cc_library(
         "src/google/protobuf/compiler/javanano/javanano_message_field.cc",
         "src/google/protobuf/compiler/javanano/javanano_primitive_field.cc",
         "src/google/protobuf/compiler/js/js_generator.cc",
+        "src/google/protobuf/compiler/js/well_known_types_embed.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_enum.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc",
         "src/google/protobuf/compiler/objectivec/objectivec_extension.cc",

--- a/BUILD
+++ b/BUILD
@@ -546,12 +546,12 @@ java_library(
     srcs = glob([
         "java/util/src/main/java/com/google/protobuf/util/*.java",
     ]),
+    visibility = ["//visibility:public"],
     deps = [
         "protobuf_java",
         "//external:gson",
         "//external:guava",
     ],
-    visibility = ["//visibility:public"],
 )
 
 ################################################################################
@@ -572,8 +572,8 @@ py_library(
             "python/google/protobuf/internal/test_util.py",
         ],
     ),
-    srcs_version = "PY2AND3",
     imports = ["python"],
+    srcs_version = "PY2AND3",
 )
 
 cc_binary(
@@ -638,8 +638,8 @@ config_setting(
 internal_copied_filegroup(
     name = "protos_python",
     srcs = WELL_KNOWN_PROTOS,
-    strip_prefix = "src",
     dest = "python",
+    strip_prefix = "src",
 )
 
 # TODO(dzc): Remove this once py_proto_library can have labels in srcs, in
@@ -661,7 +661,7 @@ py_proto_library(
     protoc = ":protoc",
     py_libs = [
         ":python_srcs",
-        "//external:six"
+        "//external:six",
     ],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
@@ -675,13 +675,14 @@ py_proto_library(
 internal_copied_filegroup(
     name = "protos_python_test",
     srcs = LITE_TEST_PROTOS + TEST_PROTOS,
-    strip_prefix = "src",
     dest = "python",
+    strip_prefix = "src",
 )
 
 # TODO(dzc): Remove this once py_proto_library can have labels in srcs, in
 # which case we can simply add :protos_python_test in srcs.
 COPIED_LITE_TEST_PROTOS = ["python/" + s for s in RELATIVE_LITE_TEST_PROTOS]
+
 COPIED_TEST_PROTOS = ["python/" + s for s in RELATIVE_TEST_PROTOS]
 
 py_proto_library(
@@ -751,8 +752,8 @@ internal_protobuf_py_tests(
 )
 
 proto_lang_toolchain(
-  name = "cc_toolchain",
-  runtime = ":protobuf",
-  command_line = "--cpp_out=$(OUT)",
-  visibility = ["//visibility:public"],
+    name = "cc_toolchain",
+    command_line = "--cpp_out=$(OUT)",
+    runtime = ":protobuf",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This fix a js failure but does not fix all the test.

```
  $ bazel test //:py_wire_format_test //:py_unknown_fields_test //:py_text_format_test //:py_text_encoding_test //:py_symbol_database_test //:py_service_reflection_test //:py_reflection_test //:py_proto_builder_test //:py_message_test //:py_message_factory_test //:py_json_format_test //:py_generator_test //:py_descriptor_test //:py_descriptor_pool_test //:py_descriptor_database_test //:protobuf_test --test_summary=none
INFO: Analysed 16 targets.
INFO: Found 16 test targets...
FAIL: //:py_descriptor_pool_test (redacted)
FAIL: //:py_generator_test (redacted)
FAIL: //:py_unknown_fields_test (redacted)
FAIL: //:py_text_format_test (redacted)
FAIL: //:py_json_format_test (redacted)
FAIL: //:py_descriptor_test (redacted)
FAIL: //:py_reflection_test (redacted)
FAIL: //:py_message_test (redacted)
FAIL: //:py_message_factory_test (redacted)
INFO: Elapsed time: 0.646s, Critical Path: 0.47s
INFO: Build completed, 9 tests FAILED, 10 total actions

Executed 9 out of 16 tests: 7 tests pass and 9 fail locally.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```