### PR TITLE
C#: Implement IReadOnlyDictionary<K,V> in MapField<K,V>

### DIFF
--- a/csharp/src/Google.Protobuf.Test/Collections/MapFieldTest.cs
+++ b/csharp/src/Google.Protobuf.Test/Collections/MapFieldTest.cs
@@ -540,6 +540,22 @@ namespace Google.Protobuf.Collections
             Assert.Throws<ArgumentException>(() => map.ToString());
         }
 
+#if !NET35
+        [Test]
+        public void IDictionaryKeys_Equals_IReadOnlyDictionaryKeys()
+        {
+            var map = new MapField<string, string> { { "foo", "bar" }, { "x", "y" } };
+            CollectionAssert.AreEquivalent(((IDictionary<string, string>)map).Keys, ((IReadOnlyDictionary<string, string>)map).Keys);
+        }
+
+        [Test]
+        public void IDictionaryValues_Equals_IReadOnlyDictionaryValues()
+        {
+            var map = new MapField<string, string> { { "foo", "bar" }, { "x", "y" } };
+            CollectionAssert.AreEquivalent(((IDictionary<string, string>)map).Values, ((IReadOnlyDictionary<string, string>)map).Values);
+        }
+#endif
+
         private static KeyValuePair<TKey, TValue> NewKeyValuePair<TKey, TValue>(TKey key, TValue value)
         {
             return new KeyValuePair<TKey, TValue>(key, value);

--- a/csharp/src/Google.Protobuf/Collections/MapField.cs
+++ b/csharp/src/Google.Protobuf/Collections/MapField.cs
@@ -67,6 +67,9 @@ namespace Google.Protobuf.Collections
     /// </para>
     /// </remarks>
     public sealed class MapField<TKey, TValue> : IDeepCloneable<MapField<TKey, TValue>>, IDictionary<TKey, TValue>, IEquatable<MapField<TKey, TValue>>, IDictionary
+#if !NET35
+        , IReadOnlyDictionary<TKey, TValue>
+#endif
     {
         // TODO: Don't create the map/list until we have an entry. (Assume many maps will be empty.)
         private readonly Dictionary<TKey, LinkedListNode<KeyValuePair<TKey, TValue>>> map =
@@ -546,6 +549,14 @@ namespace Google.Protobuf.Collections
                 this[(TKey)key] = (TValue)value;
             }
         }
+        #endregion
+
+        #region IReadOnlyDictionary explicit interface implementation
+#if !NET35
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+#endif
         #endregion
 
         private class DictionaryEnumerator : IDictionaryEnumerator


### PR DESCRIPTION
IReadOnlyDictionary<K,V> was introduced in .Net 4.5, so it is excluded when targeting .Net 3.5.
This feature request was originally mentioned in #2041.

Very similar to #2645 by @jskeet.
In this case IReadOnlyDictionary<K,V>.Keys returns an IEnumerable<K> and IReadOnlyDictionary<K,V>.Values returns an IEnumerable<V>. Even if the already implemented IDictionary<K,V>.Keys returns an ICollection<K> which implements IEnumerable<K>, .Net requires the return type in the interface implementation to be exact, so I added the explicit implementation of IReadOnlyDictionary<K,V>.Keys and IReadOnlyDictionary<K,V>.Values.

There is also a minimal test.

[ReadOnlyDictionary<TKey, TValue>](https://msdn.microsoft.com/en-us/library/gg712875(v=vs.110).aspx) exists but it is less convenient and less efficient than having MapField implement IReadOnlyDictionary.