### PR TITLE
Clean up typedefs for Atomic32/Atomic64

### DIFF
--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -63,28 +63,21 @@ namespace google {
 namespace protobuf {
 namespace internal {
 
-#if defined(GOOGLE_PROTOBUF_ARCH_POWER)
-#if defined(_LP64) || defined(__LP64__)
-typedef int32 Atomic32;
-typedef intptr_t Atomic64;
+#ifdef GOOGLE_PROTOBUF_ARCH_32_BIT
+  typedef intptr_t Atomic32;
+  typedef int64 Atomic64;
 #else
-typedef intptr_t Atomic32;
-typedef int64 Atomic64;
-#endif
-#else
-typedef int32 Atomic32;
-#ifdef GOOGLE_PROTOBUF_ARCH_64_BIT
-// We need to be able to go between Atomic64 and AtomicWord implicitly.  This
-// means Atomic64 and AtomicWord should be the same type on 64-bit.
-#if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL)
-// NaCl's intptr_t is not actually 64-bits on 64-bit!
-// http://code.google.com/p/nativeclient/issues/detail?id=1162
-// sparcv9's pointer type is 32bits
-typedef int64 Atomic64;
-#else
-typedef intptr_t Atomic64;
-#endif
-#endif
+  typedef int32 Atomic32;
+  // We need to be able to go between Atomic64 and AtomicWord implicitly.  This
+  // means Atomic64 and AtomicWord should be the same type on 64-bit.
+  #if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL)
+  // NaCl's intptr_t is not actually 64-bits on 64-bit!
+  // http://code.google.com/p/nativeclient/issues/detail?id=1162
+  // sparcv9's pointer type is 32bits
+  typedef int64 Atomic64;
+  #else
+  typedef intptr_t Atomic64;
+  #endif
 #endif
 
 // Use AtomicWord for a machine-sized pointer.  It will use the Atomic32 or


### PR DESCRIPTION
The typedefs for Atomic32 and Atomic64 were sometimes causing
Atomic32 to be an int32 rather than an intptr_t on 32-bit platforms.
On some of these platforms (ARM/CortexM building with GCC 6 in one
case) int32 is a long int, while intptr_t is an int, which causes a
compiler error even though long int and int are both 4 bytes.

Having Atomic32 always be intptr_t on 32-bit platforms and Atomic64
always be intptr_t on 64-bit platforms should resolve any of these
types of errors.