### PR TITLE
Use uint32 in GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET macro

### DIFF
--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -100,7 +100,7 @@ namespace internal {
 // choose 16 rather than some other number just in case the compiler would
 // be confused by an unaligned pointer.
 #define GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TYPE, FIELD)  \
-  static_cast<int>(                                                  \
+  static_cast< ::google::protobuf::uint32>(                          \
       reinterpret_cast<const char*>(                                 \
           &reinterpret_cast<const TYPE*>(16)->FIELD) -               \
       reinterpret_cast<const char*>(16))


### PR DESCRIPTION
This fixes compiler warnings about narrowing of int to uint32.

Original fix e19f3b5e got lost, I suspect during 5a76e633.