### PR TITLE
Change hint type to `const void*`

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -592,7 +592,7 @@ class Map {
     MapAllocator(const MapAllocator<X>& allocator)
         : arena_(allocator.arena()) {}
 
-    pointer allocate(size_type n, const_pointer hint = 0) {
+    pointer allocate(size_type n, const void* hint = 0) {
       // If arena is not given, malloc needs to be called which doesn't
       // construct element object.
       if (arena_ == NULL) {


### PR DESCRIPTION
This is both more correct, and the build fails on AIX without it