### PR TITLE
Fix libprotoc.cmake to generate well_known_types_embed.cc

### DIFF
--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -94,7 +94,7 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
 )
 
-set(js_well_known_types_sources,
+set(js_well_known_types_sources
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/any.js
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/struct.js
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/timestamp.js


### PR DESCRIPTION
Unfortunate typo. Just one extra ',' symbol, has led to the hidden implicit behavior.

Now everything will be fine.

Closes: #2705