### PR TITLE
Add property to the C#-JsonParser to ignore unknown fields during parsing

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -926,6 +926,62 @@ namespace Google.Protobuf
             Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
         }
 
+        [Test]
+        public void UnknownField_Integer()
+        {
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": 2, \"singleInt32\" : 1 }";
+            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+        }
+
+        [Test]
+        public void UnknownField_Nested()
+        {
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": { \"bb\": 20 }, \"singleInt32\" : 1 }";
+            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+        }
+
+        [Test]
+        public void UnknownField_Array()
+        {
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": [ 1, 3, 20 ], \"singleInt32\" : 1 }";
+            Assert.Throws<InvalidProtocolBufferException>(() => TestAllTypes.Parser.ParseJson(json));
+        }
+
+
+        [Test]
+        public void UnknownFieldIgnored_Integer()
+        {
+            var expected = new TestAllTypes { SingleInt32 = 1 };
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": 2, \"singleInt32\" : 1 }";
+            JsonParser parser = new JsonParser(new JsonParser.Settings(ignoreUnknownTypes:true));
+            TestAllTypes result = new TestAllTypes();
+            parser.Merge(result, json);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void UnknownFieldIgnored_Nested()
+        {
+            var expected = new TestAllTypes { SingleInt32 = 1 };
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": { \"bb\": 20 }, \"singleInt32\" : 1 }";
+            JsonParser parser = new JsonParser(new JsonParser.Settings(ignoreUnknownTypes: true));
+            TestAllTypes result = new TestAllTypes();
+            parser.Merge(result, json);
+            Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        public void UnknownFieldIgnored_Array()
+        {
+            var expected = new TestAllTypes { SingleInt32 = 1 };
+            string json = "{ \"XXXXUNKNOWNFIELDXXXXX\": [ 1, 3, 20 ], \"singleInt32\" : 1 }";
+            JsonParser parser = new JsonParser(new JsonParser.Settings(ignoreUnknownTypes: true));
+            TestAllTypes result = new TestAllTypes();
+            parser.Merge(result, json);
+            Assert.AreEqual(expected, result);
+        }
+
         /// <summary>
         /// Various tests use strings which have quotes round them for parsing or as the result
         /// of formatting, but without those quotes being specified in the tests (for the sake of readability).

--- a/csharp/src/Google.Protobuf/JsonParser.cs
+++ b/csharp/src/Google.Protobuf/JsonParser.cs
@@ -203,6 +203,11 @@ namespace Google.Protobuf
                 }
                 else
                 {
+                    if (settings.IgnoreUnknownTypes)
+                    {
+                        tokenizer.IgnoreCurrentObject(token);
+                        continue;
+                    }
                     // TODO: Is this what we want to do? If not, we'll need to skip the value,
                     // which may be an object or array. (We might want to put code in the tokenizer
                     // to do that.)
@@ -992,6 +997,11 @@ namespace Google.Protobuf
             public int RecursionLimit { get; }
 
             /// <summary>
+            /// Should an unknown Type encountered during parsing be ignored. If not set, an exception will be thrown.
+            /// </summary>
+            public bool IgnoreUnknownTypes { get; }
+
+            /// <summary>
             /// The type registry used to parse <see cref="Any"/> messages.
             /// </summary>
             public TypeRegistry TypeRegistry { get; }
@@ -1005,12 +1015,31 @@ namespace Google.Protobuf
             }
 
             /// <summary>
+            /// Creates a new <see cref="Settings"/> object with the specified unknown type handling.
+            /// </summary>
+            /// <param name="ignoreUnknownTypes">Should an unknown Type be ignored during parsing</param>
+            public Settings(bool ignoreUnknownTypes) : this(ignoreUnknownTypes, CodedInputStream.DefaultRecursionLimit, TypeRegistry.Empty)
+            {
+            }
+
+            /// <summary>
             /// Creates a new <see cref="Settings"/> object with the specified recursion limit and type registry.
             /// </summary>
             /// <param name="recursionLimit">The maximum depth of messages to parse</param>
             /// <param name="typeRegistry">The type registry used to parse <see cref="Any"/> messages</param>
-            public Settings(int recursionLimit, TypeRegistry typeRegistry)
+            public Settings(int recursionLimit, TypeRegistry typeRegistry) : this(false, recursionLimit, typeRegistry)
             {
+            }
+
+            /// <summary>
+            /// Creates a new <see cref="Settings"/> object with the specified unknown type handling, recursion limit and type registry.
+            /// </summary>
+            /// <param name="ignoreUnknownTypes">Should an unknown Type be ignored during parsing</param>
+            /// <param name="recursionLimit">The maximum depth of messages to parse</param>
+            /// <param name="typeRegistry">The type registry used to parse <see cref="Any"/> messages</param>
+            public Settings(bool ignoreUnknownTypes, int recursionLimit, TypeRegistry typeRegistry)
+            {
+                IgnoreUnknownTypes = ignoreUnknownTypes;
                 RecursionLimit = recursionLimit;
                 TypeRegistry = ProtoPreconditions.CheckNotNull(typeRegistry, nameof(typeRegistry));
             }


### PR DESCRIPTION
First version to fix #2838 . How should the JsonReplayTokenizer be handled?

It should ignore the object if it is unknown. To achieve this, the name and value is skipped if it is a simple value. If it is an array or dict, the tokens are read and discarded until the object is finished -> it has a lower remaining object-stack.