### PR TITLE
Ruby: only link against specific version of memcpy if we're using glibc

### DIFF
--- a/ruby/ext/google/protobuf_c/wrap_memcpy.c
+++ b/ruby/ext/google/protobuf_c/wrap_memcpy.c
@@ -30,15 +30,15 @@
 
 #include <string.h>
 
-// On x86-64 Linux, we link against the 2.2.5 version of memcpy so that we
-// avoid depending on the 2.14 version of the symbol. This way, distributions
-// that are using pre-2.14 versions of glibc can successfully use the gem we
-// distribute (https://github.com/google/protobuf/issues/2783).
+// On x86-64 Linux with glibc, we link against the 2.2.5 version of memcpy so
+// that we avoid depending on the 2.14 version of the symbol. This way,
+// distributions that are using pre-2.14 versions of glibc can successfully use
+// the gem we distribute (https://github.com/google/protobuf/issues/2783).
 //
 // This wrapper is enabled by passing the linker flags -Wl,-wrap,memcpy in
 // extconf.rb.
 #ifdef __linux__
-#ifdef __x86_64__
+#if defined(__x86_64__) && defined(__GNU_LIBRARY__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 void *__wrap_memcpy(void *dest, const void *src, size_t n) {
     return memcpy(dest, src, n);


### PR DESCRIPTION
We have some special code in wrap_memcpy.c to ensure that we use the
2.2.5 version of memcpy, for compatibility with older versions of glibc.
However, we need to make sure we only attempt to do this when we are
actually building with glibc, so that the code can also build
successfully against other libc implementations such as musl.