### PR TITLE
Fix warning in compiler/js/embed.cc

### DIFF
--- a/src/google/protobuf/compiler/js/embed.cc
+++ b/src/google/protobuf/compiler/js/embed.cc
@@ -48,7 +48,7 @@ static char ToDecimalDigit(int num) {
 static std::string CEscape(const std::string& str) {
   std::string dest;
 
-  for (int i = 0; i < str.size(); ++i) {
+  for (size_t i = 0; i < str.size(); ++i) {
     unsigned char ch = str[i];
     switch (ch) {
       case '\n': dest += "\\n"; break;


### PR DESCRIPTION
embed.cc: In function ‘std::string CEscape(const string&)’:
embed.cc:51:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (int i = 0; i < str.size(); ++i) {
                                ^