### PR TITLE
Defer updating local _has_bits_ in MergeFrom.

### DIFF
--- a/src/google/protobuf/any.pb.cc
+++ b/src/google/protobuf/any.pb.cc
@@ -359,6 +359,9 @@ void Any::MergeFrom(const Any& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Any)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.type_url().size() > 0) {
 
     type_url_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_url_);

--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -618,6 +618,9 @@ void Api::MergeFrom(const Api& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Api)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   methods_.MergeFrom(from.methods_);
   options_.MergeFrom(from.options_);
   mixins_.MergeFrom(from.mixins_);
@@ -1360,6 +1363,9 @@ void Method::MergeFrom(const Method& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Method)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   options_.MergeFrom(from.options_);
   if (from.name().size() > 0) {
 
@@ -1894,6 +1900,9 @@ void Mixin::MergeFrom(const Mixin& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Mixin)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.name().size() > 0) {
 
     name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -513,14 +513,15 @@ void Version::MergeFrom(const Version& from) {
       suffix_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.suffix_);
     }
     if (cached_has_bits & 0x00000002u) {
-      set_major(from.major());
+      major_ = from.major_;
     }
     if (cached_has_bits & 0x00000004u) {
-      set_minor(from.minor());
+      minor_ = from.minor_;
     }
     if (cached_has_bits & 0x00000008u) {
-      set_patch(from.patch());
+      patch_ = from.patch_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -503,18 +503,22 @@ void Version::MergeFrom(const Version& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.compiler.Version)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 15u) {
-    if (from.has_suffix()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 15u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_suffix();
       suffix_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.suffix_);
     }
-    if (from.has_major()) {
+    if (cached_has_bits & 0x00000002u) {
       set_major(from.major());
     }
-    if (from.has_minor()) {
+    if (cached_has_bits & 0x00000004u) {
       set_minor(from.minor());
     }
-    if (from.has_patch()) {
+    if (cached_has_bits & 0x00000008u) {
       set_patch(from.patch());
     }
   }
@@ -1042,14 +1046,18 @@ void CodeGeneratorRequest::MergeFrom(const CodeGeneratorRequest& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.compiler.CodeGeneratorRequest)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   file_to_generate_.MergeFrom(from.file_to_generate_);
   proto_file_.MergeFrom(from.proto_file_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_parameter()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_parameter();
       parameter_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.parameter_);
     }
-    if (from.has_compiler_version()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_compiler_version()->::google::protobuf::compiler::Version::MergeFrom(from.compiler_version());
     }
   }
@@ -1623,16 +1631,20 @@ void CodeGeneratorResponse_File::MergeFrom(const CodeGeneratorResponse_File& fro
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.compiler.CodeGeneratorResponse.File)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 7u) {
-    if (from.has_name()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 7u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_insertion_point()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_insertion_point();
       insertion_point_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.insertion_point_);
     }
-    if (from.has_content()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_content();
       content_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.content_);
     }
@@ -2114,6 +2126,9 @@ void CodeGeneratorResponse::MergeFrom(const CodeGeneratorResponse& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.compiler.CodeGeneratorResponse)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   file_.MergeFrom(from.file_);
   if (from.has_error()) {
     set_has_error();

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -2750,11 +2750,12 @@ void DescriptorProto_ExtensionRange::MergeFrom(const DescriptorProto_ExtensionRa
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
-      set_start(from.start());
+      start_ = from.start_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_end(from.end());
+      end_ = from.end_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -3079,11 +3080,12 @@ void DescriptorProto_ReservedRange::MergeFrom(const DescriptorProto_ReservedRang
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
-      set_start(from.start());
+      start_ = from.start_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_end(from.end());
+      end_ = from.end_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -4892,19 +4894,21 @@ void FieldDescriptorProto::MergeFrom(const FieldDescriptorProto& from) {
       mutable_options()->::google::protobuf::FieldOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000040u) {
-      set_number(from.number());
+      number_ = from.number_;
     }
     if (cached_has_bits & 0x00000080u) {
-      set_oneof_index(from.oneof_index());
+      oneof_index_ = from.oneof_index_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
   if (cached_has_bits & 768u) {
     if (cached_has_bits & 0x00000100u) {
-      set_label(from.label());
+      label_ = from.label_;
     }
     if (cached_has_bits & 0x00000200u) {
-      set_type(from.type());
+      type_ = from.type_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -6635,8 +6639,9 @@ void EnumValueDescriptorProto::MergeFrom(const EnumValueDescriptorProto& from) {
       mutable_options()->::google::protobuf::EnumValueOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000004u) {
-      set_number(from.number());
+      number_ = from.number_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -7767,11 +7772,12 @@ void MethodDescriptorProto::MergeFrom(const MethodDescriptorProto& from) {
       mutable_options()->::google::protobuf::MethodOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000010u) {
-      set_client_streaming(from.client_streaming());
+      client_streaming_ = from.client_streaming_;
     }
     if (cached_has_bits & 0x00000020u) {
-      set_server_streaming(from.server_streaming());
+      server_streaming_ = from.server_streaming_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -8972,34 +8978,36 @@ void FileOptions::MergeFrom(const FileOptions& from) {
       swift_prefix_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.swift_prefix_);
     }
     if (cached_has_bits & 0x00000040u) {
-      set_java_multiple_files(from.java_multiple_files());
+      java_multiple_files_ = from.java_multiple_files_;
     }
     if (cached_has_bits & 0x00000080u) {
-      set_java_generate_equals_and_hash(from.java_generate_equals_and_hash());
+      java_generate_equals_and_hash_ = from.java_generate_equals_and_hash_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
   if (cached_has_bits & 32512u) {
     if (cached_has_bits & 0x00000100u) {
-      set_java_string_check_utf8(from.java_string_check_utf8());
+      java_string_check_utf8_ = from.java_string_check_utf8_;
     }
     if (cached_has_bits & 0x00000200u) {
-      set_cc_generic_services(from.cc_generic_services());
+      cc_generic_services_ = from.cc_generic_services_;
     }
     if (cached_has_bits & 0x00000400u) {
-      set_java_generic_services(from.java_generic_services());
+      java_generic_services_ = from.java_generic_services_;
     }
     if (cached_has_bits & 0x00000800u) {
-      set_py_generic_services(from.py_generic_services());
+      py_generic_services_ = from.py_generic_services_;
     }
     if (cached_has_bits & 0x00001000u) {
-      set_deprecated(from.deprecated());
+      deprecated_ = from.deprecated_;
     }
     if (cached_has_bits & 0x00002000u) {
-      set_cc_enable_arenas(from.cc_enable_arenas());
+      cc_enable_arenas_ = from.cc_enable_arenas_;
     }
     if (cached_has_bits & 0x00004000u) {
-      set_optimize_for(from.optimize_for());
+      optimize_for_ = from.optimize_for_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -10031,17 +10039,18 @@ void MessageOptions::MergeFrom(const MessageOptions& from) {
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 15u) {
     if (cached_has_bits & 0x00000001u) {
-      set_message_set_wire_format(from.message_set_wire_format());
+      message_set_wire_format_ = from.message_set_wire_format_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_no_standard_descriptor_accessor(from.no_standard_descriptor_accessor());
+      no_standard_descriptor_accessor_ = from.no_standard_descriptor_accessor_;
     }
     if (cached_has_bits & 0x00000004u) {
-      set_deprecated(from.deprecated());
+      deprecated_ = from.deprecated_;
     }
     if (cached_has_bits & 0x00000008u) {
-      set_map_entry(from.map_entry());
+      map_entry_ = from.map_entry_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -10645,23 +10654,24 @@ void FieldOptions::MergeFrom(const FieldOptions& from) {
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 63u) {
     if (cached_has_bits & 0x00000001u) {
-      set_ctype(from.ctype());
+      ctype_ = from.ctype_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_jstype(from.jstype());
+      jstype_ = from.jstype_;
     }
     if (cached_has_bits & 0x00000004u) {
-      set_packed(from.packed());
+      packed_ = from.packed_;
     }
     if (cached_has_bits & 0x00000008u) {
-      set_lazy(from.lazy());
+      lazy_ = from.lazy_;
     }
     if (cached_has_bits & 0x00000010u) {
-      set_deprecated(from.deprecated());
+      deprecated_ = from.deprecated_;
     }
     if (cached_has_bits & 0x00000020u) {
-      set_weak(from.weak());
+      weak_ = from.weak_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -11473,11 +11483,12 @@ void EnumOptions::MergeFrom(const EnumOptions& from) {
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
-      set_allow_alias(from.allow_alias());
+      allow_alias_ = from.allow_alias_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_deprecated(from.deprecated());
+      deprecated_ = from.deprecated_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -12609,11 +12620,12 @@ void MethodOptions::MergeFrom(const MethodOptions& from) {
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
-      set_deprecated(from.deprecated());
+      deprecated_ = from.deprecated_;
     }
     if (cached_has_bits & 0x00000002u) {
-      set_idempotency_level(from.idempotency_level());
+      idempotency_level_ = from.idempotency_level_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -13011,8 +13023,9 @@ void UninterpretedOption_NamePart::MergeFrom(const UninterpretedOption_NamePart&
       name_part_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_part_);
     }
     if (cached_has_bits & 0x00000002u) {
-      set_is_extension(from.is_extension());
+      is_extension_ = from.is_extension_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -13615,14 +13628,15 @@ void UninterpretedOption::MergeFrom(const UninterpretedOption& from) {
       aggregate_value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.aggregate_value_);
     }
     if (cached_has_bits & 0x00000008u) {
-      set_positive_int_value(from.positive_int_value());
+      positive_int_value_ = from.positive_int_value_;
     }
     if (cached_has_bits & 0x00000010u) {
-      set_negative_int_value(from.negative_int_value());
+      negative_int_value_ = from.negative_int_value_;
     }
     if (cached_has_bits & 0x00000020u) {
-      set_double_value(from.double_value());
+      double_value_ = from.double_value_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 
@@ -15328,11 +15342,12 @@ void GeneratedCodeInfo_Annotation::MergeFrom(const GeneratedCodeInfo_Annotation&
       source_file_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.source_file_);
     }
     if (cached_has_bits & 0x00000002u) {
-      set_begin(from.begin());
+      begin_ = from.begin_;
     }
     if (cached_has_bits & 0x00000004u) {
-      set_end(from.end());
+      end_ = from.end_;
     }
+    _has_bits_[0] |= cached_has_bits;
   }
 }
 

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -1119,6 +1119,9 @@ void FileDescriptorSet::MergeFrom(const FileDescriptorSet& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.FileDescriptorSet)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   file_.MergeFrom(from.file_);
 }
 
@@ -1901,6 +1904,9 @@ void FileDescriptorProto::MergeFrom(const FileDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.FileDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   dependency_.MergeFrom(from.dependency_);
   public_dependency_.MergeFrom(from.public_dependency_);
   weak_dependency_.MergeFrom(from.weak_dependency_);
@@ -1908,23 +1914,24 @@ void FileDescriptorProto::MergeFrom(const FileDescriptorProto& from) {
   enum_type_.MergeFrom(from.enum_type_);
   service_.MergeFrom(from.service_);
   extension_.MergeFrom(from.extension_);
-  if (from._has_bits_[0 / 32] & 31u) {
-    if (from.has_name()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 31u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_package()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_package();
       package_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.package_);
     }
-    if (from.has_syntax()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_syntax();
       syntax_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.syntax_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000008u) {
       mutable_options()->::google::protobuf::FileOptions::MergeFrom(from.options());
     }
-    if (from.has_source_code_info()) {
+    if (cached_has_bits & 0x00000010u) {
       mutable_source_code_info()->::google::protobuf::SourceCodeInfo::MergeFrom(from.source_code_info());
     }
   }
@@ -2737,11 +2744,15 @@ void DescriptorProto_ExtensionRange::MergeFrom(const DescriptorProto_ExtensionRa
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.DescriptorProto.ExtensionRange)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_start()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_start(from.start());
     }
-    if (from.has_end()) {
+    if (cached_has_bits & 0x00000002u) {
       set_end(from.end());
     }
   }
@@ -3062,11 +3073,15 @@ void DescriptorProto_ReservedRange::MergeFrom(const DescriptorProto_ReservedRang
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.DescriptorProto.ReservedRange)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_start()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_start(from.start());
     }
-    if (from.has_end()) {
+    if (cached_has_bits & 0x00000002u) {
       set_end(from.end());
     }
   }
@@ -3752,6 +3767,9 @@ void DescriptorProto::MergeFrom(const DescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.DescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   field_.MergeFrom(from.field_);
   extension_.MergeFrom(from.extension_);
   nested_type_.MergeFrom(from.nested_type_);
@@ -3760,12 +3778,13 @@ void DescriptorProto::MergeFrom(const DescriptorProto& from) {
   oneof_decl_.MergeFrom(from.oneof_decl_);
   reserved_range_.MergeFrom(from.reserved_range_);
   reserved_name_.MergeFrom(from.reserved_name_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_name()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_options()->::google::protobuf::MessageOptions::MergeFrom(from.options());
     }
   }
@@ -4844,42 +4863,46 @@ void FieldDescriptorProto::MergeFrom(const FieldDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.FieldDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 255u) {
-    if (from.has_name()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 255u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_type_name()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_type_name();
       type_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.type_name_);
     }
-    if (from.has_extendee()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_extendee();
       extendee_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.extendee_);
     }
-    if (from.has_default_value()) {
+    if (cached_has_bits & 0x00000008u) {
       set_has_default_value();
       default_value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.default_value_);
     }
-    if (from.has_json_name()) {
+    if (cached_has_bits & 0x00000010u) {
       set_has_json_name();
       json_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.json_name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000020u) {
       mutable_options()->::google::protobuf::FieldOptions::MergeFrom(from.options());
     }
-    if (from.has_number()) {
+    if (cached_has_bits & 0x00000040u) {
       set_number(from.number());
     }
-    if (from.has_oneof_index()) {
+    if (cached_has_bits & 0x00000080u) {
       set_oneof_index(from.oneof_index());
     }
   }
-  if (from._has_bits_[8 / 32] & 768u) {
-    if (from.has_label()) {
+  if (cached_has_bits & 768u) {
+    if (cached_has_bits & 0x00000100u) {
       set_label(from.label());
     }
-    if (from.has_type()) {
+    if (cached_has_bits & 0x00000200u) {
       set_type(from.type());
     }
   }
@@ -5646,12 +5669,16 @@ void OneofDescriptorProto::MergeFrom(const OneofDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.OneofDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_name()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_options()->::google::protobuf::OneofOptions::MergeFrom(from.options());
     }
   }
@@ -6105,13 +6132,17 @@ void EnumDescriptorProto::MergeFrom(const EnumDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.EnumDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   value_.MergeFrom(from.value_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_name()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_options()->::google::protobuf::EnumOptions::MergeFrom(from.options());
     }
   }
@@ -6591,15 +6622,19 @@ void EnumValueDescriptorProto::MergeFrom(const EnumValueDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.EnumValueDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 7u) {
-    if (from.has_name()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 7u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_options()->::google::protobuf::EnumValueOptions::MergeFrom(from.options());
     }
-    if (from.has_number()) {
+    if (cached_has_bits & 0x00000004u) {
       set_number(from.number());
     }
   }
@@ -7078,13 +7113,17 @@ void ServiceDescriptorProto::MergeFrom(const ServiceDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.ServiceDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   method_.MergeFrom(from.method_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_name()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000002u) {
       mutable_options()->::google::protobuf::ServiceOptions::MergeFrom(from.options());
     }
   }
@@ -7707,26 +7746,30 @@ void MethodDescriptorProto::MergeFrom(const MethodDescriptorProto& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.MethodDescriptorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 63u) {
-    if (from.has_name()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 63u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name();
       name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
     }
-    if (from.has_input_type()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_input_type();
       input_type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.input_type_);
     }
-    if (from.has_output_type()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_output_type();
       output_type_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.output_type_);
     }
-    if (from.has_options()) {
+    if (cached_has_bits & 0x00000008u) {
       mutable_options()->::google::protobuf::MethodOptions::MergeFrom(from.options());
     }
-    if (from.has_client_streaming()) {
+    if (cached_has_bits & 0x00000010u) {
       set_client_streaming(from.client_streaming());
     }
-    if (from.has_server_streaming()) {
+    if (cached_has_bits & 0x00000020u) {
       set_server_streaming(from.server_streaming());
     }
   }
@@ -8898,59 +8941,63 @@ void FileOptions::MergeFrom(const FileOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
-  if (from._has_bits_[0 / 32] & 255u) {
-    if (from.has_java_package()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 255u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_java_package();
       java_package_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.java_package_);
     }
-    if (from.has_java_outer_classname()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_java_outer_classname();
       java_outer_classname_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.java_outer_classname_);
     }
-    if (from.has_go_package()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_go_package();
       go_package_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.go_package_);
     }
-    if (from.has_objc_class_prefix()) {
+    if (cached_has_bits & 0x00000008u) {
       set_has_objc_class_prefix();
       objc_class_prefix_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.objc_class_prefix_);
     }
-    if (from.has_csharp_namespace()) {
+    if (cached_has_bits & 0x00000010u) {
       set_has_csharp_namespace();
       csharp_namespace_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.csharp_namespace_);
     }
-    if (from.has_swift_prefix()) {
+    if (cached_has_bits & 0x00000020u) {
       set_has_swift_prefix();
       swift_prefix_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.swift_prefix_);
     }
-    if (from.has_java_multiple_files()) {
+    if (cached_has_bits & 0x00000040u) {
       set_java_multiple_files(from.java_multiple_files());
     }
-    if (from.has_java_generate_equals_and_hash()) {
+    if (cached_has_bits & 0x00000080u) {
       set_java_generate_equals_and_hash(from.java_generate_equals_and_hash());
     }
   }
-  if (from._has_bits_[8 / 32] & 32512u) {
-    if (from.has_java_string_check_utf8()) {
+  if (cached_has_bits & 32512u) {
+    if (cached_has_bits & 0x00000100u) {
       set_java_string_check_utf8(from.java_string_check_utf8());
     }
-    if (from.has_cc_generic_services()) {
+    if (cached_has_bits & 0x00000200u) {
       set_cc_generic_services(from.cc_generic_services());
     }
-    if (from.has_java_generic_services()) {
+    if (cached_has_bits & 0x00000400u) {
       set_java_generic_services(from.java_generic_services());
     }
-    if (from.has_py_generic_services()) {
+    if (cached_has_bits & 0x00000800u) {
       set_py_generic_services(from.py_generic_services());
     }
-    if (from.has_deprecated()) {
+    if (cached_has_bits & 0x00001000u) {
       set_deprecated(from.deprecated());
     }
-    if (from.has_cc_enable_arenas()) {
+    if (cached_has_bits & 0x00002000u) {
       set_cc_enable_arenas(from.cc_enable_arenas());
     }
-    if (from.has_optimize_for()) {
+    if (cached_has_bits & 0x00004000u) {
       set_optimize_for(from.optimize_for());
     }
   }
@@ -9977,18 +10024,22 @@ void MessageOptions::MergeFrom(const MessageOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
-  if (from._has_bits_[0 / 32] & 15u) {
-    if (from.has_message_set_wire_format()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 15u) {
+    if (cached_has_bits & 0x00000001u) {
       set_message_set_wire_format(from.message_set_wire_format());
     }
-    if (from.has_no_standard_descriptor_accessor()) {
+    if (cached_has_bits & 0x00000002u) {
       set_no_standard_descriptor_accessor(from.no_standard_descriptor_accessor());
     }
-    if (from.has_deprecated()) {
+    if (cached_has_bits & 0x00000004u) {
       set_deprecated(from.deprecated());
     }
-    if (from.has_map_entry()) {
+    if (cached_has_bits & 0x00000008u) {
       set_map_entry(from.map_entry());
     }
   }
@@ -10587,24 +10638,28 @@ void FieldOptions::MergeFrom(const FieldOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
-  if (from._has_bits_[0 / 32] & 63u) {
-    if (from.has_ctype()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 63u) {
+    if (cached_has_bits & 0x00000001u) {
       set_ctype(from.ctype());
     }
-    if (from.has_jstype()) {
+    if (cached_has_bits & 0x00000002u) {
       set_jstype(from.jstype());
     }
-    if (from.has_packed()) {
+    if (cached_has_bits & 0x00000004u) {
       set_packed(from.packed());
     }
-    if (from.has_lazy()) {
+    if (cached_has_bits & 0x00000008u) {
       set_lazy(from.lazy());
     }
-    if (from.has_deprecated()) {
+    if (cached_has_bits & 0x00000010u) {
       set_deprecated(from.deprecated());
     }
-    if (from.has_weak()) {
+    if (cached_has_bits & 0x00000020u) {
       set_weak(from.weak());
     }
   }
@@ -11048,6 +11103,9 @@ void OneofOptions::MergeFrom(const OneofOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
 }
 
@@ -11408,12 +11466,16 @@ void EnumOptions::MergeFrom(const EnumOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_allow_alias()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_allow_alias(from.allow_alias());
     }
-    if (from.has_deprecated()) {
+    if (cached_has_bits & 0x00000002u) {
       set_deprecated(from.deprecated());
     }
   }
@@ -11788,6 +11850,9 @@ void EnumValueOptions::MergeFrom(const EnumValueOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
   if (from.has_deprecated()) {
     set_deprecated(from.deprecated());
@@ -12138,6 +12203,9 @@ void ServiceOptions::MergeFrom(const ServiceOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
   if (from.has_deprecated()) {
     set_deprecated(from.deprecated());
@@ -12534,12 +12602,16 @@ void MethodOptions::MergeFrom(const MethodOptions& from) {
   GOOGLE_DCHECK_NE(&from, this);
   _extensions_.MergeFrom(from._extensions_);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   uninterpreted_option_.MergeFrom(from.uninterpreted_option_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_deprecated()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_deprecated(from.deprecated());
     }
-    if (from.has_idempotency_level()) {
+    if (cached_has_bits & 0x00000002u) {
       set_idempotency_level(from.idempotency_level());
     }
   }
@@ -12929,12 +13001,16 @@ void UninterpretedOption_NamePart::MergeFrom(const UninterpretedOption_NamePart&
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.UninterpretedOption.NamePart)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_name_part()) {
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_name_part();
       name_part_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_part_);
     }
-    if (from.has_is_extension()) {
+    if (cached_has_bits & 0x00000002u) {
       set_is_extension(from.is_extension());
     }
   }
@@ -13520,27 +13596,31 @@ void UninterpretedOption::MergeFrom(const UninterpretedOption& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.UninterpretedOption)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   name_.MergeFrom(from.name_);
-  if (from._has_bits_[0 / 32] & 63u) {
-    if (from.has_identifier_value()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 63u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_identifier_value();
       identifier_value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.identifier_value_);
     }
-    if (from.has_string_value()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_string_value();
       string_value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.string_value_);
     }
-    if (from.has_aggregate_value()) {
+    if (cached_has_bits & 0x00000004u) {
       set_has_aggregate_value();
       aggregate_value_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.aggregate_value_);
     }
-    if (from.has_positive_int_value()) {
+    if (cached_has_bits & 0x00000008u) {
       set_positive_int_value(from.positive_int_value());
     }
-    if (from.has_negative_int_value()) {
+    if (cached_has_bits & 0x00000010u) {
       set_negative_int_value(from.negative_int_value());
     }
-    if (from.has_double_value()) {
+    if (cached_has_bits & 0x00000020u) {
       set_double_value(from.double_value());
     }
   }
@@ -14314,15 +14394,19 @@ void SourceCodeInfo_Location::MergeFrom(const SourceCodeInfo_Location& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.SourceCodeInfo.Location)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   path_.MergeFrom(from.path_);
   span_.MergeFrom(from.span_);
   leading_detached_comments_.MergeFrom(from.leading_detached_comments_);
-  if (from._has_bits_[0 / 32] & 3u) {
-    if (from.has_leading_comments()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 3u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_leading_comments();
       leading_comments_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.leading_comments_);
     }
-    if (from.has_trailing_comments()) {
+    if (cached_has_bits & 0x00000002u) {
       set_has_trailing_comments();
       trailing_comments_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.trailing_comments_);
     }
@@ -14816,6 +14900,9 @@ void SourceCodeInfo::MergeFrom(const SourceCodeInfo& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.SourceCodeInfo)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   location_.MergeFrom(from.location_);
 }
 
@@ -15230,16 +15317,20 @@ void GeneratedCodeInfo_Annotation::MergeFrom(const GeneratedCodeInfo_Annotation&
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.GeneratedCodeInfo.Annotation)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   path_.MergeFrom(from.path_);
-  if (from._has_bits_[0 / 32] & 7u) {
-    if (from.has_source_file()) {
+  cached_has_bits = from._has_bits_[0];
+  if (cached_has_bits & 7u) {
+    if (cached_has_bits & 0x00000001u) {
       set_has_source_file();
       source_file_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.source_file_);
     }
-    if (from.has_begin()) {
+    if (cached_has_bits & 0x00000002u) {
       set_begin(from.begin());
     }
-    if (from.has_end()) {
+    if (cached_has_bits & 0x00000004u) {
       set_end(from.end());
     }
   }
@@ -15620,6 +15711,9 @@ void GeneratedCodeInfo::MergeFrom(const GeneratedCodeInfo& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.GeneratedCodeInfo)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   annotation_.MergeFrom(from.annotation_);
 }
 

--- a/src/google/protobuf/duration.pb.cc
+++ b/src/google/protobuf/duration.pb.cc
@@ -341,6 +341,9 @@ void Duration::MergeFrom(const Duration& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Duration)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.seconds() != 0) {
     set_seconds(from.seconds());
   }

--- a/src/google/protobuf/empty.pb.cc
+++ b/src/google/protobuf/empty.pb.cc
@@ -262,6 +262,9 @@ void Empty::MergeFrom(const Empty& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Empty)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
 }
 
 void Empty::CopyFrom(const ::google::protobuf::Message& from) {

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -300,6 +300,9 @@ void FieldMask::MergeFrom(const FieldMask& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.FieldMask)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   paths_.MergeFrom(from.paths_);
 }
 

--- a/src/google/protobuf/source_context.pb.cc
+++ b/src/google/protobuf/source_context.pb.cc
@@ -305,6 +305,9 @@ void SourceContext::MergeFrom(const SourceContext& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.SourceContext)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.file_name().size() > 0) {
 
     file_name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.file_name_);

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -527,6 +527,9 @@ void Struct::MergeFrom(const Struct& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Struct)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   fields_.MergeFrom(from.fields_);
 }
 
@@ -1039,6 +1042,9 @@ void Value::MergeFrom(const Value& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Value)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   switch (from.kind_case()) {
     case kNullValue: {
       set_null_value(from.null_value());
@@ -1698,6 +1704,9 @@ void ListValue::MergeFrom(const ListValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.ListValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   values_.MergeFrom(from.values_);
 }
 

--- a/src/google/protobuf/timestamp.pb.cc
+++ b/src/google/protobuf/timestamp.pb.cc
@@ -341,6 +341,9 @@ void Timestamp::MergeFrom(const Timestamp& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Timestamp)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.seconds() != 0) {
     set_seconds(from.seconds());
   }

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -779,6 +779,9 @@ void Type::MergeFrom(const Type& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Type)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   fields_.MergeFrom(from.fields_);
   oneofs_.MergeFrom(from.oneofs_);
   options_.MergeFrom(from.options_);
@@ -1683,6 +1686,9 @@ void Field::MergeFrom(const Field& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Field)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   options_.MergeFrom(from.options_);
   if (from.name().size() > 0) {
     set_name(from.name());
@@ -2543,6 +2549,9 @@ void Enum::MergeFrom(const Enum& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Enum)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   enumvalue_.MergeFrom(from.enumvalue_);
   options_.MergeFrom(from.options_);
   if (from.name().size() > 0) {
@@ -3085,6 +3094,9 @@ void EnumValue::MergeFrom(const EnumValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.EnumValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   options_.MergeFrom(from.options_);
   if (from.name().size() > 0) {
     set_name(from.name());
@@ -3542,6 +3554,9 @@ void Option::MergeFrom(const Option& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Option)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.name().size() > 0) {
     set_name(from.name());
   }

--- a/src/google/protobuf/wrappers.pb.cc
+++ b/src/google/protobuf/wrappers.pb.cc
@@ -404,6 +404,9 @@ void DoubleValue::MergeFrom(const DoubleValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.DoubleValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -660,6 +663,9 @@ void FloatValue::MergeFrom(const FloatValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.FloatValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -918,6 +924,9 @@ void Int64Value::MergeFrom(const Int64Value& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Int64Value)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -1176,6 +1185,9 @@ void UInt64Value::MergeFrom(const UInt64Value& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.UInt64Value)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -1434,6 +1446,9 @@ void Int32Value::MergeFrom(const Int32Value& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.Int32Value)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -1692,6 +1707,9 @@ void UInt32Value::MergeFrom(const UInt32Value& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.UInt32Value)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -1948,6 +1966,9 @@ void BoolValue::MergeFrom(const BoolValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.BoolValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value() != 0) {
     set_value(from.value());
   }
@@ -2224,6 +2245,9 @@ void StringValue::MergeFrom(const StringValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.StringValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value().size() > 0) {
     set_value(from.value());
   }
@@ -2540,6 +2564,9 @@ void BytesValue::MergeFrom(const BytesValue& from) {
 // @@protoc_insertion_point(class_specific_merge_from_start:google.protobuf.BytesValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
   if (from.value().size() > 0) {
     set_value(from.value());
   }


### PR DESCRIPTION
This can save us up to 7 load/or/stores per 8 fields, as the compiler may assume that `&from` and `this` alias each other, so the local `_has_bits_` need to be reloaded with each field.

This extends #2850.