### PR TITLE
Add fixed version to phpunit used in travis

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -477,7 +477,7 @@ build_php5.6_mac() {
   export PATH="$PHP_FOLDER/bin:$PATH"
 
   # Install phpunit
-  curl https://phar.phpunit.de/phpunit.phar -L -o phpunit.phar
+  curl https://phar.phpunit.de/phpunit-5.6.10.phar -L -o phpunit.phar
   chmod +x phpunit.phar
   sudo mv phpunit.phar /usr/local/bin/phpunit
 


### PR DESCRIPTION
The latest phpunit only supports php7.0+. Added an old fixed version to work with php 5.6.