### PR TITLE
Bazel can build protobuf when it's not in the root

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -263,10 +263,11 @@ def internal_gen_well_known_protos_java(srcs):
     srcs: the well known protos
   """
   root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
+  pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
   if root == "":
-    include = " -Isrc "
+    include = " -I%ssrc " % pkg
   else:
-    include = " -I%s/src " % root
+    include = " -I%s/%ssrc " % (root, pkg)
   native.genrule(
     name = "gen_well_known_protos_java",
     srcs = srcs,


### PR DESCRIPTION
That is, Bazel can now build protobuf when the latter resides in a subdirectory of a project.