### PR TITLE
If we fail to get a descriptor just super the method resolving.

### DIFF
--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -3077,7 +3077,7 @@ static void ResolveIvarSet(GPBFieldDescriptor *field,
 + (BOOL)resolveInstanceMethod:(SEL)sel {
   const GPBDescriptor *descriptor = [self descriptor];
   if (!descriptor) {
-    return NO;
+    return [super resolveInstanceMethod:sel];
   }
 
   // NOTE: hasOrCountSel_/setHasSel_ will be NULL if the field for the given


### PR DESCRIPTION
This should never happen, but if someone is swizzling or do other
hooking of methods, anything is possible, so this seems slighty
safer than they returning NO.