### PR TITLE
JS: Fix dot usage in filename alias

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.cc
+++ b/src/google/protobuf/compiler/js/js_generator.cc
@@ -192,6 +192,7 @@ string ModuleAlias(const string& filename) {
   // exposed to users so we can change it later if we need to.
   string basename = StripProto(filename);
   StripString(&basename, "-", '$');
+  StripString(&basename, ".", '$');
   StripString(&basename, "/", '_');
   return basename + "_pb";
 }


### PR DESCRIPTION
Fixes #1745. (`javascript generated code doesn't work when you use dot in a file name and include it`)

Replaced dot (`.`) with `$`.