### PR TITLE
Make sure directory exists for js well known types

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -519,7 +519,7 @@ js_well_known_types_sources =                                  \
 	google/protobuf/compiler/js/well_known_types/timestamp.js
 # We have to cd to $(srcdir) so that out-of-tree builds work properly.
 google/protobuf/compiler/js/well_known_types_embed.cc: js_embed$(EXEEXT) $(js_well_known_types_sources)
-	oldpwd=`pwd` && cd $(srcdir) && \
+	oldpwd=`pwd` && cd $(srcdir) && mkdir -p $$(dirname $$oldpwd/$@) && \
 	$$oldpwd/js_embed$(EXEEXT) $(js_well_known_types_sources) > $$oldpwd/$@
 
 # Tests ==============================================================


### PR DESCRIPTION
If the build directory is not the same as the source directory then
the build fails because the google/protobuf/compiler/js directory
doesn't exist.  Make sure that it does.