### PR TITLE
Simplify the Element dtor invocation when freeing elements in InternalDeallocate

### DIFF
--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -291,7 +291,7 @@ class RepeatedField PROTOBUF_FINAL {
       Element* e = &rep->elements[0];
       Element* limit = &rep->elements[size];
       for (; e < limit; e++) {
-        e->Element::~Element();
+        e->~Element();
       }
       if (rep->arena == NULL) {
 #if defined(__GXX_DELETE_WITH_SIZE__) || defined(__cpp_sized_deallocation)


### PR DESCRIPTION
Simplify the Element dtor invocation when freeing elements in InternalDeallocate to avoid confusing the compiler when there's a class named Element already defined in the global namespace. Fixes [issue 2972](https://github.com/google/protobuf/issues/2972).