### PR TITLE
Bugfix: Enum classes not escaped properly

### DIFF
--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -459,7 +459,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, bool is_descriptor,
           MessageName(value->message_type(), is_descriptor) + "::class");
     } else if (value->cpp_type() == FieldDescriptor::CPPTYPE_ENUM) {
       printer->Print(
-          ", ^class_name^);\n",
+          ", ^\\class_name^);\n",
           "class_name",
           EnumName(value->enum_type(), is_descriptor) + "::class");
     } else {

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -477,7 +477,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, bool is_descriptor,
           MessageName(field->message_type(), is_descriptor) + "::class");
     } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_ENUM) {
       printer->Print(
-          ", ^class_name^);\n",
+          ", ^\\class_name^);\n",
           "class_name",
           EnumName(field->enum_type(), is_descriptor) + "::class");
     } else {


### PR DESCRIPTION
The php generator isn't escaping classes properly for calls to `GPBUtil::checkRepeatedField` and `GPBUtil::checkMapField`. The current generator generates the following code:

```
GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::ENUM, My\Namespace\Foo::class);
```

Which results in an error when trying to use the class outside of its package. This fix properly escapes the class import to generate the following.  

```
GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::ENUM, \My\Namespace\Foo::class);
```