### PR TITLE
Improve fix for https://github.com/google/protobuf/issues/295

### DIFF
--- a/editors/protobuf-mode.el
+++ b/editors/protobuf-mode.el
@@ -64,9 +64,11 @@
 ;;; Code:
 
 (require 'cc-mode)
-(require 'cl)
 
 (eval-when-compile
+  (and (= emacs-major-version 24)
+       (>= emacs-minor-version 4)
+       (require 'cl))
   (require 'cc-langs)
   (require 'cc-fonts))
 


### PR DESCRIPTION
Requiring the legacy ‘cl’ library unconditionally pollutes the namespace.
Instead, require it only when compiling and in known-broken versions.

This is the same patch that opoplawski suggested.