### PR TITLE
 optimization and quick workaround to memory leak

### DIFF
--- a/python/google/protobuf/reflection.py
+++ b/python/google/protobuf/reflection.py
@@ -61,6 +61,8 @@ else:
 # Part of the public interface, but normally only used by message factories.
 GeneratedProtocolMessageType = message_impl.GeneratedProtocolMessageType
 
+MESSAGE_CLASS_CACHE = {}
+
 
 def ParseMessage(descriptor, byte_str):
   """Generate a new Message instance from this Descriptor and a byte string.
@@ -104,11 +106,16 @@ def MakeClass(descriptor):
   Returns:
     The Message class object described by the descriptor.
   """
+  if descriptor in MESSAGE_CLASS_CACHE:
+      return MESSAGE_CLASS_CACHE[descriptor]
+
   attributes = {}
   for name, nested_type in descriptor.nested_types_by_name.items():
     attributes[name] = MakeClass(nested_type)
 
   attributes[GeneratedProtocolMessageType._DESCRIPTOR_KEY] = descriptor
 
-  return GeneratedProtocolMessageType(str(descriptor.name), (message.Message,),
+  result = GeneratedProtocolMessageType(str(descriptor.name), (message.Message,),
                                       attributes)
+  MESSAGE_CLASS_CACHE[descriptor] = result
+  return result


### PR DESCRIPTION
incremental solution for https://github.com/google/protobuf/issues/156

the memory leak is caused by this call to copyreg:

https://github.com/google/protobuf/blob/39f9b43219bc5718b659ed72a2130a7b2ce66108/python/google/protobuf/internal/python_message.py#L182

the default comparator fails to detect duplicate entries, effectively filling the internal table at  `copyreg.__dict__['dispatch_table']` until the machine runs out of memory

can probably implement `__cmp__` at some point before that call as a technically more correct solution - a cache saves on cycles though, and is optimal for my use case, yada yada, hope this progresses a fix