### PR TITLE
Fix compiler warnings about unused variables in wire_format.h

### DIFF
--- a/src/google/protobuf/wire_format.h
+++ b/src/google/protobuf/wire_format.h
@@ -327,6 +327,9 @@ inline void WireFormat::VerifyUTF8StringNamedField(
 #ifdef GOOGLE_PROTOBUF_UTF8_VALIDATION_ENABLED
   WireFormatLite::VerifyUtf8String(
       data, size, static_cast<WireFormatLite::Operation>(op), field_name);
+#else
+  // Avoid the compiler warning about unused variables.
+  (void)data; (void)size; (void)op; (void)field_name;
 #endif
 }
 


### PR DESCRIPTION
For users who have GOOGLE_PROTOBUF_UTF8_VALIDATION_ENABLED turned off, compiler gives warnigns about unused variables in WireFormat::VerifyUTF8StringNamedField in wire_format.h.