### PR TITLE
Detect invalid tags with a field number of 0 in C#

### DIFF
--- a/conformance/failure_list_csharp.txt
+++ b/conformance/failure_list_csharp.txt
@@ -1,5 +1,0 @@
-Required.Proto3.ProtobufInput.IllegalZeroFieldNum_Case_0
-Required.Proto3.ProtobufInput.IllegalZeroFieldNum_Case_1
-Required.Proto3.ProtobufInput.IllegalZeroFieldNum_Case_2
-Required.Proto3.ProtobufInput.IllegalZeroFieldNum_Case_3
-

--- a/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
+++ b/csharp/src/Google.Protobuf.Test/CodedInputStreamTest.cs
@@ -284,6 +284,20 @@ namespace Google.Protobuf
             Assert.Throws<InvalidProtocolBufferException>(() => input.ReadBytes());
         }
 
+        // Representations of a tag for field 0 with various wire types
+        [Test]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(5)]
+        public void ReadTag_ZeroFieldRejected(byte tag)
+        {
+            CodedInputStream cis = new CodedInputStream(new byte[] { tag });
+            Assert.Throws<InvalidProtocolBufferException>(() => cis.ReadTag());
+        }
+
         internal static TestRecursiveMessage MakeRecursiveMessage(int depth)
         {
             if (depth == 0)

--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -373,9 +373,9 @@ namespace Google.Protobuf
 
                 lastTag = ReadRawVarint32();
             }
-            if (lastTag == 0)
+            if (WireFormat.GetTagFieldNumber(lastTag) == 0)
             {
-                // If we actually read zero, that's not a valid tag.
+                // If we actually read a tag with a field of 0, that's not a valid tag.
                 throw InvalidProtocolBufferException.InvalidTag();
             }
             return lastTag;


### PR DESCRIPTION
Previously we only rejected the tag if the tag itself was 0, i.e.
field=0, type=varint. The type doesn't matter: field 0 is always
invalid.

This removes the last of the C# conformance failures.