### PR TITLE
CMake: Install .pc Files

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,5 +1,10 @@
 include(GNUInstallDirs)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf.pc.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf-lite.pc.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc @ONLY)
+
 foreach(_library
   libprotobuf-lite
   libprotobuf
@@ -16,6 +21,8 @@ endforeach()
 
 install(TARGETS protoc EXPORT protobuf-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 file(STRINGS extract_includes.bat.in _extract_strings
   REGEX "^copy")

--- a/cmake/protobuf-lite.pc.cmake
+++ b/cmake/protobuf-lite.pc.cmake
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: Protocol Buffers
+Description: Google's Data Interchange Format
+Version: @protobuf_VERSION@
+Libs: -L${libdir} -lprotobuf-lite @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
+Conflicts: protobuf

--- a/cmake/protobuf.pc.cmake
+++ b/cmake/protobuf.pc.cmake
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: Protocol Buffers
+Description: Google's Data Interchange Format
+Version: @protobuf_VERSION@
+Libs: -L${libdir} -lprotobuf @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @CMAKE_THREAD_LIBS_INIT@
+Conflicts: protobuf-lite

--- a/tests.sh
+++ b/tests.sh
@@ -63,6 +63,7 @@ build_cpp_distcheck() {
   # List all files that should be included in the distribution package.
   git ls-files | grep "^\(java\|python\|objectivec\|csharp\|js\|ruby\|php\|cmake\|examples\)" |\
     grep -v ".gitignore" | grep -v "java/compatibility_tests" |\
+    grep -v "cmake/protobuf.*\.pc\.cmake" |\
     grep -v "python/compatibility_tests" | grep -v "csharp/compatibility_tests" > dist.lst
   # Unzip the dist tar file.
   DIST=`ls *.tar.gz`


### PR DESCRIPTION
Fix #1384: Adds pkg-config (`.pc`) files for CMake based installs.

### To Do

- [x] pthread libs not yet properly replaced in .pc files (`@PTHREAD_CFLAGS@`, `@PTHREAD_LIBS@`) -> just use `@CMAKE_THREAD_LIBS_INIT@`?