### PR TITLE
Initial value in generated code cannot be used by c extension.

### DIFF
--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -640,7 +640,7 @@ bool native_slot_set(upb_fieldtype_t type, const zend_class_entry* klass,
 bool native_slot_set_by_array(upb_fieldtype_t type,
                               const zend_class_entry* klass, void* memory,
                               zval* value TSRMLS_DC);
-void native_slot_init(upb_fieldtype_t type, void* memory, void* cache);
+void native_slot_init(upb_fieldtype_t type, void* memory, CACHED_VALUE* cache);
 // For each property, in order to avoid conversion between the zval object and
 // the actual data type during parsing/serialization, the containing message
 // object use the custom memory layout to store the actual data type for each

--- a/php/tests/encode_decode_test.php
+++ b/php/tests/encode_decode_test.php
@@ -9,6 +9,7 @@ use Foo\TestEnum;
 use Foo\TestMessage;
 use Foo\TestMessage_Sub;
 use Foo\TestPackedMessage;
+use Foo\TestRandomFieldOrder;
 use Foo\TestUnpackedMessage;
 
 class EncodeDecodeTest extends TestBase
@@ -233,6 +234,13 @@ class EncodeDecodeTest extends TestBase
         $this->assertEquals(0, $m->getOptionalInt32());
         $m->mergeFromString(hex2bin("08ffffffff0f"));
         $this->assertEquals(-1, $m->getOptionalInt32());
+    }
+
+    public function testRandomFieldOrder()
+    {
+        $m = new TestRandomFieldOrder();
+        $data = $m->serializeToString();
+        $this->assertSame("", $data);
     }
 
     /**

--- a/php/tests/memory_leak_test.php
+++ b/php/tests/memory_leak_test.php
@@ -20,6 +20,7 @@ require_once('generated/Foo/TestMessage_NestedEnum.php');
 require_once('generated/Foo/TestMessage_Sub.php');
 require_once('generated/Foo/TestPackedMessage.php');
 require_once('generated/Foo/TestPhpDoc.php');
+require_once('generated/Foo/TestRandomFieldOrder.php');
 require_once('generated/Foo/TestUnpackedMessage.php');
 require_once('generated/GPBMetadata/Proto/Test.php');
 require_once('generated/GPBMetadata/Proto/TestEmptyPhpNamespace.php');

--- a/php/tests/proto/test.proto
+++ b/php/tests/proto/test.proto
@@ -181,3 +181,9 @@ message TestIncludeNamespaceMessage {
   TestNamespace namespace_message = 1;
   TestEmptyNamespace empty_namespace_message = 2;
 }
+
+// This will cause upb fields not ordered by the order in the generated code.
+message TestRandomFieldOrder {
+  int64 tag13 = 150;
+  string tag14 = 160;
+}


### PR DESCRIPTION
In the generated code of previous versions, each php field is given an
initial value. In c extension, it was assumed that the field order in
the generated code is consistent with upb fields order, so that the
correct initial value can be bound to the correct upb field. However,
this may not be true. The order of fields in generated code is decided
by proto compiler, while the order of upb fields is decided by the hash
function used in c extension.
This PR fixes the issue by reset the initial value at runtime.