### PR TITLE
Update load() statement to latest style

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,7 +31,7 @@ LINK_OPTS = select({
 })
 
 load(
-    "protobuf",
+    ":protobuf.bzl",
     "cc_proto_library",
     "py_proto_library",
     "internal_copied_filegroup",


### PR DESCRIPTION
The first argument is currently implicitly a .bzl file.
Change this to be explicit.