### PR TITLE
[Ruby] fix floating point accuracy problem in Timestamp#to_f

### DIFF
--- a/ruby/lib/google/protobuf/well_known_types.rb
+++ b/ruby/lib/google/protobuf/well_known_types.rb
@@ -80,7 +80,7 @@ module Google
       end
 
       def to_f
-        self.seconds + (self.nanos.to_f / 1_000_000_000)
+        self.seconds + (self.nanos.quo(1_000_000_000))
       end
     end
 

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -13,10 +13,15 @@ class TestWellKnownTypes < Test::Unit::TestCase
     assert_equal Time.at(12345), ts.to_time
     assert_equal 12345, ts.to_i
 
-    ts.from_time(Time.at(123456, 654321))
+    time = Time.at(123456, 654321)
+    ts.from_time(time)
     assert_equal 123456, ts.seconds
     assert_equal 654321000, ts.nanos
-    assert_equal Time.at(123456.654321), ts.to_time
+    assert_equal time, ts.to_time
+
+    time = Time.now
+    ts.from_time(time)
+    assert_equal time.to_f, ts.to_time.to_f
   end
 
   def test_duration

--- a/ruby/tests/well_known_types_test.rb
+++ b/ruby/tests/well_known_types_test.rb
@@ -13,15 +13,18 @@ class TestWellKnownTypes < Test::Unit::TestCase
     assert_equal Time.at(12345), ts.to_time
     assert_equal 12345, ts.to_i
 
+    # millisecond accuracy
     time = Time.at(123456, 654321)
     ts.from_time(time)
     assert_equal 123456, ts.seconds
     assert_equal 654321000, ts.nanos
     assert_equal time, ts.to_time
 
-    time = Time.now
+    # nanosecond accuracy
+    time = Time.at(123456, Rational(654321321, 1000))
     ts.from_time(time)
-    assert_equal time.to_f, ts.to_time.to_f
+    assert_equal 654321321, ts.nanos
+    assert_equal time, ts.to_time
   end
 
   def test_duration


### PR DESCRIPTION
Observing the following script:

```ruby
require "bundler/inline"

gemfile true do
  source "https://rubygems.org"
  gem "google-protobuf"
end
require "google/protobuf/well_known_types"

time = Time.now
p time.to_f
p time.usec

time_pb = Google::Protobuf::Timestamp.new.tap{ |e| e.from_time(time) }
p time_pb

time2 = time_pb.to_time
p time2.to_f
p time2.usec


p time == time2
__END__
Resolving dependencies...
Using google-protobuf 3.1.0
Using bundler 1.13.6
1481419172.3675368
367536
<Google::Protobuf::Timestamp: seconds: 1481419172, nanos: 367536969>
1481419172.367537
367537
false
```

While using the `Google::Protobuf::Timestamp` class some millisecond accuracy is lost due to floating point handling in ruby.
This can be fixed by using the [quo](https://ruby-doc.org/core-2.2.0/Numeric.html#method-i-quo) method instead of a less accurate floating point division.

I adapted the tests to demonstrate the problem and changed the `to_f` method to use `quo` instead.