### PR TITLE
Removed Android-specific code from stubs/hash.h

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -615,7 +615,6 @@ class Map {
 
 #if __cplusplus >= 201103L && !defined(GOOGLE_PROTOBUF_OS_APPLE) && \
     !defined(GOOGLE_PROTOBUF_OS_NACL) &&                            \
-    !defined(GOOGLE_PROTOBUF_OS_ANDROID) &&                         \
     !defined(GOOGLE_PROTOBUF_OS_EMSCRIPTEN)
     template<class NodeType, class... Args>
     void construct(NodeType* p, Args&&... args) {

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -41,15 +41,10 @@
 #define GOOGLE_PROTOBUF_HAVE_HASH_MAP 1
 #define GOOGLE_PROTOBUF_HAVE_HASH_SET 1
 
-// Android
-#if defined(__ANDROID__)
-# undef GOOGLE_PROTOBUF_HAVE_HASH_MAP
-# undef GOOGLE_PROTOBUF_HAVE_HASH_MAP
-
 // Use C++11 unordered_{map|set} if available.
-#elif ((_LIBCPP_STD_VER >= 11) || \
-      (((__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X)) && \
-      (__GLIBCXX__ > 20090421)))
+#if ((_LIBCPP_STD_VER >= 11) || \
+    (((__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X)) && \
+    (__GLIBCXX__ > 20090421)))
 # define GOOGLE_PROTOBUF_HAS_CXX11_HASH
 
 // For XCode >= 4.6:  the compiler is clang with libc++.


### PR DESCRIPTION
This #ifdef in hash.h causes us to give up on finding a hash function on
Android, when there do seem to be hash functions available in practice.
I also had to tweak a macro in map.h that was disabling on Android an
allocator construct() method that we need.