### PR TITLE
unwrap descriptor class before comparison of RepeatedField types

### DIFF
--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -598,7 +598,7 @@ static void check_repeated_field_type(VALUE val, const upb_fielddef* field) {
   if (self->field_type == UPB_TYPE_MESSAGE ||
       self->field_type == UPB_TYPE_ENUM) {
     if (self->field_type_class !=
-        get_def_obj(upb_fielddef_subdef(field))) {
+        Descriptor_msgclass(get_def_obj(upb_fielddef_subdef(field)))) {
       rb_raise(rb_eTypeError,
                "Repeated field array has wrong message/enum class");
     }

--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -595,12 +595,20 @@ static void check_repeated_field_type(VALUE val, const upb_fielddef* field) {
     rb_raise(rb_eTypeError, "Repeated field array has wrong element type");
   }
 
-  if (self->field_type == UPB_TYPE_MESSAGE ||
-      self->field_type == UPB_TYPE_ENUM) {
+  if (self->field_type == UPB_TYPE_MESSAGE) { 
     if (self->field_type_class !=
         Descriptor_msgclass(get_def_obj(upb_fielddef_subdef(field)))) {
       rb_raise(rb_eTypeError,
-               "Repeated field array has wrong message/enum class");
+               "Repeated field array has wrong message class");
+    }
+  }
+
+
+  if (self->field_type == UPB_TYPE_ENUM) {
+    if (self->field_type_class !=
+        EnumDescriptor_enummodule(get_def_obj(upb_fielddef_subdef(field)))) {
+      rb_raise(rb_eTypeError,
+               "Repeated field array has wrong enum class");
     }
   }
 }

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -126,6 +126,12 @@ class RepeatedFieldTest < Test::Unit::TestCase
     assert_equal false, m.repeated_string.empty?
   end
 
+  def test_reassign
+    m = TestMessage.new
+    m.repeated_msg = Google::Protobuf::RepeatedField.new(:message, TestMessage2, [TestMessage2.new(:foo => 1)])
+    assert_equal m.repeated_msg.first, TestMessage2.new(:foo => 1)
+  end
+
   def test_array_accessor
     m = TestMessage.new
     reference_arr = %w(foo bar baz)


### PR DESCRIPTION
Given the protobuf file:

```proto
message OperatorPerformanceRecord {
  // ... 

  repeated OperatorServiceGroupPerformanceRecord operator_service_group_performance_records = 10;
  repeated TimebandRecord timeband_records = 11;
}

message OperatorServiceGroupPerformanceRecord {
  string name = 1;
  // ...
}

message TimebandRecord {
  int32 timeband = 1;

  // ...
}
```

On assignment of a `repeated` field from Ruby-land, the C function `check_repeated_field_type` checks the following:

1. the function has been called in the correct circumstances (the field you're assigning to is of type 'repeated')
2. the object you're trying to assign to your field is an instance of `Google::Protobuf::RepeatedField` 
3. the primitive field type of the `RepeatedField` object matches that of the field you're assigning to
4. if the field is type 'MESSAGE' or 'ENUM', it checks the class of the `RepeatedField` against that of the field

Whilst trying to use repeated message fields, as in the example above, the 4th check doesn't work out as intended.

Because `self->field_type_class` returns the Ruby class created by a Descriptor, but `get_def_obj` returns the Descriptor object used to generate the Ruby class, comparing the two objects will never be successful.

This patch passes the descriptor returned from `get_def_obj` into `Descriptor_msgclass`, so we compare `msgclass` to `msgclass`.

--- 

My method for debugging this, using this patch on master:

```
diff --git a/ruby/ext/google/protobuf_c/storage.c b/ruby/ext/google/protobuf_c/storage.c
index 3ff2bda..d1ca38f 100644
--- a/ruby/ext/google/protobuf_c/storage.c
+++ b/ruby/ext/google/protobuf_c/storage.c
@@ -599,6 +599,15 @@ static void check_repeated_field_type(VALUE val, const upb_fielddef* field) {
       self->field_type == UPB_TYPE_ENUM) {
     if (self->field_type_class !=
         get_def_obj(upb_fielddef_subdef(field))) {
+
+      printf("[PEACH-DEBUG] type invalid - error incoming shortly...\n");
+      printf("[PEACH-DEBUG] self->field_type_class:\n");
+      rb_p(self->field_type_class);
+      printf("[PEACH-DEBUG] get_def_obj(upb_fielddef_subdef(field)):\n");
+      rb_p(get_def_obj(upb_fielddef_subdef(field)));
+      printf("[PEACH-DEBUG] attempting to ascertain correct comparison variables...\n");
+      rb_p(Descriptor_msgclass(get_def_obj(upb_fielddef_subdef(field))));
+
       rb_raise(rb_eTypeError,
                "Repeated field array has wrong message/enum class");
     }
```

Which displays the following:

<img width="603" alt="screen shot 2016-12-20 at 00 27 39" src="https://cloud.githubusercontent.com/assets/816243/21334002/ea106294-c64b-11e6-9dde-65f76154234b.png">

---

This PR is more for discussion rather than a direct unit of work to be merged - I'm not positive this is the best way to solve the problem. I don't have a lot of experience dealing with the C backend of the protobuf library. For instance, I'm calling the hook Ruby calls instead of any internal API.

That said, this works for me and allows me to continue working on my project in parallel of discussion of a correct solution. I would also like to contribute some documentation & regression tests as well as this patch - repeated fields in Ruby are a little "sink-or-swim" at the moment!
