### PR TITLE
Remove "using namespace std" from stubs/common.h

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -804,8 +804,8 @@ int CommandLineInterface::Run(int argc, const char* const argv[]) {
 
     // Enforce --disallow_services.
     if (disallow_services_ && parsed_file->service_count() > 0) {
-      cerr << parsed_file->name() << ": This file contains services, but "
-              "--disallow_services was used." << endl;
+      std::cerr << parsed_file->name() << ": This file contains services, but "
+              "--disallow_services was used." << std::endl;
       return 1;
     }
 
@@ -816,7 +816,7 @@ int CommandLineInterface::Run(int argc, const char* const argv[]) {
         if (direct_dependencies_.find(parsed_file->dependency(i)->name()) ==
             direct_dependencies_.end()) {
           indirect_imports = true;
-          cerr << parsed_file->name() << ": "
+          std::cerr << parsed_file->name() << ": "
                << StringReplace(direct_dependencies_violation_msg_, "%s",
                                 parsed_file->dependency(i)->name(),
                                 true /* replace_all */)
@@ -1221,7 +1221,7 @@ CommandLineInterface::InterpretArgument(const string& name,
       if (access(disk_path.c_str(), F_OK) < 0) {
         // Try the original path; it may have just happed to have a '=' in it.
         if (access(parts[i].c_str(), F_OK) < 0) {
-          cerr << disk_path << ": warning: directory does not exist." << endl;
+          std::cerr << disk_path << ": warning: directory does not exist." << std::endl;
         } else {
           virtual_path = "";
           disk_path = parts[i];
@@ -1302,9 +1302,9 @@ CommandLineInterface::InterpretArgument(const string& name,
     if (!version_info_.empty()) {
       std::cout << version_info_ << std::endl;
     }
-    cout << "libprotoc "
+    std::cout << "libprotoc "
          << protobuf::internal::VersionString(GOOGLE_PROTOBUF_VERSION)
-         << endl;
+         << std::endl;
     return PARSE_ARGUMENT_DONE_AND_EXIT;  // Exit without running compiler.
 
   } else if (name == "--disallow_services") {

--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -322,9 +322,9 @@ std::string FieldGeneratorBase::default_value(const FieldDescriptor* descriptor)
       }
     case FieldDescriptor::TYPE_DOUBLE: {
       double value = descriptor->default_value_double();
-      if (value == numeric_limits<double>::infinity()) {
+      if (value == std::numeric_limits<double>::infinity()) {
         return "double.PositiveInfinity";
-      } else if (value == -numeric_limits<double>::infinity()) {
+      } else if (value == -std::numeric_limits<double>::infinity()) {
         return "double.NegativeInfinity";
       } else if (MathLimits<double>::IsNaN(value)) {
         return "double.NaN";
@@ -333,9 +333,9 @@ std::string FieldGeneratorBase::default_value(const FieldDescriptor* descriptor)
     }
     case FieldDescriptor::TYPE_FLOAT: {
       float value = descriptor->default_value_float();
-      if (value == numeric_limits<float>::infinity()) {
+      if (value == std::numeric_limits<float>::infinity()) {
         return "float.PositiveInfinity";
-      } else if (value == -numeric_limits<float>::infinity()) {
+      } else if (value == -std::numeric_limits<float>::infinity()) {
         return "float.NegativeInfinity";
       } else if (MathLimits<float>::IsNaN(value)) {
         return "float.NaN";

--- a/src/google/protobuf/compiler/javanano/javanano_file.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_file.cc
@@ -120,12 +120,12 @@ bool FileGenerator::Validate(string* error) {
   if (!params_.has_java_outer_classname(file_->name())
       && file_->message_type_count() == 1
       && file_->enum_type_count() == 0 && file_->extension_count() == 0) {
-    cout << "INFO: " << file_->name() << ":" << endl;
-    cout << "Javanano generator has changed to align with java generator. "
+    std::cout << "INFO: " << file_->name() << ":" << std::endl;
+    std::cout << "Javanano generator has changed to align with java generator. "
         "An outer class will be created for this file and the single message "
         "in the file will become a nested class. Use java_multiple_files to "
         "skip generating the outer class, or set an explicit "
-        "java_outer_classname to suppress this message." << endl;
+        "java_outer_classname to suppress this message." << std::endl;
   }
 
   // Check that no class name matches the file's class name.  This is a common

--- a/src/google/protobuf/compiler/javanano/javanano_helpers.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_helpers.cc
@@ -428,9 +428,9 @@ string DefaultValue(const Params& params, const FieldDescriptor* field) {
              "L";
     case FieldDescriptor::CPPTYPE_DOUBLE: {
       double value = field->default_value_double();
-      if (value == numeric_limits<double>::infinity()) {
+      if (value == std::numeric_limits<double>::infinity()) {
         return "Double.POSITIVE_INFINITY";
-      } else if (value == -numeric_limits<double>::infinity()) {
+      } else if (value == -std::numeric_limits<double>::infinity()) {
         return "Double.NEGATIVE_INFINITY";
       } else if (value != value) {
         return "Double.NaN";
@@ -440,9 +440,9 @@ string DefaultValue(const Params& params, const FieldDescriptor* field) {
     }
     case FieldDescriptor::CPPTYPE_FLOAT: {
       float value = field->default_value_float();
-      if (value == numeric_limits<float>::infinity()) {
+      if (value == std::numeric_limits<float>::infinity()) {
         return "Float.POSITIVE_INFINITY";
-      } else if (value == -numeric_limits<float>::infinity()) {
+      } else if (value == -std::numeric_limits<float>::infinity()) {
         return "Float.NEGATIVE_INFINITY";
       } else if (value != value) {
         return "Float.NaN";

--- a/src/google/protobuf/compiler/javanano/javanano_message.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_message.cc
@@ -69,7 +69,7 @@ const FieldDescriptor** SortFieldsByNumber(const Descriptor* descriptor) {
   for (int i = 0; i < descriptor->field_count(); i++) {
     fields[i] = descriptor->field(i);
   }
-  sort(fields, fields + descriptor->field_count(),
+  std::sort(fields, fields + descriptor->field_count(),
        FieldOrderingByNumber());
   return fields;
 }

--- a/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -49,9 +49,9 @@ ExtensionGenerator::ExtensionGenerator(const string& root_class_name,
   if (descriptor->is_map()) {
     // NOTE: src/google/protobuf/compiler/plugin.cc makes use of cerr for some
     // error cases, so it seems to be ok to use as a back door for errors.
-    cerr << "error: Extension is a map<>!"
-         << " That used to be blocked by the compiler." << endl;
-    cerr.flush();
+    std::cerr << "error: Extension is a map<>!"
+         << " That used to be blocked by the compiler." << std::endl;
+    std::cerr.flush();
     abort();
   }
 }

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -228,8 +228,8 @@ int FieldGenerator::ExtraRuntimeHasBitsNeeded(void) const {
 void FieldGenerator::SetExtraRuntimeHasBitsBase(int index_base) {
   // NOTE: src/google/protobuf/compiler/plugin.cc makes use of cerr for some
   // error cases, so it seems to be ok to use as a back door for errors.
-  cerr << "Error: should have overridden SetExtraRuntimeHasBitsBase()." << endl;
-  cerr.flush();
+  std::cerr << "Error: should have overridden SetExtraRuntimeHasBitsBase()." << std::endl;
+  std::cerr.flush();
   abort();
 }
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -1063,21 +1063,21 @@ bool ValidateObjCClassPrefix(
   // to Apple's rules (the checks above implicitly whitelist anything that
   // doesn't meet these rules).
   if (!ascii_isupper(prefix[0])) {
-    cerr << endl
+    std::cerr << std::endl
          << "protoc:0: warning: Invalid 'option objc_class_prefix = \""
          << prefix << "\";' in '" << file->name() << "';"
-         << " it should start with a capital letter." << endl;
-    cerr.flush();
+         << " it should start with a capital letter." << std::endl;
+    std::cerr.flush();
   }
   if (prefix.length() < 3) {
     // Apple reserves 2 character prefixes for themselves. They do use some
     // 3 character prefixes, but they haven't updated the rules/docs.
-    cerr << endl
+    std::cerr << std::endl
          << "protoc:0: warning: Invalid 'option objc_class_prefix = \""
          << prefix << "\";' in '" << file->name() << "';"
          << " Apple recommends they should be at least 3 characters long."
-         << endl;
-    cerr.flush();
+         << std::endl;
+    std::cerr.flush();
   }
 
   // Look for any other package that uses the same prefix.
@@ -1096,22 +1096,22 @@ bool ValidateObjCClassPrefix(
     // The file does not have a package and ...
     if (other_package_for_prefix.empty()) {
       // ... no other package has declared that prefix.
-      cerr << endl
+      std::cerr << std::endl
            << "protoc:0: warning: File '" << file->name() << "' has no "
            << "package. Consider adding a new package to the proto and adding '"
            << "new.package = " << prefix << "' to the expected prefixes file ("
-           << expected_prefixes_path << ")." << endl;
-      cerr.flush();
+           << expected_prefixes_path << ")." << std::endl;
+      std::cerr.flush();
     } else {
       // ... another package has declared the same prefix.
-      cerr << endl
+      std::cerr << std::endl
            << "protoc:0: warning: File '" << file->name() << "' has no package "
            << "and package '" << other_package_for_prefix << "' already uses '"
            << prefix << "' as its prefix. Consider either adding a new package "
            << "to the proto, or reusing one of the packages already using this "
            << "prefix in the expected prefixes file ("
-           << expected_prefixes_path << ")." << endl;
-      cerr.flush();
+           << expected_prefixes_path << ")." << std::endl;
+      std::cerr.flush();
     }
     return true;
   }
@@ -1133,12 +1133,12 @@ bool ValidateObjCClassPrefix(
   // Check: Warning - If the given package/prefix pair wasn't expected, issue a
   // warning issue a warning suggesting it gets added to the file.
   if (!expected_package_prefixes.empty()) {
-    cerr << endl
+    std::cerr << std::endl
          << "protoc:0: warning: Found unexpected 'option objc_class_prefix = \""
          << prefix << "\";' in '" << file->name() << "';"
          << " consider adding it to the expected prefixes file ("
-         << expected_prefixes_path << ")." << endl;
-    cerr.flush();
+         << expected_prefixes_path << ")." << std::endl;
+    std::cerr.flush();
   }
 
   return true;
@@ -1180,10 +1180,10 @@ void TextFormatDecodeData::AddString(int32 key,
   for (vector<DataEntry>::const_iterator i = entries_.begin();
        i != entries_.end(); ++i) {
     if (i->first == key) {
-      cerr << "error: duplicate key (" << key
+      std::cerr << "error: duplicate key (" << key
            << ") making TextFormat data, input: \"" << input_for_decode
-           << "\", desired: \"" << desired_output << "\"." << endl;
-      cerr.flush();
+           << "\", desired: \"" << desired_output << "\"." << std::endl;
+      std::cerr.flush();
       abort();
     }
   }
@@ -1194,7 +1194,7 @@ void TextFormatDecodeData::AddString(int32 key,
 }
 
 string TextFormatDecodeData::Data() const {
-  ostringstream data_stringstream;
+  std::ostringstream data_stringstream;
 
   if (num_entries() > 0) {
     io::OstreamOutputStream data_outputstream(&data_stringstream);
@@ -1335,18 +1335,18 @@ string DirectDecodeString(const string& str) {
 string TextFormatDecodeData::DecodeDataForString(const string& input_for_decode,
                                                  const string& desired_output) {
   if ((input_for_decode.size() == 0) || (desired_output.size() == 0)) {
-    cerr << "error: got empty string for making TextFormat data, input: \""
+    std::cerr << "error: got empty string for making TextFormat data, input: \""
          << input_for_decode << "\", desired: \"" << desired_output << "\"."
-         << endl;
-    cerr.flush();
+         << std::endl;
+    std::cerr.flush();
     abort();
   }
   if ((input_for_decode.find('\0') != string::npos) ||
       (desired_output.find('\0') != string::npos)) {
-    cerr << "error: got a null char in a string for making TextFormat data,"
+    std::cerr << "error: got a null char in a string for making TextFormat data,"
          << " input: \"" << CEscape(input_for_decode) << "\", desired: \""
-         << CEscape(desired_output) << "\"." << endl;
-    cerr.flush();
+         << CEscape(desired_output) << "\"." << std::endl;
+    std::cerr.flush();
     abort();
   }
 
@@ -1611,9 +1611,9 @@ void ImportWriter::ParseFrameworkMappings() {
   string parse_error;
   if (!ParseSimpleFile(named_framework_to_proto_path_mappings_path_,
                        &collector, &parse_error)) {
-    cerr << "error parsing " << named_framework_to_proto_path_mappings_path_
-         << " : " << parse_error << endl;
-    cerr.flush();
+    std::cerr << "error parsing " << named_framework_to_proto_path_mappings_path_
+         << " : " << parse_error << std::endl;
+    std::cerr.flush();
   }
 }
 
@@ -1643,16 +1643,16 @@ bool ImportWriter::ProtoFrameworkCollector::ConsumeLine(
       map<string, string>::iterator existing_entry =
           map_->find(proto_file.ToString());
       if (existing_entry != map_->end()) {
-        cerr << "warning: duplicate proto file reference, replacing framework entry for '"
+        std::cerr << "warning: duplicate proto file reference, replacing framework entry for '"
              << proto_file.ToString() << "' with '" << framework_name.ToString()
-             << "' (was '" << existing_entry->second << "')." << endl;
-        cerr.flush();
+             << "' (was '" << existing_entry->second << "')." << std::endl;
+        std::cerr.flush();
       }
 
       if (proto_file.find(' ') != StringPiece::npos) {
-        cerr << "note: framework mapping file had a proto file with a space in, hopefully that isn't a missing comma: '"
-             << proto_file.ToString() << "'" << endl;
-        cerr.flush();
+        std::cerr << "note: framework mapping file had a proto file with a space in, hopefully that isn't a missing comma: '"
+             << proto_file.ToString() << "'" << std::endl;
+        std::cerr.flush();
       }
 
       (*map_)[proto_file.ToString()] = framework_name.ToString();

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -156,7 +156,7 @@ const FieldDescriptor** SortFieldsByNumber(const Descriptor* descriptor) {
   for (int i = 0; i < descriptor->field_count(); i++) {
     fields[i] = descriptor->field(i);
   }
-  sort(fields, fields + descriptor->field_count(), FieldOrderingByNumber());
+  std::sort(fields, fields + descriptor->field_count(), FieldOrderingByNumber());
   return fields;
 }
 
@@ -168,7 +168,7 @@ const FieldDescriptor** SortFieldsByStorageSize(const Descriptor* descriptor) {
   for (int i = 0; i < descriptor->field_count(); i++) {
     fields[i] = descriptor->field(i);
   }
-  sort(fields, fields + descriptor->field_count(),
+  std::sort(fields, fields + descriptor->field_count(),
        FieldOrderingByStorageSize());
   return fields;
 }
@@ -430,7 +430,7 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
       sorted_extensions.push_back(descriptor_->extension_range(i));
     }
 
-    sort(sorted_extensions.begin(), sorted_extensions.end(),
+    std::sort(sorted_extensions.begin(), sorted_extensions.end(),
          ExtensionRangeOrdering());
 
     // Assign has bits:

--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -399,7 +399,7 @@ inline std::pair<char*, bool> as_string_data(string* s) {
 #ifdef LANG_CXX11
   return std::make_pair(p, true);
 #else
-  return make_pair(p, p != NULL);
+  return std::make_pair(p, p != NULL);
 #endif
 }
 

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -46,8 +46,6 @@
 #include <google/protobuf/wire_format_lite_inl.h>
 #include <google/protobuf/stubs/strutil.h>
 
-using namespace std;
-
 namespace {
 // Helper methods to test parsing merge behavior.
 void ExpectMessageMerged(const google::protobuf::unittest::TestAllTypesLite& message) {
@@ -71,7 +69,7 @@ void SetAllTypesInEmptyMessageUnknownFields(
   protobuf_unittest::TestAllTypesLite message;
   google::protobuf::TestUtilLite::ExpectClear(message);
   google::protobuf::TestUtilLite::SetAllFields(&message);
-  string data = message.SerializeAsString();
+  std::string data = message.SerializeAsString();
   empty_message->ParseFromString(data);
 }
 
@@ -83,7 +81,7 @@ void SetSomeTypesInEmptyMessageUnknownFields(
   message.set_optional_int64(102);
   message.set_optional_uint32(103);
   message.set_optional_uint64(104);
-  string data = message.SerializeAsString();
+  std::string data = message.SerializeAsString();
   empty_message->ParseFromString(data);
 }
 
@@ -96,7 +94,7 @@ void SetSomeTypesInEmptyMessageUnknownFields(
 #define ASSERT_EQ GOOGLE_CHECK_EQ
 
 int main(int argc, char* argv[]) {
-  string data, data2, packed_data;
+  std::string data, data2, packed_data;
 
   {
     protobuf_unittest::TestAllTypesLite message, message2, message3;
@@ -119,7 +117,7 @@ int main(int argc, char* argv[]) {
     google::protobuf::TestUtilLite::ExpectExtensionsClear(message);
     google::protobuf::TestUtilLite::SetAllExtensions(&message);
     message2.CopyFrom(message);
-    string extensions_data = message.SerializeAsString();
+    std::string extensions_data = message.SerializeAsString();
     message3.ParseFromString(extensions_data);
     google::protobuf::TestUtilLite::ExpectAllExtensionsSet(message);
     google::protobuf::TestUtilLite::ExpectAllExtensionsSet(message2);
@@ -151,7 +149,7 @@ int main(int argc, char* argv[]) {
     google::protobuf::TestUtilLite::ExpectPackedExtensionsClear(message);
     google::protobuf::TestUtilLite::SetPackedExtensions(&message);
     message2.CopyFrom(message);
-    string packed_extensions_data = message.SerializeAsString();
+    std::string packed_extensions_data = message.SerializeAsString();
     GOOGLE_CHECK(packed_extensions_data == packed_data);
     message3.ParseFromString(packed_extensions_data);
     google::protobuf::TestUtilLite::ExpectPackedExtensionsSet(message);
@@ -195,7 +193,7 @@ int main(int argc, char* argv[]) {
 
 #undef ASSIGN_REPEATED_GROUP
 
-    string buffer;
+    std::string buffer;
     generator.SerializeToString(&buffer);
     google::protobuf::unittest::TestParsingMergeLite parsing_merge;
     parsing_merge.ParseFromString(buffer);
@@ -330,7 +328,7 @@ int main(int argc, char* argv[]) {
   {
     // Test unknown enum value
     protobuf_unittest::TestAllTypesLite message;
-    string buffer;
+    std::string buffer;
     {
       google::protobuf::io::StringOutputStream output_stream(&buffer);
       google::protobuf::io::CodedOutputStream coded_output(&output_stream);
@@ -517,7 +515,7 @@ int main(int argc, char* argv[]) {
   {
     // Test the generated SerializeWithCachedSizesToArray()
     protobuf_unittest::TestMapLite message1, message2;
-    string data;
+    std::string data;
     google::protobuf::MapLiteTestUtil::SetMapFields(&message1);
     int size = message1.ByteSize();
     data.resize(size);
@@ -533,7 +531,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message1, message2;
     google::protobuf::MapLiteTestUtil::SetMapFields(&message1);
     int size = message1.ByteSize();
-    string data;
+    std::string data;
     data.resize(size);
     {
       // Allow the output stream to buffer only one byte at a time.
@@ -556,7 +554,7 @@ int main(int argc, char* argv[]) {
         protobuf_unittest::E_PROTO2_MAP_ENUM_FOO_LITE;
     (*from.mutable_unknown_map_field())[0] =
         protobuf_unittest::E_PROTO2_MAP_ENUM_EXTRA_LITE;
-    string data;
+    std::string data;
     from.SerializeToString(&data);
 
     protobuf_unittest::TestEnumMapLite to;
@@ -582,7 +580,7 @@ int main(int argc, char* argv[]) {
   {
     // StandardWireFormat
     protobuf_unittest::TestMapLite message;
-    string data = "\x0A\x04\x08\x01\x10\x01";
+    std::string data = "\x0A\x04\x08\x01\x10\x01";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -594,7 +592,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // put value before key in wire format
-    string data = "\x0A\x04\x10\x01\x08\x02";
+    std::string data = "\x0A\x04\x10\x01\x08\x02";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -606,7 +604,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // Two key fields in wire format
-    string data = "\x0A\x06\x08\x01\x08\x02\x10\x01";
+    std::string data = "\x0A\x06\x08\x01\x08\x02\x10\x01";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -618,7 +616,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // Two value fields in wire format
-    string data = "\x0A\x06\x08\x01\x10\x01\x10\x02";
+    std::string data = "\x0A\x06\x08\x01\x10\x01\x10\x02";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -630,7 +628,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // No key field in wire format
-    string data = "\x0A\x02\x10\x01";
+    std::string data = "\x0A\x02\x10\x01";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -642,7 +640,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // No value field in wire format
-    string data = "\x0A\x02\x08\x01";
+    std::string data = "\x0A\x02\x08\x01";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -654,7 +652,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // Unknown field in wire format
-    string data = "\x0A\x06\x08\x02\x10\x03\x18\x01";
+    std::string data = "\x0A\x06\x08\x02\x10\x03\x18\x01";
 
     EXPECT_TRUE(message.ParseFromString(data));
     EXPECT_EQ(1, message.map_int32_int32().size());
@@ -666,7 +664,7 @@ int main(int argc, char* argv[]) {
     protobuf_unittest::TestMapLite message;
 
     // corrupted data in wire format
-    string data = "\x0A\x06\x08\x02\x11\x03";
+    std::string data = "\x0A\x06\x08\x02\x11\x03";
 
     EXPECT_FALSE(message.ParseFromString(data));
   }
@@ -693,7 +691,7 @@ int main(int argc, char* argv[]) {
       v2_message.set_int_field(800);
       // Set enum field to the value not understood by the old client.
       v2_message.set_enum_field(protobuf_unittest::V2_SECOND);
-      string v2_bytes = v2_message.SerializeAsString();
+      std::string v2_bytes = v2_message.SerializeAsString();
 
       protobuf_unittest::V1MessageLite v1_message;
       v1_message.ParseFromString(v2_bytes);
@@ -704,7 +702,7 @@ int main(int argc, char* argv[]) {
       EXPECT_EQ(v1_message.enum_field(), protobuf_unittest::V1_FIRST);
 
       // However, when re-serialized, it should preserve enum value.
-      string v1_bytes = v1_message.SerializeAsString();
+      std::string v1_bytes = v1_message.SerializeAsString();
 
       protobuf_unittest::V2MessageLite same_v2_message;
       same_v2_message.ParseFromString(v1_bytes);

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -35,7 +35,12 @@
 #ifndef GOOGLE_PROTOBUF_COMMON_H__
 #define GOOGLE_PROTOBUF_COMMON_H__
 
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <set>
 #include <string>
+#include <vector>
 
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/stubs/macros.h>
@@ -220,7 +225,14 @@ class FatalException : public std::exception {
 
 // This is at the end of the file instead of the beginning to work around a bug
 // in some versions of MSVC.
-using namespace std;  // Don't do this at home, kids.
+// TODO(acozzette): remove these using statements
+using std::istream;
+using std::map;
+using std::ostream;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
 
 }  // namespace protobuf
 }  // namespace google

--- a/src/google/protobuf/stubs/int128_unittest.cc
+++ b/src/google/protobuf/stubs/int128_unittest.cc
@@ -370,29 +370,29 @@ TEST(Int128, DivideAndMod) {
   EXPECT_EQ(r, result_r);
 
   // Try the other way around.
-  swap(q, b);
+  std::swap(q, b);
   result_q = a / b;
   result_r = a % b;
   EXPECT_EQ(q, result_q);
   EXPECT_EQ(r, result_r);
   // Restore.
-  swap(b, q);
+  std::swap(b, q);
 
   // Dividend < divisor; result should be q:0 r:<dividend>.
-  swap(a, b);
+  std::swap(a, b);
   result_q = a / b;
   result_r = a % b;
   EXPECT_EQ(0, result_q);
   EXPECT_EQ(a, result_r);
   // Try the other way around.
-  swap(a, q);
+  std::swap(a, q);
   result_q = a / b;
   result_r = a % b;
   EXPECT_EQ(0, result_q);
   EXPECT_EQ(a, result_r);
   // Restore.
-  swap(q, a);
-  swap(b, a);
+  std::swap(q, a);
+  std::swap(b, a);
 
   // Try a large remainder.
   b = a / 2 + 1;
@@ -501,7 +501,7 @@ TEST(Int128, OStream) {
         {uint128(12345), std::ios::dec | std::ios::left, 6, '_', "12345_"},
   };
   for (size_t i = 0; i < GOOGLE_ARRAYSIZE(cases); ++i) {
-    ostringstream os;
+    std::ostringstream os;
     os.flags(cases[i].flags);
     os.width(cases[i].width);
     os.fill(cases[i].fill);

--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -227,7 +227,7 @@ void SplitStringToIteratorUsing(const string& full,
 void SplitStringUsing(const string& full,
                       const char* delim,
                       vector<string>* result) {
-  back_insert_iterator< vector<string> > it(*result);
+  std::back_insert_iterator< vector<string> > it(*result);
   SplitStringToIteratorUsing(full, delim, it);
 }
 
@@ -265,7 +265,7 @@ void SplitStringToIteratorAllowEmpty(const StringType& full,
 
 void SplitStringAllowEmpty(const string& full, const char* delim,
                            vector<string>* result) {
-  back_insert_iterator<vector<string> > it(*result);
+  std::back_insert_iterator<vector<string> > it(*result);
   SplitStringToIteratorAllowEmpty(full, delim, 0, it);
 }
 
@@ -1262,10 +1262,10 @@ char* DoubleToBuffer(double value, char* buffer) {
   // this assert.
   GOOGLE_COMPILE_ASSERT(DBL_DIG < 20, DBL_DIG_is_too_big);
 
-  if (value == numeric_limits<double>::infinity()) {
+  if (value == std::numeric_limits<double>::infinity()) {
     strcpy(buffer, "inf");
     return buffer;
-  } else if (value == -numeric_limits<double>::infinity()) {
+  } else if (value == -std::numeric_limits<double>::infinity()) {
     strcpy(buffer, "-inf");
     return buffer;
   } else if (MathLimits<double>::IsNaN(value)) {
@@ -1380,10 +1380,10 @@ char* FloatToBuffer(float value, char* buffer) {
   // this assert.
   GOOGLE_COMPILE_ASSERT(FLT_DIG < 10, FLT_DIG_is_too_big);
 
-  if (value == numeric_limits<double>::infinity()) {
+  if (value == std::numeric_limits<double>::infinity()) {
     strcpy(buffer, "inf");
     return buffer;
-  } else if (value == -numeric_limits<double>::infinity()) {
+  } else if (value == -std::numeric_limits<double>::infinity()) {
     strcpy(buffer, "-inf");
     return buffer;
   } else if (MathLimits<float>::IsNaN(value)) {

--- a/src/google/protobuf/util/delimited_message_util_test.cc
+++ b/src/google/protobuf/util/delimited_message_util_test.cc
@@ -15,7 +15,7 @@ namespace protobuf {
 namespace util {
 
 TEST(DelimitedMessageUtilTest, DelimitedMessages) {
-  stringstream stream;
+  std::stringstream stream;
 
   {
     protobuf_unittest::TestAllTypes message1;


### PR DESCRIPTION
This prevents the contents of the std namespace from being effectively
pulled into the top-level namespace in all translation units that
include common.h. I left in individual using statements for a few common
things like std::set and std::map, because it did not seem worth going
through the churn of updating the whole codebase to fix those right now.