### PR TITLE
Added a "protobuf_headers" target that includes only the headers.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -181,6 +181,13 @@ cc_library(
     deps = [":protobuf_lite"],
 )
 
+cc_library(
+    name = "protobuf_headers",
+    hdrs = glob(["src/**/*.h"]),
+    includes = ["src/"],
+    visibility = ["//visibility:public"],
+)
+
 objc_library(
     name = "protobuf_objc",
     hdrs = ["objectivec/GPBProtocolBuffers.h"],


### PR DESCRIPTION
Projects building multiple .so's and loading them dynamically can
link against this target instead of including all of protobuf.
TensorFlow is an example of such a project.