### PR TITLE
Change divideInt64ToInt32 to static

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBUtil.php
+++ b/php/src/Google/Protobuf/Internal/GPBUtil.php
@@ -38,7 +38,7 @@ use Google\Protobuf\Internal\MapField;
 
 class GPBUtil
 {
-    public function divideInt64ToInt32($value, &$high, &$low, $trim = false)
+    public static function divideInt64ToInt32($value, &$high, &$low, $trim = false)
     {
         $isNeg = (bccomp($value, 0) < 0);
         if ($isNeg) {


### PR DESCRIPTION
divideInt64ToInt32 is called statically from protobuf/php/src/Google/Protobuf/Internal/CodedOutputStream.php
(the only reference)
This causes fatal error in PHP 7.1 (32-bit only because 64-bit doesn't use this function)