### PR TITLE
Send all protobuf logging to logcat by default on Android

### DIFF
--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -108,11 +108,17 @@ string VersionString(int version) {
 // ===================================================================
 // emulates google3/base/logging.cc
 
+// If the minimum logging level is not set, we default to logging messages for
+// all levels.
+#ifndef GOOGLE_PROTOBUF_MIN_LOG_LEVEL
+#define GOOGLE_PROTOBUF_MIN_LOG_LEVEL LOGLEVEL_INFO
+#endif
+
 namespace internal {
+
 #if defined(__ANDROID__)
 inline void DefaultLogHandler(LogLevel level, const char* filename, int line,
                               const string& message) {
-#ifdef GOOGLE_PROTOBUF_MIN_LOG_LEVEL
   if (level < GOOGLE_PROTOBUF_MIN_LOG_LEVEL) {
     return;
   }
@@ -143,11 +149,14 @@ inline void DefaultLogHandler(LogLevel level, const char* filename, int line,
     __android_log_write(ANDROID_LOG_FATAL, "libprotobuf-native",
                         "terminating.\n");
   }
-#endif
 }
+
 #else
 void DefaultLogHandler(LogLevel level, const char* filename, int line,
                        const string& message) {
+  if (level < GOOGLE_PROTOBUF_MIN_LOG_LEVEL) {
+    return;
+  }
   static const char* level_names[] = { "INFO", "WARNING", "ERROR", "FATAL" };
 
   // We use fprintf() instead of cerr because we want this to work at static


### PR DESCRIPTION
Currently the default for protobuf on Android is to silently drop all log
messages. This makes debugging difficult because things like GOOGLE_LOG(FATAL)
will crash the process without actually logging a useful error.

This CL changes the logging so that by default we send messages for all log
levels to logcat (and stderr). Users can override this by setting
GOOGLE_PROTOBUF_MIN_LOG_LEVEL. Also, that option was not being respected for
non-Android platforms so I went ahead and fixed that to make things consistent.