### PR TITLE
Ensure that for Java, imports of .proto files with empty packages works

### DIFF
--- a/src/google/protobuf/compiler/java/java_shared_code_generator.cc
+++ b/src/google/protobuf/compiler/java/java_shared_code_generator.cc
@@ -182,10 +182,16 @@ void SharedCodeGenerator::GenerateDescriptors(io::Printer* printer) {
   std::vector<std::pair<string, string> > dependencies;
   for (int i = 0; i < file_->dependency_count(); i++) {
     string filename = file_->dependency(i)->name();
-    string classname = FileJavaPackage(file_->dependency(i)) + "." +
-                       name_resolver_->GetDescriptorClassName(
-                           file_->dependency(i));
-    dependencies.push_back(std::make_pair(filename, classname));
+    string package = FileJavaPackage(file_->dependency(i));
+    string classname = name_resolver_->GetDescriptorClassName(
+        file_->dependency(i));
+    string full_name;
+    if (package.empty()) {
+      full_name = classname;
+    } else {
+      full_name = package + "." + classname;
+    }
+    dependencies.push_back(std::make_pair(filename, full_name));
   }
 
   // -----------------------------------------------------------------


### PR DESCRIPTION
This fixes a compiler bug that caused a Java syntax error when one
.proto file would import another one with an empty package and
java_package. This fixes issue #3114.