### PR TITLE
Removed mention of Buffer in byteSourceToUint8Array

### DIFF
--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -970,10 +970,6 @@ jspb.utils.byteSourceToUint8Array = function(data) {
     return /** @type {!Uint8Array} */(new Uint8Array(data));
   }
 
-  if (data.constructor === Buffer) {
-    return /** @type {!Uint8Array} */(new Uint8Array(data));
-  }
-
   if (data.constructor === Array) {
     data = /** @type {!Array.<number>} */(data);
     return /** @type {!Uint8Array} */(new Uint8Array(data));


### PR DESCRIPTION
The Closure compiler complains about Buffer since that class exists only
in Node. That logic does not seem to be needed (unit tests and conformance
tests pass without it), so let's just remove it to solve the problem.