### PR TITLE
Fix compilation on alpine 3.5

### DIFF
--- a/src/google/protobuf/compiler/mock_code_generator.cc
+++ b/src/google/protobuf/compiler/mock_code_generator.cc
@@ -55,6 +55,13 @@
 #include <google/protobuf/stubs/substitute.h>
 #include <gtest/gtest.h>
 
+#ifdef major		
+#undef major		
+#endif		
+#ifdef minor		
+#undef minor		
+#endif		
+
 namespace google {
 namespace protobuf {
 namespace compiler {


### PR DESCRIPTION
Fixes compilation issue on alpine 3.5 (https://github.com/google/protobuf/issues/3046)

Failing docker file in issue https://github.com/google/protobuf/issues/3046:
```
FROM alpine:3.5

RUN apk update && apk add autoconf automake libtool curl make g++ unzip git

WORKDIR /usr/local/src

ARG PROTOBUF_VERSION=3.3.x

RUN git clone -b $PROTOBUF_VERSION https://github.com/google/protobuf.git && \
    cd protobuf  && \
    ./autogen.sh  && \
    ./configure  && \
    make  && \
    make check  && \
    make install  && \
    ldconfig /
```

Working docker file pulling from this PR branch:
```
FROM alpine:3.5

RUN apk update && apk add autoconf automake libtool curl make g++ unzip git

WORKDIR /usr/local/src

ARG PROTOBUF_VERSION=3.3.x

RUN git clone -b $PROTOBUF_VERSION https://github.com/chrisn-arm/protobuf.git && \
    cd protobuf  && \
    ./autogen.sh  && \
    ./configure  && \
    make  && \
    make check  && \
    make install  && \
    ldconfig /
```
