### PR TITLE
Add missing includes

### DIFF
--- a/src/google/protobuf/compiler/js/embed.cc
+++ b/src/google/protobuf/compiler/js/embed.cc
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <string>
 
 const char output_file[] = "well_known_types_embed.cc";
 

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -110,6 +110,7 @@
 #define GOOGLE_PROTOBUF_IO_CODED_STREAM_H__
 
 #include <assert.h>
+#include <climits>
 #include <string>
 #include <utility>
 #ifdef _MSC_VER

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -39,6 +39,7 @@
 #ifndef GOOGLE_PROTOBUF_MESSAGE_LITE_H__
 #define GOOGLE_PROTOBUF_MESSAGE_LITE_H__
 
+#include <climits>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/logging.h>
 


### PR DESCRIPTION
This changes fixes "use of undeclared identifier 'INT_MAX'"
compilation error.