### PR TITLE
Suppress the last unchecked warning.

### DIFF
--- a/java/core/src/test/java/com/google/protobuf/LazyStringArrayListTest.java
+++ b/java/core/src/test/java/com/google/protobuf/LazyStringArrayListTest.java
@@ -281,6 +281,7 @@ public class LazyStringArrayListTest extends TestCase {
     assertGenericListImmutable(byteArrayList, byteArrayList.get(0));
   }
   
+  @SuppressWarnings("unchecked")
   private static <T> void assertGenericListImmutable(List<T> list, T value) {
     try {
       list.add(value);


### PR DESCRIPTION
Likely to be java language issue. Varargs are considered arrays, thus
using generic with varargs will cause unchecked warning about generic
array creation.