### PR TITLE
Added Bazel genrule for generating well_known_types_embed.cc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -227,6 +227,24 @@ cc_proto_library(
 # Protocol Buffers Compiler
 ################################################################################
 
+cc_binary(
+    name = "js_embed",
+    srcs = ["src/google/protobuf/compiler/js/embed.cc"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "generate_js_well_known_types_embed",
+    srcs = [
+        "src/google/protobuf/compiler/js/well_known_types/any.js",
+        "src/google/protobuf/compiler/js/well_known_types/struct.js",
+        "src/google/protobuf/compiler/js/well_known_types/timestamp.js",
+    ],
+    outs = ["src/google/protobuf/compiler/js/well_known_types_embed.cc"],
+    cmd = "$(location :js_embed) $(SRCS) > $@",
+    tools = [":js_embed"],
+)
+
 cc_library(
     name = "protoc_lib",
     srcs = [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -494,8 +494,10 @@ js_well_known_types_sources =                                  \
 	google/protobuf/compiler/js/well_known_types/any.js          \
 	google/protobuf/compiler/js/well_known_types/struct.js       \
 	google/protobuf/compiler/js/well_known_types/timestamp.js
+# We have to cd to $(srcdir) so that out-of-tree builds work properly.
 google/protobuf/compiler/js/well_known_types_embed.cc: js_embed$(EXEEXT) $(js_well_known_types_sources)
-	./js_embed$(EXEEXT) $(js_well_known_types_sources) > $@
+	oldpwd=`pwd` && cd $(srcdir) && \
+	$$oldpwd/js_embed$(EXEEXT) $(js_well_known_types_sources) > $$oldpwd/$@
 
 # Tests ==============================================================
 
@@ -549,6 +551,7 @@ protoc_inputs =                                                   \
 
 EXTRA_DIST =                                                   \
   $(protoc_inputs)                                             \
+  $(js_well_known_types_sources)                               \
   solaris/libstdc++.la                                         \
   google/protobuf/io/gzip_stream.h                             \
   google/protobuf/io/gzip_stream_unittest.sh                   \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,7 +56,8 @@ clean-local:
 
 CLEANFILES = $(protoc_outputs) unittest_proto_middleman \
              testzip.jar testzip.list testzip.proto testzip.zip \
-             no_warning_test.cc
+             no_warning_test.cc \
+             google/protobuf/compiler/js/well_known_types_embed.cc
 
 MAINTAINERCLEANFILES =   \
   Makefile.in


### PR DESCRIPTION
In pull request #2517 I made this change for the CMake and autotools
builds but forgot to do it for the Bazel build. In this pull request I made a
fix for the Bazel build and also updated the autotools build so that it works
properly with out-of-tree builds.