### PR TITLE
add a key to ctx.action dict to prevent protoc losing the default env

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -90,6 +90,7 @@ def _proto_gen_impl(ctx):
         arguments=args + import_flags + [s.path for s in srcs],
         executable=ctx.executable.protoc,
         mnemonic="ProtoCompile",
+        use_default_shell_env=True,
     )
 
   return struct(
@@ -141,7 +142,7 @@ Args:
     compiler.
   plugin_language: the language of the generated sources
   plugin_options: a list of options to be passed to the plugin
-  gen_cc: generates C++ sources in addition to the ones from the plugin. 
+  gen_cc: generates C++ sources in addition to the ones from the plugin.
   gen_py: generates Python sources in addition to the ones from the plugin.
   outs: a list of labels of the expected outputs from the protocol compiler.
 """


### PR DESCRIPTION
This is a small change on the protobuf.bzl but very reasonable and useful.

In practice, a few protobuf client (like tensorflow, see below and etc) would call ```_proto_gen_impl(ctx)``` indirectly to generate proto implementations. However by the current definition of bazel's ctx.action rule (http://www.bazel.io/versions/master/docs/skylark/lib/ctx.html#action), the default user's custom shell env (PATH/LD_LIBRARY_PATH) is not passed to the compiled protoc binary because the user_default_shell_env is set to be ```False``` as default. This will invoke link error cuz users may link protoc with a customized library. There are a lot of reports on this issue.

In principle, when calling ```_proto_gen_impl(ctx)``` to generate proto impls, we should pass user's env to the protoc binary.

Another small change is to delete an extra space. (a bonus created by my vim editor).

Please see some issues related to this small CL:
https://github.com/tensorflow/tensorflow/issues/3261

This change will not affect any other reasonable implementations.
