### PR TITLE
Hide unnecessary exported library symbols

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,25 @@ ACX_CHECK_SUNCC
 # to the link
 AC_PROG_LIBTOOL
 
+# Check whether the linker supports version scripts
+AC_MSG_CHECKING([whether the linker supports version scripts])
+save_LDFLAGS=$LDFLAGS
+LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+cat > conftest.map <<EOF
+{
+  global:
+    main;
+  local:
+    *;
+};
+EOF
+AC_LINK_IFELSE(
+  [AC_LANG_SOURCE([int main() { return 0; }])],
+  [have_ld_version_script=yes; AC_MSG_RESULT(yes)],
+  [have_ld_version_script=no; AC_MSG_RESULT(no)])
+LDFLAGS=$save_LDFLAGS
+AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT], [test "$have_ld_version_script" == "yes"])
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h stdlib.h unistd.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,6 +180,10 @@ lib_LTLIBRARIES = libprotobuf-lite.la libprotobuf.la libprotoc.la
 
 libprotobuf_lite_la_LIBADD = $(PTHREAD_LIBS)
 libprotobuf_lite_la_LDFLAGS = -version-info 12:0:0 -export-dynamic -no-undefined
+if HAVE_LD_VERSION_SCRIPT
+libprotobuf_lite_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotobuf-lite.map
+EXTRA_libprotobuf_lite_la_DEPENDENCIES = libprotobuf-lite.map
+endif
 libprotobuf_lite_la_SOURCES =                                  \
   google/protobuf/stubs/atomicops_internals_x86_gcc.cc         \
   google/protobuf/stubs/atomicops_internals_x86_msvc.cc        \
@@ -221,6 +225,10 @@ libprotobuf_lite_la_SOURCES =                                  \
 
 libprotobuf_la_LIBADD = $(PTHREAD_LIBS)
 libprotobuf_la_LDFLAGS = -version-info 12:0:0 -export-dynamic -no-undefined
+if HAVE_LD_VERSION_SCRIPT
+libprotobuf_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotobuf.map
+EXTRA_libprotobuf_la_DEPENDENCIES = libprotobuf.map
+endif
 libprotobuf_la_SOURCES =                                       \
   $(libprotobuf_lite_la_SOURCES)                               \
   google/protobuf/any.pb.cc                                    \
@@ -305,6 +313,10 @@ nodist_libprotobuf_la_SOURCES = $(nodist_libprotobuf_lite_la_SOURCES)
 
 libprotoc_la_LIBADD = $(PTHREAD_LIBS) libprotobuf.la
 libprotoc_la_LDFLAGS = -version-info 12:0:0 -export-dynamic -no-undefined
+if HAVE_LD_VERSION_SCRIPT
+libprotoc_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libprotoc.map
+EXTRA_libprotoc_la_DEPENDENCIES = libprotoc.map
+endif
 libprotoc_la_SOURCES =                                         \
   google/protobuf/compiler/code_generator.cc                   \
   google/protobuf/compiler/command_line_interface.cc           \
@@ -580,6 +592,9 @@ EXTRA_DIST =                                                   \
   google/protobuf/compiler/ruby/ruby_generated_code_pb.rb      \
   google/protobuf/compiler/package_info.h                      \
   google/protobuf/compiler/zip_output_unittest.sh              \
+  libprotobuf-lite.map                                         \
+  libprotobuf.map                                              \
+  libprotoc.map                                                \
   README.md
 
 protoc_lite_outputs =                                          \

--- a/src/libprotobuf-lite.map
+++ b/src/libprotobuf-lite.map
@@ -1,0 +1,9 @@
+{
+  global:
+    extern "C++" {
+      *google*;
+    };
+
+  local:
+    *;
+};

--- a/src/libprotobuf.map
+++ b/src/libprotobuf.map
@@ -1,0 +1,9 @@
+{
+  global:
+    extern "C++" {
+      *google*;
+    };
+
+  local:
+    *;
+};

--- a/src/libprotoc.map
+++ b/src/libprotoc.map
@@ -1,0 +1,9 @@
+{
+  global:
+    extern "C++" {
+      *google*;
+    };
+
+  local:
+    *;
+};


### PR DESCRIPTION
The protobuf libraries currently export many symbols not useful for protobuf consumers. Although this is not usually an issue, there are some use cases where the exported symbols cause problems.

Such a problematic use case occurs due to weak symbols from C++ templates that are exported by protobuf libraries. Other libraries (including libstdc++) can bind to such symbols and prevent protobuf from properly unloading (and subsequently reloading) when protobuf itself or a library linking to it is loaded/unloaded with dlopen/dlclose. An example of such a binding from a real world example is:

binding file /usr/lib/x86_64-linux-gnu/libstdc++.so.6 [0] to /usr/lib/x86_64-linux-gnu/libprotobuf-lite.so.10 [0]: normal symbol `_ZNKSt5ctypeIcE8do_widenEc' [GLIBCXX_3.4]

This PR uses version scripts (--Wl,--version-script) to hide unnecessary symbols on platforms that support it , therefore solving problems like the one described above. Plus it's good practice to export only required symbols from libraries.

Note that the -export-symbols(-regex) libtool flag cannot be used in this case, since, at least when using gnu ld, it is implemented with --Wl,--retain-symbols-file which does not affect all the types of symbols we need to hide.