### PR TITLE
Use closurebuilder.py in favor of calcdeps.py for compiling JavaScript

### DIFF
--- a/js/commonjs/export.js
+++ b/js/commonjs/export.js
@@ -5,6 +5,10 @@
  * the google-protobuf.js file that we build at distribution time.
  */
 
+// Include a dummy provide statement so that closurebuilder.py does not skip over this
+// file.
+goog.provide('jspb.Export');
+
 goog.require('goog.object');
 goog.require('jspb.BinaryReader');
 goog.require('jspb.BinaryWriter');

--- a/js/commonjs/export_asserts.js
+++ b/js/commonjs/export_asserts.js
@@ -6,6 +6,10 @@
  * closure_asserts_commonjs.js that is only used at testing time.
  */
 
+// Include a dummy provide statement so that closurebuilder.py does not skip over this
+// file.
+goog.provide('jspb.ExportAsserts');
+
 goog.require('goog.testing.asserts');
 
 var global = Function('return this')();

--- a/js/commonjs/export_testdeps.js
+++ b/js/commonjs/export_testdeps.js
@@ -7,6 +7,10 @@
  * export_asserts.js.
  */
 
+// Include a dummy provide statement so that closurebuilder.py does not skip over this
+// file.
+goog.provide('jspb.ExportTestDeps');
+
 goog.require('goog.crypt.base64');
 goog.require('jspb.arith.Int64');
 goog.require('jspb.arith.UInt64');

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -59,10 +59,21 @@ gulp.task('genproto_wellknowntypes', function (cb) {
   });
 });
 
+function getClosureBuilderCommand(exportsFile, outputFile) {
+  return './node_modules/google-closure-library/closure/bin/build/closurebuilder.py ' +
+  '--root node_modules ' +
+  '-o compiled ' +
+  '--compiler_jar node_modules/google-closure-compiler/compiler.jar ' +
+  '-i ' + exportsFile + ' ' +
+  'map.js message.js binary/arith.js binary/constants.js binary/decoder.js ' +
+  'binary/encoder.js binary/reader.js binary/utils.js binary/writer.js ' +
+  exportsFile  + ' > ' + outputFile;
+}
+
 gulp.task('dist', ['genproto_wellknowntypes'], function (cb) {
   // TODO(haberman): minify this more aggressively.
   // Will require proper externs/exports.
-  exec('./node_modules/google-closure-library/closure/bin/calcdeps.py -i message.js -i binary/reader.js -i binary/writer.js -i commonjs/export.js -p . -p node_modules/google-closure-library/closure -o compiled --compiler_jar node_modules/google-closure-compiler/compiler.jar > google-protobuf.js',
+  exec(getClosureBuilderCommand('commonjs/export.js', 'google-protobuf.js'),
        function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
@@ -71,7 +82,10 @@ gulp.task('dist', ['genproto_wellknowntypes'], function (cb) {
 });
 
 gulp.task('commonjs_asserts', function (cb) {
-  exec('mkdir -p commonjs_out/test_node_modules && ./node_modules/google-closure-library/closure/bin/calcdeps.py -i commonjs/export_asserts.js -p . -p node_modules/google-closure-library/closure -o compiled --compiler_jar node_modules/google-closure-compiler/compiler.jar > commonjs_out/test_node_modules/closure_asserts_commonjs.js',
+  exec('mkdir -p commonjs_out/test_node_modules && ' +
+       getClosureBuilderCommand(
+           'commonjs/export_asserts.js',
+           'commonjs_out/test_node_modules/closure_asserts_commonjs.js'),
        function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
@@ -80,7 +94,10 @@ gulp.task('commonjs_asserts', function (cb) {
 });
 
 gulp.task('commonjs_testdeps', function (cb) {
-  exec('mkdir -p commonjs_out/test_node_modules && ./node_modules/google-closure-library/closure/bin/calcdeps.py -i commonjs/export_testdeps.js -p . -p node_modules/google-closure-library/closure -o compiled --compiler_jar node_modules/google-closure-compiler/compiler.jar > commonjs_out/test_node_modules/testdeps_commonjs.js',
+  exec('mkdir -p commonjs_out/test_node_modules && ' +
+       getClosureBuilderCommand(
+           'commonjs/export_testdeps.js',
+           'commonjs_out/test_node_modules/testdeps_commonjs.js'),
        function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);


### PR DESCRIPTION
There are two motivations for this:
1) calcdeps.py is deprecated and replaced by closurebuilder.py.
2) As part of this I was able to tweak things so that the Closure
compiler does not attempt to examine every .js file in the tree under
js/. This makes it possible to put compatibility tests and related files
in a subdirectory without them getting mixed up with the main .js files
we care about.