### PR TITLE
maps_test.js: check whether Symbol is defined before using it

### DIFF
--- a/js/maps_test.js
+++ b/js/maps_test.js
@@ -302,8 +302,7 @@ function makeTests(msgInfo, submessageCtor, suffix) {
     assertElementsEquals(entryIterator.next().value, ['key2', 'value2']);
     assertEquals(entryIterator.next().done, true);
 
-    if (!goog.userAgent.IE) {
-      // Symbol is not defined in IE
+    if (typeof(Symbol) != 'undefined') {
       var entryIterable = m.entries()[Symbol.iterator]();
       assertElementsEquals(entryIterable.next().value, ['key1', 'value1']);
       assertElementsEquals(entryIterable.next().value, ['key2', 'value2']);
@@ -315,8 +314,7 @@ function makeTests(msgInfo, submessageCtor, suffix) {
     assertEquals(keyIterator.next().value, 'key2');
     assertEquals(keyIterator.next().done, true);
 
-    if (!goog.userAgent.IE) {
-      // Symbol is not defined in IE
+    if (typeof(Symbol) != 'undefined') {
       var keyIterable = m.keys()[Symbol.iterator]();
       assertEquals(keyIterable.next().value, 'key1');
       assertEquals(keyIterable.next().value, 'key2');
@@ -327,8 +325,7 @@ function makeTests(msgInfo, submessageCtor, suffix) {
     assertEquals(valueIterator.next().value, 'value2');
     assertEquals(valueIterator.next().done, true);
 
-    if (!goog.userAgent.IE) {
-      // Symbol is not defined in IE
+    if (typeof(Symbol) != 'undefined') {
       var valueIterable = m.values()[Symbol.iterator]();
       assertEquals(valueIterable.next().value, 'value1');
       assertEquals(valueIterable.next().value, 'value2');


### PR DESCRIPTION
Symbol is not yet available on older versions of Node.js and so this
test fails with them. This change just directly checks whether Symbol is
available before we try to use it.