### PR TITLE
Fixes to make Google.Protobuf.dll compatible with .NET 3.5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,6 +83,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf.Test/Collections/MapFieldTest.cs                \
   csharp/src/Google.Protobuf.Test/Collections/RepeatedFieldTest.cs           \
   csharp/src/Google.Protobuf.Test/Compatibility/PropertyInfoExtensionsTest.cs \
+  csharp/src/Google.Protobuf.Test/Compatibility/StreamExtensionsTest.cs      \
   csharp/src/Google.Protobuf.Test/Compatibility/TypeExtensionsTest.cs        \
   csharp/src/Google.Protobuf.Test/DeprecatedMemberTest.cs                    \
   csharp/src/Google.Protobuf.Test/EqualityTester.cs                          \
@@ -125,6 +126,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/Collections/ReadOnlyDictionary.cs               \
   csharp/src/Google.Protobuf/Collections/RepeatedField.cs                    \
   csharp/src/Google.Protobuf/Compatibility/PropertyInfoExtensions.cs         \
+  csharp/src/Google.Protobuf/Compatibility/StreamExtensions.cs               \
   csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs                 \
   csharp/src/Google.Protobuf/FieldCodec.cs                                   \
   csharp/src/Google.Protobuf/FrameworkPortability.cs                         \

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -32,8 +32,7 @@ Building
 ========
 
 Open the `src/Google.Protobuf.sln` solution in Visual Studio 2015 or
-later. You should be able to run the NUnit test from Test Explorer
-(you might need to install NUnit Visual Studio add-in).
+later.
 
 Although *users* of this project are only expected to have Visual
 Studio 2012 or later, *developers* of the library are required to
@@ -41,6 +40,57 @@ have Visual Studio 2015 or later, as the library uses C# 6 features
 in its implementation. These features have no impact when using the
 compiled code - they're only relevant when building the
 `Google.Protobuf` assembly.
+
+Testing
+=======
+
+The unit tests use [NUnit 3](https://github.com/nunit/nunit). Vanilla NUnit doesn't 
+support .NET Core, so to run the tests you'll need to use 
+[dotnet-test-nunit](https://github.com/nunit/dotnet-test-nunit). 
+`dotnet-test-nunit` can also run tests for .NET 4.5+, so to run the tests 
+for both .NET Core and .NET 4.5, you can simply open the 
+`Package Manager Console` in Visual Studio and execute:
+```
+dotnet test Google.Protobuf.Test
+```
+
+.NET 3.5
+========
+
+We don't officially support .NET 3.5. However, there has been some effort 
+to make enabling .NET 3.5 support relatively painless in case you require it. 
+There's no guarantee that this will continue in the future, so rely on .NET 
+3.5 support at your peril.
+
+To enable .NET 3.5 support:
+
+1. Modify [src/Google.Protobuf/project.json](src/Google.Protobuf/project.json) to add `"net35": {}` to `"frameworks"`.
+2. Modify [src/Google.Protobuf.Test/project.json](src/Google.Protobuf/project.json):
+  1. Add `"net35": {}` to `"frameworks"`.
+  2. `dotnet-test-nunit` doesn't support .NET 3.5, so remove it from 
+  the project-wide `"dependencies"` and add it to the framework-specific 
+  dependencies under `"net451"` and `"netcoreapp1.0"`.
+
+Note that `dotnet-test-nunit` doesn't support .NET 3.5. You can instead run the 
+tests with [NUnit 3 console](https://github.com/nunit/nunit-console) 
+by running something like: 
+```
+nunit3-console.exe "Google.Protobuf.Test\bin\Debug\net35\win7-x64\Google.Protobuf.Test.dll" --inprocess
+```
+
+The exact path may differ depending on your environment (e.g., the `win7-x64` 
+directory may be called something else). The `--inprocess` flag seems to be a 
+necessary workaround for a bug in NUnit; otherwise, you'll receive 
+an error "Exception has been thrown by the target of an invocation" 
+([possibly related issue](https://github.com/nunit/nunit/issues/1480)).
+
+If you still want to run the .NET 4.5 and .NET Core tests, you can do so by 
+specifying the framework when using `dotnet-test-nunit`, i.e. from 
+`Package Manager Console` in Visual Studio:
+```
+dotnet test Google.Protobuf.Test --framework netcoreapp1.0
+dotnet test Google.Protobuf.Test --framework net451
+```
 
 History of C# protobufs
 =======================

--- a/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
+++ b/csharp/src/Google.Protobuf.Test/ByteStringTest.cs
@@ -34,7 +34,7 @@ using System;
 using System.Text;
 using NUnit.Framework;
 using System.IO;
-#if !DOTNET35
+#if !NET35
 using System.Threading.Tasks;
 #endif
 
@@ -196,7 +196,7 @@ namespace Google.Protobuf
             Assert.AreEqual(expected, actual, $"{expected.ToBase64()} != {actual.ToBase64()}");
         }
 
-#if !DOTNET35
+#if !NET35
         [Test]
         public async Task FromStreamAsync_Seekable()
         {

--- a/csharp/src/Google.Protobuf.Test/Compatibility/StreamExtensionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Compatibility/StreamExtensionsTest.cs
@@ -30,43 +30,38 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-using System.Reflection;
-
-namespace Google.Protobuf.Compatibility
-{
-    /// <summary>
-    /// Extension methods for <see cref="PropertyInfo"/>, effectively providing
-    /// the familiar members from previous desktop framework versions while
-    /// targeting the newer releases, .NET Core etc.
-    /// </summary>
-    internal static class PropertyInfoExtensions
-    {
-        /// <summary>
-        /// Returns the public getter of a property, or null if there is no such getter
-        /// (either because it's read-only, or the getter isn't public).
-        /// </summary>
-        internal static MethodInfo GetGetMethod(this PropertyInfo target)
-        {
 #if NET35
-            var method = target.GetGetMethod();
-#else
-            var method = target.GetMethod;
-#endif
-            return method != null && method.IsPublic ? method : null;
+using System;
+using System.IO;
+using NUnit.Framework;
+using Google.Protobuf.Compatibility;
+
+namespace Google.Protobuf.Test.Compatibility
+{
+    public class StreamExtensionsTest
+    {
+        [Test]
+        public void CopyToNullArgument()
+        {
+            var memoryStream = new MemoryStream();
+            Assert.Throws<ArgumentNullException>(() => memoryStream.CopyTo(null));
         }
 
-        /// <summary>
-        /// Returns the public setter of a property, or null if there is no such setter
-        /// (either because it's write-only, or the setter isn't public).
-        /// </summary>
-        internal static MethodInfo GetSetMethod(this PropertyInfo target)
+        [Test]
+        public void CopyToTest()
         {
-#if NET35
-            var method = target.GetSetMethod();
-#else
-            var method = target.SetMethod;
-#endif
-            return method != null && method.IsPublic ? method : null;
+            byte[] bytesToStream = new byte[] { 0x31, 0x08, 0xFF, 0x00 };
+            Stream source = new MemoryStream(bytesToStream);
+            Stream destination = new MemoryStream((int)source.Length);
+            source.CopyTo(destination);
+            destination.Seek(0, SeekOrigin.Begin);
+
+            Assert.AreEqual(0x31, destination.ReadByte());
+            Assert.AreEqual(0x08, destination.ReadByte());
+            Assert.AreEqual(0xFF, destination.ReadByte());
+            Assert.AreEqual(0x00, destination.ReadByte());
+            Assert.AreEqual(-1, destination.ReadByte());
         }
     }
 }
+#endif

--- a/csharp/src/Google.Protobuf.Test/Compatibility/TypeExtensionsTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Compatibility/TypeExtensionsTest.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-#if !DOTNET35
+#if !NET35
 namespace Google.Protobuf.Compatibility
 {
     public class TypeExtensionsTest

--- a/csharp/src/Google.Protobuf.Test/FieldCodecTest.cs
+++ b/csharp/src/Google.Protobuf.Test/FieldCodecTest.cs
@@ -158,7 +158,9 @@ namespace Google.Protobuf
             {
                 // WriteTagAndValue ignores default values
                 var stream = new MemoryStream();
-                var codedOutput = new CodedOutputStream(stream);
+                CodedOutputStream codedOutput;
+#if !NET35
+                codedOutput = new CodedOutputStream(stream);
                 codec.WriteTagAndValue(codedOutput, codec.DefaultValue);
                 codedOutput.Flush();
                 Assert.AreEqual(0, stream.Position);
@@ -167,6 +169,7 @@ namespace Google.Protobuf
                 {
                     Assert.AreEqual(default(T), codec.DefaultValue);
                 }
+#endif
 
                 // The plain ValueWriter/ValueReader delegates don't.
                 if (codec.DefaultValue != null) // This part isn't appropriate for message types.

--- a/csharp/src/Google.Protobuf.Test/project.json
+++ b/csharp/src/Google.Protobuf.Test/project.json
@@ -20,8 +20,8 @@
 
   "dependencies": {
     "Google.Protobuf": { "target": "project" },
-    "NUnit": "3.4.0",
-    "dotnet-test-nunit": "3.4.0-alpha-2"
+    "dotnet-test-nunit": "3.4.0-beta-3",
+    "NUnit": "3.6.0"
   },
 
   "testRunner": "nunit",

--- a/csharp/src/Google.Protobuf/ByteString.cs
+++ b/csharp/src/Google.Protobuf/ByteString.cs
@@ -35,9 +35,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-#if !DOTNET35
+#if !NET35
 using System.Threading;
 using System.Threading.Tasks;
+#endif
+#if NET35
+using Google.Protobuf.Compatibility;
 #endif
 
 namespace Google.Protobuf
@@ -167,7 +170,7 @@ namespace Google.Protobuf
             return AttachBytes(bytes);
         }
 
-#if !DOTNET35
+#if !NET35
         /// <summary>
         /// Constructs a <see cref="ByteString"/> from data in the given stream, asynchronously.
         /// </summary>

--- a/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
+++ b/csharp/src/Google.Protobuf/Collections/RepeatedField.cs
@@ -47,7 +47,7 @@ namespace Google.Protobuf.Collections
     /// </remarks>
     /// <typeparam name="T">The element type of the repeated field.</typeparam>
     public sealed class RepeatedField<T> : IList<T>, IList, IDeepCloneable<RepeatedField<T>>, IEquatable<RepeatedField<T>>
-#if !DOTNET35
+#if !NET35
         , IReadOnlyList<T>
 #endif
     {

--- a/csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs
+++ b/csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs
@@ -33,7 +33,7 @@
 using System;
 using System.Reflection;
 
-#if !DOTNET35
+#if !NET35
 namespace Google.Protobuf.Compatibility
 {
     /// <summary>

--- a/csharp/src/Google.Protobuf/JsonFormatter.cs
+++ b/csharp/src/Google.Protobuf/JsonFormatter.cs
@@ -831,7 +831,7 @@ namespace Google.Protobuf
                 return originalName;
             }
 
-#if DOTNET35
+#if NET35
             // TODO: Consider adding functionality to TypeExtensions to avoid this difference.
             private static Dictionary<object, string> GetNameMapping(System.Type enumType) =>
                 enumType.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)

--- a/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/MessageDescriptor.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-#if DOTNET35
+#if NET35
 // Needed for ReadOnlyDictionary, which does not exist in .NET 3.5
 using Google.Protobuf.Collections;
 #endif

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMaskPartial.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMaskPartial.cs
@@ -59,7 +59,7 @@ namespace Google.Protobuf.WellKnownTypes
             if (firstInvalid == null)
             {
                 var writer = new StringWriter();
-#if DOTNET35
+#if NET35
                 var query = paths.Select(JsonFormatter.ToJsonName);
                 JsonFormatter.WriteString(writer, string.Join(",", query.ToArray()));
 #else


### PR DESCRIPTION
I changed the DOTNET35 conditional compilation symbols to NET35 because the NET35 seems to be defined in .NET Core projects by default, whereas DOTNET35 requires a custom definition.

I also explicitly added net35 to the project.json frameworks for Google.Protobuf and Google.Protobuf.Test, and updated the csharp README with detailed testing information.

~~Not sure if you guys are doing continuous integration with the C# stuff, but if so, you may need to make modifications after merging this to account for dotnet-test-nunit's lack of .NET 3.5 support.~~ EDIT: Looks like I was able to make the appropriate modifications needed to keep Travis and AppVeyor happy.