### PR TITLE
Include __init__.py for google.* python namespacing in Bazel builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -641,6 +641,7 @@ py_library(
     name = "python_srcs",
     srcs = glob(
         [
+            "python/google/__init__.py",
             "python/google/protobuf/*.py",
             "python/google/protobuf/**/*.py",
         ],


### PR DESCRIPTION
Related to #1296: The issue seems to be fixed for consumers of the python protobuf package from pypi, but not for anyone getting it from here as a Bazel remote repository.