### PR TITLE
python: do not include internal 'strutil.h' header

### DIFF
--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -66,7 +66,6 @@
 #include <google/protobuf/pyext/message_factory.h>
 #include <google/protobuf/pyext/safe_numerics.h>
 #include <google/protobuf/pyext/scoped_pyobject_ptr.h>
-#include <google/protobuf/stubs/strutil.h>
 
 #if PY_MAJOR_VERSION >= 3
   #define PyInt_AsLong PyLong_AsLong
@@ -100,6 +99,17 @@ static PyObject* WKT_classes = NULL;
 namespace message_meta {
 
 static int InsertEmptyWeakref(PyTypeObject* base);
+
+namespace {
+// Copied oveer from internal 'google/protobuf/stubs/strutil.h'.
+inline void UpperString(string * s) {
+  string::iterator end = s->end();
+  for (string::iterator i = s->begin(); i != end; ++i) {
+    // toupper() changes based on locale.  We don't want this!
+    if ('a' <= *i && *i <= 'z') *i += 'A' - 'a';
+  }
+}
+}
 
 // Add the number of a field descriptor to the containing message class.
 // Equivalent to:


### PR DESCRIPTION
I inlined the one function call from `strutil.h` into `pyext/message.cc`. The `strutil.h`  file doesn't get install, so if you're trying to build the python extension you won't have it in your include path (see #1197).

I think the same reasoning as e.g. https://github.com/grpc/grpc/pull/3133 applies here.

(also on a different note, why don't the pip releases include the python cpp implementation? is that on purpose or an oversight?)