### PR TITLE
C#: Implement IReadOnlyList<T> in RepeatedField<T>

### DIFF
--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -47,6 +47,9 @@ namespace Google.Protobuf.Collections
     /// </remarks>
     /// <typeparam name="T">The element type of the repeated field.</typeparam>
     public sealed class RepeatedField<T> : IList<T>, IList, IDeepCloneable<RepeatedField<T>>, IEquatable<RepeatedField<T>>
+#if !DOTNET35
+        , IReadOnlyList<T>
+#endif
     {
         private static readonly T[] EmptyArray = new T[0];
         private const int MinArraySize = 8;


### PR DESCRIPTION
We explicitly don't do this when targeting .NET 3.5, where the
interface doesn't exist.

No implementation is required, as we're already implementing
everything we need for IList<T>.

Fixes #2041.