### PR TITLE
Add note about includes to README

### DIFF
--- a/protoc-artifacts/build-zip.sh
+++ b/protoc-artifacts/build-zip.sh
@@ -73,6 +73,10 @@ compiler (protoc). This binary is intended for users who want to use Protocol
 Buffers in languages other than C++ but do not want to compile protoc
 themselves. To install, simply place this binary somewhere in your PATH.
 
+If you intend to use the included well known types then don't forget to
+copy the contents of the 'include' directory somewhere as well, for example
+into '/usr/local/include/'.
+
 Please refer to our official github site for more installation instructions:
   https://github.com/google/protobuf
 EOF


### PR DESCRIPTION
Ran into an issue today where a machine had the `protoc` compiler but not the include files. Took a while to sort out, and this added note to the README included in every zip should help.