### PR TITLE
Add a proto_lang_toolchain for Java

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -771,7 +771,14 @@ internal_protobuf_py_tests(
 
 proto_lang_toolchain(
   name = "cc_toolchain",
-  runtime = ":protobuf",
   command_line = "--cpp_out=$(OUT)",
+  runtime = ":protobuf",
   visibility = ["//visibility:public"],
+)
+
+proto_lang_toolchain(
+    name = "java_toolchain",
+    command_line = "--java_out=$(OUT)",
+    runtime = ":protobuf_java",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This allows easy use of Bazel's java_proto_library native rule.