### PR TITLE
Revert ios version

### DIFF
--- a/Protobuf.podspec
+++ b/Protobuf.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.user_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1' }
   s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1' }
 
-  s.ios.deployment_target = '7.1'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
   s.requires_arc = false


### PR DESCRIPTION
The Protobuf library doesn’t require the 7.1 deployment target so
reverting it back to 7.0