### PR TITLE
Remove unused constants.

### DIFF
--- a/src/google/protobuf/util/time_util.cc
+++ b/src/google/protobuf/util/time_util.cc
@@ -49,11 +49,9 @@ static const int kNanosPerSecond = 1000000000;
 static const int kMicrosPerSecond = 1000000;
 static const int kMillisPerSecond = 1000;
 static const int kNanosPerMillisecond = 1000000;
-static const int kMicrosPerMillisecond = 1000;
 static const int kNanosPerMicrosecond = 1000;
 static const int kSecondsPerMinute = 60;  // Note that we ignore leap seconds.
 static const int kSecondsPerHour = 3600;
-static const char kTimestampFormat[] = "%E4Y-%m-%dT%H:%M:%S";
 
 template <typename T>
 T CreateNormalized(int64 seconds, int64 nanos);


### PR DESCRIPTION
When compiling with `-Werror, -Wunused-const-variable` the build fails due to those two constants not being used.

-----------
My C++ skills aren't where they should be, but my understanding is that those consts are declared in an unnamed namespace and thus can't be referenced from anywhere outside and thus it's safe to remove those.