### PR TITLE
Remove the use of dispatch_once that is heap backed.

### DIFF
--- a/objectivec/GPBMessage_PackagePrivate.h
+++ b/objectivec/GPBMessage_PackagePrivate.h
@@ -70,7 +70,6 @@ typedef struct GPBMessage_Storage *GPBMessage_StoragePtr;
   // Use of readOnlySemaphore_ must be prefaced by a call to
   // GPBPrepareReadOnlySemaphore to ensure it has been created. This allows
   // readOnlySemaphore_ to be only created when actually needed.
-  dispatch_once_t readOnlySemaphoreCreationOnce_;
   dispatch_semaphore_t readOnlySemaphore_;
 }
 
@@ -105,22 +104,7 @@ CF_EXTERN_C_BEGIN
 
 
 // Call this before using the readOnlySemaphore_. This ensures it is created only once.
-NS_INLINE void GPBPrepareReadOnlySemaphore(GPBMessage *self) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-
-// Starting on Xcode 8.3, the static analyzer complains that the dispatch_once_t
-// variable passed to dispatch_once should not be allocated on the heap or
-// stack. Given that the semaphore is also an instance variable of the message,
-// both variables are cleared at the same time, so this is safe.
-#if !defined(__clang_analyzer__)
-  dispatch_once(&self->readOnlySemaphoreCreationOnce_, ^{
-    self->readOnlySemaphore_ = dispatch_semaphore_create(1);
-  });
-#endif  // !defined(__clang_analyzer__)
-
-#pragma clang diagnostic pop
-}
+void GPBPrepareReadOnlySemaphore(GPBMessage *self);
 
 // Returns a new instance that was automatically created by |autocreator| for
 // its field |field|.


### PR DESCRIPTION
Apple recently updated the docs on dispatch_once to point out
that the storage for the dispatch_once_t must be static or global,
but not something that was ever used before as the implementation
doesn't use a memory barrier.  So we drop the use and create the
semaphore when needed and use an atomic swap deal with any
threading races.