### PR TITLE
Qualify string in java_options.h

### DIFF
--- a/src/google/protobuf/compiler/java/java_options.h
+++ b/src/google/protobuf/compiler/java/java_options.h
@@ -59,10 +59,10 @@ struct Options {
   bool annotate_code;
   // Name of a file where we will write a list of generated .meta file names,
   // one per line.
-  string annotation_list_file;
+  std::string annotation_list_file;
   // Name of a file where we will write a list of generated file names, one
   // per line.
-  string output_list_file;
+  std::string output_list_file;
 };
 
 }  // namespace java


### PR DESCRIPTION
Building the protobuf compiler with Bazel fails to resolve the unqualifed "string"s in java_options.h:

```
ERROR: .../external/com_google_protobuf/BUILD:248:1: C++ compilation of rule '@com_google_protobuf//:protoc_lib' failed: Process exited with status 1 [sandboxed].
In file included from external/com_google_protobuf/src/google/protobuf/compiler/java/java_context.h:41:0,
                 from external/com_google_protobuf/src/google/protobuf/compiler/java/java_enum_field_lite.cc:38:
external/com_google_protobuf/src/google/protobuf/compiler/java/java_options.h:59:3: error: 'string' does not name a type
   string annotation_list_file;
   ^
external/com_google_protobuf/src/google/protobuf/compiler/java/java_options.h:62:3: error: 'string' does not name a type
   string output_list_file;
   ^
Use --strategy=CppCompile=standalone to disable sandboxing for the failing actions.
INFO: Elapsed time: 41.487s, Critical Path: 6.20s
//interpreter:eval_test                                               NO STATUS

Executed 0 out of 1 test: 1 was skipped.
```