### PR TITLE
Disable MSVC warning C4309

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -135,7 +135,7 @@ endif (protobuf_BUILD_SHARED_LIBS)
 if (MSVC)
   # Build with multiple processes
   add_definitions(/MP)
-  add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305)
+  add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305 /wd4309)
   # Allow big object
   add_definitions(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})


### PR DESCRIPTION
> warning C4309: static_cast': truncation of constant value

introduced in commit 9db5b11c9cf2922435b53495b9c1e114525f0428