### PR TITLE
Fix Implicit Return Types

### DIFF
--- a/php/ext/google/protobuf/storage.c
+++ b/php/ext/google/protobuf/storage.c
@@ -744,7 +744,7 @@ void layout_set(MessageLayout* layout, MessageHeader* header,
   }
 }
 
-static native_slot_merge(const upb_fielddef* field, const void* from_memory,
+static void native_slot_merge(const upb_fielddef* field, const void* from_memory,
                          void* to_memory PHP_PROTO_TSRMLS_DC) {
   upb_fieldtype_t type = upb_fielddef_type(field);
   zend_class_entry* ce = NULL;
@@ -801,7 +801,7 @@ static native_slot_merge(const upb_fielddef* field, const void* from_memory,
   }
 }
 
-static native_slot_merge_by_array(const upb_fielddef* field, const void* from_memory,
+static void native_slot_merge_by_array(const upb_fielddef* field, const void* from_memory,
                          void* to_memory PHP_PROTO_TSRMLS_DC) {
   upb_fieldtype_t type = upb_fielddef_type(field);
   switch (type) {


### PR DESCRIPTION
Both `native_slot_merge` and `native_slot_merge_by_array` have no return type declared. GCC implicitly uses int as return type in such cases, however, these functions are actually void.