### PR TITLE
Removes unnecessary pass-by-references in PHP internal classes

### DIFF
--- a/php/src/Google/Protobuf/Internal/DescriptorPool.php
+++ b/php/src/Google/Protobuf/Internal/DescriptorPool.php
@@ -61,17 +61,17 @@ class DescriptorPool
         $files->mergeFromString($data);
         $file = FileDescriptor::buildFromProto($files->getFile()[0]);
 
-        foreach ($file->getMessageType() as &$desc) {
+        foreach ($file->getMessageType() as $desc) {
             $this->addDescriptor($desc);
         }
         unset($desc);
 
-        foreach ($file->getEnumType() as &$desc) {
+        foreach ($file->getEnumType() as $desc) {
             $this->addEnumDescriptor($desc);
         }
         unset($desc);
 
-        foreach ($file->getMessageType() as &$desc) {
+        foreach ($file->getMessageType() as $desc) {
             $this->crossLink($desc);
         }
         unset($desc);
@@ -129,9 +129,9 @@ class DescriptorPool
         return $this->class_to_enum_desc[$klass];
     }
 
-    private function crossLink(&$desc)
+    private function crossLink(Descriptor $desc)
     {
-        foreach ($desc->getField() as &$field) {
+        foreach ($desc->getField() as $field) {
             switch ($field->getType()) {
                 case GPBType::MESSAGE:
                     $proto = $field->getMessageType();
@@ -149,7 +149,7 @@ class DescriptorPool
         }
         unset($field);
 
-        foreach ($desc->getNestedType() as &$nested_type) {
+        foreach ($desc->getNestedType() as $nested_type) {
             $this->crossLink($nested_type);
         }
         unset($nested_type);
@@ -157,7 +157,7 @@ class DescriptorPool
 
     public function finish()
     {
-        foreach ($this->class_to_desc as $klass => &$desc) {
+        foreach ($this->class_to_desc as $klass => $desc) {
             $this->crossLink($desc);
         }
         unset($desc);

--- a/php/src/Google/Protobuf/Internal/MapEntry.php
+++ b/php/src/Google/Protobuf/Internal/MapEntry.php
@@ -39,7 +39,7 @@ class MapEntry extends Message
     public $key;
     public $value;
 
-    public function setKey(&$key) {
+    public function setKey($key) {
       $this->key = $key;
     }
 
@@ -47,7 +47,7 @@ class MapEntry extends Message
       return $this->key;
     }
 
-    public function setValue(&$value) {
+    public function setValue($value) {
       $this->value = $value;
     }
 

--- a/php/src/Google/Protobuf/Internal/OneofDescriptor.php
+++ b/php/src/Google/Protobuf/Internal/OneofDescriptor.php
@@ -48,7 +48,7 @@ class OneofDescriptor
         return $this->name;
     }
 
-    public function addField(&$field)
+    public function addField(Descriptor $field)
     {
         $this->fields[] = $field;
     }


### PR DESCRIPTION
Adds `Descriptor` typehints to ensure these are already passed by reference. 

The exceptions are 
 - `MapEntry::setKey` and `MapEntry::setValue` do not have typehints. 
 - `DescriptorPool::addEnumDescriptor` and `DescriptorPool::addDescriptor` could have typehints, but since these methods are public I didn't want to break BC by adding them. However, it would be better to have them.

Thoughts?