### PR TITLE
Avoid self-swap check when swapping repeated fields.

### DIFF
--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -660,9 +660,9 @@ void Api::Swap(Api* other) {
   InternalSwap(other);
 }
 void Api::InternalSwap(Api* other) {
-  methods_.UnsafeArenaSwap(&other->methods_);
-  options_.UnsafeArenaSwap(&other->options_);
-  mixins_.UnsafeArenaSwap(&other->mixins_);
+  methods_.InternalSwap(&other->methods_);
+  options_.InternalSwap(&other->options_);
+  mixins_.InternalSwap(&other->mixins_);
   name_.Swap(&other->name_);
   version_.Swap(&other->version_);
   std::swap(source_context_, other->source_context_);
@@ -1407,7 +1407,7 @@ void Method::Swap(Method* other) {
   InternalSwap(other);
 }
 void Method::InternalSwap(Method* other) {
-  options_.UnsafeArenaSwap(&other->options_);
+  options_.InternalSwap(&other->options_);
   name_.Swap(&other->name_);
   request_type_url_.Swap(&other->request_type_url_);
   response_type_url_.Swap(&other->response_type_url_);

--- a/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
@@ -318,7 +318,7 @@ GenerateMergingCode(io::Printer* printer) const {
 
 void RepeatedEnumFieldGenerator::
 GenerateSwappingCode(io::Printer* printer) const {
-  printer->Print(variables_, "$name$_.UnsafeArenaSwap(&other->$name$_);\n");
+  printer->Print(variables_, "$name$_.InternalSwap(&other->$name$_);\n");
 }
 
 void RepeatedEnumFieldGenerator::

--- a/src/google/protobuf/compiler/cpp/cpp_message_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message_field.cc
@@ -1066,7 +1066,7 @@ GenerateMergingCode(io::Printer* printer) const {
 
 void RepeatedMessageFieldGenerator::
 GenerateSwappingCode(io::Printer* printer) const {
-  printer->Print(variables_, "$name$_.UnsafeArenaSwap(&other->$name$_);\n");
+  printer->Print(variables_, "$name$_.InternalSwap(&other->$name$_);\n");
 }
 
 void RepeatedMessageFieldGenerator::

--- a/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
@@ -342,7 +342,7 @@ GenerateMergingCode(io::Printer* printer) const {
 
 void RepeatedPrimitiveFieldGenerator::
 GenerateSwappingCode(io::Printer* printer) const {
-  printer->Print(variables_, "$name$_.UnsafeArenaSwap(&other->$name$_);\n");
+  printer->Print(variables_, "$name$_.InternalSwap(&other->$name$_);\n");
 }
 
 void RepeatedPrimitiveFieldGenerator::

--- a/src/google/protobuf/compiler/cpp/cpp_string_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_string_field.cc
@@ -939,7 +939,7 @@ GenerateMergingCode(io::Printer* printer) const {
 
 void RepeatedStringFieldGenerator::
 GenerateSwappingCode(io::Printer* printer) const {
-  printer->Print(variables_, "$name$_.UnsafeArenaSwap(&other->$name$_);\n");
+  printer->Print(variables_, "$name$_.InternalSwap(&other->$name$_);\n");
 }
 
 void RepeatedStringFieldGenerator::

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -1079,8 +1079,8 @@ void CodeGeneratorRequest::Swap(CodeGeneratorRequest* other) {
   InternalSwap(other);
 }
 void CodeGeneratorRequest::InternalSwap(CodeGeneratorRequest* other) {
-  file_to_generate_.UnsafeArenaSwap(&other->file_to_generate_);
-  proto_file_.UnsafeArenaSwap(&other->proto_file_);
+  file_to_generate_.InternalSwap(&other->file_to_generate_);
+  proto_file_.InternalSwap(&other->proto_file_);
   parameter_.Swap(&other->parameter_);
   std::swap(compiler_version_, other->compiler_version_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -2144,7 +2144,7 @@ void CodeGeneratorResponse::Swap(CodeGeneratorResponse* other) {
   InternalSwap(other);
 }
 void CodeGeneratorResponse::InternalSwap(CodeGeneratorResponse* other) {
-  file_.UnsafeArenaSwap(&other->file_);
+  file_.InternalSwap(&other->file_);
   error_.Swap(&other->error_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -1146,7 +1146,7 @@ void FileDescriptorSet::Swap(FileDescriptorSet* other) {
   InternalSwap(other);
 }
 void FileDescriptorSet::InternalSwap(FileDescriptorSet* other) {
-  file_.UnsafeArenaSwap(&other->file_);
+  file_.InternalSwap(&other->file_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -1960,13 +1960,13 @@ void FileDescriptorProto::Swap(FileDescriptorProto* other) {
   InternalSwap(other);
 }
 void FileDescriptorProto::InternalSwap(FileDescriptorProto* other) {
-  dependency_.UnsafeArenaSwap(&other->dependency_);
-  public_dependency_.UnsafeArenaSwap(&other->public_dependency_);
-  weak_dependency_.UnsafeArenaSwap(&other->weak_dependency_);
-  message_type_.UnsafeArenaSwap(&other->message_type_);
-  enum_type_.UnsafeArenaSwap(&other->enum_type_);
-  service_.UnsafeArenaSwap(&other->service_);
-  extension_.UnsafeArenaSwap(&other->extension_);
+  dependency_.InternalSwap(&other->dependency_);
+  public_dependency_.InternalSwap(&other->public_dependency_);
+  weak_dependency_.InternalSwap(&other->weak_dependency_);
+  message_type_.InternalSwap(&other->message_type_);
+  enum_type_.InternalSwap(&other->enum_type_);
+  service_.InternalSwap(&other->service_);
+  extension_.InternalSwap(&other->extension_);
   name_.Swap(&other->name_);
   package_.Swap(&other->package_);
   syntax_.Swap(&other->syntax_);
@@ -3802,14 +3802,14 @@ void DescriptorProto::Swap(DescriptorProto* other) {
   InternalSwap(other);
 }
 void DescriptorProto::InternalSwap(DescriptorProto* other) {
-  field_.UnsafeArenaSwap(&other->field_);
-  extension_.UnsafeArenaSwap(&other->extension_);
-  nested_type_.UnsafeArenaSwap(&other->nested_type_);
-  enum_type_.UnsafeArenaSwap(&other->enum_type_);
-  extension_range_.UnsafeArenaSwap(&other->extension_range_);
-  oneof_decl_.UnsafeArenaSwap(&other->oneof_decl_);
-  reserved_range_.UnsafeArenaSwap(&other->reserved_range_);
-  reserved_name_.UnsafeArenaSwap(&other->reserved_name_);
+  field_.InternalSwap(&other->field_);
+  extension_.InternalSwap(&other->extension_);
+  nested_type_.InternalSwap(&other->nested_type_);
+  enum_type_.InternalSwap(&other->enum_type_);
+  extension_range_.InternalSwap(&other->extension_range_);
+  oneof_decl_.InternalSwap(&other->oneof_decl_);
+  reserved_range_.InternalSwap(&other->reserved_range_);
+  reserved_name_.InternalSwap(&other->reserved_name_);
   name_.Swap(&other->name_);
   std::swap(options_, other->options_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -6144,7 +6144,7 @@ void EnumDescriptorProto::Swap(EnumDescriptorProto* other) {
   InternalSwap(other);
 }
 void EnumDescriptorProto::InternalSwap(EnumDescriptorProto* other) {
-  value_.UnsafeArenaSwap(&other->value_);
+  value_.InternalSwap(&other->value_);
   name_.Swap(&other->name_);
   std::swap(options_, other->options_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -7117,7 +7117,7 @@ void ServiceDescriptorProto::Swap(ServiceDescriptorProto* other) {
   InternalSwap(other);
 }
 void ServiceDescriptorProto::InternalSwap(ServiceDescriptorProto* other) {
-  method_.UnsafeArenaSwap(&other->method_);
+  method_.InternalSwap(&other->method_);
   name_.Swap(&other->name_);
   std::swap(options_, other->options_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -8984,7 +8984,7 @@ void FileOptions::Swap(FileOptions* other) {
   InternalSwap(other);
 }
 void FileOptions::InternalSwap(FileOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   java_package_.Swap(&other->java_package_);
   java_outer_classname_.Swap(&other->java_outer_classname_);
   go_package_.Swap(&other->go_package_);
@@ -10022,7 +10022,7 @@ void MessageOptions::Swap(MessageOptions* other) {
   InternalSwap(other);
 }
 void MessageOptions::InternalSwap(MessageOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(message_set_wire_format_, other->message_set_wire_format_);
   std::swap(no_standard_descriptor_accessor_, other->no_standard_descriptor_accessor_);
   std::swap(deprecated_, other->deprecated_);
@@ -10638,7 +10638,7 @@ void FieldOptions::Swap(FieldOptions* other) {
   InternalSwap(other);
 }
 void FieldOptions::InternalSwap(FieldOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(ctype_, other->ctype_);
   std::swap(jstype_, other->jstype_);
   std::swap(packed_, other->packed_);
@@ -11079,7 +11079,7 @@ void OneofOptions::Swap(OneofOptions* other) {
   InternalSwap(other);
 }
 void OneofOptions::InternalSwap(OneofOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -11447,7 +11447,7 @@ void EnumOptions::Swap(EnumOptions* other) {
   InternalSwap(other);
 }
 void EnumOptions::InternalSwap(EnumOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(allow_alias_, other->allow_alias_);
   std::swap(deprecated_, other->deprecated_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -11822,7 +11822,7 @@ void EnumValueOptions::Swap(EnumValueOptions* other) {
   InternalSwap(other);
 }
 void EnumValueOptions::InternalSwap(EnumValueOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(deprecated_, other->deprecated_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -12172,7 +12172,7 @@ void ServiceOptions::Swap(ServiceOptions* other) {
   InternalSwap(other);
 }
 void ServiceOptions::InternalSwap(ServiceOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(deprecated_, other->deprecated_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
@@ -12573,7 +12573,7 @@ void MethodOptions::Swap(MethodOptions* other) {
   InternalSwap(other);
 }
 void MethodOptions::InternalSwap(MethodOptions* other) {
-  uninterpreted_option_.UnsafeArenaSwap(&other->uninterpreted_option_);
+  uninterpreted_option_.InternalSwap(&other->uninterpreted_option_);
   std::swap(deprecated_, other->deprecated_);
   std::swap(idempotency_level_, other->idempotency_level_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -13570,7 +13570,7 @@ void UninterpretedOption::Swap(UninterpretedOption* other) {
   InternalSwap(other);
 }
 void UninterpretedOption::InternalSwap(UninterpretedOption* other) {
-  name_.UnsafeArenaSwap(&other->name_);
+  name_.InternalSwap(&other->name_);
   identifier_value_.Swap(&other->identifier_value_);
   string_value_.Swap(&other->string_value_);
   aggregate_value_.Swap(&other->aggregate_value_);
@@ -14352,9 +14352,9 @@ void SourceCodeInfo_Location::Swap(SourceCodeInfo_Location* other) {
   InternalSwap(other);
 }
 void SourceCodeInfo_Location::InternalSwap(SourceCodeInfo_Location* other) {
-  path_.UnsafeArenaSwap(&other->path_);
-  span_.UnsafeArenaSwap(&other->span_);
-  leading_detached_comments_.UnsafeArenaSwap(&other->leading_detached_comments_);
+  path_.InternalSwap(&other->path_);
+  span_.InternalSwap(&other->span_);
+  leading_detached_comments_.InternalSwap(&other->leading_detached_comments_);
   leading_comments_.Swap(&other->leading_comments_);
   trailing_comments_.Swap(&other->trailing_comments_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
@@ -14842,7 +14842,7 @@ void SourceCodeInfo::Swap(SourceCodeInfo* other) {
   InternalSwap(other);
 }
 void SourceCodeInfo::InternalSwap(SourceCodeInfo* other) {
-  location_.UnsafeArenaSwap(&other->location_);
+  location_.InternalSwap(&other->location_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);
@@ -15268,7 +15268,7 @@ void GeneratedCodeInfo_Annotation::Swap(GeneratedCodeInfo_Annotation* other) {
   InternalSwap(other);
 }
 void GeneratedCodeInfo_Annotation::InternalSwap(GeneratedCodeInfo_Annotation* other) {
-  path_.UnsafeArenaSwap(&other->path_);
+  path_.InternalSwap(&other->path_);
   source_file_.Swap(&other->source_file_);
   std::swap(begin_, other->begin_);
   std::swap(end_, other->end_);
@@ -15646,7 +15646,7 @@ void GeneratedCodeInfo::Swap(GeneratedCodeInfo* other) {
   InternalSwap(other);
 }
 void GeneratedCodeInfo::InternalSwap(GeneratedCodeInfo* other) {
-  annotation_.UnsafeArenaSwap(&other->annotation_);
+  annotation_.InternalSwap(&other->annotation_);
   std::swap(_has_bits_[0], other->_has_bits_[0]);
   _internal_metadata_.Swap(&other->_internal_metadata_);
   std::swap(_cached_size_, other->_cached_size_);

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -326,7 +326,7 @@ void FieldMask::Swap(FieldMask* other) {
   InternalSwap(other);
 }
 void FieldMask::InternalSwap(FieldMask* other) {
-  paths_.UnsafeArenaSwap(&other->paths_);
+  paths_.InternalSwap(&other->paths_);
   std::swap(_cached_size_, other->_cached_size_);
 }
 

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -238,6 +238,11 @@ class RepeatedField PROTOBUF_FINAL {
     return GetArenaNoVirtual();
   }
 
+  // For internal use only.
+  //
+  // This is public due to it being called by generated code.
+  inline void InternalSwap(RepeatedField* other);
+
  private:
   static const int kInitialSize = 0;
   // A note on the representation here (see also comment below for
@@ -275,8 +280,6 @@ class RepeatedField PROTOBUF_FINAL {
 
   // Copy the elements of |from| into |to|.
   void CopyArray(Element* to, const Element* from, int size);
-
-  inline void InternalSwap(RepeatedField* other);
 
   // Internal helper expected by Arena methods.
   inline Arena* GetArenaNoVirtual() const {
@@ -970,6 +973,11 @@ class RepeatedPtrField PROTOBUF_FINAL : public internal::RepeatedPtrFieldBase {
     return GetArenaNoVirtual();
   }
 
+  // For internal use only.
+  //
+  // This is public due to it being called by generated code.
+  using RepeatedPtrFieldBase::InternalSwap;
+
  private:
   // Note:  RepeatedPtrField SHOULD NOT be subclassed by users.
   class TypeHandler;
@@ -1211,6 +1219,9 @@ inline const Element* RepeatedField<Element>::data() const {
 
 template <typename Element>
 inline void RepeatedField<Element>::InternalSwap(RepeatedField* other) {
+  GOOGLE_DCHECK(this != other);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == other->GetArenaNoVirtual());
+
   std::swap(rep_, other->rep_);
   std::swap(current_size_, other->current_size_);
   std::swap(total_size_, other->total_size_);
@@ -1232,7 +1243,6 @@ void RepeatedField<Element>::Swap(RepeatedField* other) {
 template <typename Element>
 void RepeatedField<Element>::UnsafeArenaSwap(RepeatedField* other) {
   if (this == other) return;
-  GOOGLE_DCHECK(GetArenaNoVirtual() == other->GetArenaNoVirtual());
   InternalSwap(other);
 }
 
@@ -2037,7 +2047,6 @@ inline void RepeatedPtrField<Element>::Swap(RepeatedPtrField* other) {
 template <typename Element>
 inline void RepeatedPtrField<Element>::UnsafeArenaSwap(
     RepeatedPtrField* other) {
-  GOOGLE_DCHECK(GetArenaNoVirtual() == other->GetArenaNoVirtual());
   if (this == other)
       return;
   RepeatedPtrFieldBase::InternalSwap(other);
@@ -2292,6 +2301,9 @@ class RepeatedPtrOverPtrsIterator
 };
 
 void RepeatedPtrFieldBase::InternalSwap(RepeatedPtrFieldBase* other) {
+  GOOGLE_DCHECK(this != other);
+  GOOGLE_DCHECK(GetArenaNoVirtual() == other->GetArenaNoVirtual());
+
   std::swap(rep_, other->rep_);
   std::swap(current_size_, other->current_size_);
   std::swap(total_size_, other->total_size_);

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -1739,7 +1739,7 @@ void ListValue::UnsafeArenaSwap(ListValue* other) {
   InternalSwap(other);
 }
 void ListValue::InternalSwap(ListValue* other) {
-  values_.UnsafeArenaSwap(&other->values_);
+  values_.InternalSwap(&other->values_);
   std::swap(_cached_size_, other->_cached_size_);
 }
 

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -831,9 +831,9 @@ void Type::UnsafeArenaSwap(Type* other) {
   InternalSwap(other);
 }
 void Type::InternalSwap(Type* other) {
-  fields_.UnsafeArenaSwap(&other->fields_);
-  oneofs_.UnsafeArenaSwap(&other->oneofs_);
-  options_.UnsafeArenaSwap(&other->options_);
+  fields_.InternalSwap(&other->fields_);
+  oneofs_.InternalSwap(&other->oneofs_);
+  options_.InternalSwap(&other->options_);
   name_.Swap(&other->name_);
   std::swap(source_context_, other->source_context_);
   std::swap(syntax_, other->syntax_);
@@ -1751,7 +1751,7 @@ void Field::UnsafeArenaSwap(Field* other) {
   InternalSwap(other);
 }
 void Field::InternalSwap(Field* other) {
-  options_.UnsafeArenaSwap(&other->options_);
+  options_.InternalSwap(&other->options_);
   name_.Swap(&other->name_);
   type_url_.Swap(&other->type_url_);
   json_name_.Swap(&other->json_name_);
@@ -2594,8 +2594,8 @@ void Enum::UnsafeArenaSwap(Enum* other) {
   InternalSwap(other);
 }
 void Enum::InternalSwap(Enum* other) {
-  enumvalue_.UnsafeArenaSwap(&other->enumvalue_);
-  options_.UnsafeArenaSwap(&other->options_);
+  enumvalue_.InternalSwap(&other->enumvalue_);
+  options_.InternalSwap(&other->options_);
   name_.Swap(&other->name_);
   std::swap(source_context_, other->source_context_);
   std::swap(syntax_, other->syntax_);
@@ -3132,7 +3132,7 @@ void EnumValue::UnsafeArenaSwap(EnumValue* other) {
   InternalSwap(other);
 }
 void EnumValue::InternalSwap(EnumValue* other) {
-  options_.UnsafeArenaSwap(&other->options_);
+  options_.InternalSwap(&other->options_);
   name_.Swap(&other->name_);
   std::swap(number_, other->number_);
   std::swap(_cached_size_, other->_cached_size_);


### PR DESCRIPTION
In generated code, we check for self-swap in Swap (and same Arena, for protos using Arenas) and then individually check each field for self-swap in `RepeatedField<T>::UnsafeArenaSwap`/`RepeatedPtrField<T>::UnsafeArenaSwap`.  If the first check has passed, the second (per-field) check will as well.

  `this != other` implies `&(this->some_field_) != &(other->some_field_)`

  for the same types of `this` and `other`.