### PR TITLE
Adding default shell env to allow non-default compilers

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -108,6 +108,7 @@ def _proto_gen_impl(ctx):
         arguments=args + import_flags + [s.path for s in srcs],
         executable=ctx.executable.protoc,
         mnemonic="ProtoCompile",
+        use_default_shell_env=True,
     )
 
   return struct(


### PR DESCRIPTION
I am adding default shell environment, so that protobuf compilation makes use of set
LD_LIBRARY_PATH and so on.
In this way, also non-default gcc installations (e.g. not in /usr/lib) can be used to compile protobuf.
This would fix the following issue:
https://github.com/bazelbuild/bazel/issues/2515