### PR TITLE
Add option to omit insignificant whitespaces from json output.

### DIFF
--- a/python/google/protobuf/internal/json_format_test.py
+++ b/python/google/protobuf/internal/json_format_test.py
@@ -862,6 +862,15 @@ class JsonFormatTest(JsonFormatBase):
     parsed_message = json_format_proto3_pb2.TestCustomJsonName()
     self.CheckParseBack(message, parsed_message)
 
+  def testOmittingInsignificantWhitespace(self):
+      message = json_format_proto3_pb2.TestMessage()
+      message.int32_value = 12345
+      expected = '{"int32Value": 12345}'
+      self.assertEqual(
+          expected,
+          json_format.MessageToJson(message,
+                                    omitting_insignificant_whitespace=True))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -88,7 +88,8 @@ class ParseError(Error):
 
 def MessageToJson(message,
                   including_default_value_fields=False,
-                  preserving_proto_field_name=False):
+                  preserving_proto_field_name=False,
+                  omitting_insignificant_whitespace=False):
   """Converts protobuf message to JSON format.
 
   Args:
@@ -100,12 +101,15 @@ def MessageToJson(message,
     preserving_proto_field_name: If True, use the original proto field
         names as defined in the .proto file. If False, convert the field
         names to lowerCamelCase.
+    omitting_insignificant_whitespace: If True, json output will not be
+        indented. If False, the output will be formatted with two spaces.
 
   Returns:
     A string containing the JSON formatted protocol buffer message.
   """
   printer = _Printer(including_default_value_fields,
-                     preserving_proto_field_name)
+                     preserving_proto_field_name,
+                     omitting_insignificant_whitespace)
   return printer.ToJsonString(message)
 
 
@@ -144,13 +148,16 @@ class _Printer(object):
 
   def __init__(self,
                including_default_value_fields=False,
-               preserving_proto_field_name=False):
+               preserving_proto_field_name=False,
+               omitting_insignificant_whitespace=False):
     self.including_default_value_fields = including_default_value_fields
     self.preserving_proto_field_name = preserving_proto_field_name
+    self.omitting_insignificant_whitespace = omitting_insignificant_whitespace
 
   def ToJsonString(self, message):
     js = self._MessageToJsonObject(message)
-    return json.dumps(js, indent=2)
+    indent = 2 if not self.omitting_insignificant_whitespace else None
+    return json.dumps(js, indent=indent)
 
   def _MessageToJsonObject(self, message):
     """Converts message to an object according to Proto3 JSON Specification."""


### PR DESCRIPTION
Added a new parameter called omitting_insignificant_whitespace. This
parameter is responsible for defining if the json output should be
indented or not. If False (it's default value) the output will be
formatted with 2 spaces (as it was before), if True no indentation is
set and the output will be in a single line.

This is useful for streaming json output based on NDJSON
(http://ndjson.org/) or Server Side Events where each message should be
contained in a single line.

This is the same functionally that is already present in Java
(at google/protobuf/util/JsonFormat.java#L134).