### PR TITLE
Add namespace for std::string in case ambiguous symbol error

### DIFF
--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -139,7 +139,7 @@ LIBPROTOBUF_EXPORT inline const ::std::string& GetEmptyString() {
   return GetEmptyStringAlreadyInited();
 }
 
-LIBPROTOBUF_EXPORT int StringSpaceUsedExcludingSelf(const string& str);
+LIBPROTOBUF_EXPORT int StringSpaceUsedExcludingSelf(const std::string& str);
 
 
 // True if IsInitialized() is true for all elements of t.  Type is expected

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -40,6 +40,7 @@
 #define GOOGLE_PROTOBUF_MESSAGE_LITE_H__
 
 #include <climits>
+#include <string>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/stubs/logging.h>
 
@@ -166,10 +167,10 @@ class LIBPROTOBUF_EXPORT MessageLite {
   // format, matching the encoding output by MessageLite::SerializeToString().
   // If you'd like to convert a human-readable string into a protocol buffer
   // object, see google::protobuf::TextFormat::ParseFromString().
-  bool ParseFromString(const string& data);
+  bool ParseFromString(const std::string& data);
   // Like ParseFromString(), but accepts messages that are missing
   // required fields.
-  bool ParsePartialFromString(const string& data);
+  bool ParsePartialFromString(const std::string& data);
   // Parse a protocol buffer contained in an array of bytes.
   bool ParseFromArray(const void* data, int size);
   // Like ParseFromArray(), but accepts messages that are missing


### PR DESCRIPTION
The string argument has no namespace. It will cause "ambiguous symbol" compiling error in the situation that another "string" is defined in some other header files.