### PR TITLE
imports GPBType instead of using complete classname

### DIFF
--- a/php/src/GPBMetadata/Google/Protobuf/Internal/Descriptor.php
+++ b/php/src/GPBMetadata/Google/Protobuf/Internal/Descriptor.php
@@ -4,6 +4,8 @@
 
 namespace GPBMetadata\Google\Protobuf\Internal;
 
+use Google\Protobuf\Internal\GPBType;
+
 class Descriptor
 {
     public static $is_initialized = false;
@@ -15,58 +17,58 @@ class Descriptor
           return;
         }
         $pool->addMessage('google.protobuf.internal.FileDescriptorSet', \Google\Protobuf\Internal\FileDescriptorSet::class)
-            ->repeated('file', \Google\Protobuf\Internal\GPBType::MESSAGE, 1, 'google.protobuf.internal.FileDescriptorProto')
+            ->repeated('file', GPBType::MESSAGE, 1, 'google.protobuf.internal.FileDescriptorProto')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.FileDescriptorProto', \Google\Protobuf\Internal\FileDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('package', \Google\Protobuf\Internal\GPBType::STRING, 2)
-            ->repeated('dependency', \Google\Protobuf\Internal\GPBType::STRING, 3)
-            ->repeated('public_dependency', \Google\Protobuf\Internal\GPBType::INT32, 10)
-            ->repeated('weak_dependency', \Google\Protobuf\Internal\GPBType::INT32, 11)
-            ->repeated('message_type', \Google\Protobuf\Internal\GPBType::MESSAGE, 4, 'google.protobuf.internal.DescriptorProto')
-            ->repeated('enum_type', \Google\Protobuf\Internal\GPBType::MESSAGE, 5, 'google.protobuf.internal.EnumDescriptorProto')
-            ->repeated('service', \Google\Protobuf\Internal\GPBType::MESSAGE, 6, 'google.protobuf.internal.ServiceDescriptorProto')
-            ->repeated('extension', \Google\Protobuf\Internal\GPBType::MESSAGE, 7, 'google.protobuf.internal.FieldDescriptorProto')
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 8, 'google.protobuf.internal.FileOptions')
-            ->optional('source_code_info', \Google\Protobuf\Internal\GPBType::MESSAGE, 9, 'google.protobuf.internal.SourceCodeInfo')
-            ->optional('syntax', \Google\Protobuf\Internal\GPBType::STRING, 12)
+            ->optional('name', GPBType::STRING, 1)
+            ->optional('package', GPBType::STRING, 2)
+            ->repeated('dependency', GPBType::STRING, 3)
+            ->repeated('public_dependency', GPBType::INT32, 10)
+            ->repeated('weak_dependency', GPBType::INT32, 11)
+            ->repeated('message_type', GPBType::MESSAGE, 4, 'google.protobuf.internal.DescriptorProto')
+            ->repeated('enum_type', GPBType::MESSAGE, 5, 'google.protobuf.internal.EnumDescriptorProto')
+            ->repeated('service', GPBType::MESSAGE, 6, 'google.protobuf.internal.ServiceDescriptorProto')
+            ->repeated('extension', GPBType::MESSAGE, 7, 'google.protobuf.internal.FieldDescriptorProto')
+            ->optional('options', GPBType::MESSAGE, 8, 'google.protobuf.internal.FileOptions')
+            ->optional('source_code_info', GPBType::MESSAGE, 9, 'google.protobuf.internal.SourceCodeInfo')
+            ->optional('syntax', GPBType::STRING, 12)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.DescriptorProto', \Google\Protobuf\Internal\DescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->repeated('field', \Google\Protobuf\Internal\GPBType::MESSAGE, 2, 'google.protobuf.internal.FieldDescriptorProto')
-            ->repeated('extension', \Google\Protobuf\Internal\GPBType::MESSAGE, 6, 'google.protobuf.internal.FieldDescriptorProto')
-            ->repeated('nested_type', \Google\Protobuf\Internal\GPBType::MESSAGE, 3, 'google.protobuf.internal.DescriptorProto')
-            ->repeated('enum_type', \Google\Protobuf\Internal\GPBType::MESSAGE, 4, 'google.protobuf.internal.EnumDescriptorProto')
-            ->repeated('extension_range', \Google\Protobuf\Internal\GPBType::MESSAGE, 5, 'google.protobuf.internal.DescriptorProto.ExtensionRange')
-            ->repeated('oneof_decl', \Google\Protobuf\Internal\GPBType::MESSAGE, 8, 'google.protobuf.internal.OneofDescriptorProto')
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 7, 'google.protobuf.internal.MessageOptions')
-            ->repeated('reserved_range', \Google\Protobuf\Internal\GPBType::MESSAGE, 9, 'google.protobuf.internal.DescriptorProto.ReservedRange')
-            ->repeated('reserved_name', \Google\Protobuf\Internal\GPBType::STRING, 10)
+            ->optional('name', GPBType::STRING, 1)
+            ->repeated('field', GPBType::MESSAGE, 2, 'google.protobuf.internal.FieldDescriptorProto')
+            ->repeated('extension', GPBType::MESSAGE, 6, 'google.protobuf.internal.FieldDescriptorProto')
+            ->repeated('nested_type', GPBType::MESSAGE, 3, 'google.protobuf.internal.DescriptorProto')
+            ->repeated('enum_type', GPBType::MESSAGE, 4, 'google.protobuf.internal.EnumDescriptorProto')
+            ->repeated('extension_range', GPBType::MESSAGE, 5, 'google.protobuf.internal.DescriptorProto.ExtensionRange')
+            ->repeated('oneof_decl', GPBType::MESSAGE, 8, 'google.protobuf.internal.OneofDescriptorProto')
+            ->optional('options', GPBType::MESSAGE, 7, 'google.protobuf.internal.MessageOptions')
+            ->repeated('reserved_range', GPBType::MESSAGE, 9, 'google.protobuf.internal.DescriptorProto.ReservedRange')
+            ->repeated('reserved_name', GPBType::STRING, 10)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.DescriptorProto.ExtensionRange', \Google\Protobuf\Internal\DescriptorProto_ExtensionRange::class)
-            ->optional('start', \Google\Protobuf\Internal\GPBType::INT32, 1)
-            ->optional('end', \Google\Protobuf\Internal\GPBType::INT32, 2)
+            ->optional('start', GPBType::INT32, 1)
+            ->optional('end', GPBType::INT32, 2)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.DescriptorProto.ReservedRange', \Google\Protobuf\Internal\DescriptorProto_ReservedRange::class)
-            ->optional('start', \Google\Protobuf\Internal\GPBType::INT32, 1)
-            ->optional('end', \Google\Protobuf\Internal\GPBType::INT32, 2)
+            ->optional('start', GPBType::INT32, 1)
+            ->optional('end', GPBType::INT32, 2)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.FieldDescriptorProto', \Google\Protobuf\Internal\FieldDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('number', \Google\Protobuf\Internal\GPBType::INT32, 3)
-            ->optional('label', \Google\Protobuf\Internal\GPBType::ENUM, 4, 'google.protobuf.internal.FieldDescriptorProto.Label')
-            ->optional('type', \Google\Protobuf\Internal\GPBType::ENUM, 5, 'google.protobuf.internal.FieldDescriptorProto.Type')
-            ->optional('type_name', \Google\Protobuf\Internal\GPBType::STRING, 6)
-            ->optional('extendee', \Google\Protobuf\Internal\GPBType::STRING, 2)
-            ->optional('default_value', \Google\Protobuf\Internal\GPBType::STRING, 7)
-            ->optional('oneof_index', \Google\Protobuf\Internal\GPBType::INT32, 9)
-            ->optional('json_name', \Google\Protobuf\Internal\GPBType::STRING, 10)
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 8, 'google.protobuf.internal.FieldOptions')
+            ->optional('name', GPBType::STRING, 1)
+            ->optional('number', GPBType::INT32, 3)
+            ->optional('label', GPBType::ENUM, 4, 'google.protobuf.internal.FieldDescriptorProto.Label')
+            ->optional('type', GPBType::ENUM, 5, 'google.protobuf.internal.FieldDescriptorProto.Type')
+            ->optional('type_name', GPBType::STRING, 6)
+            ->optional('extendee', GPBType::STRING, 2)
+            ->optional('default_value', GPBType::STRING, 7)
+            ->optional('oneof_index', GPBType::INT32, 9)
+            ->optional('json_name', GPBType::STRING, 10)
+            ->optional('options', GPBType::MESSAGE, 8, 'google.protobuf.internal.FieldOptions')
             ->finalizeToPool();
 
         $pool->addEnum('google.protobuf.internal.FieldDescriptorProto.Type', \Google\Protobuf\Internal\Type::class)
@@ -97,56 +99,56 @@ class Descriptor
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.OneofDescriptorProto', \Google\Protobuf\Internal\OneofDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 2, 'google.protobuf.internal.OneofOptions')
+            ->optional('name', GPBType::STRING, 1)
+            ->optional('options', GPBType::MESSAGE, 2, 'google.protobuf.internal.OneofOptions')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.EnumDescriptorProto', \Google\Protobuf\Internal\EnumDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->repeated('value', \Google\Protobuf\Internal\GPBType::MESSAGE, 2, 'google.protobuf.internal.EnumValueDescriptorProto')
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 3, 'google.protobuf.internal.EnumOptions')
+            ->optional('name', GPBType::STRING, 1)
+            ->repeated('value', GPBType::MESSAGE, 2, 'google.protobuf.internal.EnumValueDescriptorProto')
+            ->optional('options', GPBType::MESSAGE, 3, 'google.protobuf.internal.EnumOptions')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.EnumValueDescriptorProto', \Google\Protobuf\Internal\EnumValueDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('number', \Google\Protobuf\Internal\GPBType::INT32, 2)
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 3, 'google.protobuf.internal.EnumValueOptions')
+            ->optional('name', GPBType::STRING, 1)
+            ->optional('number', GPBType::INT32, 2)
+            ->optional('options', GPBType::MESSAGE, 3, 'google.protobuf.internal.EnumValueOptions')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.ServiceDescriptorProto', \Google\Protobuf\Internal\ServiceDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->repeated('method', \Google\Protobuf\Internal\GPBType::MESSAGE, 2, 'google.protobuf.internal.MethodDescriptorProto')
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 3, 'google.protobuf.internal.ServiceOptions')
+            ->optional('name', GPBType::STRING, 1)
+            ->repeated('method', GPBType::MESSAGE, 2, 'google.protobuf.internal.MethodDescriptorProto')
+            ->optional('options', GPBType::MESSAGE, 3, 'google.protobuf.internal.ServiceOptions')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.MethodDescriptorProto', \Google\Protobuf\Internal\MethodDescriptorProto::class)
-            ->optional('name', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('input_type', \Google\Protobuf\Internal\GPBType::STRING, 2)
-            ->optional('output_type', \Google\Protobuf\Internal\GPBType::STRING, 3)
-            ->optional('options', \Google\Protobuf\Internal\GPBType::MESSAGE, 4, 'google.protobuf.internal.MethodOptions')
-            ->optional('client_streaming', \Google\Protobuf\Internal\GPBType::BOOL, 5)
-            ->optional('server_streaming', \Google\Protobuf\Internal\GPBType::BOOL, 6)
+            ->optional('name', GPBType::STRING, 1)
+            ->optional('input_type', GPBType::STRING, 2)
+            ->optional('output_type', GPBType::STRING, 3)
+            ->optional('options', GPBType::MESSAGE, 4, 'google.protobuf.internal.MethodOptions')
+            ->optional('client_streaming', GPBType::BOOL, 5)
+            ->optional('server_streaming', GPBType::BOOL, 6)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.FileOptions', \Google\Protobuf\Internal\FileOptions::class)
-            ->optional('java_package', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->optional('java_outer_classname', \Google\Protobuf\Internal\GPBType::STRING, 8)
-            ->optional('java_multiple_files', \Google\Protobuf\Internal\GPBType::BOOL, 10)
-            ->optional('java_generate_equals_and_hash', \Google\Protobuf\Internal\GPBType::BOOL, 20)
-            ->optional('java_string_check_utf8', \Google\Protobuf\Internal\GPBType::BOOL, 27)
-            ->optional('optimize_for', \Google\Protobuf\Internal\GPBType::ENUM, 9, 'google.protobuf.internal.FileOptions.OptimizeMode')
-            ->optional('go_package', \Google\Protobuf\Internal\GPBType::STRING, 11)
-            ->optional('cc_generic_services', \Google\Protobuf\Internal\GPBType::BOOL, 16)
-            ->optional('java_generic_services', \Google\Protobuf\Internal\GPBType::BOOL, 17)
-            ->optional('py_generic_services', \Google\Protobuf\Internal\GPBType::BOOL, 18)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 23)
-            ->optional('cc_enable_arenas', \Google\Protobuf\Internal\GPBType::BOOL, 31)
-            ->optional('objc_class_prefix', \Google\Protobuf\Internal\GPBType::STRING, 36)
-            ->optional('csharp_namespace', \Google\Protobuf\Internal\GPBType::STRING, 37)
-            ->optional('swift_prefix', \Google\Protobuf\Internal\GPBType::STRING, 39)
-            ->optional('php_class_prefix', \Google\Protobuf\Internal\GPBType::STRING, 40)
-            ->optional('php_namespace', \Google\Protobuf\Internal\GPBType::STRING, 41)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('java_package', GPBType::STRING, 1)
+            ->optional('java_outer_classname', GPBType::STRING, 8)
+            ->optional('java_multiple_files', GPBType::BOOL, 10)
+            ->optional('java_generate_equals_and_hash', GPBType::BOOL, 20)
+            ->optional('java_string_check_utf8', GPBType::BOOL, 27)
+            ->optional('optimize_for', GPBType::ENUM, 9, 'google.protobuf.internal.FileOptions.OptimizeMode')
+            ->optional('go_package', GPBType::STRING, 11)
+            ->optional('cc_generic_services', GPBType::BOOL, 16)
+            ->optional('java_generic_services', GPBType::BOOL, 17)
+            ->optional('py_generic_services', GPBType::BOOL, 18)
+            ->optional('deprecated', GPBType::BOOL, 23)
+            ->optional('cc_enable_arenas', GPBType::BOOL, 31)
+            ->optional('objc_class_prefix', GPBType::STRING, 36)
+            ->optional('csharp_namespace', GPBType::STRING, 37)
+            ->optional('swift_prefix', GPBType::STRING, 39)
+            ->optional('php_class_prefix', GPBType::STRING, 40)
+            ->optional('php_namespace', GPBType::STRING, 41)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addEnum('google.protobuf.internal.FileOptions.OptimizeMode', \Google\Protobuf\Internal\OptimizeMode::class)
@@ -156,21 +158,21 @@ class Descriptor
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.MessageOptions', \Google\Protobuf\Internal\MessageOptions::class)
-            ->optional('message_set_wire_format', \Google\Protobuf\Internal\GPBType::BOOL, 1)
-            ->optional('no_standard_descriptor_accessor', \Google\Protobuf\Internal\GPBType::BOOL, 2)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 3)
-            ->optional('map_entry', \Google\Protobuf\Internal\GPBType::BOOL, 7)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('message_set_wire_format', GPBType::BOOL, 1)
+            ->optional('no_standard_descriptor_accessor', GPBType::BOOL, 2)
+            ->optional('deprecated', GPBType::BOOL, 3)
+            ->optional('map_entry', GPBType::BOOL, 7)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.FieldOptions', \Google\Protobuf\Internal\FieldOptions::class)
-            ->optional('ctype', \Google\Protobuf\Internal\GPBType::ENUM, 1, 'google.protobuf.internal.FieldOptions.CType')
-            ->optional('packed', \Google\Protobuf\Internal\GPBType::BOOL, 2)
-            ->optional('jstype', \Google\Protobuf\Internal\GPBType::ENUM, 6, 'google.protobuf.internal.FieldOptions.JSType')
-            ->optional('lazy', \Google\Protobuf\Internal\GPBType::BOOL, 5)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 3)
-            ->optional('weak', \Google\Protobuf\Internal\GPBType::BOOL, 10)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('ctype', GPBType::ENUM, 1, 'google.protobuf.internal.FieldOptions.CType')
+            ->optional('packed', GPBType::BOOL, 2)
+            ->optional('jstype', GPBType::ENUM, 6, 'google.protobuf.internal.FieldOptions.JSType')
+            ->optional('lazy', GPBType::BOOL, 5)
+            ->optional('deprecated', GPBType::BOOL, 3)
+            ->optional('weak', GPBType::BOOL, 10)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addEnum('google.protobuf.internal.FieldOptions.CType', \Google\Protobuf\Internal\CType::class)
@@ -186,29 +188,29 @@ class Descriptor
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.OneofOptions', \Google\Protobuf\Internal\OneofOptions::class)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.EnumOptions', \Google\Protobuf\Internal\EnumOptions::class)
-            ->optional('allow_alias', \Google\Protobuf\Internal\GPBType::BOOL, 2)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 3)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('allow_alias', GPBType::BOOL, 2)
+            ->optional('deprecated', GPBType::BOOL, 3)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.EnumValueOptions', \Google\Protobuf\Internal\EnumValueOptions::class)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 1)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('deprecated', GPBType::BOOL, 1)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.ServiceOptions', \Google\Protobuf\Internal\ServiceOptions::class)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 33)
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('deprecated', GPBType::BOOL, 33)
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.MethodOptions', \Google\Protobuf\Internal\MethodOptions::class)
-            ->optional('deprecated', \Google\Protobuf\Internal\GPBType::BOOL, 33)
-            ->optional('idempotency_level', \Google\Protobuf\Internal\GPBType::ENUM, 34, 'google.protobuf.internal.MethodOptions.IdempotencyLevel')
-            ->repeated('uninterpreted_option', \Google\Protobuf\Internal\GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
+            ->optional('deprecated', GPBType::BOOL, 33)
+            ->optional('idempotency_level', GPBType::ENUM, 34, 'google.protobuf.internal.MethodOptions.IdempotencyLevel')
+            ->repeated('uninterpreted_option', GPBType::MESSAGE, 999, 'google.protobuf.internal.UninterpretedOption')
             ->finalizeToPool();
 
         $pool->addEnum('google.protobuf.internal.MethodOptions.IdempotencyLevel', \Google\Protobuf\Internal\IdempotencyLevel::class)
@@ -218,41 +220,41 @@ class Descriptor
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.UninterpretedOption', \Google\Protobuf\Internal\UninterpretedOption::class)
-            ->repeated('name', \Google\Protobuf\Internal\GPBType::MESSAGE, 2, 'google.protobuf.internal.UninterpretedOption.NamePart')
-            ->optional('identifier_value', \Google\Protobuf\Internal\GPBType::STRING, 3)
-            ->optional('positive_int_value', \Google\Protobuf\Internal\GPBType::UINT64, 4)
-            ->optional('negative_int_value', \Google\Protobuf\Internal\GPBType::INT64, 5)
-            ->optional('double_value', \Google\Protobuf\Internal\GPBType::DOUBLE, 6)
-            ->optional('string_value', \Google\Protobuf\Internal\GPBType::BYTES, 7)
-            ->optional('aggregate_value', \Google\Protobuf\Internal\GPBType::STRING, 8)
+            ->repeated('name', GPBType::MESSAGE, 2, 'google.protobuf.internal.UninterpretedOption.NamePart')
+            ->optional('identifier_value', GPBType::STRING, 3)
+            ->optional('positive_int_value', GPBType::UINT64, 4)
+            ->optional('negative_int_value', GPBType::INT64, 5)
+            ->optional('double_value', GPBType::DOUBLE, 6)
+            ->optional('string_value', GPBType::BYTES, 7)
+            ->optional('aggregate_value', GPBType::STRING, 8)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.UninterpretedOption.NamePart', \Google\Protobuf\Internal\UninterpretedOption_NamePart::class)
-            ->required('name_part', \Google\Protobuf\Internal\GPBType::STRING, 1)
-            ->required('is_extension', \Google\Protobuf\Internal\GPBType::BOOL, 2)
+            ->required('name_part', GPBType::STRING, 1)
+            ->required('is_extension', GPBType::BOOL, 2)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.SourceCodeInfo', \Google\Protobuf\Internal\SourceCodeInfo::class)
-            ->repeated('location', \Google\Protobuf\Internal\GPBType::MESSAGE, 1, 'google.protobuf.internal.SourceCodeInfo.Location')
+            ->repeated('location', GPBType::MESSAGE, 1, 'google.protobuf.internal.SourceCodeInfo.Location')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.SourceCodeInfo.Location', \Google\Protobuf\Internal\SourceCodeInfo_Location::class)
-            ->repeated('path', \Google\Protobuf\Internal\GPBType::INT32, 1)
-            ->repeated('span', \Google\Protobuf\Internal\GPBType::INT32, 2)
-            ->optional('leading_comments', \Google\Protobuf\Internal\GPBType::STRING, 3)
-            ->optional('trailing_comments', \Google\Protobuf\Internal\GPBType::STRING, 4)
-            ->repeated('leading_detached_comments', \Google\Protobuf\Internal\GPBType::STRING, 6)
+            ->repeated('path', GPBType::INT32, 1)
+            ->repeated('span', GPBType::INT32, 2)
+            ->optional('leading_comments', GPBType::STRING, 3)
+            ->optional('trailing_comments', GPBType::STRING, 4)
+            ->repeated('leading_detached_comments', GPBType::STRING, 6)
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.GeneratedCodeInfo', \Google\Protobuf\Internal\GeneratedCodeInfo::class)
-            ->repeated('annotation', \Google\Protobuf\Internal\GPBType::MESSAGE, 1, 'google.protobuf.internal.GeneratedCodeInfo.Annotation')
+            ->repeated('annotation', GPBType::MESSAGE, 1, 'google.protobuf.internal.GeneratedCodeInfo.Annotation')
             ->finalizeToPool();
 
         $pool->addMessage('google.protobuf.internal.GeneratedCodeInfo.Annotation', \Google\Protobuf\Internal\GeneratedCodeInfo_Annotation::class)
-            ->repeated('path', \Google\Protobuf\Internal\GPBType::INT32, 1)
-            ->optional('source_file', \Google\Protobuf\Internal\GPBType::STRING, 2)
-            ->optional('begin', \Google\Protobuf\Internal\GPBType::INT32, 3)
-            ->optional('end', \Google\Protobuf\Internal\GPBType::INT32, 4)
+            ->repeated('path', GPBType::INT32, 1)
+            ->optional('source_file', GPBType::STRING, 2)
+            ->optional('begin', GPBType::INT32, 3)
+            ->optional('end', GPBType::INT32, 4)
             ->finalizeToPool();
 
         $pool->finish();

--- a/php/src/Google/Protobuf/Internal/DescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorProto.php
@@ -121,7 +121,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setField(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
         $this->field = $arr;
         $this->has_field = true;
 
@@ -149,7 +149,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setExtension(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
         $this->extension = $arr;
         $this->has_extension = true;
 
@@ -177,7 +177,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setNestedType(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto::class);
         $this->nested_type = $arr;
         $this->has_nested_type = true;
 
@@ -205,7 +205,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setEnumType(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\EnumDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\EnumDescriptorProto::class);
         $this->enum_type = $arr;
         $this->has_enum_type = true;
 
@@ -233,7 +233,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setExtensionRange(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto_ExtensionRange::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto_ExtensionRange::class);
         $this->extension_range = $arr;
         $this->has_extension_range = true;
 
@@ -261,7 +261,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setOneofDecl(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\OneofDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\OneofDescriptorProto::class);
         $this->oneof_decl = $arr;
         $this->has_oneof_decl = true;
 
@@ -317,7 +317,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setReservedRange(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto_ReservedRange::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto_ReservedRange::class);
         $this->reserved_range = $arr;
         $this->has_reserved_range = true;
 
@@ -351,7 +351,7 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setReservedName(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::STRING);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::STRING);
         $this->reserved_name = $arr;
         $this->has_reserved_name = true;
 

--- a/php/src/Google/Protobuf/Internal/EnumDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/EnumDescriptorProto.php
@@ -83,7 +83,7 @@ class EnumDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setValue(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\EnumValueDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\EnumValueDescriptorProto::class);
         $this->value = $arr;
         $this->has_value = true;
 

--- a/php/src/Google/Protobuf/Internal/EnumOptions.php
+++ b/php/src/Google/Protobuf/Internal/EnumOptions.php
@@ -139,7 +139,7 @@ class EnumOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/EnumValueOptions.php
+++ b/php/src/Google/Protobuf/Internal/EnumValueOptions.php
@@ -97,7 +97,7 @@ class EnumValueOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/FieldOptions.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions.php
@@ -406,7 +406,7 @@ class FieldOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/FileDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/FileDescriptorProto.php
@@ -189,7 +189,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setDependency(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::STRING);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::STRING);
         $this->dependency = $arr;
         $this->has_dependency = true;
 
@@ -221,7 +221,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setPublicDependency(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::INT32);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::INT32);
         $this->public_dependency = $arr;
         $this->has_public_dependency = true;
 
@@ -255,7 +255,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setWeakDependency(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::INT32);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::INT32);
         $this->weak_dependency = $arr;
         $this->has_weak_dependency = true;
 
@@ -287,7 +287,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setMessageType(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\DescriptorProto::class);
         $this->message_type = $arr;
         $this->has_message_type = true;
 
@@ -315,7 +315,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setEnumType(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\EnumDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\EnumDescriptorProto::class);
         $this->enum_type = $arr;
         $this->has_enum_type = true;
 
@@ -343,7 +343,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setService(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\ServiceDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\ServiceDescriptorProto::class);
         $this->service = $arr;
         $this->has_service = true;
 
@@ -371,7 +371,7 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setExtension(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\FieldDescriptorProto::class);
         $this->extension = $arr;
         $this->has_extension = true;
 

--- a/php/src/Google/Protobuf/Internal/FileDescriptorSet.php
+++ b/php/src/Google/Protobuf/Internal/FileDescriptorSet.php
@@ -46,7 +46,7 @@ class FileDescriptorSet extends \Google\Protobuf\Internal\Message
      */
     public function setFile(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\FileDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\FileDescriptorProto::class);
         $this->file = $arr;
         $this->has_file = true;
 

--- a/php/src/Google/Protobuf/Internal/FileOptions.php
+++ b/php/src/Google/Protobuf/Internal/FileOptions.php
@@ -814,7 +814,7 @@ class FileOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/GeneratedCodeInfo.php
+++ b/php/src/Google/Protobuf/Internal/GeneratedCodeInfo.php
@@ -56,7 +56,7 @@ class GeneratedCodeInfo extends \Google\Protobuf\Internal\Message
      */
     public function setAnnotation(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\GeneratedCodeInfo_Annotation::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\GeneratedCodeInfo_Annotation::class);
         $this->annotation = $arr;
         $this->has_annotation = true;
 

--- a/php/src/Google/Protobuf/Internal/GeneratedCodeInfo_Annotation.php
+++ b/php/src/Google/Protobuf/Internal/GeneratedCodeInfo_Annotation.php
@@ -76,7 +76,7 @@ class GeneratedCodeInfo_Annotation extends \Google\Protobuf\Internal\Message
      */
     public function setPath(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::INT32);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::INT32);
         $this->path = $arr;
         $this->has_path = true;
 

--- a/php/src/Google/Protobuf/Internal/MessageOptions.php
+++ b/php/src/Google/Protobuf/Internal/MessageOptions.php
@@ -313,7 +313,7 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/MethodOptions.php
+++ b/php/src/Google/Protobuf/Internal/MethodOptions.php
@@ -130,7 +130,7 @@ class MethodOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/OneofOptions.php
+++ b/php/src/Google/Protobuf/Internal/OneofOptions.php
@@ -49,7 +49,7 @@ class OneofOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/ServiceDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/ServiceDescriptorProto.php
@@ -83,7 +83,7 @@ class ServiceDescriptorProto extends \Google\Protobuf\Internal\Message
      */
     public function setMethod(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\MethodDescriptorProto::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\MethodDescriptorProto::class);
         $this->method = $arr;
         $this->has_method = true;
 

--- a/php/src/Google/Protobuf/Internal/ServiceOptions.php
+++ b/php/src/Google/Protobuf/Internal/ServiceOptions.php
@@ -97,7 +97,7 @@ class ServiceOptions extends \Google\Protobuf\Internal\Message
      */
     public function setUninterpretedOption(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption::class);
         $this->uninterpreted_option = $arr;
         $this->has_uninterpreted_option = true;
 

--- a/php/src/Google/Protobuf/Internal/SourceCodeInfo.php
+++ b/php/src/Google/Protobuf/Internal/SourceCodeInfo.php
@@ -172,7 +172,7 @@ class SourceCodeInfo extends \Google\Protobuf\Internal\Message
      */
     public function setLocation(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\SourceCodeInfo_Location::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\SourceCodeInfo_Location::class);
         $this->location = $arr;
         $this->has_location = true;
 

--- a/php/src/Google/Protobuf/Internal/SourceCodeInfo_Location.php
+++ b/php/src/Google/Protobuf/Internal/SourceCodeInfo_Location.php
@@ -172,7 +172,7 @@ class SourceCodeInfo_Location extends \Google\Protobuf\Internal\Message
      */
     public function setPath(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::INT32);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::INT32);
         $this->path = $arr;
         $this->has_path = true;
 
@@ -212,7 +212,7 @@ class SourceCodeInfo_Location extends \Google\Protobuf\Internal\Message
      */
     public function setSpan(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::INT32);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::INT32);
         $this->span = $arr;
         $this->has_span = true;
 
@@ -370,7 +370,7 @@ class SourceCodeInfo_Location extends \Google\Protobuf\Internal\Message
      */
     public function setLeadingDetachedComments(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::STRING);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::STRING);
         $this->leading_detached_comments = $arr;
         $this->has_leading_detached_comments = true;
 

--- a/php/src/Google/Protobuf/Internal/UninterpretedOption.php
+++ b/php/src/Google/Protobuf/Internal/UninterpretedOption.php
@@ -83,7 +83,7 @@ class UninterpretedOption extends \Google\Protobuf\Internal\Message
      */
     public function setName(&$var)
     {
-        $arr = GPBUtil::checkRepeatedField($var, \Google\Protobuf\Internal\GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption_NamePart::class);
+        $arr = GPBUtil::checkRepeatedField($var, GPBType::MESSAGE, \Google\Protobuf\Internal\UninterpretedOption_NamePart::class);
         $this->name = $arr;
         $this->has_name = true;
 

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -550,8 +550,8 @@ void GenerateFieldAccessor(const FieldDescriptor* field, bool is_descriptor,
     const FieldDescriptor* value = map_entry->FindFieldByName("value");
     printer->Print(
         "$arr = GPBUtil::checkMapField($var, "
-        "\\Google\\Protobuf\\Internal\\GPBType::^key_type^, "
-        "\\Google\\Protobuf\\Internal\\GPBType::^value_type^",
+        "GPBType::^key_type^, "
+        "GPBType::^value_type^",
         "key_type", ToUpper(key->type_name()),
         "value_type", ToUpper(value->type_name()));
     if (value->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
@@ -570,7 +570,7 @@ void GenerateFieldAccessor(const FieldDescriptor* field, bool is_descriptor,
   } else if (field->is_repeated()) {
     printer->Print(
         "$arr = GPBUtil::checkRepeatedField($var, "
-        "\\Google\\Protobuf\\Internal\\GPBType::^type^",
+        "GPBType::^type^",
         "type", ToUpper(field->type_name()));
     if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
       printer->Print(
@@ -689,8 +689,8 @@ void GenerateMessageToPool(const string& name_prefix, const Descriptor* message,
       const FieldDescriptor* val =
           field->message_type()->FindFieldByName("value");
       printer->Print(
-          "->map('^field^', \\Google\\Protobuf\\Internal\\GPBType::^key^, "
-          "\\Google\\Protobuf\\Internal\\GPBType::^value^, ^number^^other^)\n",
+          "->map('^field^', GPBType::^key^, "
+          "GPBType::^value^, ^number^^other^)\n",
           "field", field->name(),
           "key", ToUpper(key->type_name()),
           "value", ToUpper(val->type_name()),
@@ -699,7 +699,7 @@ void GenerateMessageToPool(const string& name_prefix, const Descriptor* message,
     } else if (!field->containing_oneof()) {
       printer->Print(
           "->^label^('^field^', "
-          "\\Google\\Protobuf\\Internal\\GPBType::^type^, ^number^^other^)\n",
+          "GPBType::^type^, ^number^^other^)\n",
           "field", field->name(),
           "label", LabelForField(field),
           "type", ToUpper(field->type_name()),
@@ -718,7 +718,7 @@ void GenerateMessageToPool(const string& name_prefix, const Descriptor* message,
       const FieldDescriptor* field = oneof->field(index);
       printer->Print(
           "->value('^field^', "
-          "\\Google\\Protobuf\\Internal\\GPBType::^type^, ^number^^other^)\n",
+          "GPBType::^type^, ^number^^other^)\n",
           "field", field->name(),
           "type", ToUpper(field->type_name()),
           "number", SimpleItoa(field->number()),
@@ -885,6 +885,8 @@ void GenerateMetadataFile(const FileDescriptor* file,
   printer.Print(
       "namespace ^name^;\n\n",
       "name", fullname.substr(0, lastindex));
+
+  printer.Print("use Google\\Protobuf\\Internal\\GPBType;\n\n");
 
   if (lastindex != string::npos) {
     printer.Print(


### PR DESCRIPTION
`GPBType` is already imported in the message class, but the absolute classname is being used everywhere. Because we've imported it, we can make the generated code *much* more readable by using the shortened name.