### PR TITLE
not to use std::random_device for map.Seed().

### DIFF
--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -922,16 +922,6 @@ class Map {
 
     // Return a randomish value.
     size_type Seed() const {
-      // random_device can throw, so avoid it unless we are compiling with
-      // exceptions enabled.
-#if __cpp_exceptions && LANG_CXX11
-      try {
-        std::random_device rd;
-        std::knuth_b knuth(rd());
-        std::uniform_int_distribution<size_type> u;
-        return u(knuth);
-      } catch (...) { }
-#endif
       size_type s = static_cast<size_type>(reinterpret_cast<uintptr_t>(this));
 #if defined(__x86_64__) && defined(__GNUC__)
       uint32 hi, lo;

--- a/src/google/protobuf/map.h
+++ b/src/google/protobuf/map.h
@@ -47,9 +47,6 @@
 #include <google/protobuf/generated_enum_util.h>
 #include <google/protobuf/map_type_handler.h>
 #include <google/protobuf/stubs/hash.h>
-#if __cpp_exceptions && LANG_CXX11
-#include <random>
-#endif
 
 namespace google {
 namespace protobuf {


### PR DESCRIPTION
When compiled with c++11 and with exception, each protobuf_map is doing a blocking read.  It greatly impacts the performance.