### PR TITLE
Repeated/Map field setter should accept a regular PHP array

### DIFF
--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -296,6 +296,7 @@ PHP_METHOD(Util, checkBool);
 PHP_METHOD(Util, checkString);
 PHP_METHOD(Util, checkBytes);
 PHP_METHOD(Util, checkMessage);
+PHP_METHOD(Util, checkMapField);
 PHP_METHOD(Util, checkRepeatedField);
 
 // -----------------------------------------------------------------------------
@@ -349,7 +350,11 @@ const upb_fielddef* map_entry_key(const upb_msgdef* msgdef);
 const upb_fielddef* map_entry_value(const upb_msgdef* msgdef);
 
 zend_object_value map_field_create(zend_class_entry *ce TSRMLS_DC);
-void map_field_create_with_type(zend_class_entry *ce, const upb_fielddef *field,
+void map_field_create_with_field(zend_class_entry *ce, const upb_fielddef *field,
+                                zval **map_field TSRMLS_DC);
+void map_field_create_with_type(zend_class_entry *ce, upb_fieldtype_t key_type,
+                                upb_fieldtype_t value_type,
+                                const zend_class_entry *msg_ce,
                                 zval **map_field TSRMLS_DC);
 void map_field_free(void* object TSRMLS_DC);
 void* upb_value_memory(upb_value* v);
@@ -392,8 +397,11 @@ struct RepeatedFieldIter {
   long position;
 };
 
-void repeated_field_create_with_type(zend_class_entry* ce,
+void repeated_field_create_with_field(zend_class_entry* ce,
                                      const upb_fielddef* field,
+                                     zval** repeated_field TSRMLS_DC);
+void repeated_field_create_with_type(zend_class_entry* ce, upb_fieldtype_t type,
+                                     const zend_class_entry* msg_ce,
                                      zval** repeated_field TSRMLS_DC);
 // Return the element at the index position from the repeated field. There is
 // not restriction on the type of stored elements.

--- a/php/ext/google/protobuf/storage.c
+++ b/php/ext/google/protobuf/storage.c
@@ -517,12 +517,12 @@ void layout_init(MessageLayout* layout, void* storage,
       *oneof_case = ONEOF_CASE_NONE;
     } else if (is_map_field(field)) {
       zval_ptr_dtor(property_ptr);
-      map_field_create_with_type(map_field_type, field, property_ptr TSRMLS_CC);
+      map_field_create_with_field(map_field_type, field, property_ptr TSRMLS_CC);
       DEREF(memory, zval**) = property_ptr;
     } else if (upb_fielddef_label(field) == UPB_LABEL_REPEATED) {
       zval_ptr_dtor(property_ptr);
-      repeated_field_create_with_type(repeated_field_type, field,
-                                      property_ptr TSRMLS_CC);
+      repeated_field_create_with_field(repeated_field_type, field,
+                                       property_ptr TSRMLS_CC);
       DEREF(memory, zval**) = property_ptr;
     } else {
       native_slot_init(upb_fielddef_type(field), memory, property_ptr);

--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -34,6 +34,7 @@ namespace Google\Protobuf\Internal;
 
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
+use Google\Protobuf\Internal\MapField;
 
 class GPBUtil
 {
@@ -175,19 +176,60 @@ class GPBUtil
 
     public static function checkRepeatedField(&$var, $type, $klass = null)
     {
-        if (!$var instanceof RepeatedField) {
-            trigger_error("Expect repeated field.", E_USER_ERROR);
+        if (!$var instanceof RepeatedField && !is_array($var)) {
+            trigger_error("Expect array.", E_USER_ERROR);
         }
-        if ($var->getType() != $type) {
-            trigger_error(
-                "Expect repeated field of different type.",
-                E_USER_ERROR);
+        if (is_array($var)) {
+            $tmp = new RepeatedField($type, $klass);
+            foreach ($var as $value) {
+                $tmp[] = $value;
+            }
+            return $tmp;
+        } else {
+            if ($var->getType() != $type) {
+                trigger_error(
+                    "Expect repeated field of different type.",
+                    E_USER_ERROR);
+            }
+            if ($var->getType() === GPBType::MESSAGE &&
+                $var->getClass() !== $klass) {
+                trigger_error(
+                    "Expect repeated field of different message.",
+                    E_USER_ERROR);
+            }
+            return $var;
         }
-        if ($var->getType() === GPBType::MESSAGE &&
-            $var->getClass() !== $klass) {
-            trigger_error(
-                "Expect repeated field of different message.",
-                E_USER_ERROR);
+    }
+
+    public static function checkMapField(&$var, $key_type, $value_type, $klass = null)
+    {
+        if (!$var instanceof MapField && !is_array($var)) {
+            trigger_error("Expect dict.", E_USER_ERROR);
+        }
+        if (is_array($var)) {
+            $tmp = new MapField($key_type, $value_type, $klass);
+            foreach ($var as $key => $value) {
+                $tmp[$key] = $value;
+            }
+            return $tmp;
+        } else {
+            if ($var->getKeyType() != $key_type) {
+                trigger_error(
+                    "Expect map field of key type.",
+                    E_USER_ERROR);
+            }
+            if ($var->getValueType() != $value_type) {
+                trigger_error(
+                    "Expect map field of value type.",
+                    E_USER_ERROR);
+            }
+            if ($var->getValueType() === GPBType::MESSAGE &&
+                $var->getValueClass() !== $klass) {
+                trigger_error(
+                    "Expect map field of different value message.",
+                    E_USER_ERROR);
+            }
+            return $var;
         }
     }
 

--- a/php/src/Google/Protobuf/Internal/MapField.php
+++ b/php/src/Google/Protobuf/Internal/MapField.php
@@ -204,6 +204,30 @@ class MapField implements \ArrayAccess, \IteratorAggregate, \Countable
     }
 
     /**
+     * @ignore
+     */
+    public function getKeyType()
+    {
+        return $this->key_type;
+    }
+
+    /**
+     * @ignore
+     */
+    public function getValueType()
+    {
+        return $this->value_type;
+    }
+
+    /**
+     * @ignore
+     */
+    public function getValueClass()
+    {
+        return $this->klass;
+    }
+
+    /**
      * Return the element at the given key.
      *
      * This will also be called for: $ele = $arr[$key]

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -6,6 +6,7 @@ require_once('test_base.php');
 require_once('test_util.php');
 
 use Google\Protobuf\Internal\RepeatedField;
+use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestEnum;
 use Foo\TestMessage;
@@ -526,6 +527,26 @@ class GeneratedClassTest extends TestBase
         $this->assertSame($repeated_int32, $m->getRepeatedInt32());
     }
 
+    public function testRepeatedFieldViaArray()
+    {
+        $m = new TestMessage();
+
+        $arr = array();
+        $m->setRepeatedInt32($arr);
+        $this->assertSame(0, count($m->getRepeatedInt32()));
+
+        $arr = array(1, 2.1, "3");
+        $m->setRepeatedInt32($arr);
+        $this->assertTrue($m->getRepeatedInt32() instanceof RepeatedField);
+        $this->assertSame("Google\Protobuf\Internal\RepeatedField",
+                          get_class($m->getRepeatedInt32()));
+        $this->assertSame(3, count($m->getRepeatedInt32()));
+        $this->assertSame(1, $m->getRepeatedInt32()[0]);
+        $this->assertSame(2, $m->getRepeatedInt32()[1]);
+        $this->assertSame(3, $m->getRepeatedInt32()[2]);
+        $this->assertFalse($arr instanceof RepeatedField);
+    }
+
     /**
      * @expectedException PHPUnit_Framework_Error
      */
@@ -566,6 +587,80 @@ class GeneratedClassTest extends TestBase
         $repeated_message = new RepeatedField(GPBType::MESSAGE,
                                               TestMessage::class);
         $m->setRepeatedMessage($repeated_message);
+    }
+
+    #########################################################
+    # Test map field.
+    #########################################################
+
+    public function testMapField()
+    {
+        $m = new TestMessage();
+
+        $map_int32_int32 = new MapField(GPBType::INT32, GPBType::INT32);
+        $m->setMapInt32Int32($map_int32_int32);
+        $this->assertSame($map_int32_int32, $m->getMapInt32Int32());
+    }
+
+    public function testMapFieldViaArray()
+    {
+        $m = new TestMessage();
+
+        $dict = array();
+        $m->setMapInt32Int32($dict);
+        $this->assertSame(0, count($m->getMapInt32Int32()));
+
+        $dict = array(5 => 5, 6.1 => 6.1, "7" => "7");
+        $m->setMapInt32Int32($dict);
+        $this->assertTrue($m->getMapInt32Int32() instanceof MapField);
+        $this->assertSame(3, count($m->getMapInt32Int32()));
+        $this->assertSame(5, $m->getMapInt32Int32()[5]);
+        $this->assertSame(6, $m->getMapInt32Int32()[6]);
+        $this->assertSame(7, $m->getMapInt32Int32()[7]);
+        $this->assertFalse($dict instanceof MapField);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testMapFieldWrongTypeFail()
+    {
+        $m = new TestMessage();
+        $a = 1;
+        $m->setMapInt32Int32($a);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testMapFieldWrongObjectFail()
+    {
+        $m = new TestMessage();
+        $m->setMapInt32Int32($m);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testMapFieldWrongRepeatedTypeFail()
+    {
+        $m = new TestMessage();
+
+        $map_uint32_uint32 = new MapField(GPBType::UINT32, GPBType::UINT32);
+        $m->setMapInt32Int32($map_uint32_uint32);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testMapFieldWrongRepeatedMessageClassFail()
+    {
+        $m = new TestMessage();
+
+        $map_int32_message = new MapField(GPBType::INT32,
+                                          GPBType::MESSAGE,
+                                          TestMessage::class);
+        $m->setMapInt32Message($map_int32_message);
     }
 
     #########################################################


### PR DESCRIPTION
Accept regular PHP array for repeated/map setter. Existing map/repeated
field will be swapped by a clean map/repeated field. Then, elements in
the array will be added to the map/repeated field. All elements will be
type checked before adding.

See #2686 for detail.