### PR TITLE
Show help if protoc is called without any arguments

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -1012,6 +1012,12 @@ CommandLineInterface::ParseArguments(int argc, const char* const argv[]) {
     arguments.push_back(argv[i]);
   }
 
+  // if no arguments are given, show help
+  if(arguments.empty()) {
+    PrintHelpText();
+    return PARSE_ARGUMENT_DONE_AND_EXIT;  // Exit without running compiler.
+  }
+
   // Iterate through all arguments and parse them.
   for (int i = 0; i < arguments.size(); ++i) {
     string name, value;


### PR DESCRIPTION
A minor usability improvement mostly for new(-er) users of protoc

Currently calling protoc without arguments gives a useless message 'Missing input file.'
Instead we can pre-empt further parsing in case of zero arguments given and just show help.