### PR TITLE
PHP array constructors for protobuf messages

### DIFF
--- a/php/src/Google/Protobuf/Internal/DescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorProto.php
@@ -71,9 +71,9 @@ class DescriptorProto extends \Google\Protobuf\Internal\Message
     private $reserved_name;
     private $has_reserved_name = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/DescriptorProto_ExtensionRange.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorProto_ExtensionRange.php
@@ -31,9 +31,9 @@ class DescriptorProto_ExtensionRange extends \Google\Protobuf\Internal\Message
     private $options = null;
     private $has_options = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/DescriptorProto_ReservedRange.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorProto_ReservedRange.php
@@ -34,9 +34,9 @@ class DescriptorProto_ReservedRange extends \Google\Protobuf\Internal\Message
     private $end = 0;
     private $has_end = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/EnumDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/EnumDescriptorProto.php
@@ -50,9 +50,9 @@ class EnumDescriptorProto extends \Google\Protobuf\Internal\Message
     private $reserved_name;
     private $has_reserved_name = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/EnumOptions.php
+++ b/php/src/Google/Protobuf/Internal/EnumOptions.php
@@ -41,9 +41,9 @@ class EnumOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/EnumValueDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/EnumValueDescriptorProto.php
@@ -33,9 +33,9 @@ class EnumValueDescriptorProto extends \Google\Protobuf\Internal\Message
     private $options = null;
     private $has_options = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/EnumValueOptions.php
+++ b/php/src/Google/Protobuf/Internal/EnumValueOptions.php
@@ -33,9 +33,9 @@ class EnumValueOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/FieldDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptorProto.php
@@ -94,9 +94,9 @@ class FieldDescriptorProto extends \Google\Protobuf\Internal\Message
     private $options = null;
     private $has_options = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/FieldOptions.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions.php
@@ -107,9 +107,9 @@ class FieldOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/FileDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/FileDescriptorProto.php
@@ -99,9 +99,9 @@ class FileDescriptorProto extends \Google\Protobuf\Internal\Message
     private $syntax = '';
     private $has_syntax = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/FileDescriptorSet.php
+++ b/php/src/Google/Protobuf/Internal/FileDescriptorSet.php
@@ -24,9 +24,9 @@ class FileDescriptorSet extends \Google\Protobuf\Internal\Message
     private $file;
     private $has_file = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/FileOptions.php
+++ b/php/src/Google/Protobuf/Internal/FileOptions.php
@@ -182,9 +182,9 @@ class FileOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/GeneratedCodeInfo.php
+++ b/php/src/Google/Protobuf/Internal/GeneratedCodeInfo.php
@@ -28,9 +28,9 @@ class GeneratedCodeInfo extends \Google\Protobuf\Internal\Message
     private $annotation;
     private $has_annotation = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/GeneratedCodeInfo_Annotation.php
+++ b/php/src/Google/Protobuf/Internal/GeneratedCodeInfo_Annotation.php
@@ -48,9 +48,9 @@ class GeneratedCodeInfo_Annotation extends \Google\Protobuf\Internal\Message
     private $end = 0;
     private $has_end = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -862,6 +862,42 @@ class Message
                         "Bool field only accept bool value");
                 }
                 return $value;
+            case GPBType::INT64:
+            case GPBType::SINT64:
+            case GPBType::SFIXED64:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
+                if (!is_numeric($value)) {
+                   throw new GPBDecodeException(
+                       "Invalid data type for int64 field");
+                }
+                if (bccomp($value, "9223372036854775807") > 0) {
+                    throw new GPBDecodeException(
+                        "Int64 too large");
+                }
+                if (bccomp($value, "-9223372036854775808") < 0) {
+                    throw new GPBDecodeException(
+                        "Int64 too small");
+                }
+                return $value;
+            case GPBType::UINT64:
+            case GPBType::FIXED64:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
+                if (!is_numeric($value)) {
+                   throw new GPBDecodeException(
+                       "Invalid data type for int64 field");
+                }
+                if (bccomp($value, "18446744073709551615") > 0) {
+                    throw new GPBDecodeException(
+                        "Uint64 too large");
+                }
+                if (bccomp($value, "9223372036854775807") > 0) {
+                    $value = bcsub($value, "18446744073709551616");
+                }
+                return $value;
         }
         return $this->convertNativeValueToProtoValue(
             $value,

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -831,6 +831,9 @@ class Message
                 }
                 return $submsg;
             case GPBType::BYTES:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
                 if (!is_string($value)) {
                     throw new GPBDecodeException("Expect string");
                 }
@@ -841,6 +844,9 @@ class Message
                 }
                 return $proto_value;
             case GPBType::BOOL:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
                 if ($is_map_key) {
                     if ($value === "true") {
                         return true;

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1012,6 +1012,9 @@ class Message
                     throw new GPBDecodeException(
                         "Int64 too small");
                 }
+                if (PHP_INT_SIZE == 4) {
+                    return (string) $value;
+                }
                 return $value;
             case GPBType::UINT64:
             case GPBType::FIXED64:
@@ -1028,6 +1031,9 @@ class Message
                 }
                 if (bccomp($value, "9223372036854775807") > 0) {
                     $value = bcsub($value, "18446744073709551616");
+                }
+                if (PHP_INT_SIZE == 4) {
+                    return (string) $value;
                 }
                 return $value;
             default:

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -66,19 +66,30 @@ class Message
     /**
      * @ignore
      */
-    public function __construct($desc = NULL)
+    public function __construct($data = NULL)
     {
         // MapEntry message is shared by all types of map fields, whose
         // descriptors are different from each other. Thus, we cannot find a
         // specific descriptor from the descriptor pool.
-        if (get_class($this) === 'Google\Protobuf\Internal\MapEntry') {
-            $this->desc = $desc;
-            foreach ($desc->getField() as $field) {
-                $setter = $field->getSetter();
-                $this->$setter($this->defaultValue($field));
+        if ($data instanceof Descriptor) {
+            $this->initWithDescriptor($data);
+        } else {
+            $this->initWithGeneratedPool();
+            if (is_array($data)) {
+                $this->mergeFromArray($data);
+            } else if (!empty($data)) {
+                throw new \InvalidArgumentException(
+                    'Message constructor must be an array, Descriptor, or null.'
+                );
             }
-            return;
         }
+    }
+
+    /**
+     * @ignore
+     */
+    private function initWithGeneratedPool()
+    {
         $pool = DescriptorPool::getGeneratedPool();
         $this->desc = $pool->getDescriptorByClassName(get_class($this));
         if (is_null($this->desc)) {
@@ -148,6 +159,19 @@ class Message
                         $this->$setter("0");
                 }
             }
+        }
+    }
+
+    /**
+     * @ignore
+     */
+    private function initWithDescriptor(Descriptor $desc)
+    {
+        $this->desc = $desc;
+        foreach ($desc->getField() as $field) {
+            $setter = $field->getSetter();
+            $defaultValue = $this->defaultValue($field);
+            $this->$setter($defaultValue);
         }
     }
 
@@ -737,6 +761,23 @@ class Message
         }
     }
 
+    private function convertToProtoValueImpl(
+        $is_json,
+        $value,
+        $field,
+        $is_map_key = false)
+    {
+        return $is_json
+            ? $this->convertJsonValueToProtoValue(
+                $value,
+                $field,
+                $is_map_key)
+            : $this->convertNativeValueToProtoValue(
+                $value,
+                $field,
+                $is_map_key);
+    }
+
     private function convertJsonValueToProtoValue(
         $value,
         $field,
@@ -786,9 +827,92 @@ class Message
                     } elseif (!is_object($value) && !is_array($value)) {
                         throw new GPBDecodeException("Expect message.");
                     }
-                    $submsg->mergeFromJsonArray($value);
+                    $submsg->mergeFromArrayImpl(true, $value);
                 }
                 return $submsg;
+            case GPBType::BYTES:
+                if (!is_string($value)) {
+                    throw new GPBDecodeException("Expect string");
+                }
+                $proto_value = base64_decode($value, true);
+                if ($proto_value === false) {
+                    throw new GPBDecodeException(
+                        "Invalid base64 characters");
+                }
+                return $proto_value;
+            case GPBType::BOOL:
+                if ($is_map_key) {
+                    if ($value === "true") {
+                        return true;
+                    }
+                    if ($value === "false") {
+                        return false;
+                    }
+                    throw new GPBDecodeException(
+                        "Bool field only accept bool value");
+                }
+                if (!is_bool($value)) {
+                    throw new GPBDecodeException(
+                        "Bool field only accept bool value");
+                }
+                return $value;
+        }
+        return $this->convertNativeValueToProtoValue(
+            $value,
+            $field,
+            $is_map_key);
+    }
+
+    private function convertNativeValueToProtoValue(
+        $value,
+        $field,
+        $is_map_key = false)
+    {
+        if (is_null($value)) {
+            return $this->defaultValue($field);
+        }
+        switch ($field->getType()) {
+            case GPBType::MESSAGE:
+                $klass = $field->getMessageType()->getClass();
+                if ($value instanceof $klass) {
+                    return $value;
+                }
+                if (!is_object($value) && !is_array($value)) {
+                    throw new \Exception("Expect message or array.");
+                }
+                $submsg = new $klass;
+                if (!is_null($value) &&
+                    $klass !== "Google\Protobuf\Any") {
+                    $submsg->mergeFromArrayImpl(false, $value);
+                }
+                return $submsg;
+            case GPBType::BYTES:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
+                if (!is_string($value)) {
+                    throw new GPBDecodeException("Expect string");
+                }
+                return $value;
+            case GPBType::BOOL:
+                if (is_null($value)) {
+                    return $this->defaultValue($field);
+                }
+                if ($is_map_key) {
+                    if ($value === 1) {
+                        return true;
+                    }
+                    if ($value === 0) {
+                        return false;
+                    }
+                    throw new GPBDecodeException(
+                        "Bool field only accept bool value");
+                }
+                if (!is_bool($value)) {
+                    throw new GPBDecodeException(
+                        "Bool field only accept bool value");
+                }
+                return $value;
             case GPBType::ENUM:
                 if (is_null($value)) {
                     return $this->defaultValue($field);
@@ -807,38 +931,6 @@ class Message
                 }
                 if (!is_string($value)) {
                     throw new GPBDecodeException("Expect string");
-                }
-                return $value;
-            case GPBType::BYTES:
-                if (is_null($value)) {
-                    return $this->defaultValue($field);
-                }
-                if (!is_string($value)) {
-                    throw new GPBDecodeException("Expect string");
-                }
-                $proto_value = base64_decode($value, true);
-                if ($proto_value === false) {
-                    throw new GPBDecodeException(
-                        "Invalid base64 characters");
-                }
-                return $proto_value;
-            case GPBType::BOOL:
-                if (is_null($value)) {
-                    return $this->defaultValue($field);
-                }
-                if ($is_map_key) {
-                    if ($value === "true") {
-                        return true;
-                    }
-                    if ($value === "false") {
-                        return false;
-                    }
-                    throw new GPBDecodeException(
-                        "Bool field only accept bool value");
-                }
-                if (!is_bool($value)) {
-                    throw new GPBDecodeException(
-                        "Bool field only accept bool value");
                 }
                 return $value;
             case GPBType::FLOAT:
@@ -943,17 +1035,42 @@ class Message
         }
     }
 
-    protected function mergeFromJsonArray($array)
+    /**
+     * Populates the message from a user-supplied PHP array.
+     * Array keys correspond to Message properties and nested message
+     * properties.
+     *
+     * Example:
+     * ```
+     * $message->mergeFromArray([
+     *     'name' => 'This is a message name',
+     *     'interval' => [
+     *          'startTime' => time() - 60,
+     *          'endTime' => time(),
+     *     ]
+     * ]);
+     * ```
+     *
+     * @param array $array An array containing message properties and values.
+     * @return null.
+     * @throws Exception Invalid data.
+     */
+    public function mergeFromArray($array)
+    {
+        return $this->mergeFromArrayImpl(false, $array);
+    }
+
+    protected function mergeFromArrayImpl($is_json, $array)
     {
         if (is_a($this, "Google\Protobuf\Any")) {
             $this->clear();
             $this->setTypeUrl($array["@type"]);
             $msg = $this->unpack();
             if (GPBUtil::hasSpecialJsonMapping($msg)) {
-                $msg->mergeFromJsonArray($array["value"]);
+                $msg->mergeFromArrayImpl($is_json, $array["value"]);
             } else {
                 unset($array["@type"]);
-                $msg->mergeFromJsonArray($array);
+                $msg->mergeFromArrayImpl($is_json, $array);
             }
             $this->setValue($msg->serializeToString());
             return;
@@ -989,7 +1106,7 @@ class Message
             $fields = $this->getFields();
             foreach($array as $key => $value) {
                 $v = new Value();
-                $v->mergeFromJsonArray($value);
+                $v->mergeFromArrayImpl($is_json, $value);
                 $fields[$key] = $v;
             }
         }
@@ -1012,7 +1129,7 @@ class Message
                     }
                     foreach ($array as $key => $v) {
                         $value = new Value();
-                        $value->mergeFromJsonArray($v);
+                        $value->mergeFromArrayImpl($is_json, $v);
                         $values = $struct_value->getFields();
                         $values[$key]= $value;
                     }
@@ -1025,7 +1142,7 @@ class Message
                     }
                     foreach ($array as $v) {
                         $value = new Value();
-                        $value->mergeFromJsonArray($v);
+                        $value->mergeFromArrayImpl($is_json, $v);
                         $values = $list_value->getValues();
                         $values[]= $value;
                     }
@@ -1055,15 +1172,15 @@ class Message
                         throw new \Exception(
                             "Map value field element cannot be null.");
                     }
-                    $proto_key =
-                        $this->convertJsonValueToProtoValue(
-                            $tmp_key,
-                            $key_field,
-                            true);
-                    $proto_value =
-                        $this->convertJsonValueToProtoValue(
-                            $tmp_value,
-                            $value_field);
+                    $proto_key = $this->convertToProtoValueImpl(
+                        $is_json,
+                        $tmp_key,
+                        $key_field,
+                        true);
+                    $proto_value = $this->convertToProtoValueImpl(
+                        $is_json,
+                        $tmp_value,
+                        $value_field);
                     self::kvUpdateHelper($field, $proto_key, $proto_value);
                 }
             } else if ($field->isRepeated()) {
@@ -1075,14 +1192,18 @@ class Message
                         throw new \Exception(
                             "Repeated field elements cannot be null.");
                     }
-                    $proto_value =
-                        $this->convertJsonValueToProtoValue($tmp, $field);
+                    $proto_value = $this->convertToProtoValueImpl(
+                        $is_json,
+                        $tmp,
+                        $field);
                     self::appendHelper($field, $proto_value);
                 }
             } else {
                 $setter = $field->getSetter();
-                $proto_value =
-                    $this->convertJsonValueToProtoValue($value, $field);
+                $proto_value = $this->convertToProtoValueImpl(
+                    $is_json,
+                    $value,
+                    $field);
                 if ($field->getType() === GPBType::MESSAGE) {
                     if (is_null($proto_value)) {
                         continue;
@@ -1110,7 +1231,7 @@ class Message
                 "Cannot decode json string.");
         }
         try {
-            $this->mergeFromJsonArray($array);
+            $this->mergeFromArrayImpl(true, $array);
         } catch (\Exception $e) {
             throw new GPBDecodeException($e->getMessage());
         }

--- a/php/src/Google/Protobuf/Internal/MessageOptions.php
+++ b/php/src/Google/Protobuf/Internal/MessageOptions.php
@@ -87,9 +87,9 @@ class MessageOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/MethodDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/MethodDescriptorProto.php
@@ -55,9 +55,9 @@ class MethodDescriptorProto extends \Google\Protobuf\Internal\Message
     private $server_streaming = false;
     private $has_server_streaming = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/MethodOptions.php
+++ b/php/src/Google/Protobuf/Internal/MethodOptions.php
@@ -38,9 +38,9 @@ class MethodOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/OneofDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/OneofDescriptorProto.php
@@ -28,9 +28,9 @@ class OneofDescriptorProto extends \Google\Protobuf\Internal\Message
     private $options = null;
     private $has_options = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/OneofOptions.php
+++ b/php/src/Google/Protobuf/Internal/OneofOptions.php
@@ -23,9 +23,9 @@ class OneofOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/ServiceDescriptorProto.php
+++ b/php/src/Google/Protobuf/Internal/ServiceDescriptorProto.php
@@ -33,9 +33,9 @@ class ServiceDescriptorProto extends \Google\Protobuf\Internal\Message
     private $options = null;
     private $has_options = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/ServiceOptions.php
+++ b/php/src/Google/Protobuf/Internal/ServiceOptions.php
@@ -33,9 +33,9 @@ class ServiceOptions extends \Google\Protobuf\Internal\Message
     private $uninterpreted_option;
     private $has_uninterpreted_option = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/SourceCodeInfo.php
+++ b/php/src/Google/Protobuf/Internal/SourceCodeInfo.php
@@ -66,9 +66,9 @@ class SourceCodeInfo extends \Google\Protobuf\Internal\Message
     private $location;
     private $has_location = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/SourceCodeInfo_Location.php
+++ b/php/src/Google/Protobuf/Internal/SourceCodeInfo_Location.php
@@ -106,9 +106,9 @@ class SourceCodeInfo_Location extends \Google\Protobuf\Internal\Message
     private $leading_detached_comments;
     private $has_leading_detached_comments = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/UninterpretedOption.php
+++ b/php/src/Google/Protobuf/Internal/UninterpretedOption.php
@@ -61,9 +61,9 @@ class UninterpretedOption extends \Google\Protobuf\Internal\Message
     private $aggregate_value = '';
     private $has_aggregate_value = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/src/Google/Protobuf/Internal/UninterpretedOption_NamePart.php
+++ b/php/src/Google/Protobuf/Internal/UninterpretedOption_NamePart.php
@@ -32,9 +32,9 @@ class UninterpretedOption_NamePart extends \Google\Protobuf\Internal\Message
     private $is_extension = false;
     private $has_is_extension = false;
 
-    public function __construct() {
+    public function __construct($data = NULL) {
         \GPBMetadata\Google\Protobuf\Internal\Descriptor::initOnce();
-        parent::__construct();
+        parent::__construct($data);
     }
 
     /**

--- a/php/tests/php_implementation_test.php
+++ b/php/tests/php_implementation_test.php
@@ -602,4 +602,39 @@ class ImplementationTest extends TestBase
         $this->assertEquals(34, $m->getRepeatedMessage()[0]->getA());
         $this->assertEquals(35, $m->getRepeatedMessage()[1]->getA());
     }
+
+    public function testMergeFromArrayWithNullValuesDoesNotThrowException()
+    {
+        $requestData = [
+            'optional_int32' => null,
+            'optional_int64' => null,
+            'optional_uint32' => null,
+            'optional_uint64' => null,
+            'optional_sint32' => null,
+            'optional_sint64' => null,
+            'optional_fixed32' => null,
+            'optional_fixed64' => null,
+            'optional_sfixed32' => null,
+            'optional_sfixed64' => null,
+            'optional_float' => null,
+            'optional_double' => null,
+            'optional_bool' => null,
+            'optional_string' => null,
+            'optional_bytes' => null,
+            'optional_enum' => null,
+            'optional_message' => null,
+        ];
+
+        $messageFromArray = new TestMessage($requestData);
+        $messageFromJson = new TestMessage();
+        $messageFromJson->mergeFromJsonString(json_encode($requestData));
+
+        foreach ($requestData as $key => $value) {
+            $getter = 'get' . str_replace(' ', '', ucwords(
+                str_replace('_', ' ', $key)
+            ));
+            $this->assertTrue(empty($messageFromArray->$getter()));
+            $this->assertTrue(empty($messageFromJson->$getter()));
+        }
+    }
 }

--- a/php/tests/php_implementation_test.php
+++ b/php/tests/php_implementation_test.php
@@ -3,6 +3,7 @@
 require_once('test_base.php');
 require_once('test_util.php');
 
+use Foo\TestEnum;
 use Foo\TestMessage;
 use Foo\TestMessage_Sub;
 use Foo\TestPackedMessage;
@@ -15,7 +16,6 @@ use Google\Protobuf\Internal\CodedOutputStream;
 
 class ImplementationTest extends TestBase
 {
-
     public function testReadInt32()
     {
         $value = null;
@@ -512,5 +512,94 @@ class ImplementationTest extends TestBase
         $m = new TestPackedMessage();
         TestUtil::setTestPackedMessage($m);
         $this->assertSame(166, $m->byteSize());
+    }
+
+    public function testArrayConstructor()
+    {
+        $m = new TestMessage([
+            'optional_int32' => -42,
+            'optional_int64' => -43,
+            'optional_uint32' => 42,
+            'optional_uint64' => 43,
+            'optional_sint32' => -44,
+            'optional_sint64' => -45,
+            'optional_fixed32' => 46,
+            'optional_fixed64' => 47,
+            'optional_sfixed32' => -46,
+            'optional_sfixed64' => -47,
+            'optional_float' => 1.5,
+            'optional_double' => 1.6,
+            'optional_bool' => true,
+            'optional_string' => 'a',
+            'optional_bytes' => 'b',
+            'optional_enum' => TestEnum::ONE,
+            'optional_message' => [
+                'a' => 33
+            ],
+            'repeated_int32' => [-42, -52],
+            'repeated_int64' => [-43, -53],
+            'repeated_uint32' => [42, 52],
+            'repeated_uint64' => [43, 53],
+            'repeated_sint32' => [-44, -54],
+            'repeated_sint64' => [-45, -55],
+            'repeated_fixed32' => [46, 56],
+            'repeated_fixed64' => [47, 57],
+            'repeated_sfixed32' => [-46, -56],
+            'repeated_sfixed64' => [-47, -57],
+            'repeated_float' => [1.5, 2.5],
+            'repeated_double' => [1.6, 2.6],
+            'repeated_bool' => [true, false],
+            'repeated_string' => ['a', 'c'],
+            'repeated_bytes' => ['b', 'd'],
+            'repeated_enum' => [TestEnum::ZERO, TestEnum::ONE],
+            'repeated_message' => [['a' => 34], ['a' => 35]],
+            'map_int32_int32' => [-62 => -62],
+            'map_int64_int64' => [-63 => -63],
+            'map_uint32_uint32' => [62 => 62],
+            'map_uint64_uint64' => [63 => 63],
+            'map_sint32_sint32' => [-64 => -64],
+            'map_sint64_sint64' => [-65 => -65],
+            'map_fixed32_fixed32' => [66 => 66],
+            'map_fixed64_fixed64' => [67 => 67],
+            'map_sfixed32_sfixed32' => [-68 => -68],
+            'map_sfixed64_sfixed64' => [-69 => -69],
+            'map_int32_float' => [1 => 3.5],
+            'map_int32_double' => [1 => 3.6],
+            'map_bool_bool' => [true => true],
+            'map_string_string' => ['e' => 'e'],
+            'map_int32_bytes' => [1 => 'f'],
+            'map_int32_enum' => [1 => TestEnum::ONE],
+            'map_int32_message' => [1 => ['a' => 36]],
+        ]);
+
+        TestUtil::assertTestMessage($m);
+
+        // Using message objects
+        $m = new TestMessage([
+            'optional_message' => new TestMessage_Sub(['a' => 33]),
+            'repeated_message' => [
+                new TestMessage_Sub(['a' => 34]),
+                new TestMessage_Sub(['a' => 35]),
+            ],
+            'map_int32_message' => [
+                1 => new TestMessage_Sub(['a' => 36])
+            ],
+        ]);
+
+        $this->assertEquals(33, $m->getOptionalMessage()->getA());
+        $this->assertEquals(34, $m->getRepeatedMessage()[0]->getA());
+        $this->assertEquals(35, $m->getRepeatedMessage()[1]->getA());
+        $this->assertEquals(36, $m->getMapInt32Message()[1]->getA());
+
+        // Using both arrays and objects
+        $m = new TestMessage([
+            'repeated_message' => [
+                new TestMessage_Sub(['a' => 34]),
+                ['a' => 35],
+            ],
+        ]);
+
+        $this->assertEquals(34, $m->getRepeatedMessage()[0]->getA());
+        $this->assertEquals(35, $m->getRepeatedMessage()[1]->getA());
     }
 }

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1092,7 +1092,7 @@ void GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   printer.Print("\n");
 
   printer.Print(
-      "public function __construct() {\n");
+      "public function __construct($data = NULL) {\n");
   Indent(&printer);
 
   std::string metadata_filename =
@@ -1100,7 +1100,7 @@ void GenerateMessageFile(const FileDescriptor* file, const Descriptor* message,
   std::string metadata_fullname = FilenameToClassname(metadata_filename);
   printer.Print(
       "\\^fullname^::initOnce();\n"
-      "parent::__construct();\n",
+      "parent::__construct($data);\n",
       "fullname", metadata_fullname);
 
   Outdent(&printer);


### PR DESCRIPTION
RFC for adding array construction for PHP messages, i.e.

```php
$m = new TestMessage([
    'int' => -42,
    'message' => ['a' => 33],
    'repeated_message' => [
        new TestMessage_Sub(['a' => 34]),
        ['a' => 35],
    ],
    'map_message' => [
        1 => new TestMessage_Sub(['a' => 36])
    ],
]);
```