### PR TITLE
Make //:protobuf_python have correct __init__.py.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -693,6 +693,7 @@ py_proto_library(
         ":python_srcs",
         "//external:six",
     ],
+    py_extra_srcs = glob(["python/**/__init__.py"]),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Previously `//:protobuf_python` set no `__init__.py` so Bazel created an
empty one. This change makes it use the `__init__.py` from the repository.

This is necessary for anyone depending on this target who also wants to use any other library that contributes to the `google` module, like https://pypi.python.org/pypi/google-apputils.

Fixes https://github.com/google/protobuf/issues/2833.