### PR TITLE
Add headers as part of cmake project generation

### DIFF
--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -24,8 +24,32 @@ set(libprotobuf_lite_files
   ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.cc
 )
 
+set(libprotobuf_lite_includes
+  ${protobuf_source_dir}/src/google/protobuf/arena.h
+  ${protobuf_source_dir}/src/google/protobuf/arenastring.h
+  ${protobuf_source_dir}/src/google/protobuf/extension_set.h
+  ${protobuf_source_dir}/src/google/protobuf/generated_message_util.h
+  ${protobuf_source_dir}/src/google/protobuf/io/coded_stream.h
+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream.h
+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/message_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/repeated_field.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/atomicops_internals_x86_msvc.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/bytestream.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/common.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/int128.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/once.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/status.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/statusor.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringpiece.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringprintf.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/strutil.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/time.h
+  ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.h
+)
+
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files})
+  ${libprotobuf_lite_files} ${libprotobuf_lite_includes})
 target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -55,8 +55,64 @@ set(libprotobuf_files
   ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.cc
 )
 
+set(libprotobuf_includes
+  ${protobuf_source_dir}/src/google/protobuf/any.h
+  ${protobuf_source_dir}/src/google/protobuf/any.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/api.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/importer.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/parser.h
+  ${protobuf_source_dir}/src/google/protobuf/descriptor.h
+  ${protobuf_source_dir}/src/google/protobuf/descriptor.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/descriptor_database.h
+  ${protobuf_source_dir}/src/google/protobuf/duration.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/dynamic_message.h
+  ${protobuf_source_dir}/src/google/protobuf/empty.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/field_mask.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/generated_message_reflection.h
+  ${protobuf_source_dir}/src/google/protobuf/io/gzip_stream.h
+  ${protobuf_source_dir}/src/google/protobuf/io/printer.h
+  ${protobuf_source_dir}/src/google/protobuf/io/strtod.h
+  ${protobuf_source_dir}/src/google/protobuf/io/tokenizer.h
+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream_impl.h
+  ${protobuf_source_dir}/src/google/protobuf/map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/message.h
+  ${protobuf_source_dir}/src/google/protobuf/reflection_ops.h
+  ${protobuf_source_dir}/src/google/protobuf/service.h
+  ${protobuf_source_dir}/src/google/protobuf/source_context.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/struct.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/mathlimits.h
+  ${protobuf_source_dir}/src/google/protobuf/stubs/substitute.h
+  ${protobuf_source_dir}/src/google/protobuf/text_format.h
+  ${protobuf_source_dir}/src/google/protobuf/timestamp.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/type.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/unknown_field_set.h
+  ${protobuf_source_dir}/src/google/protobuf/util/delimited_message_util.h
+  ${protobuf_source_dir}/src/google/protobuf/util/field_comparator.h
+  ${protobuf_source_dir}/src/google/protobuf/util/field_mask_util.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/datapiece.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/default_value_objectwriter.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/error_listener.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/field_mask_utility.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/json_escaping.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/json_objectwriter.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/json_stream_parser.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/object_writer.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/proto_writer.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/protostream_objectsource.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/protostream_objectwriter.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/type_info.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/type_info_test_helper.h
+  ${protobuf_source_dir}/src/google/protobuf/util/internal/utility.h
+  ${protobuf_source_dir}/src/google/protobuf/util/json_util.h
+  ${protobuf_source_dir}/src/google/protobuf/util/message_differencer.h
+  ${protobuf_source_dir}/src/google/protobuf/util/time_util.h
+  ${protobuf_source_dir}/src/google/protobuf/util/type_resolver_util.h
+  ${protobuf_source_dir}/src/google/protobuf/wire_format.h
+  ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.h
+)
+
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_files})
+  ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes})
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
 if(protobuf_WITH_ZLIB)
     target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -95,6 +95,115 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
 )
 
+set(libprotoc_headers
+  ${protobuf_source_dir}/src/google/protobuf/compiler/code_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/command_line_interface.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/importer.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/mock_code_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/package_info.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/parser.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/profile.pb.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_extension.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_file.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_options.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_service.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_string_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/cpp/cpp_unittest.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_doc_comment.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_field_base.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_names.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_options.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_reflection_class.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_source_generator_base.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/csharp/csharp_wrapper_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_context.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_doc_comment.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_enum_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_extension.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_extension_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_file.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_generator_factory.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_lazy_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_lazy_message_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_map_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_builder.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_builder_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_message_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_names.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_name_resolver.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_options.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_primitive_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_service.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_shared_code_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_extension.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_file.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_params.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_file.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_map_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_message_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_oneof.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/php/php_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/python/python_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.h
+  ${protobuf_source_dir}/src/google/protobuf/compiler/plugin.pb.h
+)
+
 set(js_well_known_types_sources
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/any.js
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/struct.js
@@ -108,7 +217,7 @@ add_custom_command(
 )
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
-  ${libprotoc_files})
+  ${libprotoc_files} ${libprotoc_headers})
 target_link_libraries(libprotoc libprotobuf)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc


### PR DESCRIPTION
tested only on windows with visual studio 2015 as generator

This change makes allows the IDE functionality like search project etc to also search in headers.

![image](https://cloud.githubusercontent.com/assets/7057293/26555420/41a9c852-4495-11e7-8b0f-a9b8c65e32a9.png)


PR created on advice of @acozzette  ( https://groups.google.com/forum/#!topic/protobuf/BJ-D0TF1QxI )