### PR TITLE
Export symbols used in inline functions

### DIFF
--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -164,7 +164,7 @@ class ExplicitlyConstructed {
 
 // Default empty string object. Don't use this directly. Instead, call
 // GetEmptyString() to get the reference.
-extern ExplicitlyConstructed< ::std::string> fixed_address_empty_string;
+LIBPROTOBUF_EXPORT extern ExplicitlyConstructed< ::std::string> fixed_address_empty_string;
 LIBPROTOBUF_EXPORT extern ProtobufOnceType empty_string_once_init_;
 LIBPROTOBUF_EXPORT void InitEmptyString();
 


### PR DESCRIPTION
fixed_address_empty_string symbol is used in an inline function.
We have to export it to avoid undefined reference link errors.

It is the change proposed by @jbrianceau that was already discussed and merged by @xfxyjwf  in https://github.com/google/protobuf/pull/2407 , but that apparently wiped out by https://github.com/google/protobuf/commit/d36c0c538a545fac5d9db6ba65c525246d4efa95 .

The same change was applied to the 3.1 branch in https://github.com/google/protobuf/pull/2421 .