### PR TITLE
Add missing include in embed.cc

### DIFF
--- a/src/google/protobuf/compiler/js/embed.cc
+++ b/src/google/protobuf/compiler/js/embed.cc
@@ -28,6 +28,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cassert>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
This changes fixes "use of undeclared identifier 'assert'"
compilation error.