### PR TITLE
Make .bzl files compatible with future versions of Bazel

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -245,9 +245,9 @@ def cc_proto_library(
   )
 
   if default_runtime and not default_runtime in cc_libs:
-    cc_libs += [default_runtime]
+    cc_libs = cc_libs + [default_runtime]
   if use_grpc_plugin:
-    cc_libs += ["//external:grpc_lib"]
+    cc_libs = cc_libs + ["//external:grpc_lib"]
 
   native.cc_library(
       name=name,
@@ -371,7 +371,7 @@ def py_proto_library(
   )
 
   if default_runtime and not default_runtime in py_libs + deps:
-    py_libs += [default_runtime]
+    py_libs = py_libs + [default_runtime]
 
   native.py_library(
       name=name,


### PR DESCRIPTION
In future versions of Bazel += on lists will mutate the lhs list instead of copying it. That will fail if the list is frozen, in that case it has to be copied explicitly.