### PR TITLE
Remove unused output_file variable from js_embed

### DIFF
--- a/src/google/protobuf/compiler/js/embed.cc
+++ b/src/google/protobuf/compiler/js/embed.cc
@@ -34,8 +34,6 @@
 #include <iostream>
 #include <string>
 
-const char output_file[] = "well_known_types_embed.cc";
-
 static bool AsciiIsPrint(unsigned char c) {
   return c >= 32 && c < 127;
 }


### PR DESCRIPTION
The js_embed tool outputs to stdout, so the output_file variable is
unnecessary and unused.