### PR TITLE
Revert "Fix Timestamps with dates before the Unix epoch that contain fractional seconds."

### DIFF
--- a/objectivec/GPBWellKnownTypes.m
+++ b/objectivec/GPBWellKnownTypes.m
@@ -50,15 +50,6 @@ static int32_t SecondsAndNanosFromTimeIntervalSince1970(NSTimeInterval time,
                                                         int64_t *outSeconds) {
   NSTimeInterval seconds;
   NSTimeInterval nanos = modf(time, &seconds);
-
-  // Per Timestamp.proto, nanos is non-negative and "Negative second values with
-  // fractions must still have non-negative nanos values that count forward in
-  // time. Must be from 0 to 999,999,999 inclusive."
-  if (nanos < 0) {
-    --seconds;
-    nanos = 1.0 + nanos;
-  }
-
   nanos *= 1e9;
   *outSeconds = (int64_t)seconds;
   return (int32_t)nanos;

--- a/objectivec/Tests/GPBWellKnownTypesTest.m
+++ b/objectivec/Tests/GPBWellKnownTypesTest.m
@@ -46,54 +46,39 @@ static const NSTimeInterval kTimeAccuracy = 1e-9;
 @implementation WellKnownTypesTest
 
 - (void)testTimeStamp {
-  // Test a pre-Unix epoch date with fractional seconds.
-  NSTimeInterval interval = -428027599.0 + -483999967/1e9;
-  NSDate *preEpochDate = [NSDate dateWithTimeIntervalSince1970:interval];
-  NSDate *now = [NSDate date];
-  NSDate *future = [NSDate dateWithTimeIntervalSinceNow:kFutureOffsetInterval];
-  NSArray *datesToTest = @[preEpochDate, now, future];
+  // Test Creation.
+  NSDate *date = [NSDate date];
+  GPBTimestamp *timeStamp = [[GPBTimestamp alloc] initWithDate:date];
+  NSDate *timeStampDate = timeStamp.date;
 
-  for (NSDate *date in datesToTest) {
-    // Test Creation.
-    GPBTimestamp *timeStamp = [[GPBTimestamp alloc] initWithDate:date];
-    NSDate *timeStampDate = timeStamp.date;
+  // Comparing timeIntervals instead of directly comparing dates because date
+  // equality requires the time intervals to be exactly the same, and the
+  // timeintervals go through a bit of floating point error as they are
+  // converted back and forth from the internal representation.
+  XCTAssertEqualWithAccuracy(date.timeIntervalSince1970,
+                             timeStampDate.timeIntervalSince1970,
+                             kTimeAccuracy);
 
-    XCTAssertGreaterThanOrEqual(timeStamp.nanos, 0,
-                                @"|nanos| must be >= 0. Failing date: %@", date);
-    XCTAssertLessThan(timeStamp.nanos, 1e9, @"|nanos| must be < 1e9. Failing date: %@", date);
+  NSTimeInterval time = [date timeIntervalSince1970];
+  GPBTimestamp *timeStamp2 =
+      [[GPBTimestamp alloc] initWithTimeIntervalSince1970:time];
+  NSTimeInterval durationTime = timeStamp2.timeIntervalSince1970;
+  XCTAssertEqualWithAccuracy(time, durationTime, kTimeAccuracy);
+  [timeStamp release];
 
-    // Comparing timeIntervals instead of directly comparing dates because date
-    // equality requires the time intervals to be exactly the same, and the
-    // timeintervals go through a bit of floating point error as they are
-    // converted back and forth from the internal representation.
-    XCTAssertEqualWithAccuracy(date.timeIntervalSince1970,
-                               timeStampDate.timeIntervalSince1970,
-                               kTimeAccuracy,
-                               @"Failing date: %@", date);
+  // Test Mutation.
+  date = [NSDate dateWithTimeIntervalSinceNow:kFutureOffsetInterval];
+  timeStamp2.date = date;
+  timeStampDate = timeStamp2.date;
+  XCTAssertEqualWithAccuracy(date.timeIntervalSince1970,
+                             timeStampDate.timeIntervalSince1970,
+                             kTimeAccuracy);
 
-    NSTimeInterval time = [date timeIntervalSince1970];
-    GPBTimestamp *timeStamp2 =
-        [[GPBTimestamp alloc] initWithTimeIntervalSince1970:time];
-    NSTimeInterval durationTime = timeStamp2.timeIntervalSince1970;
-    XCTAssertEqualWithAccuracy(time, durationTime, kTimeAccuracy, @"Failing date: %@", date);
-    [timeStamp release];
-    [timeStamp2 release];
-
-    // Test Mutation.
-    GPBTimestamp *timeStamp3 = [[GPBTimestamp alloc] init];
-    timeStamp3.date = date;
-    timeStampDate = timeStamp3.date;
-    XCTAssertEqualWithAccuracy(date.timeIntervalSince1970,
-                               timeStampDate.timeIntervalSince1970,
-                               kTimeAccuracy,
-                               @"Failing date: %@", date);
-
-    time = date.timeIntervalSince1970;
-    timeStamp3.timeIntervalSince1970 = time;
-    durationTime = timeStamp3.timeIntervalSince1970;
-    XCTAssertEqualWithAccuracy(time, durationTime, kTimeAccuracy, @"Failing date: %@", date);
-    [timeStamp3 release];
-  }
+  time = date.timeIntervalSince1970;
+  timeStamp2.timeIntervalSince1970 = time;
+  durationTime = timeStamp2.timeIntervalSince1970;
+  XCTAssertEqualWithAccuracy(time, durationTime, kTimeAccuracy);
+  [timeStamp2 release];
 }
 
 - (void)testDuration {


### PR DESCRIPTION
Reverts google/protobuf#2586

Just realized this breaks duration handing for negative values, reverting to handle both.