### PR TITLE
README.md: Make docs URL a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Usage
 The complete documentation for Protocol Buffers is available via the
 web at:
 
-    https://developers.google.com/protocol-buffers/
+https://developers.google.com/protocol-buffers/


### PR DESCRIPTION
Dedent URL so it renders as a link and not as code (fixed width font and not clickable).