### PR TITLE
Update comments for setSizeLimit.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -354,9 +354,9 @@ public abstract class CodedInputStream {
    *
    * <p>Set the maximum message size. In order to prevent malicious messages from exhausting memory
    * or causing integer overflows, {@code CodedInputStream} limits how large a message may be. The
-   * default limit is 64MB. You should set this limit as small as you can without harming your app's
-   * functionality. Note that size limits only apply when reading from an {@code InputStream}, not
-   * when constructed around a raw byte array (nor with {@link ByteString#newCodedInput}).
+   * default limit is {@code Integer.MAX_INT}. You should set this limit as small as you can without
+   * harming your app's functionality. Note that size limits only apply when reading from an
+   * {@code InputStream}, not when constructed around a raw byte array.
    *
    * <p>If you want to read several messages from a single CodedInputStream, you could call {@link
    * #resetSizeCounter()} after each one to avoid hitting the size limit.


### PR DESCRIPTION
Fixes https://github.com/google/protobuf/issues/1251

Updated the comment about default limit and removed an incorrect comment about ByteString.newCodedInput().