### PR TITLE
Add a notice for nano.

### DIFF
--- a/javanano/README.md
+++ b/javanano/README.md
@@ -7,6 +7,9 @@ Copyright 2008 Google Inc.
 
 This directory contains the Java Protocol Buffers Nano runtime library.
 
+**Nano is no longer supported by protobuf team. We recommend Android users to
+use protobuf lite runtime instead.**
+
 Installation - With Maven
 -------------------------
 


### PR DESCRIPTION
We no longer supports nano and recommend protobuf lite over nano for
Android users.