### PR TITLE
Fix protobuf-c compilation

### DIFF
--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -233,6 +233,7 @@ using std::pair;
 using std::set;
 using std::string;
 using std::vector;
+using std::back_insert_iterator;
 
 }  // namespace protobuf
 }  // namespace google


### PR DESCRIPTION
c_helpers.cc: In function 'void google::protobuf::compiler::c::SplitStringUsing(const string&, const char*, std::vector<std::__cxx11::basic_string<char> >*)':
c_helpers.cc:507:3: error: 'back_insert_iterator' was not declared in this scope
   back_insert_iterator< vector<string> > it(*result);
   ^
c_helpers.cc:507:3: note: suggested alternative:
In file included from /usr/include/c++/5/bits/stl_algobase.h:67:0,
                 from /usr/include/c++/5/vector:60,
                 from c_helpers.cc:63:
/usr/include/c++/5/bits/stl_iterator.h:415:11: note:   'std::back_insert_iterator'
     class back_insert_iterator
           ^
c_helpers.cc:507:40: error: expected primary-expression before '>' token
   back_insert_iterator< vector<string> > it(*result);
                                        ^
c_helpers.cc:507:52: error: 'it' was not declared in this scope
   back_insert_iterator< vector<string> > it(*result);