### PR TITLE
Reduce size of GPBDictionary by getting rid of class creation methods

### DIFF
--- a/objectivec/GPBDictionary.h
+++ b/objectivec/GPBDictionary.h
@@ -60,55 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const uint32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -202,55 +153,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const uint32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32Int32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -348,55 +250,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const uint32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -490,55 +343,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const uint32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32Int64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -636,55 +440,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const uint32_t [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32BoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -778,55 +533,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const uint32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32FloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -924,55 +630,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const uint32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32DoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -1068,70 +725,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const uint32_t [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32EnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -1294,55 +887,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param object     The value to be placed in the dictionary.
- * @param key        The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithObject:(ObjectType)object
-                              forKey:(uint32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param objects      The values to be placed in the dictionary.
- * @param keys         The keys under which to store the values.
- * @param count        The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType __nonnull GPB_UNSAFE_UNRETAINED [__nullable])objects
-                              forKeys:(const uint32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32ObjectDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param objects      The values to be placed in this dictionary.
@@ -1435,55 +979,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const int32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32UInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -1581,55 +1076,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const int32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32Int32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -1723,55 +1169,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const int32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32UInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -1869,55 +1266,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const int32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32Int64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -2011,55 +1359,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const int32_t [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32BoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -2157,55 +1456,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const int32_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32FloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -2299,55 +1549,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const int32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32DoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -2445,70 +1646,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const int32_t [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32EnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -2671,55 +1808,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param object     The value to be placed in the dictionary.
- * @param key        The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithObject:(ObjectType)object
-                              forKey:(int32_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param objects      The values to be placed in the dictionary.
- * @param keys         The keys under which to store the values.
- * @param count        The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType __nonnull GPB_UNSAFE_UNRETAINED [__nullable])objects
-                              forKeys:(const int32_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt32ObjectDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param objects      The values to be placed in this dictionary.
@@ -2812,55 +1900,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const uint64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -2958,55 +1997,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const uint64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64Int32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -3100,55 +2090,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const uint64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -3246,55 +2187,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const uint64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64Int64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -3388,55 +2280,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const uint64_t [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64BoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -3534,55 +2377,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const uint64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64FloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -3676,55 +2470,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const uint64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64DoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -3822,70 +2567,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const uint64_t [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64EnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -4048,55 +2729,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param object     The value to be placed in the dictionary.
- * @param key        The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithObject:(ObjectType)object
-                              forKey:(uint64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param objects      The values to be placed in the dictionary.
- * @param keys         The keys under which to store the values.
- * @param count        The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType __nonnull GPB_UNSAFE_UNRETAINED [__nullable])objects
-                              forKeys:(const uint64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64ObjectDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param objects      The values to be placed in this dictionary.
@@ -4189,55 +2821,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const int64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64UInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -4335,55 +2918,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const int64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64Int32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -4477,55 +3011,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const int64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64UInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -4623,55 +3108,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const int64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64Int64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -4765,55 +3201,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const int64_t [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64BoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -4911,55 +3298,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const int64_t [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64FloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -5053,55 +3391,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const int64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64DoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -5199,70 +3488,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const int64_t [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64EnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -5425,55 +3650,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param object     The value to be placed in the dictionary.
- * @param key        The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithObject:(ObjectType)object
-                              forKey:(int64_t)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param objects      The values to be placed in the dictionary.
- * @param keys         The keys under which to store the values.
- * @param count        The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType __nonnull GPB_UNSAFE_UNRETAINED [__nullable])objects
-                              forKeys:(const int64_t [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBInt64ObjectDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param objects      The values to be placed in this dictionary.
@@ -5566,55 +3742,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const BOOL [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolUInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -5712,55 +3839,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const BOOL [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -5854,55 +3932,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const BOOL [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolUInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -6000,55 +4029,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const BOOL [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -6142,55 +4122,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const BOOL [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolBoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -6288,55 +4219,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const BOOL [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolFloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -6430,55 +4312,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const BOOL [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolDoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -6576,70 +4409,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const BOOL [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolEnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -6802,55 +4571,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param object     The value to be placed in the dictionary.
- * @param key        The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithObject:(ObjectType)object
-                              forKey:(BOOL)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param objects      The values to be placed in the dictionary.
- * @param keys         The keys under which to store the values.
- * @param count        The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType __nonnull GPB_UNSAFE_UNRETAINED [__nullable])objects
-                              forKeys:(const BOOL [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBBoolObjectDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param objects      The values to be placed in this dictionary.
@@ -6943,55 +4663,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [__nullable])values
-                              forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringUInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -7089,55 +4760,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [__nullable])values
-                             forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringInt32Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -7231,55 +4853,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [__nullable])values
-                              forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringUInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -7377,55 +4950,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [__nullable])values
-                             forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringInt64Dictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -7519,55 +5043,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithBools:(const BOOL [__nullable])values
-                            forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                              count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringBoolDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -7665,55 +5140,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 
 /**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithFloats:(const float [__nullable])values
-                             forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                               count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringFloatDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-
-/**
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
@@ -7807,55 +5233,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Number of entries stored in this dictionary. */
 @property(nonatomic, readonly) NSUInteger count;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param value     The value to be placed in the dictionary.
- * @param key       The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param values      The values to be placed in the dictionary.
- * @param keys        The keys under which to store the values.
- * @param count       The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithDoubles:(const double [__nullable])values
-                              forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                                count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringDoubleDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 
 /**
  * Initializes this dictionary, copying the given values and keys.
@@ -7953,70 +5330,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSUInteger count;
 /** The validation function to check if the enums are valid. */
 @property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-
-/**
- * @return A newly instanced and empty dictionary.
- **/
-+ (instancetype)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given validation function.
- *
- * @param func The enum validation function for the dictionary.
- *
- * @return A newly instanced dictionary.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-
-/**
- * Creates and initializes a dictionary with the single entry given.
- *
- * @param func     The enum validation function for the dictionary.
- * @param rawValue The raw enum value to be placed in the dictionary.
- * @param key      The key under which to store the value.
- *
- * @return A newly instanced dictionary with the key and value in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(NSString *)key;
-
-/**
- * Creates and initializes a dictionary with the entries given.
- *
- * @param func   The enum validation function for the dictionary.
- * @param values The raw enum values values to be placed in the dictionary.
- * @param keys   The keys under which to store the values.
- * @param count  The number of entries to store in the dictionary.
- *
- * @return A newly instanced dictionary with the keys and values in it.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [__nullable])values
-                                         forKeys:(const NSString * __nonnull GPB_UNSAFE_UNRETAINED [__nullable])keys
-                                           count:(NSUInteger)count;
-
-/**
- * Creates and initializes a dictionary with the entries from the given.
- * dictionary.
- *
- * @param dictionary Dictionary containing the entries to add to the dictionary.
- *
- * @return A newly instanced dictionary with the entries from the given
- *         dictionary in it.
- **/
-+ (instancetype)dictionaryWithDictionary:(GPBStringEnumDictionary *)dictionary;
-
-/**
- * Creates and initializes a dictionary with the given capacity.
- *
- * @param func     The enum validation function for the dictionary.
- * @param numItems Capacity needed for the dictionary.
- *
- * @return A newly instanced dictionary with the given capacity.
- **/
-+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems;
 
 /**
  * Initializes a dictionary with the given validation function.
@@ -8240,55 +5553,6 @@ NS_ASSUME_NONNULL_END
 //%@property(nonatomic, readonly) NSUInteger count;
 //%
 //%/**
-//% * @return A newly instanced and empty dictionary.
-//% **/
-//%+ (instancetype)dictionary;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the single entry given.
-//% *
-//% * @param ##VNAME_VAR     The value to be placed in the dictionary.
-//% * @param key ##VNAME_VAR$S## The key under which to store the value.
-//% *
-//% * @return A newly instanced dictionary with the key and value in it.
-//% **/
-//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)##VNAME_VAR
-//%                       ##VNAME$S## forKey:(KEY_TYPE##KisP$S##KisP)key;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the entries given.
-//% *
-//% * @param ##VNAME_VAR##s      The values to be placed in the dictionary.
-//% * @param keys ##VNAME_VAR$S##  The keys under which to store the values.
-//% * @param count ##VNAME_VAR$S## The number of entries to store in the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the keys and values in it.
-//% **/
-//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[__nullable])##VNAME_VAR##s
-//%                      ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[__nullable])keys
-//%                      ##VNAME$S##    count:(NSUInteger)count;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the entries from the given.
-//% * dictionary.
-//% *
-//% * @param dictionary Dictionary containing the entries to add to the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the entries from the given
-//% *         dictionary in it.
-//% **/
-//%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the given capacity.
-//% *
-//% * @param numItems Capacity needed for the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the given capacity.
-//% **/
-//%+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
-//%
-//%/**
 //% * Initializes this dictionary, copying the given values and keys.
 //% *
 //% * @param ##VNAME_VAR##s      The values to be placed in this dictionary.
@@ -8351,70 +5615,6 @@ NS_ASSUME_NONNULL_END
 //%@property(nonatomic, readonly) NSUInteger count;
 //%/** The validation function to check if the enums are valid. */
 //%@property(nonatomic, readonly) GPBEnumValidationFunc validationFunc;
-//%
-//%/**
-//% * @return A newly instanced and empty dictionary.
-//% **/
-//%+ (instancetype)dictionary;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the given validation function.
-//% *
-//% * @param func The enum validation function for the dictionary.
-//% *
-//% * @return A newly instanced dictionary.
-//% **/
-//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the single entry given.
-//% *
-//% * @param func     The enum validation function for the dictionary.
-//% * @param rawValue The raw enum value to be placed in the dictionary.
-//% * @param key      The key under which to store the value.
-//% *
-//% * @return A newly instanced dictionary with the key and value in it.
-//% **/
-//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-//%                                        rawValue:(VALUE_TYPE)rawValue
-//%                                          forKey:(KEY_TYPE##KisP$S##KisP)key;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the entries given.
-//% *
-//% * @param func   The enum validation function for the dictionary.
-//% * @param values The raw enum values values to be placed in the dictionary.
-//% * @param keys   The keys under which to store the values.
-//% * @param count  The number of entries to store in the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the keys and values in it.
-//% **/
-//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-//%                                       rawValues:(const VALUE_TYPE ARRAY_ARG_MODIFIER##VHELPER()[__nullable])values
-//%                                         forKeys:(const KEY_TYPE##KisP$S##KisP ARRAY_ARG_MODIFIER##KHELPER()[__nullable])keys
-//%                                           count:(NSUInteger)count;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the entries from the given.
-//% * dictionary.
-//% *
-//% * @param dictionary Dictionary containing the entries to add to the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the entries from the given
-//% *         dictionary in it.
-//% **/
-//%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary;
-//%
-//%/**
-//% * Creates and initializes a dictionary with the given capacity.
-//% *
-//% * @param func     The enum validation function for the dictionary.
-//% * @param numItems Capacity needed for the dictionary.
-//% *
-//% * @return A newly instanced dictionary with the given capacity.
-//% **/
-//%+ (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-//%                                        capacity:(NSUInteger)numItems;
 //%
 //%/**
 //% * Initializes a dictionary with the given validation function.

--- a/objectivec/GPBDictionary.m
+++ b/objectivec/GPBDictionary.m
@@ -596,39 +596,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%  NSMutableDictionary *_dictionary;
 //%}
 //%
-//%+ (instancetype)dictionary {
-//%  return [[[self alloc] initWith##VNAME##s:NULL forKeys:NULL count:0] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)##VNAME_VAR
-//%                      ##VNAME$S##  forKey:(KEY_TYPE##KisP$S##KisP)key {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:&##VNAME_VAR
-//%               KEY_NAME$S VALUE_NAME$S                        ##VNAME$S##  forKeys:&key
-//%               KEY_NAME$S VALUE_NAME$S                        ##VNAME$S##    count:1] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE [])##VNAME_VAR##s
-//%                      ##VNAME$S##  forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
-//%                      ##VNAME$S##    count:(NSUInteger)count {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:##VNAME_VAR##s
-//%               KEY_NAME$S VALUE_NAME$S                               forKeys:keys
-//%               KEY_NAME$S VALUE_NAME$S                                 count:count] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary {
-//%  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-//%  return [[[self alloc] initWithCapacity:numItems] autorelease];
-//%}
-//%
 //%- (instancetype)init {
 //%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
 //%}
@@ -684,54 +651,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //%}
 //%
 //%@synthesize validationFunc = _validationFunc;
-//%
-//%+ (instancetype)dictionary {
-//%  return [[[self alloc] initWithValidationFunction:NULL
-//%                                         rawValues:NULL
-//%                                           forKeys:NULL
-//%                                             count:0] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-//%  return [[[self alloc] initWithValidationFunction:func
-//%                                         rawValues:NULL
-//%                                           forKeys:NULL
-//%                                             count:0] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-//%                                        rawValue:(VALUE_TYPE)rawValue
-//%                                          forKey:(KEY_TYPE##KisP$S##KisP)key {
-//%  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWithValidationFunction:func
-//%               KEY_NAME$S VALUE_NAME$S                                         rawValues:&rawValue
-//%               KEY_NAME$S VALUE_NAME$S                                           forKeys:&key
-//%               KEY_NAME$S VALUE_NAME$S                                             count:1] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-//%                                       rawValues:(const VALUE_TYPE [])rawValues
-//%                                         forKeys:(const KEY_TYPE##KisP$S##KisP [])keys
-//%                                           count:(NSUInteger)count {
-//%  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWithValidationFunction:func
-//%               KEY_NAME$S VALUE_NAME$S                                         rawValues:rawValues
-//%               KEY_NAME$S VALUE_NAME$S                                           forKeys:keys
-//%               KEY_NAME$S VALUE_NAME$S                                             count:count] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithDictionary:(GPB##KEY_NAME##VALUE_NAME##Dictionary *)dictionary {
-//%  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPB##KEY_NAME##VALUE_NAME##Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-//%                                        capacity:(NSUInteger)numItems {
-//%  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-//%}
 //%
 //%- (instancetype)init {
 //%  return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -987,39 +906,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 //% @package
 //%  VALUE_TYPE _values[2];
 //%BOOL_DICT_HAS_STORAGE_##HELPER()}
-//%
-//%+ (instancetype)dictionary {
-//%  return [[[self alloc] initWith##VNAME##s:NULL forKeys:NULL count:0] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWith##VNAME##:(VALUE_TYPE)VNAME_VAR
-//%                      ##VNAME$S##  forKey:(BOOL)key {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:&##VNAME_VAR
-//%                    VALUE_NAME$S                        ##VNAME$S##  forKeys:&key
-//%                    VALUE_NAME$S                        ##VNAME$S##    count:1] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWith##VNAME##s:(const VALUE_TYPE [])##VNAME_VAR##s
-//%                      ##VNAME$S##  forKeys:(const BOOL [])keys
-//%                      ##VNAME$S##    count:(NSUInteger)count {
-//%  // Cast is needed so the compiler knows what class we are invoking initWith##VNAME##s:forKeys:count:
-//%  // on to get the type correct.
-//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWith##VNAME##s:##VNAME_VAR##s
-//%                    VALUE_NAME$S                        ##VNAME$S##  forKeys:keys
-//%                    VALUE_NAME$S                        ##VNAME$S##    count:count] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithDictionary:(GPBBool##VALUE_NAME##Dictionary *)dictionary {
-//%  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-//%  // on to get the type correct.
-//%  return [[(GPBBool##VALUE_NAME##Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-//%}
-//%
-//%+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-//%  return [[[self alloc] initWithCapacity:numItems] autorelease];
-//%}
 //%
 //%- (instancetype)init {
 //%  return [self initWith##VNAME##s:NULL forKeys:NULL count:0];
@@ -1549,39 +1435,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const uint32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32UInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -1763,39 +1616,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt32Int32Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithInt32s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32Int32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32Int32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -1981,39 +1801,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const uint32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32UInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32UInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -2195,39 +1982,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt32Int64Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithInt64s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32Int64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32Int64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -2413,39 +2167,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithBools:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const uint32_t [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithBools:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32BoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32BoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -2629,39 +2350,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithFloats:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const uint32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithFloats:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32FloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32FloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithFloats:NULL forKeys:NULL count:0];
 }
@@ -2843,39 +2531,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt32DoubleDictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const uint32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithDoubles:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32DoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32DoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -3063,54 +2718,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 @synthesize validationFunc = _validationFunc;
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithValidationFunction:NULL
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-  return [[[self alloc] initWithValidationFunction:func
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:&rawValue
-                                                                     forKeys:&key
-                                                                       count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])rawValues
-                                         forKeys:(const uint32_t [])keys
-                                           count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:rawValues
-                                                                     forKeys:keys
-                                                                       count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32EnumDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32EnumDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-}
 
 - (instancetype)init {
   return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -3361,39 +2968,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithObjects:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithObject:(id)object
-                              forKey:(uint32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32ObjectDictionary*)[self alloc] initWithObjects:&object
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithObjects:(const id [])objects
-                              forKeys:(const uint32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt32ObjectDictionary*)[self alloc] initWithObjects:objects
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt32ObjectDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt32ObjectDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithObjects:NULL forKeys:NULL count:0];
 }
@@ -3609,39 +3183,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const int32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32UInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32UInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -3823,39 +3364,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt32Int32Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithInt32s:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithInt32s:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32Int32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32Int32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -4041,39 +3549,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const int32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32UInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32UInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -4255,39 +3730,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt32Int64Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithInt64s:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithInt64s:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32Int64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32Int64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -4473,39 +3915,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32BoolDictionary*)[self alloc] initWithBools:&value
-                                                       forKeys:&key
-                                                         count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const int32_t [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32BoolDictionary*)[self alloc] initWithBools:values
-                                                        forKeys:keys
-                                                          count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32BoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32BoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -4689,39 +4098,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32FloatDictionary*)[self alloc] initWithFloats:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const int32_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32FloatDictionary*)[self alloc] initWithFloats:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32FloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32FloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithFloats:NULL forKeys:NULL count:0];
 }
@@ -4903,39 +4279,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt32DoubleDictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const int32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithDoubles:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32DoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32DoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -5123,54 +4466,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 @synthesize validationFunc = _validationFunc;
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithValidationFunction:NULL
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-  return [[[self alloc] initWithValidationFunction:func
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                  rawValues:&rawValue
-                                                                    forKeys:&key
-                                                                      count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])rawValues
-                                         forKeys:(const int32_t [])keys
-                                           count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                  rawValues:rawValues
-                                                                    forKeys:keys
-                                                                      count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32EnumDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32EnumDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-}
 
 - (instancetype)init {
   return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -5421,39 +4716,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithObjects:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithObject:(id)object
-                              forKey:(int32_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32ObjectDictionary*)[self alloc] initWithObjects:&object
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithObjects:(const id [])objects
-                              forKeys:(const int32_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt32ObjectDictionary*)[self alloc] initWithObjects:objects
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt32ObjectDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt32ObjectDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithObjects:NULL forKeys:NULL count:0];
 }
@@ -5669,39 +4931,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const uint64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64UInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -5883,39 +5112,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt64Int32Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithInt32s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64Int32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64Int32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -6101,39 +5297,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const uint64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64UInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64UInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -6315,39 +5478,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt64Int64Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithInt64s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64Int64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64Int64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -6533,39 +5663,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithBools:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const uint64_t [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithBools:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64BoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64BoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -6749,39 +5846,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithFloats:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const uint64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithFloats:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64FloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64FloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithFloats:NULL forKeys:NULL count:0];
 }
@@ -6963,39 +6027,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBUInt64DoubleDictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const uint64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithDoubles:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64DoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64DoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -7183,54 +6214,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 @synthesize validationFunc = _validationFunc;
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithValidationFunction:NULL
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-  return [[[self alloc] initWithValidationFunction:func
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:&rawValue
-                                                                     forKeys:&key
-                                                                       count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])rawValues
-                                         forKeys:(const uint64_t [])keys
-                                           count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:rawValues
-                                                                     forKeys:keys
-                                                                       count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64EnumDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64EnumDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-}
 
 - (instancetype)init {
   return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -7481,39 +6464,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithObjects:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithObject:(id)object
-                              forKey:(uint64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64ObjectDictionary*)[self alloc] initWithObjects:&object
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithObjects:(const id [])objects
-                              forKeys:(const uint64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBUInt64ObjectDictionary*)[self alloc] initWithObjects:objects
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBUInt64ObjectDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBUInt64ObjectDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithObjects:NULL forKeys:NULL count:0];
 }
@@ -7729,39 +6679,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const int64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64UInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64UInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -7943,39 +6860,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt64Int32Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithInt32s:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithInt32s:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64Int32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64Int32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -8161,39 +7045,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const int64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64UInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64UInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -8375,39 +7226,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt64Int64Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithInt64s:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithInt64s:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64Int64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64Int64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -8593,39 +7411,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64BoolDictionary*)[self alloc] initWithBools:&value
-                                                       forKeys:&key
-                                                         count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const int64_t [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64BoolDictionary*)[self alloc] initWithBools:values
-                                                        forKeys:keys
-                                                          count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64BoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64BoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -8809,39 +7594,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64FloatDictionary*)[self alloc] initWithFloats:&value
-                                                         forKeys:&key
-                                                           count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const int64_t [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64FloatDictionary*)[self alloc] initWithFloats:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64FloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64FloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithFloats:NULL forKeys:NULL count:0];
 }
@@ -9023,39 +7775,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBInt64DoubleDictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const int64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithDoubles:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64DoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64DoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -9243,54 +7962,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 @synthesize validationFunc = _validationFunc;
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithValidationFunction:NULL
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-  return [[[self alloc] initWithValidationFunction:func
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                  rawValues:&rawValue
-                                                                    forKeys:&key
-                                                                      count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])rawValues
-                                         forKeys:(const int64_t [])keys
-                                           count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64EnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                  rawValues:rawValues
-                                                                    forKeys:keys
-                                                                      count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64EnumDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64EnumDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-}
 
 - (instancetype)init {
   return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -9541,39 +8212,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithObjects:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithObject:(id)object
-                              forKey:(int64_t)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64ObjectDictionary*)[self alloc] initWithObjects:&object
-                                                           forKeys:&key
-                                                             count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithObjects:(const id [])objects
-                              forKeys:(const int64_t [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBInt64ObjectDictionary*)[self alloc] initWithObjects:objects
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBInt64ObjectDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBInt64ObjectDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithObjects:NULL forKeys:NULL count:0];
 }
@@ -9789,39 +8427,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const NSString * [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringUInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringUInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -10011,39 +8616,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBStringInt32Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringInt32Dictionary*)[self alloc] initWithInt32s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringInt32Dictionary*)[self alloc] initWithInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -10237,39 +8809,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const NSString * [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringUInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringUInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -10459,39 +8998,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBStringInt64Dictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringInt64Dictionary*)[self alloc] initWithInt64s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringInt64Dictionary*)[self alloc] initWithInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -10685,39 +9191,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringBoolDictionary*)[self alloc] initWithBools:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const NSString * [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringBoolDictionary*)[self alloc] initWithBools:values
-                                                         forKeys:keys
-                                                           count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringBoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringBoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -10909,39 +9382,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   NSMutableDictionary *_dictionary;
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringFloatDictionary*)[self alloc] initWithFloats:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const NSString * [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringFloatDictionary*)[self alloc] initWithFloats:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringFloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringFloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithFloats:NULL forKeys:NULL count:0];
 }
@@ -11131,39 +9571,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBStringDoubleDictionary {
  @package
   NSMutableDictionary *_dictionary;
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringDoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                            forKeys:&key
-                                                              count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const NSString * [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringDoubleDictionary*)[self alloc] initWithDoubles:values
-                                                           forKeys:keys
-                                                             count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringDoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBStringDoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -11359,54 +9766,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 }
 
 @synthesize validationFunc = _validationFunc;
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithValidationFunction:NULL
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func {
-  return [[[self alloc] initWithValidationFunction:func
-                                         rawValues:NULL
-                                           forKeys:NULL
-                                             count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        rawValue:(int32_t)rawValue
-                                          forKey:(NSString *)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringEnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:&rawValue
-                                                                     forKeys:&key
-                                                                       count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])rawValues
-                                         forKeys:(const NSString * [])keys
-                                           count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringEnumDictionary*)[self alloc] initWithValidationFunction:func
-                                                                   rawValues:rawValues
-                                                                     forKeys:keys
-                                                                       count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBStringEnumDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithValues:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBStringEnumDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithValidationFunction:(GPBEnumValidationFunc)func
-                                        capacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithValidationFunction:func capacity:numItems] autorelease];
-}
 
 - (instancetype)init {
   return [self initWithValidationFunction:NULL rawValues:NULL forKeys:NULL count:0];
@@ -11676,39 +10035,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   BOOL _valueSet[2];
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32:(uint32_t)value
-                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithUInt32s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const BOOL [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithUInt32s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolUInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolUInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt32s:NULL forKeys:NULL count:0];
 }
@@ -11916,39 +10242,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
  @package
   int32_t _values[2];
   BOOL _valueSet[2];
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt32s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32:(int32_t)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithInt32s:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt32s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithInt32s:values
-                                                        forKeys:keys
-                                                          count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolInt32Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolInt32Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -12160,39 +10453,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   BOOL _valueSet[2];
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithUInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64:(uint64_t)value
-                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithUInt64s:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const BOOL [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithUInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithUInt64s:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolUInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolUInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithUInt64s:NULL forKeys:NULL count:0];
 }
@@ -12400,39 +10660,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
  @package
   int64_t _values[2];
   BOOL _valueSet[2];
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithInt64s:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64:(int64_t)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithInt64s:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithInt64s:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithInt64s:values
-                                                        forKeys:keys
-                                                          count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolInt64Dictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -12644,39 +10871,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   BOOL _valueSet[2];
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithBools:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithBool:(BOOL)value
-                            forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolBoolDictionary*)[self alloc] initWithBools:&value
-                                                      forKeys:&key
-                                                        count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const BOOL [])keys
-                              count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithBools:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolBoolDictionary*)[self alloc] initWithBools:values
-                                                      forKeys:keys
-                                                        count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolBoolDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolBoolDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithBools:NULL forKeys:NULL count:0];
 }
@@ -12884,39 +11078,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
  @package
   float _values[2];
   BOOL _valueSet[2];
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithFloats:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloat:(float)value
-                             forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolFloatDictionary*)[self alloc] initWithFloats:&value
-                                                        forKeys:&key
-                                                          count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const BOOL [])keys
-                               count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithFloats:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolFloatDictionary*)[self alloc] initWithFloats:values
-                                                        forKeys:keys
-                                                          count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolFloatDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolFloatDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {
@@ -13128,39 +11289,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
   BOOL _valueSet[2];
 }
 
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithDoubles:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithDouble:(double)value
-                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithDoubles:&value
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const BOOL [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithDoubles:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithDoubles:values
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolDoubleDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolDoubleDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
-}
-
 - (instancetype)init {
   return [self initWithDoubles:NULL forKeys:NULL count:0];
 }
@@ -13367,39 +11495,6 @@ void GPBDictionaryReadEntry(id mapDictionary,
 @implementation GPBBoolObjectDictionary {
  @package
   id _values[2];
-}
-
-+ (instancetype)dictionary {
-  return [[[self alloc] initWithObjects:NULL forKeys:NULL count:0] autorelease];
-}
-
-+ (instancetype)dictionaryWithObject:(id)object
-                              forKey:(BOOL)key {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolObjectDictionary*)[self alloc] initWithObjects:&object
-                                                          forKeys:&key
-                                                            count:1] autorelease];
-}
-
-+ (instancetype)dictionaryWithObjects:(const id [])objects
-                              forKeys:(const BOOL [])keys
-                                count:(NSUInteger)count {
-  // Cast is needed so the compiler knows what class we are invoking initWithObjects:forKeys:count:
-  // on to get the type correct.
-  return [[(GPBBoolObjectDictionary*)[self alloc] initWithObjects:objects
-                                                          forKeys:keys
-                                                            count:count] autorelease];
-}
-
-+ (instancetype)dictionaryWithDictionary:(GPBBoolObjectDictionary *)dictionary {
-  // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
-  // on to get the type correct.
-  return [[(GPBBoolObjectDictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
-}
-
-+ (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
-  return [[[self alloc] initWithCapacity:numItems] autorelease];
 }
 
 - (instancetype)init {

--- a/objectivec/Tests/GPBDictionaryTests+Bool.m
+++ b/objectivec/Tests/GPBDictionaryTests+Bool.m
@@ -63,7 +63,8 @@
 }
 
 - (void)testOne {
-  GPBBoolUInt32Dictionary *dict = [GPBBoolUInt32Dictionary dictionaryWithUInt32:100U forKey:YES];
+  GPBBoolUInt32Dictionary *dict = [[GPBBoolUInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -76,6 +77,7 @@
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -214,17 +216,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolUInt32Dictionary *dict2 =
-      [GPBBoolUInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBBoolUInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolUInt32Dictionary *dict = [GPBBoolUInt32Dictionary dictionary];
+  GPBBoolUInt32Dictionary *dict = [[GPBBoolUInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -249,6 +252,7 @@
   XCTAssertTrue([dict getUInt32:&value forKey:NO]);
   XCTAssertEqual(value, 101U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -364,7 +368,8 @@
 }
 
 - (void)testOne {
-  GPBBoolInt32Dictionary *dict = [GPBBoolInt32Dictionary dictionaryWithInt32:200 forKey:YES];
+  GPBBoolInt32Dictionary *dict = [[GPBBoolInt32Dictionary alloc] init];
+  [dict setInt32:200 forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -377,6 +382,7 @@
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -515,17 +521,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolInt32Dictionary *dict2 =
-      [GPBBoolInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBBoolInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolInt32Dictionary *dict = [GPBBoolInt32Dictionary dictionary];
+  GPBBoolInt32Dictionary *dict = [[GPBBoolInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -550,6 +557,7 @@
   XCTAssertTrue([dict getInt32:&value forKey:NO]);
   XCTAssertEqual(value, 201);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -665,7 +673,8 @@
 }
 
 - (void)testOne {
-  GPBBoolUInt64Dictionary *dict = [GPBBoolUInt64Dictionary dictionaryWithUInt64:300U forKey:YES];
+  GPBBoolUInt64Dictionary *dict = [[GPBBoolUInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -678,6 +687,7 @@
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -816,17 +826,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolUInt64Dictionary *dict2 =
-      [GPBBoolUInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBBoolUInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolUInt64Dictionary *dict = [GPBBoolUInt64Dictionary dictionary];
+  GPBBoolUInt64Dictionary *dict = [[GPBBoolUInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -851,6 +862,7 @@
   XCTAssertTrue([dict getUInt64:&value forKey:NO]);
   XCTAssertEqual(value, 301U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -966,7 +978,8 @@
 }
 
 - (void)testOne {
-  GPBBoolInt64Dictionary *dict = [GPBBoolInt64Dictionary dictionaryWithInt64:400 forKey:YES];
+  GPBBoolInt64Dictionary *dict = [[GPBBoolInt64Dictionary alloc] init];
+  [dict setInt64:400 forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -979,6 +992,7 @@
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1117,17 +1131,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolInt64Dictionary *dict2 =
-      [GPBBoolInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBBoolInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolInt64Dictionary *dict = [GPBBoolInt64Dictionary dictionary];
+  GPBBoolInt64Dictionary *dict = [[GPBBoolInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1152,6 +1167,7 @@
   XCTAssertTrue([dict getInt64:&value forKey:NO]);
   XCTAssertEqual(value, 401);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1267,7 +1283,8 @@
 }
 
 - (void)testOne {
-  GPBBoolBoolDictionary *dict = [GPBBoolBoolDictionary dictionaryWithBool:NO forKey:YES];
+  GPBBoolBoolDictionary *dict = [[GPBBoolBoolDictionary alloc] init];
+  [dict setBool:NO forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1280,6 +1297,7 @@
     XCTAssertEqual(aValue, NO);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1418,17 +1436,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolBoolDictionary *dict2 =
-      [GPBBoolBoolDictionary dictionaryWithDictionary:dict];
+      [[GPBBoolBoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolBoolDictionary *dict = [GPBBoolBoolDictionary dictionary];
+  GPBBoolBoolDictionary *dict = [[GPBBoolBoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1453,6 +1472,7 @@
   XCTAssertTrue([dict getBool:&value forKey:NO]);
   XCTAssertEqual(value, YES);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1568,7 +1588,8 @@
 }
 
 - (void)testOne {
-  GPBBoolFloatDictionary *dict = [GPBBoolFloatDictionary dictionaryWithFloat:500.f forKey:YES];
+  GPBBoolFloatDictionary *dict = [[GPBBoolFloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1581,6 +1602,7 @@
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1719,17 +1741,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolFloatDictionary *dict2 =
-      [GPBBoolFloatDictionary dictionaryWithDictionary:dict];
+      [[GPBBoolFloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolFloatDictionary *dict = [GPBBoolFloatDictionary dictionary];
+  GPBBoolFloatDictionary *dict = [[GPBBoolFloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1754,6 +1777,7 @@
   XCTAssertTrue([dict getFloat:&value forKey:NO]);
   XCTAssertEqual(value, 501.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1869,7 +1893,8 @@
 }
 
 - (void)testOne {
-  GPBBoolDoubleDictionary *dict = [GPBBoolDoubleDictionary dictionaryWithDouble:600. forKey:YES];
+  GPBBoolDoubleDictionary *dict = [[GPBBoolDoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -1882,6 +1907,7 @@
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2020,17 +2046,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolDoubleDictionary *dict2 =
-      [GPBBoolDoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBBoolDoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolDoubleDictionary *dict = [GPBBoolDoubleDictionary dictionary];
+  GPBBoolDoubleDictionary *dict = [[GPBBoolDoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2055,6 +2082,7 @@
   XCTAssertTrue([dict getDouble:&value forKey:NO]);
   XCTAssertEqual(value, 601.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2170,7 +2198,8 @@
 }
 
 - (void)testOne {
-  GPBBoolObjectDictionary<NSString*> *dict = [GPBBoolObjectDictionary dictionaryWithObject:@"abc" forKey:YES];
+  GPBBoolObjectDictionary<NSString*> *dict = [[GPBBoolObjectDictionary alloc] init];
+  [dict setObject:@"abc" forKey:YES];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   XCTAssertEqualObjects([dict objectForKey:YES], @"abc");
@@ -2180,6 +2209,7 @@
     XCTAssertEqualObjects(aObject, @"abc");
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2313,17 +2343,18 @@
   XCTAssertNotNil(dict);
 
   GPBBoolObjectDictionary<NSString*> *dict2 =
-      [GPBBoolObjectDictionary dictionaryWithDictionary:dict];
+      [[GPBBoolObjectDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBBoolObjectDictionary<NSString*> *dict = [GPBBoolObjectDictionary dictionary];
+  GPBBoolObjectDictionary<NSString*> *dict = [[GPBBoolObjectDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2343,6 +2374,7 @@
   XCTAssertEqualObjects([dict objectForKey:YES], @"abc");
   XCTAssertEqualObjects([dict objectForKey:NO], @"def");
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {

--- a/objectivec/Tests/GPBDictionaryTests+Int32.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int32.m
@@ -103,7 +103,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32UInt32Dictionary *dict = [GPBInt32UInt32Dictionary dictionaryWithUInt32:100U forKey:11];
+  GPBInt32UInt32Dictionary *dict = [[GPBInt32UInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -116,6 +117,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -258,17 +260,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32UInt32Dictionary *dict2 =
-      [GPBInt32UInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt32UInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32UInt32Dictionary *dict = [GPBInt32UInt32Dictionary dictionary];
+  GPBInt32UInt32Dictionary *dict = [[GPBInt32UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -299,6 +302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt32:&value forKey:14]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -460,7 +464,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32Int32Dictionary *dict = [GPBInt32Int32Dictionary dictionaryWithInt32:200 forKey:11];
+  GPBInt32Int32Dictionary *dict = [[GPBInt32Int32Dictionary alloc] init];
+  [dict setInt32:200 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -473,6 +478,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -615,17 +621,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32Int32Dictionary *dict2 =
-      [GPBInt32Int32Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt32Int32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32Int32Dictionary *dict = [GPBInt32Int32Dictionary dictionary];
+  GPBInt32Int32Dictionary *dict = [[GPBInt32Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -656,6 +663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt32:&value forKey:14]);
   XCTAssertEqual(value, 203);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -817,7 +825,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32UInt64Dictionary *dict = [GPBInt32UInt64Dictionary dictionaryWithUInt64:300U forKey:11];
+  GPBInt32UInt64Dictionary *dict = [[GPBInt32UInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -830,6 +839,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -972,17 +982,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32UInt64Dictionary *dict2 =
-      [GPBInt32UInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt32UInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32UInt64Dictionary *dict = [GPBInt32UInt64Dictionary dictionary];
+  GPBInt32UInt64Dictionary *dict = [[GPBInt32UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1013,6 +1024,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt64:&value forKey:14]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1174,7 +1186,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32Int64Dictionary *dict = [GPBInt32Int64Dictionary dictionaryWithInt64:400 forKey:11];
+  GPBInt32Int64Dictionary *dict = [[GPBInt32Int64Dictionary alloc] init];
+  [dict setInt64:400 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -1187,6 +1200,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1329,17 +1343,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32Int64Dictionary *dict2 =
-      [GPBInt32Int64Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt32Int64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32Int64Dictionary *dict = [GPBInt32Int64Dictionary dictionary];
+  GPBInt32Int64Dictionary *dict = [[GPBInt32Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1370,6 +1385,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt64:&value forKey:14]);
   XCTAssertEqual(value, 403);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1531,7 +1547,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32BoolDictionary *dict = [GPBInt32BoolDictionary dictionaryWithBool:YES forKey:11];
+  GPBInt32BoolDictionary *dict = [[GPBInt32BoolDictionary alloc] init];
+  [dict setBool:YES forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1544,6 +1561,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1686,17 +1704,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32BoolDictionary *dict2 =
-      [GPBInt32BoolDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32BoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32BoolDictionary *dict = [GPBInt32BoolDictionary dictionary];
+  GPBInt32BoolDictionary *dict = [[GPBInt32BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1727,6 +1746,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getBool:&value forKey:14]);
   XCTAssertEqual(value, NO);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1888,7 +1908,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32FloatDictionary *dict = [GPBInt32FloatDictionary dictionaryWithFloat:500.f forKey:11];
+  GPBInt32FloatDictionary *dict = [[GPBInt32FloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1901,6 +1922,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2043,17 +2065,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32FloatDictionary *dict2 =
-      [GPBInt32FloatDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32FloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32FloatDictionary *dict = [GPBInt32FloatDictionary dictionary];
+  GPBInt32FloatDictionary *dict = [[GPBInt32FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2084,6 +2107,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getFloat:&value forKey:14]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2245,7 +2269,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32DoubleDictionary *dict = [GPBInt32DoubleDictionary dictionaryWithDouble:600. forKey:11];
+  GPBInt32DoubleDictionary *dict = [[GPBInt32DoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -2258,6 +2283,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2400,17 +2426,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32DoubleDictionary *dict2 =
-      [GPBInt32DoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32DoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32DoubleDictionary *dict = [GPBInt32DoubleDictionary dictionary];
+  GPBInt32DoubleDictionary *dict = [[GPBInt32DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2441,6 +2468,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getDouble:&value forKey:14]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2602,7 +2630,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32EnumDictionary *dict = [GPBInt32EnumDictionary dictionaryWithEnum:700 forKey:11];
+  GPBInt32EnumDictionary *dict = [[GPBInt32EnumDictionary alloc] init];
+  [dict setEnum:700 forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -2615,6 +2644,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2757,17 +2787,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32EnumDictionary *dict2 =
-      [GPBInt32EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32EnumDictionary *dict = [GPBInt32EnumDictionary dictionary];
+  GPBInt32EnumDictionary *dict = [[GPBInt32EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2798,6 +2829,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getEnum:&value forKey:14]);
   XCTAssertEqual(value, 703);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -3120,19 +3152,20 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32EnumDictionary *dict2 =
-      [GPBInt32EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
   XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+  [dict2 release];
   [dict release];
 }
 
 - (void)testUnknownAdds {
   GPBInt32EnumDictionary *dict =
-    [GPBInt32EnumDictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+      [[GPBInt32EnumDictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3172,6 +3205,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getRawValue:&value forKey:14]);
   XCTAssertEqual(value, 803);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testUnknownRemove {
@@ -3375,7 +3409,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt32ObjectDictionary<NSString*> *dict = [GPBInt32ObjectDictionary dictionaryWithObject:@"abc" forKey:11];
+  GPBInt32ObjectDictionary<NSString*> *dict = [[GPBInt32ObjectDictionary alloc] init];
+  [dict setObject:@"abc" forKey:11];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   XCTAssertEqualObjects([dict objectForKey:11], @"abc");
@@ -3385,6 +3420,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqualObjects(aObject, @"abc");
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -3520,17 +3556,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt32ObjectDictionary<NSString*> *dict2 =
-      [GPBInt32ObjectDictionary dictionaryWithDictionary:dict];
+      [[GPBInt32ObjectDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt32ObjectDictionary<NSString*> *dict = [GPBInt32ObjectDictionary dictionary];
+  GPBInt32ObjectDictionary<NSString*> *dict = [[GPBInt32ObjectDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3552,6 +3589,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqualObjects([dict objectForKey:13], @"ghi");
   XCTAssertEqualObjects([dict objectForKey:14], @"jkl");
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {

--- a/objectivec/Tests/GPBDictionaryTests+Int64.m
+++ b/objectivec/Tests/GPBDictionaryTests+Int64.m
@@ -103,7 +103,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64UInt32Dictionary *dict = [GPBInt64UInt32Dictionary dictionaryWithUInt32:100U forKey:21LL];
+  GPBInt64UInt32Dictionary *dict = [[GPBInt64UInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -116,6 +117,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -258,17 +260,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64UInt32Dictionary *dict2 =
-      [GPBInt64UInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt64UInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64UInt32Dictionary *dict = [GPBInt64UInt32Dictionary dictionary];
+  GPBInt64UInt32Dictionary *dict = [[GPBInt64UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -299,6 +302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -460,7 +464,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64Int32Dictionary *dict = [GPBInt64Int32Dictionary dictionaryWithInt32:200 forKey:21LL];
+  GPBInt64Int32Dictionary *dict = [[GPBInt64Int32Dictionary alloc] init];
+  [dict setInt32:200 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -473,6 +478,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -615,17 +621,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64Int32Dictionary *dict2 =
-      [GPBInt64Int32Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt64Int32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64Int32Dictionary *dict = [GPBInt64Int32Dictionary dictionary];
+  GPBInt64Int32Dictionary *dict = [[GPBInt64Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -656,6 +663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt32:&value forKey:24LL]);
   XCTAssertEqual(value, 203);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -817,7 +825,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64UInt64Dictionary *dict = [GPBInt64UInt64Dictionary dictionaryWithUInt64:300U forKey:21LL];
+  GPBInt64UInt64Dictionary *dict = [[GPBInt64UInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -830,6 +839,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -972,17 +982,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64UInt64Dictionary *dict2 =
-      [GPBInt64UInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt64UInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64UInt64Dictionary *dict = [GPBInt64UInt64Dictionary dictionary];
+  GPBInt64UInt64Dictionary *dict = [[GPBInt64UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1013,6 +1024,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1174,7 +1186,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64Int64Dictionary *dict = [GPBInt64Int64Dictionary dictionaryWithInt64:400 forKey:21LL];
+  GPBInt64Int64Dictionary *dict = [[GPBInt64Int64Dictionary alloc] init];
+  [dict setInt64:400 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -1187,6 +1200,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1329,17 +1343,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64Int64Dictionary *dict2 =
-      [GPBInt64Int64Dictionary dictionaryWithDictionary:dict];
+      [[GPBInt64Int64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64Int64Dictionary *dict = [GPBInt64Int64Dictionary dictionary];
+  GPBInt64Int64Dictionary *dict = [[GPBInt64Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1370,6 +1385,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt64:&value forKey:24LL]);
   XCTAssertEqual(value, 403);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1531,7 +1547,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64BoolDictionary *dict = [GPBInt64BoolDictionary dictionaryWithBool:YES forKey:21LL];
+  GPBInt64BoolDictionary *dict = [[GPBInt64BoolDictionary alloc] init];
+  [dict setBool:YES forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1544,6 +1561,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1686,17 +1704,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64BoolDictionary *dict2 =
-      [GPBInt64BoolDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64BoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64BoolDictionary *dict = [GPBInt64BoolDictionary dictionary];
+  GPBInt64BoolDictionary *dict = [[GPBInt64BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1727,6 +1746,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getBool:&value forKey:24LL]);
   XCTAssertEqual(value, NO);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1888,7 +1908,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64FloatDictionary *dict = [GPBInt64FloatDictionary dictionaryWithFloat:500.f forKey:21LL];
+  GPBInt64FloatDictionary *dict = [[GPBInt64FloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1901,6 +1922,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2043,17 +2065,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64FloatDictionary *dict2 =
-      [GPBInt64FloatDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64FloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64FloatDictionary *dict = [GPBInt64FloatDictionary dictionary];
+  GPBInt64FloatDictionary *dict = [[GPBInt64FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2084,6 +2107,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getFloat:&value forKey:24LL]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2245,7 +2269,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64DoubleDictionary *dict = [GPBInt64DoubleDictionary dictionaryWithDouble:600. forKey:21LL];
+  GPBInt64DoubleDictionary *dict = [[GPBInt64DoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -2258,6 +2283,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2400,17 +2426,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64DoubleDictionary *dict2 =
-      [GPBInt64DoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64DoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64DoubleDictionary *dict = [GPBInt64DoubleDictionary dictionary];
+  GPBInt64DoubleDictionary *dict = [[GPBInt64DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2441,6 +2468,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getDouble:&value forKey:24LL]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2602,7 +2630,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64EnumDictionary *dict = [GPBInt64EnumDictionary dictionaryWithEnum:700 forKey:21LL];
+  GPBInt64EnumDictionary *dict = [[GPBInt64EnumDictionary alloc] init];
+  [dict setEnum:700 forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -2615,6 +2644,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2757,17 +2787,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64EnumDictionary *dict2 =
-      [GPBInt64EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64EnumDictionary *dict = [GPBInt64EnumDictionary dictionary];
+  GPBInt64EnumDictionary *dict = [[GPBInt64EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2798,6 +2829,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getEnum:&value forKey:24LL]);
   XCTAssertEqual(value, 703);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -3120,19 +3152,20 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64EnumDictionary *dict2 =
-      [GPBInt64EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
   XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+  [dict2 release];
   [dict release];
 }
 
 - (void)testUnknownAdds {
   GPBInt64EnumDictionary *dict =
-    [GPBInt64EnumDictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+      [[GPBInt64EnumDictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3172,6 +3205,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getRawValue:&value forKey:24LL]);
   XCTAssertEqual(value, 803);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testUnknownRemove {
@@ -3375,7 +3409,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBInt64ObjectDictionary<NSString*> *dict = [GPBInt64ObjectDictionary dictionaryWithObject:@"abc" forKey:21LL];
+  GPBInt64ObjectDictionary<NSString*> *dict = [[GPBInt64ObjectDictionary alloc] init];
+  [dict setObject:@"abc" forKey:21LL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   XCTAssertEqualObjects([dict objectForKey:21LL], @"abc");
@@ -3385,6 +3420,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqualObjects(aObject, @"abc");
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -3520,17 +3556,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBInt64ObjectDictionary<NSString*> *dict2 =
-      [GPBInt64ObjectDictionary dictionaryWithDictionary:dict];
+      [[GPBInt64ObjectDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBInt64ObjectDictionary<NSString*> *dict = [GPBInt64ObjectDictionary dictionary];
+  GPBInt64ObjectDictionary<NSString*> *dict = [[GPBInt64ObjectDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3552,6 +3589,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqualObjects([dict objectForKey:23LL], @"ghi");
   XCTAssertEqualObjects([dict objectForKey:24LL], @"jkl");
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {

--- a/objectivec/Tests/GPBDictionaryTests+String.m
+++ b/objectivec/Tests/GPBDictionaryTests+String.m
@@ -103,7 +103,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringUInt32Dictionary *dict = [GPBStringUInt32Dictionary dictionaryWithUInt32:100U forKey:@"foo"];
+  GPBStringUInt32Dictionary *dict = [[GPBStringUInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -116,6 +117,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -258,17 +260,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringUInt32Dictionary *dict2 =
-      [GPBStringUInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBStringUInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringUInt32Dictionary *dict = [GPBStringUInt32Dictionary dictionary];
+  GPBStringUInt32Dictionary *dict = [[GPBStringUInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -299,6 +302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -460,7 +464,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringInt32Dictionary *dict = [GPBStringInt32Dictionary dictionaryWithInt32:200 forKey:@"foo"];
+  GPBStringInt32Dictionary *dict = [[GPBStringInt32Dictionary alloc] init];
+  [dict setInt32:200 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -473,6 +478,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -615,17 +621,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringInt32Dictionary *dict2 =
-      [GPBStringInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBStringInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringInt32Dictionary *dict = [GPBStringInt32Dictionary dictionary];
+  GPBStringInt32Dictionary *dict = [[GPBStringInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -656,6 +663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt32:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 203);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -817,7 +825,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringUInt64Dictionary *dict = [GPBStringUInt64Dictionary dictionaryWithUInt64:300U forKey:@"foo"];
+  GPBStringUInt64Dictionary *dict = [[GPBStringUInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -830,6 +839,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -972,17 +982,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringUInt64Dictionary *dict2 =
-      [GPBStringUInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBStringUInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringUInt64Dictionary *dict = [GPBStringUInt64Dictionary dictionary];
+  GPBStringUInt64Dictionary *dict = [[GPBStringUInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1013,6 +1024,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1174,7 +1186,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringInt64Dictionary *dict = [GPBStringInt64Dictionary dictionaryWithInt64:400 forKey:@"foo"];
+  GPBStringInt64Dictionary *dict = [[GPBStringInt64Dictionary alloc] init];
+  [dict setInt64:400 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -1187,6 +1200,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1329,17 +1343,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringInt64Dictionary *dict2 =
-      [GPBStringInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBStringInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringInt64Dictionary *dict = [GPBStringInt64Dictionary dictionary];
+  GPBStringInt64Dictionary *dict = [[GPBStringInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1370,6 +1385,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt64:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 403);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1531,7 +1547,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringBoolDictionary *dict = [GPBStringBoolDictionary dictionaryWithBool:YES forKey:@"foo"];
+  GPBStringBoolDictionary *dict = [[GPBStringBoolDictionary alloc] init];
+  [dict setBool:YES forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1544,6 +1561,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1686,17 +1704,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringBoolDictionary *dict2 =
-      [GPBStringBoolDictionary dictionaryWithDictionary:dict];
+      [[GPBStringBoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringBoolDictionary *dict = [GPBStringBoolDictionary dictionary];
+  GPBStringBoolDictionary *dict = [[GPBStringBoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1727,6 +1746,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getBool:&value forKey:@"mumble"]);
   XCTAssertEqual(value, NO);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1888,7 +1908,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringFloatDictionary *dict = [GPBStringFloatDictionary dictionaryWithFloat:500.f forKey:@"foo"];
+  GPBStringFloatDictionary *dict = [[GPBStringFloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1901,6 +1922,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2043,17 +2065,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringFloatDictionary *dict2 =
-      [GPBStringFloatDictionary dictionaryWithDictionary:dict];
+      [[GPBStringFloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringFloatDictionary *dict = [GPBStringFloatDictionary dictionary];
+  GPBStringFloatDictionary *dict = [[GPBStringFloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2084,6 +2107,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getFloat:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2245,7 +2269,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringDoubleDictionary *dict = [GPBStringDoubleDictionary dictionaryWithDouble:600. forKey:@"foo"];
+  GPBStringDoubleDictionary *dict = [[GPBStringDoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -2258,6 +2283,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2400,17 +2426,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringDoubleDictionary *dict2 =
-      [GPBStringDoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBStringDoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringDoubleDictionary *dict = [GPBStringDoubleDictionary dictionary];
+  GPBStringDoubleDictionary *dict = [[GPBStringDoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2441,6 +2468,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getDouble:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2602,7 +2630,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBStringEnumDictionary *dict = [GPBStringEnumDictionary dictionaryWithEnum:700 forKey:@"foo"];
+  GPBStringEnumDictionary *dict = [[GPBStringEnumDictionary alloc] init];
+  [dict setEnum:700 forKey:@"foo"];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -2615,6 +2644,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2757,17 +2787,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringEnumDictionary *dict2 =
-      [GPBStringEnumDictionary dictionaryWithDictionary:dict];
+      [[GPBStringEnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBStringEnumDictionary *dict = [GPBStringEnumDictionary dictionary];
+  GPBStringEnumDictionary *dict = [[GPBStringEnumDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2798,6 +2829,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getEnum:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 703);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -3120,19 +3152,20 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBStringEnumDictionary *dict2 =
-      [GPBStringEnumDictionary dictionaryWithDictionary:dict];
+      [[GPBStringEnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
   XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+  [dict2 release];
   [dict release];
 }
 
 - (void)testUnknownAdds {
   GPBStringEnumDictionary *dict =
-    [GPBStringEnumDictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+      [[GPBStringEnumDictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3172,6 +3205,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getRawValue:&value forKey:@"mumble"]);
   XCTAssertEqual(value, 803);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testUnknownRemove {

--- a/objectivec/Tests/GPBDictionaryTests+UInt32.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt32.m
@@ -103,7 +103,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32UInt32Dictionary *dict = [GPBUInt32UInt32Dictionary dictionaryWithUInt32:100U forKey:1U];
+  GPBUInt32UInt32Dictionary *dict = [[GPBUInt32UInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -116,6 +117,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -258,17 +260,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt32Dictionary *dict2 =
-      [GPBUInt32UInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32UInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32UInt32Dictionary *dict = [GPBUInt32UInt32Dictionary dictionary];
+  GPBUInt32UInt32Dictionary *dict = [[GPBUInt32UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -299,6 +302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt32:&value forKey:4U]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -460,7 +464,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32Int32Dictionary *dict = [GPBUInt32Int32Dictionary dictionaryWithInt32:200 forKey:1U];
+  GPBUInt32Int32Dictionary *dict = [[GPBUInt32Int32Dictionary alloc] init];
+  [dict setInt32:200 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -473,6 +478,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -615,17 +621,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32Int32Dictionary *dict2 =
-      [GPBUInt32Int32Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32Int32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32Int32Dictionary *dict = [GPBUInt32Int32Dictionary dictionary];
+  GPBUInt32Int32Dictionary *dict = [[GPBUInt32Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -656,6 +663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt32:&value forKey:4U]);
   XCTAssertEqual(value, 203);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -817,7 +825,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32UInt64Dictionary *dict = [GPBUInt32UInt64Dictionary dictionaryWithUInt64:300U forKey:1U];
+  GPBUInt32UInt64Dictionary *dict = [[GPBUInt32UInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -830,6 +839,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -972,17 +982,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32UInt64Dictionary *dict2 =
-      [GPBUInt32UInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32UInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32UInt64Dictionary *dict = [GPBUInt32UInt64Dictionary dictionary];
+  GPBUInt32UInt64Dictionary *dict = [[GPBUInt32UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1013,6 +1024,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt64:&value forKey:4U]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1174,7 +1186,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32Int64Dictionary *dict = [GPBUInt32Int64Dictionary dictionaryWithInt64:400 forKey:1U];
+  GPBUInt32Int64Dictionary *dict = [[GPBUInt32Int64Dictionary alloc] init];
+  [dict setInt64:400 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -1187,6 +1200,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1329,17 +1343,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32Int64Dictionary *dict2 =
-      [GPBUInt32Int64Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32Int64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32Int64Dictionary *dict = [GPBUInt32Int64Dictionary dictionary];
+  GPBUInt32Int64Dictionary *dict = [[GPBUInt32Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1370,6 +1385,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt64:&value forKey:4U]);
   XCTAssertEqual(value, 403);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1531,7 +1547,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32BoolDictionary *dict = [GPBUInt32BoolDictionary dictionaryWithBool:YES forKey:1U];
+  GPBUInt32BoolDictionary *dict = [[GPBUInt32BoolDictionary alloc] init];
+  [dict setBool:YES forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1544,6 +1561,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1686,17 +1704,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32BoolDictionary *dict2 =
-      [GPBUInt32BoolDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32BoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32BoolDictionary *dict = [GPBUInt32BoolDictionary dictionary];
+  GPBUInt32BoolDictionary *dict = [[GPBUInt32BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1727,6 +1746,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getBool:&value forKey:4U]);
   XCTAssertEqual(value, NO);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1888,7 +1908,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32FloatDictionary *dict = [GPBUInt32FloatDictionary dictionaryWithFloat:500.f forKey:1U];
+  GPBUInt32FloatDictionary *dict = [[GPBUInt32FloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1901,6 +1922,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2043,17 +2065,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32FloatDictionary *dict2 =
-      [GPBUInt32FloatDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32FloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32FloatDictionary *dict = [GPBUInt32FloatDictionary dictionary];
+  GPBUInt32FloatDictionary *dict = [[GPBUInt32FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2084,6 +2107,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getFloat:&value forKey:4U]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2245,7 +2269,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32DoubleDictionary *dict = [GPBUInt32DoubleDictionary dictionaryWithDouble:600. forKey:1U];
+  GPBUInt32DoubleDictionary *dict = [[GPBUInt32DoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -2258,6 +2283,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2400,17 +2426,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32DoubleDictionary *dict2 =
-      [GPBUInt32DoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32DoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32DoubleDictionary *dict = [GPBUInt32DoubleDictionary dictionary];
+  GPBUInt32DoubleDictionary *dict = [[GPBUInt32DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2441,6 +2468,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getDouble:&value forKey:4U]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2602,7 +2630,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32EnumDictionary *dict = [GPBUInt32EnumDictionary dictionaryWithEnum:700 forKey:1U];
+  GPBUInt32EnumDictionary *dict = [[GPBUInt32EnumDictionary alloc] init];
+  [dict setEnum:700 forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -2615,6 +2644,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2757,17 +2787,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32EnumDictionary *dict2 =
-      [GPBUInt32EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32EnumDictionary *dict = [GPBUInt32EnumDictionary dictionary];
+  GPBUInt32EnumDictionary *dict = [[GPBUInt32EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2798,6 +2829,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getEnum:&value forKey:4U]);
   XCTAssertEqual(value, 703);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -3120,19 +3152,20 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32EnumDictionary *dict2 =
-      [GPBUInt32EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
   XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+  [dict2 release];
   [dict release];
 }
 
 - (void)testUnknownAdds {
   GPBUInt32EnumDictionary *dict =
-    [GPBUInt32EnumDictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+      [[GPBUInt32EnumDictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3172,6 +3205,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getRawValue:&value forKey:4U]);
   XCTAssertEqual(value, 803);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testUnknownRemove {
@@ -3375,7 +3409,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt32ObjectDictionary<NSString*> *dict = [GPBUInt32ObjectDictionary dictionaryWithObject:@"abc" forKey:1U];
+  GPBUInt32ObjectDictionary<NSString*> *dict = [[GPBUInt32ObjectDictionary alloc] init];
+  [dict setObject:@"abc" forKey:1U];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   XCTAssertEqualObjects([dict objectForKey:1U], @"abc");
@@ -3385,6 +3420,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqualObjects(aObject, @"abc");
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -3520,17 +3556,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt32ObjectDictionary<NSString*> *dict2 =
-      [GPBUInt32ObjectDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt32ObjectDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt32ObjectDictionary<NSString*> *dict = [GPBUInt32ObjectDictionary dictionary];
+  GPBUInt32ObjectDictionary<NSString*> *dict = [[GPBUInt32ObjectDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3552,6 +3589,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqualObjects([dict objectForKey:3U], @"ghi");
   XCTAssertEqualObjects([dict objectForKey:4U], @"jkl");
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {

--- a/objectivec/Tests/GPBDictionaryTests+UInt64.m
+++ b/objectivec/Tests/GPBDictionaryTests+UInt64.m
@@ -103,7 +103,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64UInt32Dictionary *dict = [GPBUInt64UInt32Dictionary dictionaryWithUInt32:100U forKey:31ULL];
+  GPBUInt64UInt32Dictionary *dict = [[GPBUInt64UInt32Dictionary alloc] init];
+  [dict setUInt32:100U forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint32_t value;
@@ -116,6 +117,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 100U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -258,17 +260,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt32Dictionary *dict2 =
-      [GPBUInt64UInt32Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64UInt32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64UInt32Dictionary *dict = [GPBUInt64UInt32Dictionary dictionary];
+  GPBUInt64UInt32Dictionary *dict = [[GPBUInt64UInt32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -299,6 +302,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 103U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -460,7 +464,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64Int32Dictionary *dict = [GPBUInt64Int32Dictionary dictionaryWithInt32:200 forKey:31ULL];
+  GPBUInt64Int32Dictionary *dict = [[GPBUInt64Int32Dictionary alloc] init];
+  [dict setInt32:200 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -473,6 +478,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 200);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -615,17 +621,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64Int32Dictionary *dict2 =
-      [GPBUInt64Int32Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64Int32Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64Int32Dictionary *dict = [GPBUInt64Int32Dictionary dictionary];
+  GPBUInt64Int32Dictionary *dict = [[GPBUInt64Int32Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -656,6 +663,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt32:&value forKey:34ULL]);
   XCTAssertEqual(value, 203);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -817,7 +825,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64UInt64Dictionary *dict = [GPBUInt64UInt64Dictionary dictionaryWithUInt64:300U forKey:31ULL];
+  GPBUInt64UInt64Dictionary *dict = [[GPBUInt64UInt64Dictionary alloc] init];
+  [dict setUInt64:300U forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   uint64_t value;
@@ -830,6 +839,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 300U);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -972,17 +982,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64UInt64Dictionary *dict2 =
-      [GPBUInt64UInt64Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64UInt64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64UInt64Dictionary *dict = [GPBUInt64UInt64Dictionary dictionary];
+  GPBUInt64UInt64Dictionary *dict = [[GPBUInt64UInt64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1013,6 +1024,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getUInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 303U);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1174,7 +1186,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64Int64Dictionary *dict = [GPBUInt64Int64Dictionary dictionaryWithInt64:400 forKey:31ULL];
+  GPBUInt64Int64Dictionary *dict = [[GPBUInt64Int64Dictionary alloc] init];
+  [dict setInt64:400 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int64_t value;
@@ -1187,6 +1200,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 400);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1329,17 +1343,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64Int64Dictionary *dict2 =
-      [GPBUInt64Int64Dictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64Int64Dictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64Int64Dictionary *dict = [GPBUInt64Int64Dictionary dictionary];
+  GPBUInt64Int64Dictionary *dict = [[GPBUInt64Int64Dictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1370,6 +1385,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getInt64:&value forKey:34ULL]);
   XCTAssertEqual(value, 403);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1531,7 +1547,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64BoolDictionary *dict = [GPBUInt64BoolDictionary dictionaryWithBool:YES forKey:31ULL];
+  GPBUInt64BoolDictionary *dict = [[GPBUInt64BoolDictionary alloc] init];
+  [dict setBool:YES forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   BOOL value;
@@ -1544,6 +1561,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, YES);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -1686,17 +1704,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64BoolDictionary *dict2 =
-      [GPBUInt64BoolDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64BoolDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64BoolDictionary *dict = [GPBUInt64BoolDictionary dictionary];
+  GPBUInt64BoolDictionary *dict = [[GPBUInt64BoolDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -1727,6 +1746,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getBool:&value forKey:34ULL]);
   XCTAssertEqual(value, NO);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -1888,7 +1908,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64FloatDictionary *dict = [GPBUInt64FloatDictionary dictionaryWithFloat:500.f forKey:31ULL];
+  GPBUInt64FloatDictionary *dict = [[GPBUInt64FloatDictionary alloc] init];
+  [dict setFloat:500.f forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   float value;
@@ -1901,6 +1922,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 500.f);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2043,17 +2065,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64FloatDictionary *dict2 =
-      [GPBUInt64FloatDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64FloatDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64FloatDictionary *dict = [GPBUInt64FloatDictionary dictionary];
+  GPBUInt64FloatDictionary *dict = [[GPBUInt64FloatDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2084,6 +2107,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getFloat:&value forKey:34ULL]);
   XCTAssertEqual(value, 503.f);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2245,7 +2269,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64DoubleDictionary *dict = [GPBUInt64DoubleDictionary dictionaryWithDouble:600. forKey:31ULL];
+  GPBUInt64DoubleDictionary *dict = [[GPBUInt64DoubleDictionary alloc] init];
+  [dict setDouble:600. forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   double value;
@@ -2258,6 +2283,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 600.);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2400,17 +2426,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64DoubleDictionary *dict2 =
-      [GPBUInt64DoubleDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64DoubleDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64DoubleDictionary *dict = [GPBUInt64DoubleDictionary dictionary];
+  GPBUInt64DoubleDictionary *dict = [[GPBUInt64DoubleDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2441,6 +2468,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getDouble:&value forKey:34ULL]);
   XCTAssertEqual(value, 603.);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -2602,7 +2630,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64EnumDictionary *dict = [GPBUInt64EnumDictionary dictionaryWithEnum:700 forKey:31ULL];
+  GPBUInt64EnumDictionary *dict = [[GPBUInt64EnumDictionary alloc] init];
+  [dict setEnum:700 forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   int32_t value;
@@ -2615,6 +2644,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqual(aValue, 700);
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -2757,17 +2787,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64EnumDictionary *dict2 =
-      [GPBUInt64EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64EnumDictionary *dict = [GPBUInt64EnumDictionary dictionary];
+  GPBUInt64EnumDictionary *dict = [[GPBUInt64EnumDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -2798,6 +2829,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getEnum:&value forKey:34ULL]);
   XCTAssertEqual(value, 703);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {
@@ -3120,19 +3152,20 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64EnumDictionary *dict2 =
-      [GPBUInt64EnumDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64EnumDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
   XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+  [dict2 release];
   [dict release];
 }
 
 - (void)testUnknownAdds {
   GPBUInt64EnumDictionary *dict =
-    [GPBUInt64EnumDictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+      [[GPBUInt64EnumDictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3172,6 +3205,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertTrue([dict getRawValue:&value forKey:34ULL]);
   XCTAssertEqual(value, 803);
   [dict2 release];
+  [dict release];
 }
 
 - (void)testUnknownRemove {
@@ -3375,7 +3409,8 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
 }
 
 - (void)testOne {
-  GPBUInt64ObjectDictionary<NSString*> *dict = [GPBUInt64ObjectDictionary dictionaryWithObject:@"abc" forKey:31ULL];
+  GPBUInt64ObjectDictionary<NSString*> *dict = [[GPBUInt64ObjectDictionary alloc] init];
+  [dict setObject:@"abc" forKey:31ULL];
   XCTAssertNotNil(dict);
   XCTAssertEqual(dict.count, 1U);
   XCTAssertEqualObjects([dict objectForKey:31ULL], @"abc");
@@ -3385,6 +3420,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
     XCTAssertEqualObjects(aObject, @"abc");
     XCTAssertNotEqual(stop, NULL);
   }];
+  [dict release];
 }
 
 - (void)testBasics {
@@ -3520,17 +3556,18 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertNotNil(dict);
 
   GPBUInt64ObjectDictionary<NSString*> *dict2 =
-      [GPBUInt64ObjectDictionary dictionaryWithDictionary:dict];
+      [[GPBUInt64ObjectDictionary alloc] initWithDictionary:dict];
   XCTAssertNotNil(dict2);
 
   // Should be new pointer, but equal objects.
   XCTAssertNotEqual(dict, dict2);
   XCTAssertEqualObjects(dict, dict2);
+  [dict2 release];
   [dict release];
 }
 
 - (void)testAdds {
-  GPBUInt64ObjectDictionary<NSString*> *dict = [GPBUInt64ObjectDictionary dictionary];
+  GPBUInt64ObjectDictionary<NSString*> *dict = [[GPBUInt64ObjectDictionary alloc] init];
   XCTAssertNotNil(dict);
 
   XCTAssertEqual(dict.count, 0U);
@@ -3552,6 +3589,7 @@ static BOOL TestingEnum_IsValidValue(int32_t value) {
   XCTAssertEqualObjects([dict objectForKey:33ULL], @"ghi");
   XCTAssertEqualObjects([dict objectForKey:34ULL], @"jkl");
   [dict2 release];
+  [dict release];
 }
 
 - (void)testRemove {

--- a/objectivec/Tests/GPBDictionaryTests.pddm
+++ b/objectivec/Tests/GPBDictionaryTests.pddm
@@ -78,7 +78,8 @@
 //%}
 //%
 //%- (void)testOne {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VALUE_NAME$u##:VAL1 forKey:KEY1];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
+//%  [dict set##VALUE_NAME$u##:VAL1 forKey:KEY1];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 1U);
 //%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
@@ -88,6 +89,7 @@
 //%    XCTAssertEqual##VSUFFIX(a##VNAME$u, VAL1);
 //%    XCTAssertNotEqual(stop, NULL);
 //%  }];
+//%  [dict release];
 //%}
 //%
 //%- (void)testBasics {
@@ -223,17 +225,18 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWithDictionary:dict];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithDictionary:dict];
 //%  XCTAssertNotNil(dict2);
 //%
 //%  // Should be new pointer, but equal objects.
 //%  XCTAssertNotEqual(dict, dict2);
 //%  XCTAssertEqualObjects(dict, dict2);
+//%  [dict2 release];
 //%  [dict release];
 //%}
 //%
 //%- (void)testAdds {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionary];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
@@ -255,6 +258,7 @@
 //%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY3, VAL3)
 //%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY4, VAL4)
 //%  [dict2 release];
+//%  [dict release];
 //%}
 //%
 //%- (void)testRemove {
@@ -522,19 +526,20 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWithDictionary:dict];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithDictionary:dict];
 //%  XCTAssertNotNil(dict2);
 //%
 //%  // Should be new pointer, but equal objects.
 //%  XCTAssertNotEqual(dict, dict2);
 //%  XCTAssertEqualObjects(dict, dict2);
 //%  XCTAssertEqual(dict.validationFunc, dict2.validationFunc);  // Pointer comparison
+//%  [dict2 release];
 //%  [dict release];
 //%}
 //%
 //%- (void)testUnknownAdds {
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict =
-//%    [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWithValidationFunction:TestingEnum_IsValidValue];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithValidationFunction:TestingEnum_IsValidValue];
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
@@ -561,6 +566,7 @@
 //%TEST_VALUE##VHELPER(VALUE_NAME, dict, value, KEY4, kGPBUnrecognizedEnumeratorValue)
 //%TEST_RAW_VALUE##VHELPER(dict, value, KEY4, VAL4)
 //%  [dict2 release];
+//%  [dict release];
 //%}
 //%
 //%- (void)testUnknownRemove {
@@ -801,7 +807,8 @@
 //%}
 //%
 //%- (void)testOne {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWith##VALUE_NAME$u##:VAL1 forKey:KEY1];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
+//%  [dict set##VALUE_NAME$u##:VAL1 forKey:KEY1];
 //%  XCTAssertNotNil(dict);
 //%  XCTAssertEqual(dict.count, 1U);
 //%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
@@ -811,6 +818,7 @@
 //%    XCTAssertEqual##VSUFFIX(a##VNAME$u, VAL1);
 //%    XCTAssertNotEqual(stop, NULL);
 //%  }];
+//%  [dict release];
 //%}
 //%
 //%- (void)testBasics {
@@ -944,17 +952,18 @@
 //%  XCTAssertNotNil(dict);
 //%
 //%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict2 =
-//%      [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionaryWithDictionary:dict];
+//%      [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] initWithDictionary:dict];
 //%  XCTAssertNotNil(dict2);
 //%
 //%  // Should be new pointer, but equal objects.
 //%  XCTAssertNotEqual(dict, dict2);
 //%  XCTAssertEqualObjects(dict, dict2);
+//%  [dict2 release];
 //%  [dict release];
 //%}
 //%
 //%- (void)testAdds {
-//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [GPB##KEY_NAME##VALUE_NAME##Dictionary dictionary];
+//%  DICTIONARY_CLASS_DECL##VHELPER(KEY_NAME, VALUE_NAME, VALUE_TYPE) *dict = [[GPB##KEY_NAME##VALUE_NAME##Dictionary alloc] init];
 //%  XCTAssertNotNil(dict);
 //%
 //%  XCTAssertEqual(dict.count, 0U);
@@ -974,6 +983,7 @@
 //%DECLARE_VALUE_STORAGE##VHELPER(VALUE_TYPE, VNAME)TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY1, VAL1)
 //%TEST_VALUE##VHELPER(VALUE_NAME, dict, VNAME, KEY2, VAL2)
 //%  [dict2 release];
+//%  [dict release];
 //%}
 //%
 //%- (void)testRemove {

--- a/objectivec/Tests/GPBMessageTests+Serialization.m
+++ b/objectivec/Tests/GPBMessageTests+Serialization.m
@@ -1102,10 +1102,10 @@ static NSData *DataFromCStr(const char *str) {
 - (void)testMap_Proto2UnknownEnum {
   TestEnumMapPlusExtra *orig = [[TestEnumMapPlusExtra alloc] init];
 
-  orig.knownMapField = [GPBInt32EnumDictionary
-      dictionaryWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue];
-  orig.unknownMapField = [GPBInt32EnumDictionary
-      dictionaryWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue];
+  orig.knownMapField = [[[GPBInt32EnumDictionary alloc]
+      initWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue] autorelease];
+  orig.unknownMapField = [[[GPBInt32EnumDictionary alloc]
+      initWithValidationFunction:Proto2MapEnumPlusExtra_IsValidValue] autorelease];
   [orig.knownMapField setEnum:Proto2MapEnumPlusExtra_EProto2MapEnumFoo
                        forKey:0];
   [orig.unknownMapField setEnum:Proto2MapEnumPlusExtra_EProto2MapEnumExtra

--- a/objectivec/Tests/GPBMessageTests.m
+++ b/objectivec/Tests/GPBMessageTests.m
@@ -1238,7 +1238,8 @@
   // with different objects that are equal).
   TestRecursiveMessageWithRepeatedField *message3 =
       [TestRecursiveMessageWithRepeatedField message];
-  message3.iToI = [GPBInt32Int32Dictionary dictionaryWithInt32:10 forKey:20];
+  message3.iToI = [[GPBInt32Int32Dictionary alloc] init];
+  [message3.iToI setInt32:10 forKey:20];
   message3.strToStr =
       [NSMutableDictionary dictionaryWithObject:@"abc" forKey:@"123"];
   XCTAssertNotNil(message.iToI);
@@ -1323,7 +1324,8 @@
     XCTAssertFalse([message hasA]);
     GPBInt32Int32Dictionary *iToI = [message.a.iToI retain];
     XCTAssertEqual(iToI->_autocreator, message.a);  // Pointer comparision
-    message.a.iToI = [GPBInt32Int32Dictionary dictionaryWithInt32:6 forKey:7];
+    message.a.iToI = [[GPBInt32Int32Dictionary alloc] init];
+    [message.a.iToI setInt32:6 forKey:7];
     XCTAssertTrue([message hasA]);
     XCTAssertNotEqual(message.a.iToI, iToI);  // Pointer comparision
     XCTAssertNil(iToI->_autocreator);


### PR DESCRIPTION
By my quick and dirty back of the envelope calculations, this reduces the size of the libraries by about 80k per architecture.

It removes +dictionary... methods which are all just syntactic sugar for alloc] init...