### PR TITLE
Fix freebsd build.

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_file.h
+++ b/src/google/protobuf/compiler/cpp/cpp_file.h
@@ -133,6 +133,15 @@ class FileGenerator {
 
   void GenerateProto2NamespaceEnumSpecializations(io::Printer* printer);
 
+  // Sometimes the names we use in a .proto file happen to be defined as macros
+  // on some platforms (e.g., macro/minor used in plugin.proto are defined as
+  // macros in sys/types.h on FreeBSD and a few other platforms). To make the
+  // generated code compile on these platforms, we either have to undef the
+  // macro for these few platforms, or rename the field name for all platforms.
+  // Since these names are part of protobuf public API, renaming is generally
+  // a breaking change so we prefer the #undef approach.
+  void GenerateMacroUndefs(io::Printer* printer);
+
   const FileDescriptor* file_;
   const Options options_;
 

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -30,6 +30,12 @@
 #include <google/protobuf/unknown_field_set.h>
 #include <google/protobuf/descriptor.pb.h>
 // @@protoc_insertion_point(includes)
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
 namespace google {
 namespace protobuf {
 class DescriptorProto;

--- a/src/google/protobuf/stubs/stringpiece_unittest.cc
+++ b/src/google/protobuf/stubs/stringpiece_unittest.cc
@@ -783,11 +783,13 @@ TEST(FindOneCharTest, EdgeCases) {
   EXPECT_EQ(StringPiece::npos, a.rfind('x'));
 }
 
+#ifdef PROTOBUF_HAS_DEATH_TEST
 #ifndef NDEBUG
 TEST(NonNegativeLenTest, NonNegativeLen) {
   EXPECT_DEATH(StringPiece("xyz", -1), "len >= 0");
 }
 #endif  // ndef DEBUG
+#endif  // PROTOBUF_HAS_DEATH_TEST
 
 }  // namespace
 }  // namespace protobuf


### PR DESCRIPTION
Fixes https://github.com/google/protobuf/issues/2757

It turns out system headers included by generated plugin.pb.h file already contains
major/minor macro definitions when built on FreeBSD and we need to add #undefs to
the generated header file.

This change also fixes another compile error regarding EXPECT_DEATH on FreeBSD.