### PR TITLE
Compile the Java proto runtime with Java 6

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -570,6 +570,7 @@ java_library(
     ]) + [
         ":gen_well_known_protos_java",
     ],
+    javacopts = ["-source 6"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
in order to avoid errors related to generics when 
building user code in newer versions of Java.