### PR TITLE
Ruby: wrap calls to memcpy so that gem is compatible with pre-2.14 glibc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -795,6 +795,7 @@ ruby_EXTRA_DIST=                                                             \
   ruby/ext/google/protobuf_c/storage.c                                       \
   ruby/ext/google/protobuf_c/upb.c                                           \
   ruby/ext/google/protobuf_c/upb.h                                           \
+  ruby/ext/google/protobuf_c/wrap_memcpy.c                                   \
   ruby/google-protobuf.gemspec                                               \
   ruby/lib/google/protobuf/message_exts.rb                                   \
   ruby/lib/google/protobuf/repeated_field.rb                                 \

--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -4,7 +4,14 @@ require 'mkmf'
 
 $CFLAGS += " -std=c99 -O3 -DNDEBUG"
 
+
+if RUBY_PLATFORM =~ /linux/
+  # Instruct the linker to point memcpy calls at our __wrap_memcpy wrapper.
+  $LDFLAGS += " -Wl,-wrap,memcpy"
+end
+
 $objs = ["protobuf.o", "defs.o", "storage.o", "message.o",
-         "repeated_field.o", "map.o", "encode_decode.o", "upb.o"]
+         "repeated_field.o", "map.o", "encode_decode.o", "upb.o",
+         "wrap_memcpy.o"]
 
 create_makefile("google/protobuf_c")

--- a/ruby/ext/google/protobuf_c/wrap_memcpy.c
+++ b/ruby/ext/google/protobuf_c/wrap_memcpy.c
@@ -1,0 +1,51 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2017 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <string.h>
+
+// On x86-64 Linux, we link against the 2.2.5 version of memcpy so that we
+// avoid depending on the 2.14 version of the symbol. This way, distributions
+// that are using pre-2.14 versions of glibc can successfully use the gem we
+// distribute (https://github.com/google/protobuf/issues/2783).
+//
+// This wrapper is enabled by passing the linker flags -Wl,-wrap,memcpy in
+// extconf.rb.
+#ifdef __linux__
+#ifdef __x86_64__
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+void *__wrap_memcpy(void *dest, const void *src, size_t n) {
+    return memcpy(dest, src, n);
+}
+#else
+void *__wrap_memcpy(void *dest, const void *src, size_t n) {
+    return memmove(dest, src, n);
+}
+#endif
+#endif


### PR DESCRIPTION
This commit adds a __wrap_memcpy function and a linker flag to use that
in place of memcpy for our Ruby gem C extension. This allows us to
always use the 2.2.5 version of memcpy, making it possible to use the
gem on distributions with pre-2.14 versions of glibc.

Before this change:
$ objdump -T protobuf_c.so | grep memcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3.4 __memcpy_chk
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.14  memcpy

After:
$ objdump -T protobuf_c.so | grep memcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.2.5 memcpy
0000000000000000      DF *UND*  0000000000000000  GLIBC_2.3.4 __memcpy_chk
0000000000042450 g    DF .text  0000000000000005  Base __wrap_memcpy

This is based on gRPC's solution to a similar problem:
https://github.com/grpc/grpc/blob/5098508d2d41a116113f7e333c516cd9ef34a943/src/core/lib/support/wrap_memcpy.c
However, we have not so far run into any issues with callers using
memcpy when they should be using memmove, so in this commit I did not
add anything to redirect memcpy to memmove.

This fixes issue #2783.