### PR TITLE
includes the expected class in the exception, otherwise the error is …

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -176,7 +176,7 @@ class GPBUtil
     public static function checkMessage(&$var, $klass)
     {
         if (!$var instanceof $klass && !is_null($var)) {
-            throw new \Exception("Expect message.");
+            throw new \Exception("Expect $klass.");
         }
     }
 


### PR DESCRIPTION
…harder to track down