### PR TITLE
const FieldDescriptorCompare

### DIFF
--- a/src/google/protobuf/compiler/java/java_file.cc
+++ b/src/google/protobuf/compiler/java/java_file.cc
@@ -65,7 +65,7 @@ namespace java {
 namespace {
 
 struct FieldDescriptorCompare {
-  bool operator ()(const FieldDescriptor* f1, const FieldDescriptor* f2) {
+  bool operator ()(const FieldDescriptor* f1, const FieldDescriptor* f2) const {
     if(f1 == NULL) {
       return false;
     }


### PR DESCRIPTION
Clang now validates that <set> comparators must have a const operator():
https://reviews.llvm.org/rL291969

Discussion:
https://groups.google.com/d/msg/protobuf/9W6zFIHaJ-4/9RrfwelpEQAJ