### PR TITLE
Add insertion points for field modifiers in C# and Java

### DIFF
--- a/csharp/src/AddressBook/Addressbook.cs
+++ b/csharp/src/AddressBook/Addressbook.cs
@@ -88,6 +88,7 @@ namespace Google.Protobuf.Examples.AddressBook {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:tutorial.Person.setName)
       }
     }
 
@@ -102,6 +103,7 @@ namespace Google.Protobuf.Examples.AddressBook {
       get { return id_; }
       set {
         id_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:tutorial.Person.setId)
       }
     }
 
@@ -113,6 +115,7 @@ namespace Google.Protobuf.Examples.AddressBook {
       get { return email_; }
       set {
         email_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:tutorial.Person.setEmail)
       }
     }
 
@@ -126,6 +129,7 @@ namespace Google.Protobuf.Examples.AddressBook {
       get { return phones_; }
     }
 
+    //@@protoc_insertion_point(class_scope:tutorial.Person)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Person);
@@ -163,6 +167,7 @@ namespace Google.Protobuf.Examples.AddressBook {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:tutorial.Person)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -290,6 +295,7 @@ namespace Google.Protobuf.Examples.AddressBook {
           get { return number_; }
           set {
             number_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            //@@protoc_insertion_point(field_modifier_scope_after:tutorial.Person.PhoneNumber.setNumber)
           }
         }
 
@@ -301,9 +307,11 @@ namespace Google.Protobuf.Examples.AddressBook {
           get { return type_; }
           set {
             type_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:tutorial.Person.PhoneNumber.setType)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:tutorial.Person.PhoneNumber)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as PhoneNumber);
@@ -337,6 +345,7 @@ namespace Google.Protobuf.Examples.AddressBook {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:tutorial.Person.PhoneNumber)
           if (Number.Length != 0) {
             output.WriteRawTag(10);
             output.WriteString(Number);
@@ -444,6 +453,7 @@ namespace Google.Protobuf.Examples.AddressBook {
       get { return people_; }
     }
 
+    //@@protoc_insertion_point(class_scope:tutorial.AddressBook)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as AddressBook);
@@ -475,6 +485,7 @@ namespace Google.Protobuf.Examples.AddressBook {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:tutorial.AddressBook)
       people_.WriteTo(output, _repeated_people_codec);
     }
 

--- a/csharp/src/Google.Protobuf.Conformance/Conformance.cs
+++ b/csharp/src/Google.Protobuf.Conformance/Conformance.cs
@@ -134,6 +134,7 @@ namespace Conformance {
       get { return requestedOutputFormat_; }
       set {
         requestedOutputFormat_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:conformance.ConformanceRequest.setRequestedOutputFormat)
       }
     }
 
@@ -156,6 +157,7 @@ namespace Conformance {
       payload_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:conformance.ConformanceRequest)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ConformanceRequest);
@@ -193,6 +195,7 @@ namespace Conformance {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:conformance.ConformanceRequest)
       if (payloadCase_ == PayloadOneofCase.ProtobufPayload) {
         output.WriteRawTag(10);
         output.WriteBytes(ProtobufPayload);
@@ -440,6 +443,7 @@ namespace Conformance {
       result_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:conformance.ConformanceResponse)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ConformanceResponse);
@@ -483,6 +487,7 @@ namespace Conformance {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:conformance.ConformanceResponse)
       if (resultCase_ == ResultOneofCase.ParseError) {
         output.WriteRawTag(10);
         output.WriteString(ParseError);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/MapUnittestProto3.cs
@@ -392,6 +392,7 @@ namespace Google.Protobuf.TestProtos {
       get { return mapInt32ForeignMessage_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMap)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMap);
@@ -455,6 +456,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMap)
       mapInt32Int32_.WriteTo(output, _map_mapInt32Int32_codec);
       mapInt64Int64_.WriteTo(output, _map_mapInt64Int64_codec);
       mapUint32Uint32_.WriteTo(output, _map_mapUint32Uint32_codec);
@@ -646,6 +648,7 @@ namespace Google.Protobuf.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMapSubmessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMapSubmessage);
@@ -677,6 +680,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMapSubmessage)
       if (testMap_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(TestMap);
@@ -768,6 +772,7 @@ namespace Google.Protobuf.TestProtos {
       get { return mapInt32Message_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMessageMap)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMessageMap);
@@ -799,6 +804,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMessageMap)
       mapInt32Message_.WriteTo(output, _map_mapInt32Message_codec);
     }
 
@@ -891,6 +897,7 @@ namespace Google.Protobuf.TestProtos {
       get { return map2_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestSameTypeMap)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestSameTypeMap);
@@ -924,6 +931,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestSameTypeMap)
       map1_.WriteTo(output, _map_map1_codec);
       map2_.WriteTo(output, _map_map2_codec);
     }
@@ -1163,6 +1171,7 @@ namespace Google.Protobuf.TestProtos {
       get { return mapInt32ForeignMessage_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestArenaMap)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestArenaMap);
@@ -1222,6 +1231,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestArenaMap)
       mapInt32Int32_.WriteTo(output, _map_mapInt32Int32_codec);
       mapInt64Int64_.WriteTo(output, _map_mapInt64Int64_codec);
       mapUint32Uint32_.WriteTo(output, _map_mapUint32Uint32_codec);
@@ -1402,6 +1412,7 @@ namespace Google.Protobuf.TestProtos {
       get { return type_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.MessageContainingEnumCalledType)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MessageContainingEnumCalledType);
@@ -1433,6 +1444,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.MessageContainingEnumCalledType)
       type_.WriteTo(output, _map_type_codec);
     }
 
@@ -1525,6 +1537,7 @@ namespace Google.Protobuf.TestProtos {
       get { return entry_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.MessageContainingMapCalledEntry)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MessageContainingMapCalledEntry);
@@ -1556,6 +1569,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.MessageContainingMapCalledEntry)
       entry_.WriteTo(output, _map_entry_codec);
     }
 

--- a/csharp/src/Google.Protobuf.Test/TestProtos/TestMessagesProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/TestMessagesProto3.cs
@@ -409,6 +409,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalInt32_; }
       set {
         optionalInt32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalInt32)
       }
     }
 
@@ -420,6 +421,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalInt64_; }
       set {
         optionalInt64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalInt64)
       }
     }
 
@@ -431,6 +433,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalUint32_; }
       set {
         optionalUint32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalUint32)
       }
     }
 
@@ -442,6 +445,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalUint64_; }
       set {
         optionalUint64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalUint64)
       }
     }
 
@@ -453,6 +457,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalSint32_; }
       set {
         optionalSint32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalSint32)
       }
     }
 
@@ -464,6 +469,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalSint64_; }
       set {
         optionalSint64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalSint64)
       }
     }
 
@@ -475,6 +481,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalFixed32_; }
       set {
         optionalFixed32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalFixed32)
       }
     }
 
@@ -486,6 +493,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalFixed64_; }
       set {
         optionalFixed64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalFixed64)
       }
     }
 
@@ -497,6 +505,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalSfixed32_; }
       set {
         optionalSfixed32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalSfixed32)
       }
     }
 
@@ -508,6 +517,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalSfixed64_; }
       set {
         optionalSfixed64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalSfixed64)
       }
     }
 
@@ -519,6 +529,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalFloat_; }
       set {
         optionalFloat_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalFloat)
       }
     }
 
@@ -530,6 +541,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalDouble_; }
       set {
         optionalDouble_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalDouble)
       }
     }
 
@@ -541,6 +553,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalBool_; }
       set {
         optionalBool_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalBool)
       }
     }
 
@@ -552,6 +565,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalString_; }
       set {
         optionalString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalString)
       }
     }
 
@@ -563,6 +577,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalBytes_; }
       set {
         optionalBytes_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalBytes)
       }
     }
 
@@ -596,6 +611,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalNestedEnum_; }
       set {
         optionalNestedEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalNestedEnum)
       }
     }
 
@@ -607,6 +623,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalForeignEnum_; }
       set {
         optionalForeignEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalForeignEnum)
       }
     }
 
@@ -618,6 +635,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalStringPiece_; }
       set {
         optionalStringPiece_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalStringPiece)
       }
     }
 
@@ -629,6 +647,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return optionalCord_; }
       set {
         optionalCord_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setOptionalCord)
       }
     }
 
@@ -1487,6 +1506,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldname1_; }
       set {
         fieldname1_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldname1)
       }
     }
 
@@ -1498,6 +1518,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName2_; }
       set {
         fieldName2_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName2)
       }
     }
 
@@ -1509,6 +1530,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return FieldName3_; }
       set {
         FieldName3_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName3)
       }
     }
 
@@ -1520,6 +1542,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName4_; }
       set {
         fieldName4_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName4)
       }
     }
 
@@ -1531,6 +1554,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return field0Name5_; }
       set {
         field0Name5_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setField0Name5)
       }
     }
 
@@ -1542,6 +1566,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return field0Name6_; }
       set {
         field0Name6_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setField0Name6)
       }
     }
 
@@ -1553,6 +1578,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName7_; }
       set {
         fieldName7_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName7)
       }
     }
 
@@ -1564,6 +1590,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName8_; }
       set {
         fieldName8_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName8)
       }
     }
 
@@ -1575,6 +1602,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName9_; }
       set {
         fieldName9_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName9)
       }
     }
 
@@ -1586,6 +1614,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName10_; }
       set {
         fieldName10_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName10)
       }
     }
 
@@ -1597,6 +1626,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fIELDNAME11_; }
       set {
         fIELDNAME11_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFIELDNAME11)
       }
     }
 
@@ -1608,6 +1638,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fIELDName12_; }
       set {
         fIELDName12_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFIELDName12)
       }
     }
 
@@ -1619,6 +1650,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return FieldName13_; }
       set {
         FieldName13_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName13)
       }
     }
 
@@ -1630,6 +1662,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return FieldName14_; }
       set {
         FieldName14_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName14)
       }
     }
 
@@ -1641,6 +1674,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName15_; }
       set {
         fieldName15_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName15)
       }
     }
 
@@ -1652,6 +1686,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName16_; }
       set {
         fieldName16_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName16)
       }
     }
 
@@ -1663,6 +1698,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName17_; }
       set {
         fieldName17_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName17)
       }
     }
 
@@ -1674,6 +1710,7 @@ namespace ProtobufTestMessages.Proto3 {
       get { return fieldName18_; }
       set {
         fieldName18_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.setFieldName18)
       }
     }
 
@@ -1703,6 +1740,7 @@ namespace ProtobufTestMessages.Proto3 {
       oneofField_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_test_messages.proto3.TestAllTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestAllTypes);
@@ -1972,6 +2010,7 @@ namespace ProtobufTestMessages.Proto3 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_test_messages.proto3.TestAllTypes)
       if (OptionalInt32 != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(OptionalInt32);
@@ -3449,6 +3488,7 @@ namespace ProtobufTestMessages.Proto3 {
           get { return a_; }
           set {
             a_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.TestAllTypes.NestedMessage.setA)
           }
         }
 
@@ -3463,6 +3503,7 @@ namespace ProtobufTestMessages.Proto3 {
           }
         }
 
+        //@@protoc_insertion_point(class_scope:protobuf_test_messages.proto3.TestAllTypes.NestedMessage)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NestedMessage);
@@ -3496,6 +3537,7 @@ namespace ProtobufTestMessages.Proto3 {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:protobuf_test_messages.proto3.TestAllTypes.NestedMessage)
           if (A != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(A);
@@ -3604,9 +3646,11 @@ namespace ProtobufTestMessages.Proto3 {
       get { return c_; }
       set {
         c_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_test_messages.proto3.ForeignMessage.setC)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_test_messages.proto3.ForeignMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ForeignMessage);
@@ -3638,6 +3682,7 @@ namespace ProtobufTestMessages.Proto3 {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_test_messages.proto3.ForeignMessage)
       if (C != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(C);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestCustomOptionsProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestCustomOptionsProto3.cs
@@ -227,6 +227,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return field1_; }
       set {
         field1_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestMessageWithCustomOptions.setField1)
       }
     }
 
@@ -259,6 +260,7 @@ namespace UnitTest.Issues.TestProtos {
       anOneof_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMessageWithCustomOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMessageWithCustomOptions);
@@ -294,6 +296,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMessageWithCustomOptions)
       if (Field1.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Field1);
@@ -402,6 +405,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionFooRequest(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionFooRequest)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooRequest);
@@ -431,6 +435,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionFooRequest)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -491,6 +496,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionFooResponse(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionFooResponse)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooResponse);
@@ -520,6 +526,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionFooResponse)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -580,6 +587,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionFooClientMessage(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionFooClientMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooClientMessage);
@@ -609,6 +617,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionFooClientMessage)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -669,6 +678,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionFooServerMessage(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionFooServerMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionFooServerMessage);
@@ -698,6 +708,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionFooServerMessage)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -758,6 +769,7 @@ namespace UnitTest.Issues.TestProtos {
       return new DummyMessageContainingEnum(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.DummyMessageContainingEnum)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DummyMessageContainingEnum);
@@ -787,6 +799,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.DummyMessageContainingEnum)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -860,6 +873,7 @@ namespace UnitTest.Issues.TestProtos {
       return new DummyMessageInvalidAsOptionType(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.DummyMessageInvalidAsOptionType)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DummyMessageInvalidAsOptionType);
@@ -889,6 +903,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.DummyMessageInvalidAsOptionType)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -949,6 +964,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionMinIntegerValues(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionMinIntegerValues)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionMinIntegerValues);
@@ -978,6 +994,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionMinIntegerValues)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1038,6 +1055,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionMaxIntegerValues(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionMaxIntegerValues)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionMaxIntegerValues);
@@ -1067,6 +1085,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionMaxIntegerValues)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1127,6 +1146,7 @@ namespace UnitTest.Issues.TestProtos {
       return new CustomOptionOtherValues(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.CustomOptionOtherValues)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as CustomOptionOtherValues);
@@ -1156,6 +1176,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.CustomOptionOtherValues)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1216,6 +1237,7 @@ namespace UnitTest.Issues.TestProtos {
       return new SettingRealsFromPositiveInts(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.SettingRealsFromPositiveInts)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as SettingRealsFromPositiveInts);
@@ -1245,6 +1267,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.SettingRealsFromPositiveInts)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1305,6 +1328,7 @@ namespace UnitTest.Issues.TestProtos {
       return new SettingRealsFromNegativeInts(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.SettingRealsFromNegativeInts)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as SettingRealsFromNegativeInts);
@@ -1334,6 +1358,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.SettingRealsFromNegativeInts)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1406,6 +1431,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return foo_; }
       set {
         foo_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType1.setFoo)
       }
     }
 
@@ -1417,6 +1443,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return foo2_; }
       set {
         foo2_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType1.setFoo2)
       }
     }
 
@@ -1428,6 +1455,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return foo3_; }
       set {
         foo3_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType1.setFoo3)
       }
     }
 
@@ -1441,6 +1469,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return foo4_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.ComplexOptionType1)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ComplexOptionType1);
@@ -1478,6 +1507,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.ComplexOptionType1)
       if (Foo != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Foo);
@@ -1611,6 +1641,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return baz_; }
       set {
         baz_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType2.setBaz)
       }
     }
 
@@ -1635,6 +1666,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return barney_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.ComplexOptionType2)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ComplexOptionType2);
@@ -1672,6 +1704,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.ComplexOptionType2)
       if (bar_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Bar);
@@ -1804,9 +1837,11 @@ namespace UnitTest.Issues.TestProtos {
           get { return waldo_; }
           set {
             waldo_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType2.ComplexOptionType4.setWaldo)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:protobuf_unittest.ComplexOptionType2.ComplexOptionType4)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as ComplexOptionType4);
@@ -1838,6 +1873,7 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.ComplexOptionType2.ComplexOptionType4)
           if (Waldo != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(Waldo);
@@ -1926,9 +1962,11 @@ namespace UnitTest.Issues.TestProtos {
       get { return qux_; }
       set {
         qux_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ComplexOptionType3.setQux)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.ComplexOptionType3)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ComplexOptionType3);
@@ -1960,6 +1998,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.ComplexOptionType3)
       if (Qux != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Qux);
@@ -2037,6 +2076,7 @@ namespace UnitTest.Issues.TestProtos {
       return new VariousComplexOptions(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.VariousComplexOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as VariousComplexOptions);
@@ -2066,6 +2106,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.VariousComplexOptions)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2140,6 +2181,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return i_; }
       set {
         i_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Aggregate.setI)
       }
     }
 
@@ -2151,6 +2193,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return s_; }
       set {
         s_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Aggregate.setS)
       }
     }
 
@@ -2168,6 +2211,7 @@ namespace UnitTest.Issues.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.Aggregate)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Aggregate);
@@ -2203,6 +2247,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.Aggregate)
       if (I != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(I);
@@ -2320,9 +2365,11 @@ namespace UnitTest.Issues.TestProtos {
       get { return fieldname_; }
       set {
         fieldname_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.AggregateMessage.setFieldname)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.AggregateMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as AggregateMessage);
@@ -2354,6 +2401,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.AggregateMessage)
       if (Fieldname != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Fieldname);
@@ -2431,6 +2479,7 @@ namespace UnitTest.Issues.TestProtos {
       return new NestedOptionType(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.NestedOptionType)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as NestedOptionType);
@@ -2460,6 +2509,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.NestedOptionType)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2536,9 +2586,11 @@ namespace UnitTest.Issues.TestProtos {
           get { return nestedField_; }
           set {
             nestedField_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.NestedOptionType.NestedMessage.setNestedField)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:protobuf_unittest.NestedOptionType.NestedMessage)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NestedMessage);
@@ -2570,6 +2622,7 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.NestedOptionType.NestedMessage)
           if (NestedField != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(NestedField);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportProto3.cs
@@ -90,9 +90,11 @@ namespace Google.Protobuf.TestProtos {
       get { return d_; }
       set {
         d_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest_import.ImportMessage.setD)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest_import.ImportMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ImportMessage);
@@ -124,6 +126,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest_import.ImportMessage)
       if (D != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(D);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestImportPublicProto3.cs
@@ -76,9 +76,11 @@ namespace Google.Protobuf.TestProtos {
       get { return e_; }
       set {
         e_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest_import.PublicImportMessage.setE)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest_import.PublicImportMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as PublicImportMessage);
@@ -110,6 +112,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest_import.PublicImportMessage)
       if (E != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(E);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestIssues.cs
@@ -113,6 +113,7 @@ namespace UnitTest.Issues.TestProtos {
       return new Issue307(this);
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.Issue307)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Issue307);
@@ -142,6 +143,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.Issue307)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -204,6 +206,7 @@ namespace UnitTest.Issues.TestProtos {
           return new NestedOnce(this);
         }
 
+        //@@protoc_insertion_point(class_scope:unittest_issues.Issue307.NestedOnce)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NestedOnce);
@@ -233,6 +236,7 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.Issue307.NestedOnce)
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -295,6 +299,7 @@ namespace UnitTest.Issues.TestProtos {
               return new NestedTwice(this);
             }
 
+            //@@protoc_insertion_point(class_scope:unittest_issues.Issue307.NestedOnce.NestedTwice)
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public override bool Equals(object other) {
               return Equals(other as NestedTwice);
@@ -324,6 +329,7 @@ namespace UnitTest.Issues.TestProtos {
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
             public void WriteTo(pb::CodedOutputStream output) {
+              //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.Issue307.NestedOnce.NestedTwice)
             }
 
             [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -405,6 +411,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.NegativeEnumMessage.setValue)
       }
     }
 
@@ -428,6 +435,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return packedValues_; }
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.NegativeEnumMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as NegativeEnumMessage);
@@ -463,6 +471,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.NegativeEnumMessage)
       if (Value != 0) {
         output.WriteRawTag(8);
         output.WriteEnum((int) Value);
@@ -553,6 +562,7 @@ namespace UnitTest.Issues.TestProtos {
       return new DeprecatedChild(this);
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.DeprecatedChild)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DeprecatedChild);
@@ -582,6 +592,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.DeprecatedChild)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -657,6 +668,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return primitiveValue_; }
       set {
         primitiveValue_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.DeprecatedFieldsMessage.setPrimitiveValue)
       }
     }
 
@@ -703,6 +715,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return enumValue_; }
       set {
         enumValue_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.DeprecatedFieldsMessage.setEnumValue)
       }
     }
 
@@ -717,6 +730,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return enumArray_; }
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.DeprecatedFieldsMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DeprecatedFieldsMessage);
@@ -758,6 +772,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.DeprecatedFieldsMessage)
       if (PrimitiveValue != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(PrimitiveValue);
@@ -901,9 +916,11 @@ namespace UnitTest.Issues.TestProtos {
       get { return item_; }
       set {
         item_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.ItemField.setItem)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.ItemField)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ItemField);
@@ -935,6 +952,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.ItemField)
       if (Item != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Item);
@@ -1019,6 +1037,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return types_; }
       set {
         types_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.ReservedNames.setTypes_)
       }
     }
 
@@ -1030,9 +1049,11 @@ namespace UnitTest.Issues.TestProtos {
       get { return descriptor_; }
       set {
         descriptor_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.ReservedNames.setDescriptor_)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.ReservedNames)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ReservedNames);
@@ -1066,6 +1087,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.ReservedNames)
       if (Types_ != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Types_);
@@ -1159,6 +1181,7 @@ namespace UnitTest.Issues.TestProtos {
           return new SomeNestedType(this);
         }
 
+        //@@protoc_insertion_point(class_scope:unittest_issues.ReservedNames.SomeNestedType)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as SomeNestedType);
@@ -1188,6 +1211,7 @@ namespace UnitTest.Issues.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.ReservedNames.SomeNestedType)
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1293,6 +1317,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return plainInt32_; }
       set {
         plainInt32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.TestJsonFieldOrdering.setPlainInt32)
       }
     }
 
@@ -1326,6 +1351,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return plainString_; }
       set {
         plainString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.TestJsonFieldOrdering.setPlainString)
       }
     }
 
@@ -1389,6 +1415,7 @@ namespace UnitTest.Issues.TestProtos {
       o2_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.TestJsonFieldOrdering)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestJsonFieldOrdering);
@@ -1434,6 +1461,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.TestJsonFieldOrdering)
       if (PlainString.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(PlainString);
@@ -1598,6 +1626,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.TestJsonName.setName)
       }
     }
 
@@ -1609,6 +1638,7 @@ namespace UnitTest.Issues.TestProtos {
       get { return description_; }
       set {
         description_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.TestJsonName.setDescription)
       }
     }
 
@@ -1620,9 +1650,11 @@ namespace UnitTest.Issues.TestProtos {
       get { return guid_; }
       set {
         guid_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:unittest_issues.TestJsonName.setGuid)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:unittest_issues.TestJsonName)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestJsonName);
@@ -1658,6 +1690,7 @@ namespace UnitTest.Issues.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:unittest_issues.TestJsonName)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestProto3.cs
@@ -338,6 +338,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleInt32_; }
       set {
         singleInt32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleInt32)
       }
     }
 
@@ -349,6 +350,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleInt64_; }
       set {
         singleInt64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleInt64)
       }
     }
 
@@ -360,6 +362,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleUint32_; }
       set {
         singleUint32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleUint32)
       }
     }
 
@@ -371,6 +374,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleUint64_; }
       set {
         singleUint64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleUint64)
       }
     }
 
@@ -382,6 +386,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleSint32_; }
       set {
         singleSint32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleSint32)
       }
     }
 
@@ -393,6 +398,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleSint64_; }
       set {
         singleSint64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleSint64)
       }
     }
 
@@ -404,6 +410,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleFixed32_; }
       set {
         singleFixed32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleFixed32)
       }
     }
 
@@ -415,6 +422,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleFixed64_; }
       set {
         singleFixed64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleFixed64)
       }
     }
 
@@ -426,6 +434,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleSfixed32_; }
       set {
         singleSfixed32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleSfixed32)
       }
     }
 
@@ -437,6 +446,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleSfixed64_; }
       set {
         singleSfixed64_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleSfixed64)
       }
     }
 
@@ -448,6 +458,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleFloat_; }
       set {
         singleFloat_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleFloat)
       }
     }
 
@@ -459,6 +470,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleDouble_; }
       set {
         singleDouble_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleDouble)
       }
     }
 
@@ -470,6 +482,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleBool_; }
       set {
         singleBool_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleBool)
       }
     }
 
@@ -481,6 +494,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleString_; }
       set {
         singleString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleString)
       }
     }
 
@@ -492,6 +506,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleBytes_; }
       set {
         singleBytes_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleBytes)
       }
     }
 
@@ -536,6 +551,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleNestedEnum_; }
       set {
         singleNestedEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleNestedEnum)
       }
     }
 
@@ -547,6 +563,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleForeignEnum_; }
       set {
         singleForeignEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleForeignEnum)
       }
     }
 
@@ -558,6 +575,7 @@ namespace Google.Protobuf.TestProtos {
       get { return singleImportEnum_; }
       set {
         singleImportEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.setSingleImportEnum)
       }
     }
 
@@ -866,6 +884,7 @@ namespace Google.Protobuf.TestProtos {
       oneofField_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestAllTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestAllTypes);
@@ -993,6 +1012,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestAllTypes)
       if (SingleInt32 != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(SingleInt32);
@@ -1646,9 +1666,11 @@ namespace Google.Protobuf.TestProtos {
           get { return bb_; }
           set {
             bb_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestAllTypes.NestedMessage.setBb)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:protobuf_unittest.TestAllTypes.NestedMessage)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NestedMessage);
@@ -1680,6 +1702,7 @@ namespace Google.Protobuf.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestAllTypes.NestedMessage)
           if (Bb != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(Bb);
@@ -1797,6 +1820,7 @@ namespace Google.Protobuf.TestProtos {
       get { return repeatedChild_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.NestedTestAllTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as NestedTestAllTypes);
@@ -1832,6 +1856,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.NestedTestAllTypes)
       if (child_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Child);
@@ -1949,9 +1974,11 @@ namespace Google.Protobuf.TestProtos {
       get { return deprecatedInt32_; }
       set {
         deprecatedInt32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestDeprecatedFields.setDeprecatedInt32)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestDeprecatedFields)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestDeprecatedFields);
@@ -1983,6 +2010,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestDeprecatedFields)
       if (DeprecatedInt32 != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(DeprecatedInt32);
@@ -2070,9 +2098,11 @@ namespace Google.Protobuf.TestProtos {
       get { return c_; }
       set {
         c_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.ForeignMessage.setC)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.ForeignMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ForeignMessage);
@@ -2104,6 +2134,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.ForeignMessage)
       if (C != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(C);
@@ -2178,6 +2209,7 @@ namespace Google.Protobuf.TestProtos {
       return new TestReservedFields(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestReservedFields)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestReservedFields);
@@ -2207,6 +2239,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestReservedFields)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2282,6 +2315,7 @@ namespace Google.Protobuf.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestForeignNested)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestForeignNested);
@@ -2313,6 +2347,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestForeignNested)
       if (foreignNested_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(ForeignNested);
@@ -2410,6 +2445,7 @@ namespace Google.Protobuf.TestProtos {
       get { return a_; }
       set {
         a_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestReallyLargeTagNumber.setA)
       }
     }
 
@@ -2421,9 +2457,11 @@ namespace Google.Protobuf.TestProtos {
       get { return bb_; }
       set {
         bb_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestReallyLargeTagNumber.setBb)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestReallyLargeTagNumber)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestReallyLargeTagNumber);
@@ -2457,6 +2495,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestReallyLargeTagNumber)
       if (A != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(A);
@@ -2566,9 +2605,11 @@ namespace Google.Protobuf.TestProtos {
       get { return i_; }
       set {
         i_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestRecursiveMessage.setI)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestRecursiveMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestRecursiveMessage);
@@ -2602,6 +2643,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestRecursiveMessage)
       if (a_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(A);
@@ -2711,6 +2753,7 @@ namespace Google.Protobuf.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMutualRecursionA)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMutualRecursionA);
@@ -2742,6 +2785,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMutualRecursionA)
       if (bb_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(Bb);
@@ -2843,9 +2887,11 @@ namespace Google.Protobuf.TestProtos {
       get { return optionalInt32_; }
       set {
         optionalInt32_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestMutualRecursionB.setOptionalInt32)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestMutualRecursionB)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestMutualRecursionB);
@@ -2879,6 +2925,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestMutualRecursionB)
       if (a_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(A);
@@ -2982,9 +3029,11 @@ namespace Google.Protobuf.TestProtos {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestEnumAllowAlias.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestEnumAllowAlias)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestEnumAllowAlias);
@@ -3016,6 +3065,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestEnumAllowAlias)
       if (Value != 0) {
         output.WriteRawTag(8);
         output.WriteEnum((int) Value);
@@ -3110,6 +3160,7 @@ namespace Google.Protobuf.TestProtos {
       get { return primitiveField_; }
       set {
         primitiveField_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestCamelCaseFieldNames.setPrimitiveField)
       }
     }
 
@@ -3121,6 +3172,7 @@ namespace Google.Protobuf.TestProtos {
       get { return stringField_; }
       set {
         stringField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestCamelCaseFieldNames.setStringField)
       }
     }
 
@@ -3132,6 +3184,7 @@ namespace Google.Protobuf.TestProtos {
       get { return enumField_; }
       set {
         enumField_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestCamelCaseFieldNames.setEnumField)
       }
     }
 
@@ -3186,6 +3239,7 @@ namespace Google.Protobuf.TestProtos {
       get { return repeatedMessageField_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestCamelCaseFieldNames)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestCamelCaseFieldNames);
@@ -3231,6 +3285,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestCamelCaseFieldNames)
       if (PrimitiveField != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(PrimitiveField);
@@ -3399,6 +3454,7 @@ namespace Google.Protobuf.TestProtos {
       get { return myString_; }
       set {
         myString_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestFieldOrderings.setMyString)
       }
     }
 
@@ -3410,6 +3466,7 @@ namespace Google.Protobuf.TestProtos {
       get { return myInt_; }
       set {
         myInt_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestFieldOrderings.setMyInt)
       }
     }
 
@@ -3421,6 +3478,7 @@ namespace Google.Protobuf.TestProtos {
       get { return myFloat_; }
       set {
         myFloat_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestFieldOrderings.setMyFloat)
       }
     }
 
@@ -3435,6 +3493,7 @@ namespace Google.Protobuf.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestFieldOrderings)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestFieldOrderings);
@@ -3472,6 +3531,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestFieldOrderings)
       if (MyInt != 0L) {
         output.WriteRawTag(8);
         output.WriteInt64(MyInt);
@@ -3606,6 +3666,7 @@ namespace Google.Protobuf.TestProtos {
           get { return oo_; }
           set {
             oo_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestFieldOrderings.NestedMessage.setOo)
           }
         }
 
@@ -3622,9 +3683,11 @@ namespace Google.Protobuf.TestProtos {
           get { return bb_; }
           set {
             bb_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestFieldOrderings.NestedMessage.setBb)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:protobuf_unittest.TestFieldOrderings.NestedMessage)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NestedMessage);
@@ -3658,6 +3721,7 @@ namespace Google.Protobuf.TestProtos {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestFieldOrderings.NestedMessage)
           if (Bb != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(Bb);
@@ -3760,9 +3824,11 @@ namespace Google.Protobuf.TestProtos {
       get { return sparseEnum_; }
       set {
         sparseEnum_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.SparseEnumMessage.setSparseEnum)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.SparseEnumMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as SparseEnumMessage);
@@ -3794,6 +3860,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.SparseEnumMessage)
       if (SparseEnum != 0) {
         output.WriteRawTag(8);
         output.WriteEnum((int) SparseEnum);
@@ -3880,9 +3947,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.OneString.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.OneString)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as OneString);
@@ -3914,6 +3983,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.OneString)
       if (Data.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Data);
@@ -3999,6 +4069,7 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.MoreString)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MoreString);
@@ -4030,6 +4101,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.MoreString)
       data_.WriteTo(output, _repeated_data_codec);
     }
 
@@ -4106,9 +4178,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.OneBytes.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.OneBytes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as OneBytes);
@@ -4140,6 +4214,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.OneBytes)
       if (Data.Length != 0) {
         output.WriteRawTag(10);
         output.WriteBytes(Data);
@@ -4223,9 +4298,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.MoreBytes.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.MoreBytes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MoreBytes);
@@ -4257,6 +4334,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.MoreBytes)
       if (Data.Length != 0) {
         output.WriteRawTag(10);
         output.WriteBytes(Data);
@@ -4343,9 +4421,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Int32Message.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.Int32Message)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Int32Message);
@@ -4377,6 +4457,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.Int32Message)
       if (Data != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Data);
@@ -4460,9 +4541,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Uint32Message.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.Uint32Message)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Uint32Message);
@@ -4494,6 +4577,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.Uint32Message)
       if (Data != 0) {
         output.WriteRawTag(8);
         output.WriteUInt32(Data);
@@ -4577,9 +4661,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Int64Message.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.Int64Message)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Int64Message);
@@ -4611,6 +4697,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.Int64Message)
       if (Data != 0L) {
         output.WriteRawTag(8);
         output.WriteInt64(Data);
@@ -4694,9 +4781,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.Uint64Message.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.Uint64Message)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Uint64Message);
@@ -4728,6 +4817,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.Uint64Message)
       if (Data != 0UL) {
         output.WriteRawTag(8);
         output.WriteUInt64(Data);
@@ -4811,9 +4901,11 @@ namespace Google.Protobuf.TestProtos {
       get { return data_; }
       set {
         data_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.BoolMessage.setData)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.BoolMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as BoolMessage);
@@ -4845,6 +4937,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.BoolMessage)
       if (Data != false) {
         output.WriteRawTag(8);
         output.WriteBool(Data);
@@ -4987,6 +5080,7 @@ namespace Google.Protobuf.TestProtos {
       foo_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestOneof)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestOneof);
@@ -5024,6 +5118,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestOneof)
       if (fooCase_ == FooOneofCase.FooInt) {
         output.WriteRawTag(8);
         output.WriteInt32(FooInt);
@@ -5288,6 +5383,7 @@ namespace Google.Protobuf.TestProtos {
       get { return packedEnum_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestPackedTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestPackedTypes);
@@ -5345,6 +5441,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestPackedTypes)
       packedInt32_.WriteTo(output, _repeated_packedInt32_codec);
       packedInt64_.WriteTo(output, _repeated_packedInt64_codec);
       packedUint32_.WriteTo(output, _repeated_packedUint32_codec);
@@ -5675,6 +5772,7 @@ namespace Google.Protobuf.TestProtos {
       get { return unpackedEnum_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestUnpackedTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestUnpackedTypes);
@@ -5732,6 +5830,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestUnpackedTypes)
       unpackedInt32_.WriteTo(output, _repeated_unpackedInt32_codec);
       unpackedInt64_.WriteTo(output, _repeated_unpackedInt64_codec);
       unpackedUint32_.WriteTo(output, _repeated_unpackedUint32_codec);
@@ -5984,6 +6083,7 @@ namespace Google.Protobuf.TestProtos {
       get { return repeatedUint64_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestRepeatedScalarDifferentTagSizes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestRepeatedScalarDifferentTagSizes);
@@ -6025,6 +6125,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestRepeatedScalarDifferentTagSizes)
       repeatedFixed32_.WriteTo(output, _repeated_repeatedFixed32_codec);
       repeatedInt32_.WriteTo(output, _repeated_repeatedInt32_codec);
       repeatedFixed64_.WriteTo(output, _repeated_repeatedFixed64_codec);
@@ -6145,9 +6246,11 @@ namespace Google.Protobuf.TestProtos {
       get { return a_; }
       set {
         a_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:protobuf_unittest.TestCommentInjectionMessage.setA)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestCommentInjectionMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestCommentInjectionMessage);
@@ -6179,6 +6282,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestCommentInjectionMessage)
       if (A.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(A);
@@ -6256,6 +6360,7 @@ namespace Google.Protobuf.TestProtos {
       return new FooRequest(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.FooRequest)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FooRequest);
@@ -6285,6 +6390,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.FooRequest)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6345,6 +6451,7 @@ namespace Google.Protobuf.TestProtos {
       return new FooResponse(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.FooResponse)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FooResponse);
@@ -6374,6 +6481,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.FooResponse)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6434,6 +6542,7 @@ namespace Google.Protobuf.TestProtos {
       return new FooClientMessage(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.FooClientMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FooClientMessage);
@@ -6463,6 +6572,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.FooClientMessage)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6523,6 +6633,7 @@ namespace Google.Protobuf.TestProtos {
       return new FooServerMessage(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.FooServerMessage)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FooServerMessage);
@@ -6552,6 +6663,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.FooServerMessage)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6612,6 +6724,7 @@ namespace Google.Protobuf.TestProtos {
       return new BarRequest(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.BarRequest)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as BarRequest);
@@ -6641,6 +6754,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.BarRequest)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6701,6 +6815,7 @@ namespace Google.Protobuf.TestProtos {
       return new BarResponse(this);
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.BarResponse)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as BarResponse);
@@ -6730,6 +6845,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.BarResponse)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
+++ b/csharp/src/Google.Protobuf.Test/TestProtos/UnittestWellKnownTypes.cs
@@ -448,6 +448,7 @@ namespace Google.Protobuf.TestProtos {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.TestWellKnownTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as TestWellKnownTypes);
@@ -515,6 +516,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.TestWellKnownTypes)
       if (anyField_ != null) {
         output.WriteRawTag(10);
         output.WriteMessage(AnyField);
@@ -1141,6 +1143,7 @@ namespace Google.Protobuf.TestProtos {
       get { return bytesField_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.RepeatedWellKnownTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as RepeatedWellKnownTypes);
@@ -1206,6 +1209,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.RepeatedWellKnownTypes)
       anyField_.WriteTo(output, _repeated_anyField_codec);
       apiField_.WriteTo(output, _repeated_apiField_codec);
       durationField_.WriteTo(output, _repeated_durationField_codec);
@@ -1691,6 +1695,7 @@ namespace Google.Protobuf.TestProtos {
       oneofField_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.OneofWellKnownTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as OneofWellKnownTypes);
@@ -1758,6 +1763,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.OneofWellKnownTypes)
       if (oneofFieldCase_ == OneofFieldOneofCase.AnyField) {
         output.WriteRawTag(10);
         output.WriteMessage(AnyField);
@@ -2312,6 +2318,7 @@ namespace Google.Protobuf.TestProtos {
       get { return bytesField_; }
     }
 
+    //@@protoc_insertion_point(class_scope:protobuf_unittest.MapWellKnownTypes)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MapWellKnownTypes);
@@ -2377,6 +2384,7 @@ namespace Google.Protobuf.TestProtos {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:protobuf_unittest.MapWellKnownTypes)
       anyField_.WriteTo(output, _map_anyField_codec);
       apiField_.WriteTo(output, _map_apiField_codec);
       durationField_.WriteTo(output, _map_durationField_codec);

--- a/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/Descriptor.cs
@@ -223,6 +223,7 @@ namespace Google.Protobuf.Reflection {
       get { return file_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FileDescriptorSet)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FileDescriptorSet);
@@ -254,6 +255,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FileDescriptorSet)
       file_.WriteTo(output, _repeated_file_codec);
     }
 
@@ -347,6 +349,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileDescriptorProto.setName)
       }
     }
 
@@ -361,6 +364,7 @@ namespace Google.Protobuf.Reflection {
       get { return package_; }
       set {
         package_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileDescriptorProto.setPackage)
       }
     }
 
@@ -487,9 +491,11 @@ namespace Google.Protobuf.Reflection {
       get { return syntax_; }
       set {
         syntax_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileDescriptorProto.setSyntax)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FileDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FileDescriptorProto);
@@ -543,6 +549,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FileDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -757,6 +764,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DescriptorProto.setName)
       }
     }
 
@@ -855,6 +863,7 @@ namespace Google.Protobuf.Reflection {
       get { return reservedName_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.DescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DescriptorProto);
@@ -904,6 +913,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.DescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -1066,6 +1076,7 @@ namespace Google.Protobuf.Reflection {
           get { return start_; }
           set {
             start_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DescriptorProto.ExtensionRange.setStart)
           }
         }
 
@@ -1077,9 +1088,11 @@ namespace Google.Protobuf.Reflection {
           get { return end_; }
           set {
             end_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DescriptorProto.ExtensionRange.setEnd)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:google.protobuf.DescriptorProto.ExtensionRange)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as ExtensionRange);
@@ -1113,6 +1126,7 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.DescriptorProto.ExtensionRange)
           if (Start != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(Start);
@@ -1219,6 +1233,7 @@ namespace Google.Protobuf.Reflection {
           get { return start_; }
           set {
             start_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DescriptorProto.ReservedRange.setStart)
           }
         }
 
@@ -1233,9 +1248,11 @@ namespace Google.Protobuf.Reflection {
           get { return end_; }
           set {
             end_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DescriptorProto.ReservedRange.setEnd)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:google.protobuf.DescriptorProto.ReservedRange)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as ReservedRange);
@@ -1269,6 +1286,7 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.DescriptorProto.ReservedRange)
           if (Start != 0) {
             output.WriteRawTag(8);
             output.WriteInt32(Start);
@@ -1383,6 +1401,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setName)
       }
     }
 
@@ -1394,6 +1413,7 @@ namespace Google.Protobuf.Reflection {
       get { return number_; }
       set {
         number_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setNumber)
       }
     }
 
@@ -1405,6 +1425,7 @@ namespace Google.Protobuf.Reflection {
       get { return label_; }
       set {
         label_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setLabel)
       }
     }
 
@@ -1420,6 +1441,7 @@ namespace Google.Protobuf.Reflection {
       get { return type_; }
       set {
         type_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setType)
       }
     }
 
@@ -1438,6 +1460,7 @@ namespace Google.Protobuf.Reflection {
       get { return typeName_; }
       set {
         typeName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setTypeName)
       }
     }
 
@@ -1453,6 +1476,7 @@ namespace Google.Protobuf.Reflection {
       get { return extendee_; }
       set {
         extendee_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setExtendee)
       }
     }
 
@@ -1471,6 +1495,7 @@ namespace Google.Protobuf.Reflection {
       get { return defaultValue_; }
       set {
         defaultValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setDefaultValue)
       }
     }
 
@@ -1486,6 +1511,7 @@ namespace Google.Protobuf.Reflection {
       get { return oneofIndex_; }
       set {
         oneofIndex_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setOneofIndex)
       }
     }
 
@@ -1503,6 +1529,7 @@ namespace Google.Protobuf.Reflection {
       get { return jsonName_; }
       set {
         jsonName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldDescriptorProto.setJsonName)
       }
     }
 
@@ -1517,6 +1544,7 @@ namespace Google.Protobuf.Reflection {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FieldDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FieldDescriptorProto);
@@ -1566,6 +1594,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FieldDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -1852,6 +1881,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.OneofDescriptorProto.setName)
       }
     }
 
@@ -1866,6 +1896,7 @@ namespace Google.Protobuf.Reflection {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.OneofDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as OneofDescriptorProto);
@@ -1899,6 +1930,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.OneofDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -2007,6 +2039,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumDescriptorProto.setName)
       }
     }
 
@@ -2031,6 +2064,7 @@ namespace Google.Protobuf.Reflection {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.EnumDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as EnumDescriptorProto);
@@ -2066,6 +2100,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.EnumDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -2181,6 +2216,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumValueDescriptorProto.setName)
       }
     }
 
@@ -2192,6 +2228,7 @@ namespace Google.Protobuf.Reflection {
       get { return number_; }
       set {
         number_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumValueDescriptorProto.setNumber)
       }
     }
 
@@ -2206,6 +2243,7 @@ namespace Google.Protobuf.Reflection {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.EnumValueDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as EnumValueDescriptorProto);
@@ -2241,6 +2279,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.EnumValueDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -2363,6 +2402,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.ServiceDescriptorProto.setName)
       }
     }
 
@@ -2387,6 +2427,7 @@ namespace Google.Protobuf.Reflection {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.ServiceDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ServiceDescriptorProto);
@@ -2422,6 +2463,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.ServiceDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -2540,6 +2582,7 @@ namespace Google.Protobuf.Reflection {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodDescriptorProto.setName)
       }
     }
 
@@ -2555,6 +2598,7 @@ namespace Google.Protobuf.Reflection {
       get { return inputType_; }
       set {
         inputType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodDescriptorProto.setInputType)
       }
     }
 
@@ -2566,6 +2610,7 @@ namespace Google.Protobuf.Reflection {
       get { return outputType_; }
       set {
         outputType_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodDescriptorProto.setOutputType)
       }
     }
 
@@ -2591,6 +2636,7 @@ namespace Google.Protobuf.Reflection {
       get { return clientStreaming_; }
       set {
         clientStreaming_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodDescriptorProto.setClientStreaming)
       }
     }
 
@@ -2605,9 +2651,11 @@ namespace Google.Protobuf.Reflection {
       get { return serverStreaming_; }
       set {
         serverStreaming_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodDescriptorProto.setServerStreaming)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.MethodDescriptorProto)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MethodDescriptorProto);
@@ -2649,6 +2697,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.MethodDescriptorProto)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -2832,6 +2881,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaPackage_; }
       set {
         javaPackage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaPackage)
       }
     }
 
@@ -2850,6 +2900,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaOuterClassname_; }
       set {
         javaOuterClassname_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaOuterClassname)
       }
     }
 
@@ -2869,6 +2920,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaMultipleFiles_; }
       set {
         javaMultipleFiles_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaMultipleFiles)
       }
     }
 
@@ -2884,6 +2936,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaGenerateEqualsAndHash_; }
       set {
         javaGenerateEqualsAndHash_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaGenerateEqualsAndHash)
       }
     }
 
@@ -2903,6 +2956,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaStringCheckUtf8_; }
       set {
         javaStringCheckUtf8_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaStringCheckUtf8)
       }
     }
 
@@ -2914,6 +2968,7 @@ namespace Google.Protobuf.Reflection {
       get { return optimizeFor_; }
       set {
         optimizeFor_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setOptimizeFor)
       }
     }
 
@@ -2932,6 +2987,7 @@ namespace Google.Protobuf.Reflection {
       get { return goPackage_; }
       set {
         goPackage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setGoPackage)
       }
     }
 
@@ -2955,6 +3011,7 @@ namespace Google.Protobuf.Reflection {
       get { return ccGenericServices_; }
       set {
         ccGenericServices_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setCcGenericServices)
       }
     }
 
@@ -2966,6 +3023,7 @@ namespace Google.Protobuf.Reflection {
       get { return javaGenericServices_; }
       set {
         javaGenericServices_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setJavaGenericServices)
       }
     }
 
@@ -2977,6 +3035,7 @@ namespace Google.Protobuf.Reflection {
       get { return pyGenericServices_; }
       set {
         pyGenericServices_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setPyGenericServices)
       }
     }
 
@@ -2994,6 +3053,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setDeprecated)
       }
     }
 
@@ -3009,6 +3069,7 @@ namespace Google.Protobuf.Reflection {
       get { return ccEnableArenas_; }
       set {
         ccEnableArenas_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setCcEnableArenas)
       }
     }
 
@@ -3024,6 +3085,7 @@ namespace Google.Protobuf.Reflection {
       get { return objcClassPrefix_; }
       set {
         objcClassPrefix_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setObjcClassPrefix)
       }
     }
 
@@ -3038,6 +3100,7 @@ namespace Google.Protobuf.Reflection {
       get { return csharpNamespace_; }
       set {
         csharpNamespace_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setCsharpNamespace)
       }
     }
 
@@ -3055,6 +3118,7 @@ namespace Google.Protobuf.Reflection {
       get { return swiftPrefix_; }
       set {
         swiftPrefix_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setSwiftPrefix)
       }
     }
 
@@ -3070,6 +3134,7 @@ namespace Google.Protobuf.Reflection {
       get { return phpClassPrefix_; }
       set {
         phpClassPrefix_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FileOptions.setPhpClassPrefix)
       }
     }
 
@@ -3086,6 +3151,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FileOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FileOptions);
@@ -3149,6 +3215,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FileOptions)
       if (JavaPackage.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(JavaPackage);
@@ -3500,6 +3567,7 @@ namespace Google.Protobuf.Reflection {
       get { return messageSetWireFormat_; }
       set {
         messageSetWireFormat_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MessageOptions.setMessageSetWireFormat)
       }
     }
 
@@ -3516,6 +3584,7 @@ namespace Google.Protobuf.Reflection {
       get { return noStandardDescriptorAccessor_; }
       set {
         noStandardDescriptorAccessor_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MessageOptions.setNoStandardDescriptorAccessor)
       }
     }
 
@@ -3533,6 +3602,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MessageOptions.setDeprecated)
       }
     }
 
@@ -3567,6 +3637,7 @@ namespace Google.Protobuf.Reflection {
       get { return mapEntry_; }
       set {
         mapEntry_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MessageOptions.setMapEntry)
       }
     }
 
@@ -3583,6 +3654,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.MessageOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MessageOptions);
@@ -3622,6 +3694,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.MessageOptions)
       if (MessageSetWireFormat != false) {
         output.WriteRawTag(8);
         output.WriteBool(MessageSetWireFormat);
@@ -3768,6 +3841,7 @@ namespace Google.Protobuf.Reflection {
       get { return ctype_; }
       set {
         ctype_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setCtype)
       }
     }
 
@@ -3786,6 +3860,7 @@ namespace Google.Protobuf.Reflection {
       get { return packed_; }
       set {
         packed_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setPacked)
       }
     }
 
@@ -3808,6 +3883,7 @@ namespace Google.Protobuf.Reflection {
       get { return jstype_; }
       set {
         jstype_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setJstype)
       }
     }
 
@@ -3848,6 +3924,7 @@ namespace Google.Protobuf.Reflection {
       get { return lazy_; }
       set {
         lazy_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setLazy)
       }
     }
 
@@ -3865,6 +3942,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setDeprecated)
       }
     }
 
@@ -3879,6 +3957,7 @@ namespace Google.Protobuf.Reflection {
       get { return weak_; }
       set {
         weak_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FieldOptions.setWeak)
       }
     }
 
@@ -3895,6 +3974,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FieldOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FieldOptions);
@@ -3938,6 +4018,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FieldOptions)
       if (Ctype != 0) {
         output.WriteRawTag(8);
         output.WriteEnum((int) Ctype);
@@ -4136,6 +4217,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.OneofOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as OneofOptions);
@@ -4167,6 +4249,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.OneofOptions)
       uninterpretedOption_.WriteTo(output, _repeated_uninterpretedOption_codec);
     }
 
@@ -4251,6 +4334,7 @@ namespace Google.Protobuf.Reflection {
       get { return allowAlias_; }
       set {
         allowAlias_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumOptions.setAllowAlias)
       }
     }
 
@@ -4268,6 +4352,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumOptions.setDeprecated)
       }
     }
 
@@ -4284,6 +4369,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.EnumOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as EnumOptions);
@@ -4319,6 +4405,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.EnumOptions)
       if (AllowAlias != false) {
         output.WriteRawTag(16);
         output.WriteBool(AllowAlias);
@@ -4432,6 +4519,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumValueOptions.setDeprecated)
       }
     }
 
@@ -4448,6 +4536,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.EnumValueOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as EnumValueOptions);
@@ -4481,6 +4570,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.EnumValueOptions)
       if (Deprecated != false) {
         output.WriteRawTag(8);
         output.WriteBool(Deprecated);
@@ -4580,6 +4670,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.ServiceOptions.setDeprecated)
       }
     }
 
@@ -4596,6 +4687,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.ServiceOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ServiceOptions);
@@ -4629,6 +4721,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.ServiceOptions)
       if (Deprecated != false) {
         output.WriteRawTag(136, 2);
         output.WriteBool(Deprecated);
@@ -4729,6 +4822,7 @@ namespace Google.Protobuf.Reflection {
       get { return deprecated_; }
       set {
         deprecated_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodOptions.setDeprecated)
       }
     }
 
@@ -4740,6 +4834,7 @@ namespace Google.Protobuf.Reflection {
       get { return idempotencyLevel_; }
       set {
         idempotencyLevel_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.MethodOptions.setIdempotencyLevel)
       }
     }
 
@@ -4756,6 +4851,7 @@ namespace Google.Protobuf.Reflection {
       get { return uninterpretedOption_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.MethodOptions)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as MethodOptions);
@@ -4791,6 +4887,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.MethodOptions)
       if (Deprecated != false) {
         output.WriteRawTag(136, 2);
         output.WriteBool(Deprecated);
@@ -4947,6 +5044,7 @@ namespace Google.Protobuf.Reflection {
       get { return identifierValue_; }
       set {
         identifierValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setIdentifierValue)
       }
     }
 
@@ -4958,6 +5056,7 @@ namespace Google.Protobuf.Reflection {
       get { return positiveIntValue_; }
       set {
         positiveIntValue_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setPositiveIntValue)
       }
     }
 
@@ -4969,6 +5068,7 @@ namespace Google.Protobuf.Reflection {
       get { return negativeIntValue_; }
       set {
         negativeIntValue_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setNegativeIntValue)
       }
     }
 
@@ -4980,6 +5080,7 @@ namespace Google.Protobuf.Reflection {
       get { return doubleValue_; }
       set {
         doubleValue_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setDoubleValue)
       }
     }
 
@@ -4991,6 +5092,7 @@ namespace Google.Protobuf.Reflection {
       get { return stringValue_; }
       set {
         stringValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setStringValue)
       }
     }
 
@@ -5002,9 +5104,11 @@ namespace Google.Protobuf.Reflection {
       get { return aggregateValue_; }
       set {
         aggregateValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.setAggregateValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.UninterpretedOption)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as UninterpretedOption);
@@ -5048,6 +5152,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.UninterpretedOption)
       name_.WriteTo(output, _repeated_name_codec);
       if (IdentifierValue.Length != 0) {
         output.WriteRawTag(26);
@@ -5218,6 +5323,7 @@ namespace Google.Protobuf.Reflection {
           get { return namePart_; }
           set {
             namePart_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.NamePart.setNamePart_)
           }
         }
 
@@ -5229,9 +5335,11 @@ namespace Google.Protobuf.Reflection {
           get { return isExtension_; }
           set {
             isExtension_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UninterpretedOption.NamePart.setIsExtension)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:google.protobuf.UninterpretedOption.NamePart)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as NamePart);
@@ -5265,6 +5373,7 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.UninterpretedOption.NamePart)
           if (NamePart_.Length != 0) {
             output.WriteRawTag(10);
             output.WriteString(NamePart_);
@@ -5418,6 +5527,7 @@ namespace Google.Protobuf.Reflection {
       get { return location_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.SourceCodeInfo)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as SourceCodeInfo);
@@ -5449,6 +5559,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.SourceCodeInfo)
       location_.WriteTo(output, _repeated_location_codec);
     }
 
@@ -5632,6 +5743,7 @@ namespace Google.Protobuf.Reflection {
           get { return leadingComments_; }
           set {
             leadingComments_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.SourceCodeInfo.Location.setLeadingComments)
           }
         }
 
@@ -5643,6 +5755,7 @@ namespace Google.Protobuf.Reflection {
           get { return trailingComments_; }
           set {
             trailingComments_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.SourceCodeInfo.Location.setTrailingComments)
           }
         }
 
@@ -5656,6 +5769,7 @@ namespace Google.Protobuf.Reflection {
           get { return leadingDetachedComments_; }
         }
 
+        //@@protoc_insertion_point(class_scope:google.protobuf.SourceCodeInfo.Location)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as Location);
@@ -5695,6 +5809,7 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.SourceCodeInfo.Location)
           path_.WriteTo(output, _repeated_path_codec);
           span_.WriteTo(output, _repeated_span_codec);
           if (LeadingComments.Length != 0) {
@@ -5831,6 +5946,7 @@ namespace Google.Protobuf.Reflection {
       get { return annotation_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.GeneratedCodeInfo)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as GeneratedCodeInfo);
@@ -5862,6 +5978,7 @@ namespace Google.Protobuf.Reflection {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.GeneratedCodeInfo)
       annotation_.WriteTo(output, _repeated_annotation_codec);
     }
 
@@ -5960,6 +6077,7 @@ namespace Google.Protobuf.Reflection {
           get { return sourceFile_; }
           set {
             sourceFile_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.GeneratedCodeInfo.Annotation.setSourceFile)
           }
         }
 
@@ -5975,6 +6093,7 @@ namespace Google.Protobuf.Reflection {
           get { return begin_; }
           set {
             begin_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.GeneratedCodeInfo.Annotation.setBegin)
           }
         }
 
@@ -5991,9 +6110,11 @@ namespace Google.Protobuf.Reflection {
           get { return end_; }
           set {
             end_ = value;
+            //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.GeneratedCodeInfo.Annotation.setEnd)
           }
         }
 
+        //@@protoc_insertion_point(class_scope:google.protobuf.GeneratedCodeInfo.Annotation)
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public override bool Equals(object other) {
           return Equals(other as Annotation);
@@ -6031,6 +6152,7 @@ namespace Google.Protobuf.Reflection {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void WriteTo(pb::CodedOutputStream output) {
+          //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.GeneratedCodeInfo.Annotation)
           path_.WriteTo(output, _repeated_path_codec);
           if (SourceFile.Length != 0) {
             output.WriteRawTag(18);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Any.cs
@@ -171,6 +171,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return typeUrl_; }
       set {
         typeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Any.setTypeUrl)
       }
     }
 
@@ -185,9 +186,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Any.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Any)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Any);
@@ -221,6 +224,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Any)
       if (TypeUrl.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(TypeUrl);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Api.cs
@@ -104,6 +104,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Api.setName)
       }
     }
 
@@ -163,6 +164,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return version_; }
       set {
         version_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Api.setVersion)
       }
     }
 
@@ -205,9 +207,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return syntax_; }
       set {
         syntax_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Api.setSyntax)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Api)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Api);
@@ -251,6 +255,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Api)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -415,6 +420,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setName)
       }
     }
 
@@ -429,6 +435,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return requestTypeUrl_; }
       set {
         requestTypeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setRequestTypeUrl)
       }
     }
 
@@ -443,6 +450,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return requestStreaming_; }
       set {
         requestStreaming_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setRequestStreaming)
       }
     }
 
@@ -457,6 +465,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return responseTypeUrl_; }
       set {
         responseTypeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setResponseTypeUrl)
       }
     }
 
@@ -471,6 +480,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return responseStreaming_; }
       set {
         responseStreaming_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setResponseStreaming)
       }
     }
 
@@ -498,9 +508,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return syntax_; }
       set {
         syntax_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Method.setSyntax)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Method)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Method);
@@ -544,6 +556,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Method)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -787,6 +800,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Mixin.setName)
       }
     }
 
@@ -802,9 +816,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return root_; }
       set {
         root_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Mixin.setRoot)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Mixin)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Mixin);
@@ -838,6 +854,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Mixin)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Duration.cs
@@ -144,6 +144,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return seconds_; }
       set {
         seconds_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Duration.setSeconds)
       }
     }
 
@@ -163,9 +164,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return nanos_; }
       set {
         nanos_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Duration.setNanos)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Duration)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Duration);
@@ -199,6 +202,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Duration)
       if (Seconds != 0L) {
         output.WriteRawTag(8);
         output.WriteInt64(Seconds);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Empty.cs
@@ -79,6 +79,7 @@ namespace Google.Protobuf.WellKnownTypes {
       return new Empty(this);
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Empty)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Empty);
@@ -108,6 +109,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Empty)
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/FieldMask.cs
@@ -285,6 +285,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return paths_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FieldMask)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FieldMask);
@@ -316,6 +317,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FieldMask)
       paths_.WriteTo(output, _repeated_paths_codec);
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/SourceContext.cs
@@ -86,9 +86,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return fileName_; }
       set {
         fileName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.SourceContext.setFileName)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.SourceContext)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as SourceContext);
@@ -120,6 +122,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.SourceContext)
       if (FileName.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(FileName);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Struct.cs
@@ -120,6 +120,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return fields_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Struct)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Struct);
@@ -151,6 +152,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Struct)
       fields_.WriteTo(output, _map_fields_codec);
     }
 
@@ -354,6 +356,7 @@ namespace Google.Protobuf.WellKnownTypes {
       kind_ = null;
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Value)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Value);
@@ -397,6 +400,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Value)
       if (kindCase_ == KindOneofCase.NullValue) {
         output.WriteRawTag(8);
         output.WriteEnum((int) NullValue);
@@ -574,6 +578,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return values_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.ListValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ListValue);
@@ -605,6 +610,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.ListValue)
       values_.WriteTo(output, _repeated_values_codec);
     }
 

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
@@ -161,6 +161,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return seconds_; }
       set {
         seconds_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Timestamp.setSeconds)
       }
     }
 
@@ -178,9 +179,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return nanos_; }
       set {
         nanos_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Timestamp.setNanos)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Timestamp)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Timestamp);
@@ -214,6 +217,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Timestamp)
       if (Seconds != 0L) {
         output.WriteRawTag(8);
         output.WriteInt64(Seconds);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Type.cs
@@ -140,6 +140,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Type.setName)
       }
     }
 
@@ -207,9 +208,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return syntax_; }
       set {
         syntax_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Type.setSyntax)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Type)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Type);
@@ -251,6 +254,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Type)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -404,6 +408,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return kind_; }
       set {
         kind_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setKind)
       }
     }
 
@@ -418,6 +423,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return cardinality_; }
       set {
         cardinality_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setCardinality)
       }
     }
 
@@ -432,6 +438,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return number_; }
       set {
         number_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setNumber)
       }
     }
 
@@ -446,6 +453,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setName)
       }
     }
 
@@ -461,6 +469,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return typeUrl_; }
       set {
         typeUrl_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setTypeUrl)
       }
     }
 
@@ -476,6 +485,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return oneofIndex_; }
       set {
         oneofIndex_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setOneofIndex)
       }
     }
 
@@ -490,6 +500,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return packed_; }
       set {
         packed_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setPacked)
       }
     }
 
@@ -517,6 +528,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return jsonName_; }
       set {
         jsonName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setJsonName)
       }
     }
 
@@ -531,9 +543,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return defaultValue_; }
       set {
         defaultValue_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Field.setDefaultValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Field)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Field);
@@ -583,6 +597,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Field)
       if (Kind != 0) {
         output.WriteRawTag(8);
         output.WriteEnum((int) Kind);
@@ -906,6 +921,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Enum.setName)
       }
     }
 
@@ -960,9 +976,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return syntax_; }
       set {
         syntax_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Enum.setSyntax)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Enum)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Enum);
@@ -1002,6 +1020,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Enum)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -1141,6 +1160,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumValue.setName)
       }
     }
 
@@ -1155,6 +1175,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return number_; }
       set {
         number_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.EnumValue.setNumber)
       }
     }
 
@@ -1171,6 +1192,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return options_; }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.EnumValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as EnumValue);
@@ -1206,6 +1228,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.EnumValue)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);
@@ -1321,6 +1344,7 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return name_; }
       set {
         name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Option.setName)
       }
     }
 
@@ -1341,6 +1365,7 @@ namespace Google.Protobuf.WellKnownTypes {
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Option)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Option);
@@ -1374,6 +1399,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Option)
       if (Name.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Name);

--- a/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Wrappers.cs
@@ -98,9 +98,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.DoubleValue.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.DoubleValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as DoubleValue);
@@ -132,6 +134,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.DoubleValue)
       if (Value != 0D) {
         output.WriteRawTag(9);
         output.WriteDouble(Value);
@@ -223,9 +226,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.FloatValue.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.FloatValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as FloatValue);
@@ -257,6 +262,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.FloatValue)
       if (Value != 0F) {
         output.WriteRawTag(13);
         output.WriteFloat(Value);
@@ -348,9 +354,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Int64Value.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Int64Value)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Int64Value);
@@ -382,6 +390,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Int64Value)
       if (Value != 0L) {
         output.WriteRawTag(8);
         output.WriteInt64(Value);
@@ -473,9 +482,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UInt64Value.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.UInt64Value)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as UInt64Value);
@@ -507,6 +518,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.UInt64Value)
       if (Value != 0UL) {
         output.WriteRawTag(8);
         output.WriteUInt64(Value);
@@ -598,9 +610,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.Int32Value.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.Int32Value)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Int32Value);
@@ -632,6 +646,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.Int32Value)
       if (Value != 0) {
         output.WriteRawTag(8);
         output.WriteInt32(Value);
@@ -723,9 +738,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.UInt32Value.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.UInt32Value)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as UInt32Value);
@@ -757,6 +774,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.UInt32Value)
       if (Value != 0) {
         output.WriteRawTag(8);
         output.WriteUInt32(Value);
@@ -848,9 +866,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = value;
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.BoolValue.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.BoolValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as BoolValue);
@@ -882,6 +902,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.BoolValue)
       if (Value != false) {
         output.WriteRawTag(8);
         output.WriteBool(Value);
@@ -973,9 +994,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.StringValue.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.StringValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as StringValue);
@@ -1007,6 +1030,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.StringValue)
       if (Value.Length != 0) {
         output.WriteRawTag(10);
         output.WriteString(Value);
@@ -1098,9 +1122,11 @@ namespace Google.Protobuf.WellKnownTypes {
       get { return value_; }
       set {
         value_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        //@@protoc_insertion_point(field_modifier_scope_after:google.protobuf.BytesValue.setValue)
       }
     }
 
+    //@@protoc_insertion_point(class_scope:google.protobuf.BytesValue)
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as BytesValue);
@@ -1132,6 +1158,7 @@ namespace Google.Protobuf.WellKnownTypes {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void WriteTo(pb::CodedOutputStream output) {
+      //@@protoc_insertion_point(write_to_scope_begin:google.protobuf.BytesValue)
       if (Value.Length != 0) {
         output.WriteRawTag(10);
         output.WriteBytes(Value);

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -106,6 +106,7 @@ void MessageGenerator::AddDeprecatedFlag(io::Printer* printer) {
 
 void MessageGenerator::Generate(io::Printer* printer) {
   map<string, string> vars;
+  vars["full_name"] = descriptor_->full_name();
   vars["class_name"] = class_name();
   vars["access_level"] = class_access_level();
 
@@ -227,6 +228,7 @@ void MessageGenerator::Generate(io::Printer* printer) {
       "}\n\n");
   }
 
+  printer->Print(vars, "//@@protoc_insertion_point(class_scope:$full_name$)\n");
   // Standard methods
   GenerateFrameworkMethods(printer);
   GenerateMessageSerializationMethods(printer);
@@ -396,10 +398,13 @@ void MessageGenerator::GenerateFrameworkMethods(io::Printer* printer) {
 }
 
 void MessageGenerator::GenerateMessageSerializationMethods(io::Printer* printer) {
+  map<string, string> vars;
+  vars["full_name"] = descriptor_->full_name();
   WriteGeneratedCodeAttributes(printer);
   printer->Print(
       "public void WriteTo(pb::CodedOutputStream output) {\n");
   printer->Indent();
+  printer->Print(vars, "//@@protoc_insertion_point(write_to_scope_begin:$full_name$)\n");
 
   // Serialize all the fields
   for (int i = 0; i < fields_by_number().size(); i++) {

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
@@ -49,11 +49,17 @@ namespace compiler {
 namespace csharp {
 
 PrimitiveFieldGenerator::PrimitiveFieldGenerator(
-    const FieldDescriptor* descriptor, int fieldOrdinal, const Options *options)
+    const FieldDescriptor* descriptor, int fieldOrdinal, const Options* options)
     : FieldGeneratorBase(descriptor, fieldOrdinal, options) {
   // TODO(jonskeet): Make this cleaner...
   is_value_type = descriptor->type() != FieldDescriptor::TYPE_STRING
       && descriptor->type() != FieldDescriptor::TYPE_BYTES;
+
+  if (descriptor->containing_type() != NULL) {
+    variables_["containing_type_full_name"] = descriptor->containing_type()->full_name();
+  } else {
+    variables_["containing_type_full_name"] = descriptor->full_name();
+  }
   if (!is_value_type) {
     variables_["has_property_check"] = variables_["property_name"] + ".Length != 0";
     variables_["other_has_property_check"] = "other." + variables_["property_name"] + ".Length != 0";
@@ -87,6 +93,8 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer) {
       "    $name$_ = pb::ProtoPreconditions.CheckNotNull(value, \"value\");\n");
   }
   printer->Print(
+    variables_,
+    "    //@@protoc_insertion_point(field_modifier_scope_after:$containing_type_full_name$.set$property_name$)\n"
     "  }\n"
     "}\n");
 }

--- a/src/google/protobuf/compiler/java/java_map_field.cc
+++ b/src/google/protobuf/compiler/java/java_map_field.cc
@@ -81,6 +81,8 @@ void SetMessageVariables(const FieldDescriptor* descriptor,
                          const FieldGeneratorInfo* info,
                          Context* context,
                          std::map<string, string>* variables) {
+  (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
+
   SetCommonFieldVariables(descriptor, info, variables);
   ClassNameResolver* name_resolver = context->GetNameResolver();
 
@@ -354,6 +356,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                  "public Builder clear$capitalized_name$() {\n"
                  "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                  "      .clear();\n"
+                 "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -364,6 +367,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                  "  $key_null_check$\n"
                  "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                  "      .remove(key);\n"
+                 "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.remove$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   if (GetJavaType(ValueField(descriptor_)) == JAVATYPE_ENUM) {
@@ -387,6 +391,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                    "  $value_null_check$\n"
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .put(key, $name$ValueConverter.doBackward(value));\n"
+                   "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.put$capitalized_name$)\n"
                    "  return this;\n"
                    "}\n");
     WriteFieldDocComment(printer, descriptor_);
@@ -397,6 +402,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
         "  internalGetAdapted$capitalized_name$Map(\n"
         "      internalGetMutable$capitalized_name$().getMutableMap())\n"
         "          .putAll(values);\n"
+        "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.putAll$capitalized_name$)\n"
         "  return this;\n"
         "}\n");
     if (SupportUnknownEnumValue(descriptor_->file())) {
@@ -422,6 +428,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
           "  }\n"
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .put(key, value);\n"
+          "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.put$capitalized_name$)\n"
           "  return this;\n"
           "}\n");
       WriteFieldDocComment(printer, descriptor_);
@@ -431,6 +438,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
           "    java.util.Map<$boxed_key_type$, $boxed_value_type$> values) {\n"
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .putAll(values);\n"
+          "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.putAll$capitalized_name$)\n"
           "  return this;\n"
           "}\n");
     }
@@ -455,6 +463,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                    "  $value_null_check$\n"
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .put(key, value);\n"
+                   "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.put$capitalized_name$)\n"
                    "  return this;\n"
                    "}\n");
     WriteFieldDocComment(printer, descriptor_);
@@ -464,6 +473,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                    "    java.util.Map<$type_parameters$> values) {\n"
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .putAll(values);\n"
+                   "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.putAll$capitalized_name$)\n"
                    "  return this;\n"
                    "}\n");
   }

--- a/src/google/protobuf/compiler/java/java_message_builder.cc
+++ b/src/google/protobuf/compiler/java/java_message_builder.cc
@@ -473,26 +473,32 @@ GenerateCommonBuilderMethods(io::Printer* printer) {
     "public Builder setField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.setField)\n"
     "  return (Builder) super.setField(field, value);\n"
     "}\n"
     "public Builder clearField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.clearField)\n"
     "  return (Builder) super.clearField(field);\n"
     "}\n"
     "public Builder clearOneof(\n"
     "    com.google.protobuf.Descriptors.OneofDescriptor oneof) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.clearOneOf)\n"
     "  return (Builder) super.clearOneof(oneof);\n"
     "}\n"
     "public Builder setRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    int index, Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.setRepeatedField)\n"
     "  return (Builder) super.setRepeatedField(field, index, value);\n"
     "}\n"
     "public Builder addRepeatedField(\n"
     "    com.google.protobuf.Descriptors.FieldDescriptor field,\n"
     "    Object value) {\n"
+    "  //@@protoc_insertion_point(field_modifier_scope_after:$full_name$.addRepeatedField)\n"
     "  return (Builder) super.addRepeatedField(field, value);\n"
-    "}\n");
+    "}\n",
+    "full_name", descriptor_->full_name());
 
   if (descriptor_->extension_range_count() > 0) {
     printer->Print(

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -59,6 +59,7 @@ void SetMessageVariables(const FieldDescriptor* descriptor,
                          std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
   (*variables)["type"] =
       name_resolver->GetImmutableClassName(descriptor->message_type());
   (*variables)["mutable_type"] =
@@ -299,6 +300,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$Builder_.setMessage(value);\n",
 
     "$set_has_field_bit_builder$\n"
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "return this;\n");
 
   // Field.Builder setField(Field.Builder builderForValue)
@@ -313,6 +315,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$Builder_.setMessage(builderForValue.build());\n",
 
     "$set_has_field_bit_builder$\n"
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "return this;\n");
 
   // Field.Builder mergeField(Field value)
@@ -974,6 +977,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$_.set(index, value);\n"
     "$on_changed$\n",
     "$name$Builder_.setMessage(index, value);\n",
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.setIndex$capitalized_name$)\n"
     "return this;\n");
 
   // Builder setRepeatedField(int index, Field.Builder builderForValue)
@@ -987,14 +991,13 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.setMessage(index, builderForValue.build());\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.setBuilderIndex$capitalized_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(Field value)
   WriteFieldDocComment(printer, descriptor_);
   PrintNestedBuilderFunction(printer,
     "$deprecation$public Builder add$capitalized_name$($type$ value)",
-
     "if (value == null) {\n"
     "  throw new NullPointerException();\n"
     "}\n"
@@ -1004,7 +1007,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.addMessage(value);\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(int index, Field value)
@@ -1012,7 +1015,6 @@ GenerateBuilderMembers(io::Printer* printer) const {
   PrintNestedBuilderFunction(printer,
     "$deprecation$public Builder add$capitalized_name$(\n"
     "    int index, $type$ value)",
-
     "if (value == null) {\n"
     "  throw new NullPointerException();\n"
     "}\n"
@@ -1021,7 +1023,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.addMessage(index, value);\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addIndex$capitalized_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(Field.Builder builderForValue)
@@ -1035,7 +1037,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.addMessage(builderForValue.build());\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addBuilder$capitalized_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(int index, Field.Builder builderForValue)
@@ -1049,7 +1051,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.addMessage(index, builderForValue.build());\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addBuilderIndex$capitalized_name$)\n"
     "return this;\n");
 
   // Builder addAllRepeatedField(Iterable<Field> values)
@@ -1064,7 +1066,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.addAllMessages(values);\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "return this;\n");
 
   // Builder clearAllRepeatedField()
@@ -1077,7 +1079,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.clear();\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "return this;\n");
 
   // Builder removeRepeatedField(int index)
@@ -1090,7 +1092,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$on_changed$\n",
 
     "$name$Builder_.remove(index);\n",
-
+    "// @@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.removeIndex$capitalized_name$)\n"
     "return this;\n");
 
   WriteFieldDocComment(printer, descriptor_);

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -64,6 +64,11 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  if(descriptor->containing_type() != NULL) {
+    (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
+  } else {
+    (*variables)["containing_type_full_name"] = descriptor->full_name();
+  }
   (*variables)["type"] = PrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["boxed_type"] = BoxedPrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["field_type"] = (*variables)["type"];
@@ -228,6 +233,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -247,6 +253,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   }
   printer->Print(variables_,
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 }
@@ -483,6 +490,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -494,6 +502,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 }
@@ -675,6 +684,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.setIndex$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -684,6 +694,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -694,6 +705,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -702,6 +714,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 }

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -65,6 +65,11 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  if(descriptor->containing_type() != NULL) {
+    (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
+  } else {
+    (*variables)["containing_type_full_name"] = descriptor->full_name();
+  }
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
 
   (*variables)["default"] = ImmutableDefaultValue(descriptor, name_resolver);
@@ -322,6 +327,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -334,6 +340,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = getDefaultInstance().get$capitalized_name$();\n");
   printer->Print(variables_,
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -341,7 +348,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   printer->Print(variables_,
     "$deprecation$public Builder set$capitalized_name$Bytes(\n"
     "    com.google.protobuf.ByteString value) {\n"
-    "$null_check$");
+    "  $null_check$");
   if (CheckUtf8(descriptor_)) {
     printer->Print(variables_,
       "  checkByteStringIsUtf8(value);\n");
@@ -350,6 +357,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "  return this;\n"
     "}\n");
 }
@@ -606,6 +614,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -616,6 +625,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -632,6 +642,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
     "  return this;\n"
     "}\n");
 }
@@ -821,6 +832,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.setIndex$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -831,6 +843,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -841,6 +854,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.addAll$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
   WriteFieldDocComment(printer, descriptor_);
@@ -849,6 +863,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.clear$capitalized_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -865,6 +880,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "  //@@protoc_insertion_point(builder_field_modifier_scope_after:$containing_type_full_name$.add$capitalized_name$Bytes)\n"
     "  return this;\n"
     "}\n");
 }


### PR DESCRIPTION
With those insertion points, we're able to implement a plugin that does what is
described on #2684. ie: with those patches, we're able to make a distinction
between a field which has a default value and a field which isn't set.

Said differently, this is how we solve #1606 for Java and C#