### PR TITLE
Add MacOS and Linux tests to Kokoro

### DIFF
--- a/kokoro/README.md
+++ b/kokoro/README.md
@@ -1,0 +1,6 @@
+
+Kokoro Infrastructure
+----------------------
+
+The files in this directory serve as plumbing for running Protobuf
+tests under Kokoro, our internal CI.

--- a/kokoro/linux/cpp_distcheck/build.sh
+++ b/kokoro/linux/cpp_distcheck/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/linux/prepare_build_linux_rc
+
+./tests.sh cpp_distcheck

--- a/kokoro/linux/cpp_distcheck/presubmit.cfg
+++ b/kokoro/linux/cpp_distcheck/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/cpp_distcheck/build.sh"
+timeout_mins: 1440

--- a/kokoro/linux/csharp/build.sh
+++ b/kokoro/linux/csharp/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/linux/prepare_build_linux_rc
+
+./tests.sh csharp

--- a/kokoro/linux/csharp/presubmit.cfg
+++ b/kokoro/linux/csharp/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/csharp/build.sh"
+timeout_mins: 1440

--- a/kokoro/linux/java_compatibility/build.sh
+++ b/kokoro/linux/java_compatibility/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/linux/prepare_build_linux_rc
+
+./tests.sh java_compatibility

--- a/kokoro/linux/java_compatibility/presubmit.cfg
+++ b/kokoro/linux/java_compatibility/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/java_compatibility/build.sh"
+timeout_mins: 1440

--- a/kokoro/linux/prepare_build_linux_rc
+++ b/kokoro/linux/prepare_build_linux_rc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Source this rc script to prepare the environment for Linux builds
+
+# Set up dotnet
+sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+sudo apt-get update
+sudo apt-get install -y dotnet-dev-1.0.4

--- a/kokoro/linux/python_compatibility/build.sh
+++ b/kokoro/linux/python_compatibility/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/linux/prepare_build_linux_rc
+
+./tests.sh python_compatibility

--- a/kokoro/linux/python_compatibility/presubmit.cfg
+++ b/kokoro/linux/python_compatibility/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/linux/python_compatibility/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/cpp/build.sh
+++ b/kokoro/macos/cpp/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh cpp

--- a/kokoro/macos/cpp/presubmit.cfg
+++ b/kokoro/macos/cpp/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/cpp/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/cpp_distcheck/build.sh
+++ b/kokoro/macos/cpp_distcheck/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh cpp_distcheck

--- a/kokoro/macos/cpp_distcheck/presubmit.cfg
+++ b/kokoro/macos/cpp_distcheck/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/cpp_distcheck/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/javascript/build.sh
+++ b/kokoro/macos/javascript/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh javascript

--- a/kokoro/macos/javascript/presubmit.cfg
+++ b/kokoro/macos/javascript/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/javascript/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/jruby/build.sh
+++ b/kokoro/macos/jruby/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh jruby

--- a/kokoro/macos/jruby/presubmit.cfg
+++ b/kokoro/macos/jruby/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/jruby/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/objectivec_cocoapods_integration/build.sh
+++ b/kokoro/macos/objectivec_cocoapods_integration/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh objectivec_cocoapods_integration

--- a/kokoro/macos/objectivec_cocoapods_integration/presubmit.cfg
+++ b/kokoro/macos/objectivec_cocoapods_integration/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/objectivec_cocoapods_integration/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/objectivec_ios_debug/build.sh
+++ b/kokoro/macos/objectivec_ios_debug/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh objectivec_ios_debug

--- a/kokoro/macos/objectivec_ios_debug/presubmit.cfg
+++ b/kokoro/macos/objectivec_ios_debug/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/objectivec_ios_debug/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/objectivec_ios_release/build.sh
+++ b/kokoro/macos/objectivec_ios_release/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh objectivec_ios_release

--- a/kokoro/macos/objectivec_ios_release/presubmit.cfg
+++ b/kokoro/macos/objectivec_ios_release/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/objectivec_ios_release/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/objectivec_osx/build.sh
+++ b/kokoro/macos/objectivec_osx/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh objectivec_osx

--- a/kokoro/macos/objectivec_osx/presubmit.cfg
+++ b/kokoro/macos/objectivec_osx/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/objectivec_osx/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/php5.6_mac/build.sh
+++ b/kokoro/macos/php5.6_mac/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh php5.6_mac

--- a/kokoro/macos/php5.6_mac/presubmit.cfg
+++ b/kokoro/macos/php5.6_mac/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/php5.6_mac/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/php7.0_mac/build.sh
+++ b/kokoro/macos/php7.0_mac/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh php7.0_mac

--- a/kokoro/macos/php7.0_mac/presubmit.cfg
+++ b/kokoro/macos/php7.0_mac/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/php7.0_mac/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/prepare_build_macos_rc
+++ b/kokoro/macos/prepare_build_macos_rc
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# This script sets up a Kokoro MacOS worker for running Protobuf tests
+
+##
+# Select Xcode version
+
+export DEVELOPER_DIR=/Applications/Xcode_8.1.app/Contents/Developer
+
+##
+# Select C/C++ compilers
+
+export CC=gcc
+export CXX=g++
+
+##
+# Install Brew and core softwares
+
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew tap homebrew/homebrew-php
+brew install autoconf automake ccache cmake gflags gpg gpg2 libtool maven node pcre php56 ruby wget
+
+##
+# Install Tox
+
+sudo pip install tox==2.4.1
+
+##
+# Install RVM
+
+gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+curl -sSL https://get.rvm.io | bash -s stable --ruby

--- a/kokoro/macos/python/build.sh
+++ b/kokoro/macos/python/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh python

--- a/kokoro/macos/python/presubmit.cfg
+++ b/kokoro/macos/python/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/python/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/python_cpp/build.sh
+++ b/kokoro/macos/python_cpp/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+g++ --version
+
+./tests.sh python_cpp

--- a/kokoro/macos/python_cpp/presubmit.cfg
+++ b/kokoro/macos/python_cpp/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/python_cpp/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/ruby21/build.sh
+++ b/kokoro/macos/ruby21/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh ruby21

--- a/kokoro/macos/ruby21/presubmit.cfg
+++ b/kokoro/macos/ruby21/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby21/build.sh"
+timeout_mins: 1440

--- a/kokoro/macos/ruby22/build.sh
+++ b/kokoro/macos/ruby22/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build file to set up and run tests
+
+# Change to repo root
+cd $(dirname $0)/../../..
+
+# Prepare worker environment to run tests
+source kokoro/macos/prepare_build_macos_rc
+
+./tests.sh ruby22

--- a/kokoro/macos/ruby22/presubmit.cfg
+++ b/kokoro/macos/ruby22/presubmit.cfg
@@ -1,0 +1,5 @@
+# Config file for running tests in Kokoro
+
+# Location of the build script in repository
+build_file: "protobuf/kokoro/macos/ruby22/build.sh"
+timeout_mins: 1440


### PR DESCRIPTION
These files must be committed on GitHub to run tests on Kokoro. They cover all tests currently running on Travis.