### PR TITLE
Class deprecation support

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -126,6 +126,16 @@ void FieldGeneratorBase::AddDeprecatedFlag(io::Printer* printer) {
   {
     printer->Print("[global::System.ObsoleteAttribute]\n");
   }
+  else 
+  {
+    if (descriptor_->type() == FieldDescriptor::TYPE_MESSAGE) 
+    {
+      if (descriptor_->message_type()->options().deprecated())
+      {
+        printer->Print("[global::System.ObsoleteAttribute]\n");
+      }
+    }
+  }
 }
 
 void FieldGeneratorBase::AddPublicMemberAttributes(io::Printer* printer) {

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -122,19 +122,11 @@ void FieldGeneratorBase::GenerateCodecCode(io::Printer* printer) {
 }
 
 void FieldGeneratorBase::AddDeprecatedFlag(io::Printer* printer) {
-  if (descriptor_->options().deprecated())
-  {
+  if (descriptor_->options().deprecated()) {
     printer->Print("[global::System.ObsoleteAttribute]\n");
-  }
-  else 
-  {
-    if (descriptor_->type() == FieldDescriptor::TYPE_MESSAGE) 
-    {
-      if (descriptor_->message_type()->options().deprecated())
-      {
-        printer->Print("[global::System.ObsoleteAttribute]\n");
-      }
-    }
+  } else if (descriptor_->type() == FieldDescriptor::TYPE_MESSAGE &&
+           descriptor_->message_type()->options().deprecated()) {
+    printer->Print("[global::System.ObsoleteAttribute]\n");
   }
 }
 

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -99,8 +99,7 @@ const std::vector<const FieldDescriptor*>& MessageGenerator::fields_by_number() 
 }
 
 void MessageGenerator::AddDeprecatedFlag(io::Printer* printer) {
-  if (descriptor_->options().deprecated())
-  {
+  if (descriptor_->options().deprecated()) {
     printer->Print("[global::System.ObsoleteAttribute]\n");
   }
 }

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -98,12 +98,21 @@ const std::vector<const FieldDescriptor*>& MessageGenerator::fields_by_number() 
   return fields_by_number_;
 }
 
+void MessageGenerator::AddDeprecatedFlag(io::Printer* printer) {
+  if (descriptor_->options().deprecated())
+  {
+    printer->Print("[global::System.ObsoleteAttribute]\n");
+  }
+}
+
 void MessageGenerator::Generate(io::Printer* printer) {
   map<string, string> vars;
   vars["class_name"] = class_name();
   vars["access_level"] = class_access_level();
 
   WriteMessageDocComment(printer, descriptor_);
+  AddDeprecatedFlag(printer);
+  
   printer->Print(
     vars,
     "$access_level$ sealed partial class $class_name$ : pb::IMessage<$class_name$> {\n");
@@ -115,6 +124,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
 	  "private static readonly pb::MessageParser<$class_name$> _parser = new pb::MessageParser<$class_name$>(() => new $class_name$());\n");
 
   WriteGeneratedCodeAttributes(printer);
+
   printer->Print(
 	  vars,
 	  "public static pb::MessageParser<$class_name$> Parser { get { return _parser; } }\n\n");

--- a/src/google/protobuf/compiler/csharp/csharp_message.h
+++ b/src/google/protobuf/compiler/csharp/csharp_message.h
@@ -69,6 +69,8 @@ class MessageGenerator : public SourceGeneratorBase {
 
   bool HasNestedGeneratedTypes();
 
+  void AddDeprecatedFlag(io::Printer* printer);
+  
   std::string class_name();
   std::string full_class_name();
 


### PR DESCRIPTION
Added the support for class level deprecation which will in turn also deprecate any fields that are currently using that type.

It was requested that support for deprecating a class in the c# code generation was added. In this implementation we deprecate the class as well as any fields that are also using that class. 

I think this ensures that users don't continue to use the class in other places, maybe some food for thought that its another option to allow for class->field level deprecation. 