### PR TITLE
Add JsonFormat option to use unrecognized enum value when enum value is unknown

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/Descriptors.java
+++ b/java/core/src/main/java/com/google/protobuf/Descriptors.java
@@ -1595,6 +1595,23 @@ public final class Descriptors {
       if (result != null) {
         return result;
       }
+
+      return createEnumValueDescriptor(number);
+    }
+
+    /**
+     * Create the UNRECOGNIZED enum value descriptor by using a number outside the range of valid
+     * numbers.
+     */
+    public EnumValueDescriptor createUnrecognizedValueDescriptor() {
+      return createEnumValueDescriptor(-1);
+    }
+
+    /**
+     * Construct an EnumValueDescriptor for a number.
+     */
+    private EnumValueDescriptor createEnumValueDescriptor(final int number) {
+      EnumValueDescriptor result = null;
       // The number represents an unknown enum value.
       synchronized (this) {
         // Descriptors are compared by object identity so for the same number

--- a/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
+++ b/java/util/src/test/java/com/google/protobuf/util/JsonFormatTest.java
@@ -1168,6 +1168,13 @@ public class JsonFormatTest extends TestCase {
     }
   }
 
+  public void testParserUsingUnrecognizedEnumValues() throws Exception {
+    TestAllTypes.Builder builder = TestAllTypes.newBuilder();
+    String json = "{\n" + "  \"optionalNestedEnum\": \"XXX\"\n" + "}";
+    JsonFormat.parser().usingUnrecognizedEnumValue().merge(json, builder);
+    assertEquals(NestedEnum.UNRECOGNIZED, builder.getOptionalNestedEnum());
+  }
+
   public void testParserIgnoringUnknownFields() throws Exception {
     TestAllTypes.Builder builder = TestAllTypes.newBuilder();
     String json = "{\n" + "  \"unknownField\": \"XXX\"\n" + "}";


### PR DESCRIPTION
Instead of throwing a parse exception when a unknown enum value is seen, use the protobuf UNRECOGNIZED enum value.

This behavior can be enabled via `Parser.usingUnrecognizedEnumValue()`, similar to what `Parser.ignoringUnknownFields()` did for unknown fields.
This allows different parties to add new enum values without all parties needing to know about the value.

[See Issue 3012](https://github.com/google/protobuf/issues/3012)

Signed-off-by: Veeren Mandalia <veeren@postmates.com>