### PR TITLE
Undef TYPE_BOOL to avoid conflict with iOS.

### DIFF
--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -45,6 +45,16 @@
 #include <google/protobuf/message_lite.h>
 #include <google/protobuf/io/coded_stream.h>  // for CodedOutputStream::Varint32Size
 
+// Avoid conflict with iOS where <ConditionalMacros.h> #defines TYPE_BOOL.
+//
+// If some one needs the macro TYPE_BOOL in a file that includes this header, it's
+// possible to bring it back using push/pop_macro as follows.
+//
+// #pragma push_macro("TYPE_BOOL")
+// #include this header and/or all headers that need the macro to be undefined.
+// #pragma pop_macro("TYPE_BOOL")
+#undef TYPE_BOOL
+
 namespace google {
 
 namespace protobuf {


### PR DESCRIPTION
TYPE_BOOL is defined as a macro in <ConditionalMacros.h>, which gets implicitly included in almost all iOS source files.

This fixes complaints like http://go/soverflow/15759559

For some context, here is how TYPE_BOOL is defined in ConditionalMacros.h

  #ifdef __cplusplus
     #define TYPE_BOOL                1
  #else
     #define TYPE_BOOL                0
  #endif