### PR TITLE
Add insertion points for field modifiers

### DIFF
--- a/src/google/protobuf/compiler/java/java_message_builder.cc
+++ b/src/google/protobuf/compiler/java/java_message_builder.cc
@@ -473,26 +473,37 @@ GenerateCommonBuilderMethods(io::Printer* printer) {
     "public Builder setField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.setField)\n"
     "  return (Builder) super.setField(field, value);\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.setField)\n"
     "}\n"
     "public Builder clearField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.clearField)\n"
     "  return (Builder) super.clearField(field);\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.clearField)\n"
     "}\n"
     "public Builder clearOneof(\n"
     "    com.google.protobuf.Descriptors.OneofDescriptor oneof) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.clearOneOf)\n"
     "  return (Builder) super.clearOneof(oneof);\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.clearOneOf)\n"
     "}\n"
     "public Builder setRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    int index, Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.setRepeatedField)\n"
     "  return (Builder) super.setRepeatedField(field, index, value);\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.setRepeatedField)\n"
     "}\n"
     "public Builder addRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.addRepeatedField)\n"
     "  return (Builder) super.addRepeatedField(field, value);\n"
-    "}\n");
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$full_name$.addRepeatedField)\n"
+    "}\n",
+    "full_name", descriptor_->full_name());
 
   if (descriptor_->extension_range_count() > 0) {
     printer->Print(

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -64,6 +64,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
   (*variables)["type"] = PrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["boxed_type"] = BoxedPrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["field_type"] = (*variables)["type"];
@@ -224,11 +225,13 @@ GenerateBuilderMembers(io::Printer* printer) const {
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
@@ -480,21 +483,25 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
     "$null_check$"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
     "  if ($has_oneof_case_message$) {\n"
     "    $clear_oneof_case_message$;\n"
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
     "}\n");
 }
 
@@ -653,38 +660,46 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, $type$ value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$($type$ value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder addAll$capitalized_name$(\n"
     "    java.lang.Iterable<? extends $boxed_type$> values) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.addAll$capitalized_name$)\n"
     "  ensure$capitalized_name$IsMutable();\n"
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.addAll$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -64,7 +64,11 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
-  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
+  if(descriptor->containing_type() != NULL) {
+    (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
+  } else {
+    (*variables)["containing_type_full_name"] = descriptor->full_name();
+  }
   (*variables)["type"] = PrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["boxed_type"] = BoxedPrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["field_type"] = (*variables)["type"];
@@ -225,18 +229,19 @@ GenerateBuilderMembers(io::Printer* printer) const {
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  $clear_has_field_bit_builder$\n");
   JavaType type = GetJavaType(descriptor_);
   if (type == JAVATYPE_STRING || type == JAVATYPE_BYTES) {
@@ -251,6 +256,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 }
 
@@ -483,25 +489,25 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$($type$ value) {\n"
     "$null_check$"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  if ($has_oneof_case_message$) {\n"
     "    $clear_oneof_case_message$;\n"
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 }
 
@@ -660,46 +666,46 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, $type$ value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$($type$ value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.add$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder addAll$capitalized_name$(\n"
     "    java.lang.Iterable<? extends $boxed_type$> values) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.addAll$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "  ensure$capitalized_name$IsMutable();\n"
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.addAll$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -65,6 +65,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
 
   (*variables)["default"] = ImmutableDefaultValue(descriptor, name_resolver);
@@ -318,15 +319,18 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
     "  $clear_has_field_bit_builder$\n");
   // The default value is not a simple literal so we want to avoid executing
   // it multiple times.  Instead, get the default out of the default instance.
@@ -335,12 +339,14 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -351,6 +357,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "}\n");
 }
 
@@ -602,27 +609,32 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
     "  if ($has_oneof_case_message$) {\n"
     "    $clear_oneof_case_message$;\n"
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -633,6 +645,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$Bytes)\n"
     "}\n");
 }
 
@@ -817,45 +830,54 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$(\n"
     "    java.lang.String value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder addAll$capitalized_name$(\n"
     "    java.lang.Iterable<java.lang.String> values) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.addAll$capitalized_name$)\n"
     "  ensure$capitalized_name$IsMutable();\n"
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.addAll$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -866,6 +888,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$Bytes)\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -65,7 +65,11 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
-  (*variables)["containing_type_name"] = descriptor->containing_type()->name();
+  if(descriptor->containing_type() != NULL) {
+    (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
+  } else {
+    (*variables)["containing_type_full_name"] = descriptor->full_name();
+  }
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
 
   (*variables)["default"] = ImmutableDefaultValue(descriptor, name_resolver);
@@ -319,18 +323,18 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  $clear_has_field_bit_builder$\n");
   // The default value is not a simple literal so we want to avoid executing
   // it multiple times.  Instead, get the default out of the default instance.
@@ -339,14 +343,14 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -357,7 +361,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "}\n");
 }
 
@@ -609,32 +613,32 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    java.lang.String value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  if ($has_oneof_case_message$) {\n"
     "    $clear_oneof_case_message$;\n"
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -645,7 +649,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "}\n");
 }
 
@@ -830,54 +834,54 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$(\n"
     "    int index, java.lang.String value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.set$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.set$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$(\n"
     "    java.lang.String value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.add$capitalized_name$)\n"
     "$null_check$"
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder addAll$capitalized_name$(\n"
     "    java.lang.Iterable<java.lang.String> values) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.addAll$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "  ensure$capitalized_name$IsMutable();\n"
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.addAll$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder clear$capitalized_name$() {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.clear$capitalized_name$)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "}\n");
 
   WriteFieldDocComment(printer, descriptor_);
   printer->Print(variables_,
     "$deprecation$public Builder add$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_before:$containing_type_name$.add$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_before:$containing_type_full_name$.add$capitalized_name$Bytes)\n"
     "$null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
@@ -888,7 +892,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
     "  return this;\n"
-    "  //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_name$.add$capitalized_name$Bytes)\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$Bytes)\n"
     "}\n");
 }
 


### PR DESCRIPTION
Add the following insertion points:
- field_modifier_scope_{before,after}:<fullname>.setField
- field_modifier_scope_{before,after}:<fullname>.clearField
- field_modifier_scope_{before,after}:<fullname>.clearOneOf
- field_modifier_scope_{before,after}:<fullname>.setRepeatedField
- field_modifier_scope_{before,after}:<fullname>.addRepeatedField
- field_modifier_scope_{before,after}:<fullname>.set<capitalized_name>)
- field_modifier_scope_{before,after}:<fullname>.set<capitalized_name>Bytes)
- field_modifier_scope_{before,after}:<fullname>.add<capitalized_name>)
- field_modifier_scope_{before,after}:<fullname>.addAll<capitalized_name>Bytes)

Two entry points are provided for each at scope start and end.

Github Issue: #2684