### PR TITLE
Ruby: removed redundant RepeatedField#slice.

### DIFF
--- a/ruby/lib/google/protobuf/repeated_field.rb
+++ b/ruby/lib/google/protobuf/repeated_field.rb
@@ -74,7 +74,7 @@ module Google
         :include?, :index, :inspect, :join,
         :pack, :permutation, :product, :pretty_print, :pretty_print_cycle,
         :rassoc, :repeated_combination, :repeated_permutation, :reverse,
-        :rindex, :rotate, :sample, :shuffle, :shelljoin, :slice,
+        :rindex, :rotate, :sample, :shuffle, :shelljoin,
         :to_s, :transpose, :uniq, :|
 
 


### PR DESCRIPTION
Fixes: https://github.com/google/protobuf/issues/1174