### PR TITLE
Python manylinux wheel builds

### DIFF
--- a/python/manylinux-build.sh
+++ b/python/manylinux-build.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -xe
+
+pushd /tmp
+
+curl -O https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+gunzip autoconf-2.69.tar.gz
+tar xvf autoconf-2.69.tar
+
+pushd autoconf-2.69
+
+./configure
+make
+make install
+
+popd
+
+curl -O https://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+tar xvzf automake-1.15.tar.gz
+
+pushd automake-1.15
+
+./configure
+make
+make install
+
+popd
+
+curl -O https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
+tar xzvf libtool-2.4.6.tar.gz
+
+pushd libtool-2.4.6
+
+./configure
+make
+make install
+
+popd
+
+popd
+
+export SED=$(which sed)
+
+./autogen.sh
+./configure --disable-shared "CFLAGS=-fPIC" "CXXFLAGS=-fPIC"
+make
+make check
+
+cd python
+PYTHON_VERSIONS="cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m"
+for PYVER in $PYTHON_VERSIONS
+do
+	/opt/python/$PYVER/bin/python setup.py bdist_wheel --cpp_implementation --compile_static_extension
+done


### PR DESCRIPTION
So far this PR just includes a shell script for running inside a https://github.com/pypa/manylinux CentOS5 build container. It will produce statically linked, `cpp-implementation` enabled, python2 and python3 compatible wheels for whatever arch of manylinux builder it's run inside of.

It seems protobuf requires a much newer version of autotools that is present in CentOS5 so this has to download and install newer versions of those first. I'm not sure if there's a better way to do this upgrade (yum backports somewhere?), I'm a bit new to the RedHat ecosystem.

Run this like

```
docker run -w /io/protobuf -v $(pwd):/io/protobuf --rm \
    quay.io/pypa/manylinux1_x86_64 python/manylinux-build.sh
```

And it will dump wheels into `python/dist` for you.

See also #2623 