### PR TITLE
Add insertion points for field modifiers

### DIFF
--- a/src/google/protobuf/compiler/java/java_message_builder.cc
+++ b/src/google/protobuf/compiler/java/java_message_builder.cc
@@ -473,26 +473,32 @@ GenerateCommonBuilderMethods(io::Printer* printer) {
     "public Builder setField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(builder_setter_scope:$full_name$.setField)\n"
     "  return (Builder) super.setField(field, value);\n"
     "}\n"
     "public Builder clearField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field) {\n"
+    "  //@@protoc_insertion_point(builder_setter_scope:$full_name$.clearField)\n"
     "  return (Builder) super.clearField(field);\n"
     "}\n"
     "public Builder clearOneof(\n"
     "    com.google.protobuf.Descriptors.OneofDescriptor oneof) {\n"
+    "  //@@protoc_insertion_point(builder_setter_scope:$full_name$.clearOneOf)\n"
     "  return (Builder) super.clearOneof(oneof);\n"
     "}\n"
     "public Builder setRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    int index, Object value) {\n"
+    "  //@@protoc_insertion_point(builder_setter_scope:$full_name$.setRepeatedField)\n"
     "  return (Builder) super.setRepeatedField(field, index, value);\n"
     "}\n"
     "public Builder addRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(builder_setter_scope:$full_name$.addRepeatedField)\n"
     "  return (Builder) super.addRepeatedField(field, value);\n"
-    "}\n");
+    "}\n",
+    "full_name", descriptor_->full_name());
 
   if (descriptor_->extension_range_count() > 0) {
     printer->Print(

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -64,6 +64,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
   (*variables)["type"] = PrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["boxed_type"] = BoxedPrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["field_type"] = (*variables)["type"];
@@ -224,6 +225,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
@@ -480,6 +482,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
     "$null_check$"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
@@ -653,6 +656,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, $type$ value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -65,6 +65,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
 
   (*variables)["default"] = ImmutableDefaultValue(descriptor, name_resolver);
@@ -318,6 +319,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
@@ -341,6 +343,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -602,6 +605,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
@@ -623,6 +627,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -817,6 +822,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(setter_scope:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"


### PR DESCRIPTION
    
Add the following insertion points:
  - field_modifier_scope_{before,after}:<fullname>.setField
  - field_modifier_scope_{before,after}:<fullname>.clearField
  - field_modifier_scope_{before,after}:<fullname>.clearOneOf
  - field_modifier_scope_{before,after}:<fullname>.setRepeatedField
  - field_modifier_scope_{before,after}:<fullname>.addRepeatedField
  - field_modifier_scope_{before,after}:<fullname>.set<capitalized_name>)
  - field_modifier_scope_{before,after}:<fullname>.set<capitalized_name>Bytes)
  - field_modifier_scope_{before,after}:<fullname>.add<capitalized_name>)
  - field_modifier_scope_{before,after}:<fullname>.addAll<capitalized_name>Bytes)
    
Two entry points are provided for each at scope start and end.
   

Github Issue: #2684