### PR TITLE
Update protobuf.bzl for recent versions of Bazel

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -88,13 +88,13 @@ _proto_gen = rule(
         "deps": attr.label_list(providers = ["proto"]),
         "includes": attr.string_list(),
         "protoc": attr.label(
-            cfg = HOST_CFG,
+            cfg = "host",
             executable = True,
             single_file = True,
             mandatory = True,
         ),
         "grpc_cpp_plugin": attr.label(
-            cfg = HOST_CFG,
+            cfg = "host",
             executable = True,
             single_file = True,
         ),


### PR DESCRIPTION
HOST_CFG has been deprecated in favor of "host".