### PR TITLE
Use per-type table to lookup JSON name.

### DIFF
--- a/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
@@ -74,6 +74,8 @@ using google::protobuf::testing::Primitive;
 using google::protobuf::testing::Proto3Message;
 using google::protobuf::testing::Publisher;
 using google::protobuf::testing::StructType;
+using google::protobuf::testing::TestJsonName1;
+using google::protobuf::testing::TestJsonName2;
 using google::protobuf::testing::TimestampDuration;
 using google::protobuf::testing::ValueWrapper;
 using google::protobuf::testing::oneofs::OneOfsRequest;
@@ -269,6 +271,26 @@ TEST_P(ProtoStreamObjectWriterTest, CustomJsonName) {
       ->EndObject()
       ->EndObject();
   CheckOutput(book);
+}
+
+// Test that two messages can have different fields mapped to the same JSON
+// name. See: https://github.com/google/protobuf/issues/1415
+TEST_P(ProtoStreamObjectWriterTest, ConflictingJsonName) {
+  ResetTypeInfo(TestJsonName1::descriptor());
+  TestJsonName1 message1;
+  message1.set_one_value(12345);
+  ow_->StartObject("")
+      ->RenderInt32("value", 12345)
+      ->EndObject();
+  CheckOutput(message1);
+
+  ResetTypeInfo(TestJsonName2::descriptor());
+  TestJsonName2 message2;
+  message2.set_another_value(12345);
+  ow_->StartObject("")
+      ->RenderInt32("value", 12345)
+      ->EndObject();
+  CheckOutput(message2);
 }
 
 TEST_P(ProtoStreamObjectWriterTest, IntEnumValuesAreAccepted) {

--- a/src/google/protobuf/util/internal/testdata/books.proto
+++ b/src/google/protobuf/util/internal/testdata/books.proto
@@ -190,3 +190,12 @@ message Cyclic {
   repeated Author m_author = 5;
   optional Cyclic m_cyclic = 4;
 }
+
+// Test that two messages can have different fields mapped to the same JSON
+// name. See: https://github.com/google/protobuf/issues/1415
+message TestJsonName1 {
+  optional int32 one_value = 1 [json_name = "value"];
+}
+message TestJsonName2 {
+  optional int32 another_value = 1 [json_name = "value"];
+}


### PR DESCRIPTION
Fixes https://github.com/google/protobuf/issues/1415 https://github.com/google/protobuf/issues/2651

C++ JSON parser uses one global lookup table to store the mapping from JSON name to proto field name. Because different messages may have different fields mapped to the same JSON name, such a global lookup table can only store the mapping for one of the fields and that causes parse failures (https://github.com/google/protobuf/issues/1415 https://github.com/google/protobuf/issues/2651).

This PR replaces the global lookup table with per-type tables to solve the problem.