### PR TITLE
Return uint32 from Log2FloorNonZero64

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -358,7 +358,7 @@ class Bits {
 #endif
   }
 
-  static uint64 Log2FloorNonZero64(uint64 n) {
+  static uint32 Log2FloorNonZero64(uint64 n) {
 #if defined(__GNUC__)
   return 63 ^ __builtin_clzll(n);
 #else


### PR DESCRIPTION
A uint32 is big enough to hold any return value from that function, and
doing it this way prevents compiler warnings in coded_stream.h about
narrowing a uint64 to a uint32.