### PR TITLE
Workaround the docker bug when compiling artifacts

### DIFF
--- a/protoc-artifacts/Dockerfile
+++ b/protoc-artifacts/Dockerfile
@@ -30,7 +30,7 @@ RUN wget http://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -P /etc/yum
 RUN bash -c 'echo "enabled=1" >> /etc/yum.repos.d/devtools-1.1.repo'
 RUN bash -c "sed -e 's/\$basearch/i386/g' /etc/yum.repos.d/devtools-1.1.repo > /etc/yum.repos.d/devtools-i386-1.1.repo"
 RUN sed -e 's/testing-/testing-i386-/g' -i /etc/yum.repos.d/devtools-i386-1.1.repo
-RUN yum install -y devtoolset-1.1 \
+RUN rpm --rebuilddb && yum install -y devtoolset-1.1 \
                    devtoolset-1.1-libstdc++-devel \
                    devtoolset-1.1-libstdc++-devel.i686
 


### PR DESCRIPTION
This is a workaround (https://github.com/moby/moby/issues/10180#issuecomment-190429512) the docker issue (https://github.com/moby/moby/issues/10180) which breaks protoc-artifacts build process with following error

```Rpmdb checksum is invalid: dCDPT(pkg checksums): devtoolset-1.1-elfutils.x86_64 0:0.154-6.el6 - u

The command '/bin/sh -c yum clean all && yum install -y devtoolset-1.1                    devtoolset-1.1-libstdc++-devel                    devtoolset-1.1-libstdc++-devel.i686' returned a non-zero code: 1```

https://github.com/moby/moby/issues/10180#issuecomment-190429512