### PR TITLE
Add Java insertion points for field modifiers

### DIFF
--- a/src/google/protobuf/compiler/java/java_enum_field.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field.cc
@@ -61,6 +61,7 @@ void SetEnumVariables(const FieldDescriptor* descriptor,
                       std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["full_name"] = descriptor->full_name();
   (*variables)["type"] =
       name_resolver->GetImmutableClassName(descriptor->enum_type());
   (*variables)["mutable_type"] =
@@ -230,6 +231,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "${$set$capitalized_name$Value$}$(int value) {\n"
       "  $name$_ = value;\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_setValue:$full_name$)\n"
       "  return this;\n"
       "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -250,6 +252,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value.getNumber();\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -259,6 +262,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $clear_has_field_bit_builder$\n"
     "  $name$_ = $default_number$;\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -730,6 +734,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value.getNumber());\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -742,6 +747,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value.getNumber());\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_add:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -754,6 +760,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "    $name$_.add(value.getNumber());\n"
     "  }\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_addAll:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -763,6 +770,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = java.util.Collections.emptyList();\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -788,6 +796,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "  ensure$capitalized_name$IsMutable();\n"
       "  $name$_.set(index, value);\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_set:$full_name$)\n"
       "  return this;\n"
       "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -798,6 +807,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "  ensure$capitalized_name$IsMutable();\n"
       "  $name$_.add(value);\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_add:$full_name$)\n"
       "  return this;\n"
       "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -810,6 +820,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "    $name$_.add(value);\n"
       "  }\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_addAll:$full_name$)\n"
       "  return this;\n"
       "}\n");
     printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/java_map_field.cc
+++ b/src/google/protobuf/compiler/java/java_map_field.cc
@@ -84,6 +84,7 @@ void SetMessageVariables(const FieldDescriptor* descriptor,
   SetCommonFieldVariables(descriptor, info, variables);
   ClassNameResolver* name_resolver = context->GetNameResolver();
 
+  (*variables)["full_name"] = descriptor->full_name();
   (*variables)["type"] =
       name_resolver->GetImmutableClassName(descriptor->message_type());
   const FieldDescriptor* key = KeyField(descriptor);
@@ -369,6 +370,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "public Builder ${$clear$capitalized_name$$}$() {\n"
       "  internalGetMutable$capitalized_name$().getMutableMap()\n"
       "      .clear();\n"
+      "// @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -381,6 +383,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
       "  $key_null_check$\n"
       "  internalGetMutable$capitalized_name$().getMutableMap()\n"
       "      .remove(key);\n"
+      "// @@protoc_insertion_point(builder_field_remove:$full_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -406,6 +409,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
                    "  $value_null_check$\n"
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .put(key, $name$ValueConverter.doBackward(value));\n"
+                   "// @@protoc_insertion_point(builder_field_put:$full_name$)\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -417,6 +421,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
         "  internalGetAdapted$capitalized_name$Map(\n"
         "      internalGetMutable$capitalized_name$().getMutableMap())\n"
         "          .putAll(values);\n"
+        "// @@protoc_insertion_point(builder_field_putAll:$full_name$)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -441,6 +446,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
           "  $key_null_check$\n"
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .put(key, value);\n"
+          "// @@protoc_insertion_point(builder_field_put:$full_name$)\n"
           "  return this;\n"
           "}\n");
       printer->Annotate("{", "}", descriptor_);
@@ -451,6 +457,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
           "    java.util.Map<$boxed_key_type$, $boxed_value_type$> values) {\n"
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .putAll(values);\n"
+          "// @@protoc_insertion_point(builder_field_putAll:$full_name$)\n"
           "  return this;\n"
           "}\n");
       printer->Annotate("{", "}", descriptor_);
@@ -478,6 +485,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
         "  $value_null_check$\n"
         "  internalGetMutable$capitalized_name$().getMutableMap()\n"
         "      .put(key, value);\n"
+        "// @@protoc_insertion_point(builder_field_put:$full_name$)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -489,6 +497,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
         "    java.util.Map<$type_parameters$> values) {\n"
         "  internalGetMutable$capitalized_name$().getMutableMap()\n"
         "      .putAll(values);\n"
+        "// @@protoc_insertion_point(builder_field_putAll:$full_name$)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -59,6 +59,7 @@ void SetMessageVariables(const FieldDescriptor* descriptor,
                          std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["full_name"] = descriptor->full_name();
   (*variables)["type"] =
       name_resolver->GetImmutableClassName(descriptor->message_type());
   (*variables)["mutable_type"] =
@@ -305,6 +306,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$Builder_.setMessage(value);\n",
 
     "$set_has_field_bit_builder$\n"
+    "// @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "return this;\n");
 
   // Field.Builder setField(Field.Builder builderForValue)
@@ -319,6 +321,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$Builder_.setMessage(builderForValue.build());\n",
 
     "$set_has_field_bit_builder$\n"
+    "// @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "return this;\n");
 
   // Field.Builder mergeField(Field value)
@@ -999,6 +1002,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "$name$_.set(index, value);\n"
     "$on_changed$\n",
     "$name$Builder_.setMessage(index, value);\n",
+    "// @@protoc_insertion_point(builder_field_setIndex:$full_name$)\n"
     "return this;\n");
 
   // Builder setRepeatedField(int index, Field.Builder builderForValue)
@@ -1013,6 +1017,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.setMessage(index, builderForValue.build());\n",
 
+    "// @@protoc_insertion_point(builder_field_setBuilderIndex:$full_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(Field value)
@@ -1030,6 +1035,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.addMessage(value);\n",
 
+    "// @@protoc_insertion_point(builder_field_add:$full_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(int index, Field value)
@@ -1047,6 +1053,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.addMessage(index, value);\n",
 
+    "// @@protoc_insertion_point(builder_field_addIndex:$full_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(Field.Builder builderForValue)
@@ -1061,6 +1068,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.addMessage(builderForValue.build());\n",
 
+    "// @@protoc_insertion_point(builder_field_addBuilder:$full_name$)\n"
     "return this;\n");
 
   // Builder addRepeatedField(int index, Field.Builder builderForValue)
@@ -1075,6 +1083,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.addMessage(index, builderForValue.build());\n",
 
+    "// @@protoc_insertion_point(builder_field_addBuilderIndex:$full_name$)\n"
     "return this;\n");
 
   // Builder addAllRepeatedField(Iterable<Field> values)
@@ -1090,6 +1099,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.addAllMessages(values);\n",
 
+    "// @@protoc_insertion_point(builder_field_addAll:$full_name$)\n"
     "return this;\n");
 
   // Builder clearAllRepeatedField()
@@ -1103,6 +1113,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.clear();\n",
 
+    "// @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "return this;\n");
 
   // Builder removeRepeatedField(int index)
@@ -1116,6 +1127,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
 
     "$name$Builder_.remove(index);\n",
 
+    "// @@protoc_insertion_point(builder_field_removeIndex:$full_name$)\n"
     "return this;\n");
 
   WriteFieldDocComment(printer, descriptor_);

--- a/src/google/protobuf/compiler/java/java_primitive_field.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field.cc
@@ -64,6 +64,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["full_name"] = descriptor->full_name();
   (*variables)["type"] = PrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["boxed_type"] = BoxedPrimitiveTypeName(GetJavaType(descriptor));
   (*variables)["field_type"] = (*variables)["type"];
@@ -232,6 +233,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -253,6 +255,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
   }
   printer->Print(variables_,
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
 }
@@ -493,6 +496,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -505,6 +509,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
+    "  // @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -693,6 +698,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_setIndex:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -703,6 +709,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_add:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -714,6 +721,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_addAll:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -723,6 +731,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
+    "  // @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -65,6 +65,7 @@ void SetPrimitiveVariables(const FieldDescriptor* descriptor,
                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
+  (*variables)["full_name"] = descriptor->full_name();
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
 
   (*variables)["default"] = ImmutableDefaultValue(descriptor, name_resolver);
@@ -328,6 +329,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -342,6 +344,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = getDefaultInstance().get$capitalized_name$();\n");
   printer->Print(variables_,
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
 
@@ -359,6 +362,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_has_field_bit_builder$\n"
     "  $name$_ = value;\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_setBytes:$full_name$)\n"
     "  return this;\n"
     "}\n");
 }
@@ -621,6 +625,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_set:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -632,6 +637,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "    $oneof_name$_ = null;\n"
     "    $on_changed$\n"
     "  }\n"
+    "// @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -650,6 +656,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $set_oneof_case_message$;\n"
     "  $oneof_name$_ = value;\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_setBytes:$full_name$)\n"
     "  return this;\n"
     "}\n");
 }
@@ -849,6 +856,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.set(index, value);\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_setIndex:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -860,6 +868,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_add:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -871,6 +880,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
     "      values, $name$_);\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_addAll:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -880,6 +890,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  $name$_ = $empty_list$;\n"
     "  $clear_mutable_bit_builder$;\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_clear:$full_name$)\n"
     "  return this;\n"
     "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -898,6 +909,7 @@ GenerateBuilderMembers(io::Printer* printer) const {
     "  ensure$capitalized_name$IsMutable();\n"
     "  $name$_.add(value);\n"
     "  $on_changed$\n"
+    "// @@protoc_insertion_point(builder_field_addBytes:$full_name$)\n"
     "  return this;\n"
     "}\n");
 }


### PR DESCRIPTION
With those insertion points, we're able to implement a plugin that does what is
described on #2684. ie: with those patches, we're able to make a distinction
between a field which has a default value and a field which isn't set.

Said differently, this is how we solve #1606 for Java