### PR TITLE
Undef major/minor if they are defined as macro.

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -37,6 +37,12 @@
 
 #include <stdio.h>
 #include <sys/types.h>
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #ifdef _MSC_VER

--- a/src/google/protobuf/compiler/mock_code_generator.cc
+++ b/src/google/protobuf/compiler/mock_code_generator.cc
@@ -40,7 +40,6 @@
 #endif
 #include <vector>
 
-#include <google/protobuf/compiler/plugin.pb.h>
 #include <google/protobuf/stubs/logging.h>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/testing/file.h>
@@ -53,6 +52,14 @@
 #include <google/protobuf/stubs/strutil.h>
 #include <google/protobuf/stubs/substitute.h>
 #include <gtest/gtest.h>
+
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+#include <google/protobuf/compiler/plugin.pb.h>
 
 namespace google {
 namespace protobuf {


### PR DESCRIPTION
Fixes https://github.com/google/protobuf/issues/2695

We use major/minor as field names in plugin.proto to represent version numbers and these names are unfortunately defined as macros by some header files in some platforms. This PR adds the necessary #undef's to make the code compile on these platforms.