### PR TITLE
Use `require_relative` rather than `require`

### DIFF
--- a/src/google/protobuf/compiler/ruby/ruby_generator.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator.cc
@@ -429,7 +429,7 @@ bool MaybeEmitDependency(const FileDescriptor* import,
     return true;
   } else {
     printer->Print(
-      "require '$name$'\n", "name", GetRequireName(import->name()));
+      "require_relative '$name$'\n", "name", GetRequireName(import->name()));
     return true;
   }
 }


### PR DESCRIPTION
Maintainers PTAL

Local imports should not work like gem imports. Otherwise you need to add the base directory with generated Ruby files to the `$LOAD_PATH` which is suboptimal.