### PR TITLE
Java: Mark sun.misc dependency as optional

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -132,6 +132,7 @@
             <Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
             <Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
             <Export-Package>com.google.protobuf;version=${project.version}</Export-Package>
+            <Import-Package>sun.misc;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
 Mark sun.misc dependency as optional (which it is).
The pull request makes protobuf 3 usage possible in osgi environments where sun.misc is not availabe (which is by default)