### PR TITLE
Removed log statement from writer_test.js

### DIFF
--- a/js/binary/writer_test.js
+++ b/js/binary/writer_test.js
@@ -48,8 +48,6 @@ goog.require('jspb.BinaryWriter');
  */
 function assertFails(func) {
   var e = assertThrows(func);
-  console.log(e);
-  //assertNotNull(e.toString().match(/Error/));
 }
 
 


### PR DESCRIPTION
This tweak makes the test output a bit easier to read because it cuts
out a lot of unnecessary logging.