### PR TITLE
Patched a move-constructor into the generated code

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_message.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message.cc
@@ -1039,9 +1039,12 @@ GenerateClassDefinition(io::Printer* printer) {
 
   printer->Print(vars,
     "$classname$();\n"
-    "virtual ~$classname$();\n"
-    "\n"
+    "$classname$($classname$&& from) : $classname$() {\n"
+    "  Swap(&from);\n"
+    "}\n"
     "$classname$(const $classname$& from);\n"
+    "\n"
+    "virtual ~$classname$();\n"
     "\n"
     "inline $classname$& operator=(const $classname$& from) {\n"
     "  CopyFrom(from);\n"


### PR DESCRIPTION
 - the functionality exists already, this patch just plugs it into
   C++11 move semantics
 - this way a message can be std::moved into a function (i.e. pass by value)