### PR TITLE
Allow proto files to import descriptor.proto

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -656,6 +656,7 @@ php_EXTRA_DIST=                                                       \
   php/tests/map_field_test.php                                        \
   php/tests/memory_leak_test.php                                      \
   php/tests/php_implementation_test.php                               \
+  php/tests/proto/test_import_descriptor_proto.proto                  \
   php/tests/proto/test_include.proto                                  \
   php/tests/proto/test.proto                                          \
   php/tests/proto/test_prefix.proto                                   \

--- a/php/src/Google/Protobuf/Internal/MapField.php
+++ b/php/src/Google/Protobuf/Internal/MapField.php
@@ -155,7 +155,6 @@ function checkKey($key_type, &$key)
             GPBUtil::checkString($key, true);
             break;
         default:
-            var_dump($key_type);
             trigger_error(
                 "Given type cannot be map key.",
                 E_USER_ERROR);

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -71,7 +71,6 @@ class Message
             return;
         }
         $pool = DescriptorPool::getGeneratedPool();
-        var_dump(get_class($this));
         $this->desc = $pool->getDescriptorByClassName(get_class($this));
         foreach ($this->desc->getField() as $field) {
             $setter = $field->getSetter();

--- a/php/tests/gdb_test.sh
+++ b/php/tests/gdb_test.sh
@@ -3,7 +3,7 @@
 # gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which
 # phpunit` --bootstrap autoload.php tmp_test.php
 #
-gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php encode_decode_test.php
+gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php well_known_test.php
 #
 # gdb --args php -dextension=../ext/google/protobuf/modules/protobuf.so memory_leak_test.php
 #

--- a/php/tests/proto/test_import_descriptor_proto.proto
+++ b/php/tests/proto/test_import_descriptor_proto.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+message TestImportDescriptorProto {
+  extend google.protobuf.MethodOptions {
+    int32 a = 72295727;
+  }
+}
+
+extend google.protobuf.MethodOptions {
+  int32 a = 72295728;
+}
+

--- a/php/tests/well_known_test.php
+++ b/php/tests/well_known_test.php
@@ -4,8 +4,14 @@ use Google\Protobuf\GPBEmpty;
 
 class WellKnownTest extends PHPUnit_Framework_TestCase {
 
-    public function testNone() {
-      $msg = new GPBEmpty();
+    public function testNone()
+    {
+        $msg = new GPBEmpty();
+    }
+
+    public function testImportDescriptorProto()
+    {
+        $msg = new TestImportDescriptorProto();
     }
 
 }

--- a/tests.sh
+++ b/tests.sh
@@ -362,6 +362,7 @@ generate_php_test_proto() {
   ../../src/protoc --php_out=generated proto/test.proto proto/test_include.proto proto/test_no_namespace.proto proto/test_prefix.proto
   pushd ../../src
   ./protoc --php_out=../php/tests/generated google/protobuf/empty.proto
+  ./protoc --php_out=../php/tests/generated -I../php/tests -I. ../php/tests/proto/test_import_descriptor_proto.proto
   popd
   popd
 }


### PR DESCRIPTION
descriptor.proto uses proto2 syntax, which is not ready for external
usage. However, some proto3 files import descriptor.proto and cannot be
used. In this PR, all references (We cheated by only removing
extensions, which is enough for now. User should avoid using messages
defined in descriptor.proto as field type.) to content in
descriptor.proto are removed from generated files. Those that import
descriptor.proto can be used like other proto files.
Fix #2901.