### PR TITLE
Remove inclusion of ext/json/php_json.h.

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -30,7 +30,6 @@
 
 #include <php.h>
 #include <stdlib.h>
-#include <ext/json/php_json.h>
 
 #include "protobuf.h"
 


### PR DESCRIPTION
That PHP included implementation of json is not being used - this extension is using
a json encoder/decoder provided by 'upb'.

The Google App Engine Flexible Environment PHP runtime for 5.6.x does not enable the built-in json support because of licensing issues, instead providing the same functionality via the [jsonc extension](https://github.com/remicollet/pecl-json-c). In order to compile protobuf for our PHP 5.6.x, we need to remove this include (which isn't being used anyways).

Also see: https://github.com/GoogleCloudPlatform/php-docker/issues/311