### PR TITLE
changed the URL for google tests it was failing for protobuf version 2.5

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -19,8 +19,11 @@ fi
 # directory is set up as an SVN external.
 if test ! -e gtest; then
   echo "Google Test not present.  Fetching gtest-1.5.0 from the web..."
-  curl http://googletest.googlecode.com/files/gtest-1.5.0.tar.bz2 | tar jx
-  mv gtest-1.5.0 gtest
+  #Add the new path to download the google test with redirection since gihub redirects
+  curl -L https://github.com/google/googletest/archive/release-1.5.0.tar.gz | tar zx
+  mv googletest-release-1.5.0 gtest
+  #curl http://googletest.googlecode.com/files/gtest-1.5.0.tar.bz2 | tar jx
+  #mv gtest-1.5.0 gtest
 fi
 
 set -ex


### PR DESCRIPTION
autogen.sh needs update in the older version. Later version autogen.sh have the updated google test URLs. protobuf v2,5 isn't available easily on the latest linux builds, 