### PR TITLE
bazel: Make compiled jars java 6 binary compatible.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -600,7 +600,7 @@ java_library(
     ]) + [
         ":gen_well_known_protos_java",
     ],
-    javacopts = ["-source 6"],
+    javacopts = ["-source 6", "-target 6"],
     visibility = ["//visibility:public"],
 )
 
@@ -609,6 +609,7 @@ java_library(
     srcs = glob([
         "java/util/src/main/java/com/google/protobuf/util/*.java",
     ]),
+    javacopts = ["-source 6", "-target 6"],
     visibility = ["//visibility:public"],
     deps = [
         "protobuf_java",


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/3198