### PR TITLE
Give C# ByteString a sensible GetHashCode implementation.

### DIFF
--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -167,5 +167,18 @@ namespace Google.Protobuf
             // Optimization which also fixes issue 61.
             Assert.AreSame(ByteString.Empty, ByteString.FromBase64(""));
         }
+
+        [Test]
+        public void GetHashCode_Regression()
+        {
+            // We used to have an awful hash algorithm where only the last four
+            // bytes were relevant. This is a regression test for
+            // https://github.com/google/protobuf/issues/2511
+
+            ByteString b1 = ByteString.CopyFrom(100, 1, 2, 3, 4);
+            ByteString b2 = ByteString.CopyFrom(200, 1, 2, 3, 4);
+            Assert.AreNotEqual(b1.GetHashCode(), b2.GetHashCode());
+        }
+
     }
 }

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -303,7 +303,7 @@ namespace Google.Protobuf
             int ret = 23;
             foreach (byte b in bytes)
             {
-                ret = (ret << 8) | b;
+                ret = (ret * 31) + b;
             }
             return ret;
         }


### PR DESCRIPTION
Fixes #2511.