### PR TITLE
Update AbstractMessage.java

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
@@ -328,8 +328,11 @@ public abstract class AbstractMessage
       extends AbstractMessageLite.Builder
       implements Message.Builder {
     // The compiler produces an error if this is not declared explicitly.
+    /** Method isn't abstact to bypass Java 1.6 compiler issue. */
     @Override
-    public abstract BuilderType clone();
+    public BuilderType clone() {
+      throw new UnsupportedOperationException("clone() should be implemented in subclasses.");
+    }
 
     /** TODO(jieluo): Clear it when all subclasses have implemented this method. */
     @Override

--- a/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
+++ b/java/core/src/main/java/com/google/protobuf/AbstractMessage.java
@@ -328,7 +328,7 @@ public abstract class AbstractMessage
       extends AbstractMessageLite.Builder
       implements Message.Builder {
     // The compiler produces an error if this is not declared explicitly.
-    /** Method isn't abstact to bypass Java 1.6 compiler issue. */
+    // Method isn't abstract to bypass Java 1.6 compiler issue http://bugs.java.com/view_bug.do?bug_id=6908259
     @Override
     public BuilderType clone() {
       throw new UnsupportedOperationException("clone() should be implemented in subclasses.");


### PR DESCRIPTION
Method Builder#clone() has been changed to bypass Java 1.6 compiler issue.

google/protobuf#2428