### PR TITLE
Avoid aliasing RepeatedField<T>::Rep* during serialization.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
@@ -461,20 +461,14 @@ GenerateSerializeWithCachedSizesToArray(io::Printer* printer) const {
       "    target);\n"
       "  target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray("
       "    _$name$_cached_byte_size_, target);\n"
-      "}\n");
-  }
-  printer->Print(variables_,
-      "for (int i = 0, n = this->$name$_size(); i < n; i++) {\n");
-  if (descriptor_->is_packed()) {
-    printer->Print(variables_,
       "  target = ::google::protobuf::internal::WireFormatLite::WriteEnumNoTagToArray(\n"
-      "    this->$name$(i), target);\n");
+      "    this->$name$_, target);\n"
+      "}\n");
   } else {
     printer->Print(variables_,
-      "  target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(\n"
-      "    $number$, this->$name$(i), target);\n");
+      "target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(\n"
+      "  $number$, this->$name$_, target);\n");
   }
-  printer->Print("}\n");
 }
 
 void RepeatedEnumFieldGenerator::

--- a/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
@@ -385,6 +385,9 @@ GenerateSerializeWithCachedSizes(io::Printer* printer) const {
       "  output->WriteVarint32(_$name$_cached_byte_size_);\n");
 
     if (FixedSize(descriptor_->type()) > 0) {
+      // TODO(ckennelly): Use RepeatedField<T>::unsafe_data() via
+      // WireFormatLite to access the contents of this->$name$_ to save
+      // a branch here.
       printer->Print(variables_,
         "  ::google::protobuf::internal::WireFormatLite::Write$declared_type$Array(\n"
         "    this->$name$().data(), this->$name$_size(), output);\n");
@@ -420,20 +423,14 @@ GenerateSerializeWithCachedSizesToArray(io::Printer* printer) const {
       "    target);\n"
       "  target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(\n"
       "    _$name$_cached_byte_size_, target);\n"
-      "}\n");
-  }
-  printer->Print(variables_,
-      "for (int i = 0, n = this->$name$_size(); i < n; i++) {\n");
-  if (descriptor_->is_packed()) {
-    printer->Print(variables_,
       "  target = ::google::protobuf::internal::WireFormatLite::\n"
-      "    Write$declared_type$NoTagToArray(this->$name$(i), target);\n");
+            "    Write$declared_type$NoTagToArray(this->$name$_, target);\n"
+      "}\n");
   } else {
     printer->Print(variables_,
-      "  target = ::google::protobuf::internal::WireFormatLite::\n"
-      "    Write$declared_type$ToArray($number$, this->$name$(i), target);\n");
+      "target = ::google::protobuf::internal::WireFormatLite::\n"
+      "  Write$declared_type$ToArray($number$, this->$name$_, target);\n");
   }
-  printer->Print("}\n");
 }
 
 void RepeatedPrimitiveFieldGenerator::

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -1729,16 +1729,12 @@ void FileDescriptorProto::SerializeWithCachedSizes(
   }
 
   // repeated int32 public_dependency = 10;
-  for (int i = 0, n = this->public_dependency_size(); i < n; i++) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32ToArray(10, this->public_dependency(i), target);
-  }
+  target = ::google::protobuf::internal::WireFormatLite::
+    WriteInt32ToArray(10, this->public_dependency_, target);
 
   // repeated int32 weak_dependency = 11;
-  for (int i = 0, n = this->weak_dependency_size(); i < n; i++) {
-    target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32ToArray(11, this->weak_dependency(i), target);
-  }
+  target = ::google::protobuf::internal::WireFormatLite::
+    WriteInt32ToArray(11, this->weak_dependency_, target);
 
   // optional string syntax = 12;
   if (has_syntax()) {
@@ -14165,10 +14161,8 @@ void SourceCodeInfo_Location::SerializeWithCachedSizes(
       target);
     target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(
       _path_cached_byte_size_, target);
-  }
-  for (int i = 0, n = this->path_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32NoTagToArray(this->path(i), target);
+      WriteInt32NoTagToArray(this->path_, target);
   }
 
   // repeated int32 span = 2 [packed = true];
@@ -14179,10 +14173,8 @@ void SourceCodeInfo_Location::SerializeWithCachedSizes(
       target);
     target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(
       _span_cached_byte_size_, target);
-  }
-  for (int i = 0, n = this->span_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32NoTagToArray(this->span(i), target);
+      WriteInt32NoTagToArray(this->span_, target);
   }
 
   // optional string leading_comments = 3;
@@ -15122,10 +15114,8 @@ void GeneratedCodeInfo_Annotation::SerializeWithCachedSizes(
       target);
     target = ::google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(
       _path_cached_byte_size_, target);
-  }
-  for (int i = 0, n = this->path_size(); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
-      WriteInt32NoTagToArray(this->path(i), target);
+      WriteInt32NoTagToArray(this->path_, target);
   }
 
   // optional string source_file = 2;

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -303,6 +303,9 @@ class RepeatedField PROTOBUF_FINAL {
       }
     }
   }
+
+  friend class internal::WireFormatLite;
+  const Element* unsafe_data() const;
 };
 
 template<typename Element>
@@ -1206,6 +1209,12 @@ inline Element* RepeatedField<Element>::mutable_data() {
 template <typename Element>
 inline const Element* RepeatedField<Element>::data() const {
   return rep_ ? rep_->elements : NULL;
+}
+
+template <typename Element>
+inline const Element* RepeatedField<Element>::unsafe_data() const {
+  GOOGLE_DCHECK(rep_);
+  return rep_->elements;
 }
 
 

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -465,6 +465,45 @@ class LIBPROTOBUF_EXPORT WireFormatLite {
   INL static uint8* WriteBoolNoTagToArray    (bool value, output);
   INL static uint8* WriteEnumNoTagToArray    (int value, output);
 
+  // Write fields, without tags.  These require that value.size() > 0.
+  template<typename T>
+  INL static uint8* WritePrimitiveNoTagToArray(
+      const RepeatedField<T>& value,
+      uint8* (*Writer)(T, uint8*), uint8* target);
+  template<typename T>
+  INL static uint8* WriteFixedNoTagToArray(
+      const RepeatedField<T>& value,
+      uint8* (*Writer)(T, uint8*), uint8* target);
+
+  INL static uint8* WriteInt32NoTagToArray(
+      const RepeatedField< int32>& value, output);
+  INL static uint8* WriteInt64NoTagToArray(
+      const RepeatedField< int64>& value, output);
+  INL static uint8* WriteUInt32NoTagToArray(
+      const RepeatedField<uint32>& value, output);
+  INL static uint8* WriteUInt64NoTagToArray(
+      const RepeatedField<uint64>& value, output);
+  INL static uint8* WriteSInt32NoTagToArray(
+      const RepeatedField< int32>& value, output);
+  INL static uint8* WriteSInt64NoTagToArray(
+      const RepeatedField< int64>& value, output);
+  INL static uint8* WriteFixed32NoTagToArray(
+      const RepeatedField<uint32>& value, output);
+  INL static uint8* WriteFixed64NoTagToArray(
+      const RepeatedField<uint64>& value, output);
+  INL static uint8* WriteSFixed32NoTagToArray(
+      const RepeatedField< int32>& value, output);
+  INL static uint8* WriteSFixed64NoTagToArray(
+      const RepeatedField< int64>& value, output);
+  INL static uint8* WriteFloatNoTagToArray(
+      const RepeatedField< float>& value, output);
+  INL static uint8* WriteDoubleNoTagToArray(
+      const RepeatedField<double>& value, output);
+  INL static uint8* WriteBoolNoTagToArray(
+      const RepeatedField<  bool>& value, output);
+  INL static uint8* WriteEnumNoTagToArray(
+      const RepeatedField<   int>& value, output);
+
   // Write fields, including tags.
   INL static uint8* WriteInt32ToArray(field_number, int32 value, output);
   INL static uint8* WriteInt64ToArray(field_number, int64 value, output);
@@ -480,6 +519,41 @@ class LIBPROTOBUF_EXPORT WireFormatLite {
   INL static uint8* WriteDoubleToArray(field_number, double value, output);
   INL static uint8* WriteBoolToArray(field_number, bool value, output);
   INL static uint8* WriteEnumToArray(field_number, int value, output);
+
+  template<typename T>
+  INL static uint8* WritePrimitiveToArray(
+      field_number,
+      const RepeatedField<T>& value,
+      uint8* (*Writer)(int, T, uint8*), uint8* target);
+
+  INL static uint8* WriteInt32ToArray(
+      field_number, const RepeatedField< int32>& value, output);
+  INL static uint8* WriteInt64ToArray(
+      field_number, const RepeatedField< int64>& value, output);
+  INL static uint8* WriteUInt32ToArray(
+      field_number, const RepeatedField<uint32>& value, output);
+  INL static uint8* WriteUInt64ToArray(
+      field_number, const RepeatedField<uint64>& value, output);
+  INL static uint8* WriteSInt32ToArray(
+      field_number, const RepeatedField< int32>& value, output);
+  INL static uint8* WriteSInt64ToArray(
+      field_number, const RepeatedField< int64>& value, output);
+  INL static uint8* WriteFixed32ToArray(
+      field_number, const RepeatedField<uint32>& value, output);
+  INL static uint8* WriteFixed64ToArray(
+      field_number, const RepeatedField<uint64>& value, output);
+  INL static uint8* WriteSFixed32ToArray(
+      field_number, const RepeatedField< int32>& value, output);
+  INL static uint8* WriteSFixed64ToArray(
+      field_number, const RepeatedField< int64>& value, output);
+  INL static uint8* WriteFloatToArray(
+      field_number, const RepeatedField< float>& value, output);
+  INL static uint8* WriteDoubleToArray(
+      field_number, const RepeatedField<double>& value, output);
+  INL static uint8* WriteBoolToArray(
+      field_number, const RepeatedField<  bool>& value, output);
+  INL static uint8* WriteEnumToArray(
+      field_number, const RepeatedField<   int>& value, output);
 
   INL static uint8* WriteStringToArray(
     field_number, const string& value, output);

--- a/src/google/protobuf/wire_format_lite_inl.h
+++ b/src/google/protobuf/wire_format_lite_inl.h
@@ -671,6 +671,98 @@ inline uint8* WireFormatLite::WriteEnumNoTagToArray(int value,
   return io::CodedOutputStream::WriteVarint32SignExtendedToArray(value, target);
 }
 
+template<typename T>
+inline uint8* WireFormatLite::WritePrimitiveNoTagToArray(
+      const RepeatedField<T>& value,
+      uint8* (*Writer)(T, uint8*), uint8* target) {
+  const int n = value.size();
+  GOOGLE_DCHECK_GT(n, 0);
+
+  const T* ii = value.unsafe_data();
+  int i = 0;
+  do {
+    target = Writer(ii[i], target);
+  } while (++i < n);
+
+  return target;
+}
+
+template<typename T>
+inline uint8* WireFormatLite::WriteFixedNoTagToArray(
+      const RepeatedField<T>& value,
+      uint8* (*Writer)(T, uint8*), uint8* target) {
+#if defined(PROTOBUF_LITTLE_ENDIAN)
+  (void) Writer;
+
+  const int n = value.size();
+  GOOGLE_DCHECK_GT(n, 0);
+
+  const T* ii = value.unsafe_data();
+  const int bytes = n * sizeof(ii[0]);
+  memcpy(target, ii, bytes);
+  return target + bytes;
+#else
+  return WritePrimitiveNoTagToArray(value, Writer, target);
+#endif
+}
+
+inline uint8* WireFormatLite::WriteInt32NoTagToArray(
+    const RepeatedField< int32>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteInt32NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteInt64NoTagToArray(
+    const RepeatedField< int64>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteInt64NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteUInt32NoTagToArray(
+    const RepeatedField<uint32>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteUInt32NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteUInt64NoTagToArray(
+    const RepeatedField<uint64>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteUInt64NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteSInt32NoTagToArray(
+    const RepeatedField< int32>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteSInt32NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteSInt64NoTagToArray(
+    const RepeatedField< int64>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteSInt64NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteFixed32NoTagToArray(
+    const RepeatedField<uint32>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteFixed32NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteFixed64NoTagToArray(
+    const RepeatedField<uint64>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteFixed64NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteSFixed32NoTagToArray(
+    const RepeatedField< int32>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteSFixed32NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteSFixed64NoTagToArray(
+    const RepeatedField< int64>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteSFixed64NoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteFloatNoTagToArray(
+    const RepeatedField< float>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteFloatNoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteDoubleNoTagToArray(
+    const RepeatedField<double>& value, uint8* target) {
+  return WriteFixedNoTagToArray(value, WriteDoubleNoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteBoolNoTagToArray(
+    const RepeatedField<  bool>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteBoolNoTagToArray, target);
+}
+inline uint8* WireFormatLite::WriteEnumNoTagToArray(
+    const RepeatedField<   int>& value, uint8* target) {
+  return WritePrimitiveNoTagToArray(value, WriteEnumNoTagToArray, target);
+}
+
 inline uint8* WireFormatLite::WriteInt32ToArray(int field_number,
                                                 int32 value,
                                                 uint8* target) {
@@ -754,6 +846,86 @@ inline uint8* WireFormatLite::WriteEnumToArray(int field_number,
                                                uint8* target) {
   target = WriteTagToArray(field_number, WIRETYPE_VARINT, target);
   return WriteEnumNoTagToArray(value, target);
+}
+
+template<typename T>
+inline uint8* WireFormatLite::WritePrimitiveToArray(
+    int field_number,
+    const RepeatedField<T>& value,
+    uint8* (*Writer)(int, T, uint8*), uint8* target) {
+  const int n = value.size();
+  if (n == 0) {
+    return target;
+  }
+
+  const T* ii = value.unsafe_data();
+  int i = 0;
+  do {
+    target = Writer(field_number, ii[i], target);
+  } while (++i < n);
+
+  return target;
+}
+
+inline uint8* WireFormatLite::WriteInt32ToArray(
+    int field_number, const RepeatedField< int32>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteInt32ToArray, target);
+}
+inline uint8* WireFormatLite::WriteInt64ToArray(
+    int field_number, const RepeatedField< int64>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteInt64ToArray, target);
+}
+inline uint8* WireFormatLite::WriteUInt32ToArray(
+    int field_number, const RepeatedField<uint32>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteUInt32ToArray, target);
+}
+inline uint8* WireFormatLite::WriteUInt64ToArray(
+    int field_number, const RepeatedField<uint64>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteUInt64ToArray, target);
+}
+inline uint8* WireFormatLite::WriteSInt32ToArray(
+    int field_number, const RepeatedField< int32>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteSInt32ToArray, target);
+}
+inline uint8* WireFormatLite::WriteSInt64ToArray(
+    int field_number, const RepeatedField< int64>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteSInt64ToArray, target);
+}
+inline uint8* WireFormatLite::WriteFixed32ToArray(
+    int field_number, const RepeatedField<uint32>& value, uint8* target) {
+  return WritePrimitiveToArray(
+      field_number, value, WriteFixed32ToArray, target);
+}
+inline uint8* WireFormatLite::WriteFixed64ToArray(
+    int field_number, const RepeatedField<uint64>& value, uint8* target) {
+  return WritePrimitiveToArray(
+      field_number, value, WriteFixed64ToArray, target);
+}
+inline uint8* WireFormatLite::WriteSFixed32ToArray(
+    int field_number, const RepeatedField< int32>& value, uint8* target) {
+  return WritePrimitiveToArray(
+      field_number, value, WriteSFixed32ToArray, target);
+}
+inline uint8* WireFormatLite::WriteSFixed64ToArray(
+    int field_number, const RepeatedField< int64>& value, uint8* target) {
+  return WritePrimitiveToArray(
+      field_number, value, WriteSFixed64ToArray, target);
+}
+inline uint8* WireFormatLite::WriteFloatToArray(
+    int field_number, const RepeatedField< float>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteFloatToArray, target);
+}
+inline uint8* WireFormatLite::WriteDoubleToArray(
+    int field_number, const RepeatedField<double>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteDoubleToArray, target);
+}
+inline uint8* WireFormatLite::WriteBoolToArray(
+    int field_number, const RepeatedField<  bool>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteBoolToArray, target);
+}
+inline uint8* WireFormatLite::WriteEnumToArray(
+    int field_number, const RepeatedField<   int>& value, uint8* target) {
+  return WritePrimitiveToArray(field_number, value, WriteEnumToArray, target);
 }
 
 inline uint8* WireFormatLite::WriteStringToArray(int field_number,


### PR DESCRIPTION
This removes a load per element when a repeated primitive field by avoiding a reload of RepeatedField<T>::rep_.  This is also a data dependency for the subsequent (and remaining) load.

For fixed-sized fields, this extends the changes to SerializeWithCachedSizes in 7f3e23707 to SerializeWithCachedSizesToArray.