### PR TITLE
Fix build on MinGW32

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -108,7 +108,7 @@ namespace compiler {
 #endif
 
 namespace {
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_MSC_VER)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::access;

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -69,7 +69,7 @@ namespace google {
 namespace protobuf {
 namespace compiler {
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::access;

--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -59,6 +59,9 @@
 
 #ifdef _WIN32
 #include <ctype.h>
+#endif
+
+#ifdef _MSC_VER
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::access;

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -50,7 +50,7 @@
 #include <google/protobuf/stubs/io_win32.h>
 #include <google/protobuf/stubs/strutil.h>
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::open;

--- a/src/google/protobuf/compiler/plugin.cc
+++ b/src/google/protobuf/compiler/plugin.cc
@@ -49,7 +49,7 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::setmode;

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -52,6 +52,16 @@ namespace google {
 namespace protobuf {
 namespace compiler {
 
+namespace {
+char* portable_strdup(const char* s) {
+  char* ns = malloc(strlen(s) + 1);
+  if (ns) {
+    strcpy(ns, s);
+  }
+  return ns;
+}
+}  // namespace
+
 #ifdef _WIN32
 
 static void CloseHandleOrDie(HANDLE handle) {
@@ -115,7 +125,7 @@ void Subprocess::Start(const string& program, SearchMode search_mode) {
   }
 
   // CreateProcess() mutates its second parameter.  WTF?
-  char* name_copy = strdup(program.c_str());
+  char* name_copy = portable_strdup(program.c_str());
 
   // Create the process.
   PROCESS_INFORMATION process_info;
@@ -299,7 +309,7 @@ void Subprocess::Start(const string& program, SearchMode search_mode) {
   GOOGLE_CHECK(pipe(stdin_pipe) != -1);
   GOOGLE_CHECK(pipe(stdout_pipe) != -1);
 
-  char* argv[2] = { strdup(program.c_str()), NULL };
+  char* argv[2] = { portable_strdup(program.c_str()), NULL };
 
   child_pid_ = fork();
   if (child_pid_ == -1) {

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -54,8 +54,8 @@ namespace compiler {
 
 namespace {
 char* portable_strdup(const char* s) {
-  char* ns = malloc(strlen(s) + 1);
-  if (ns) {
+  char* ns = (char*) malloc(strlen(s) + 1);
+  if (ns != NULL) {
     strcpy(ns, s);
   }
   return ns;

--- a/src/google/protobuf/compiler/subprocess.cc
+++ b/src/google/protobuf/compiler/subprocess.cc
@@ -33,6 +33,7 @@
 #include <google/protobuf/compiler/subprocess.h>
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 #ifndef _WIN32

--- a/src/google/protobuf/io/zero_copy_stream_impl.cc
+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc
@@ -56,6 +56,9 @@ namespace io {
 // Win32 lseek is broken:  If invoked on a non-seekable file descriptor, its
 // return value is undefined.  We re-define it to always produce an error.
 #define lseek(fd, offset, origin) ((off_t)-1)
+#endif
+
+#ifdef _MSC_VER
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::access;

--- a/src/google/protobuf/io/zero_copy_stream_unittest.cc
+++ b/src/google/protobuf/io/zero_copy_stream_unittest.cc
@@ -83,6 +83,9 @@ namespace {
 
 #ifdef _WIN32
 #define pipe(fds) _pipe(fds, 4096, O_BINARY)
+#endif
+
+#ifdef _MSC_VER
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::access;

--- a/src/google/protobuf/message_unittest.cc
+++ b/src/google/protobuf/message_unittest.cc
@@ -63,7 +63,7 @@
 namespace google {
 namespace protobuf {
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::close;

--- a/src/google/protobuf/stubs/io_win32.cc
+++ b/src/google/protobuf/stubs/io_win32.cc
@@ -39,15 +39,13 @@
 //
 // This file is only used on Windows, it's empty on other platforms.
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 
 // Comment this out to fall back to using the ANSI versions (open, mkdir, ...)
 // instead of the Unicode ones (_wopen, _wmkdir, ...). Doing so can be useful to
 // debug failing tests if that's caused by the long path support.
 // Long path support is disabled in MinGW
-#ifndef __MINGW32__
 #define SUPPORT_LONGPATHS
-#endif  // !__MINGW32__
 
 #include <ctype.h>
 #include <direct.h>
@@ -361,5 +359,5 @@ wstring testonly_path_to_winpath(const string& path) {
 }  // namespace protobuf
 }  // namespace google
 
-#endif  // defined(_WIN32)
+#endif  // defined(_MSC_VER)
 

--- a/src/google/protobuf/stubs/io_win32.cc
+++ b/src/google/protobuf/stubs/io_win32.cc
@@ -44,7 +44,10 @@
 // Comment this out to fall back to using the ANSI versions (open, mkdir, ...)
 // instead of the Unicode ones (_wopen, _wmkdir, ...). Doing so can be useful to
 // debug failing tests if that's caused by the long path support.
+// Long path support is disabled in MinGW
+#ifndef __MINGW32__
 #define SUPPORT_LONGPATHS
+#endif  // !__MINGW32__
 
 #include <ctype.h>
 #include <direct.h>

--- a/src/google/protobuf/stubs/io_win32.cc
+++ b/src/google/protobuf/stubs/io_win32.cc
@@ -44,7 +44,6 @@
 // Comment this out to fall back to using the ANSI versions (open, mkdir, ...)
 // instead of the Unicode ones (_wopen, _wmkdir, ...). Doing so can be useful to
 // debug failing tests if that's caused by the long path support.
-// Long path support is disabled in MinGW
 #define SUPPORT_LONGPATHS
 
 #include <ctype.h>

--- a/src/google/protobuf/stubs/io_win32.cc
+++ b/src/google/protobuf/stubs/io_win32.cc
@@ -108,15 +108,15 @@ bool has_longpath_prefix(const char_type* path) {
          path[3] == '\\';
 }
 
+template <typename char_type>
+bool is_separator(char_type c) {
+  return c == '/' || c == '\\';
+}
+
 // Returns true if the path starts with a drive specifier (e.g. "c:\").
 template <typename char_type>
 bool is_path_absolute(const char_type* path) {
   return has_drive_letter(path) && is_separator(path[2]);
-}
-
-template <typename char_type>
-bool is_separator(char_type c) {
-  return c == '/' || c == '\\';
 }
 
 template <typename char_type>

--- a/src/google/protobuf/stubs/io_win32.h
+++ b/src/google/protobuf/stubs/io_win32.h
@@ -45,7 +45,7 @@
 #ifndef GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 #define GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 
 #include <string>
 #include <google/protobuf/stubs/port.h>
@@ -91,7 +91,7 @@ LIBPROTOBUF_EXPORT std::wstring testonly_path_to_winpath(
 #define STDOUT_FILENO 1
 #endif
 
-#endif  // defined(_WIN32)
+#endif  // defined(_MSC_VER)
 
 #endif  // GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 

--- a/src/google/protobuf/stubs/io_win32.h
+++ b/src/google/protobuf/stubs/io_win32.h
@@ -45,11 +45,12 @@
 #ifndef GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 #define GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 
 #include <string>
 #include <google/protobuf/stubs/port.h>
 
+#ifdef _MSC_VER
 namespace google {
 namespace protobuf {
 namespace internal {
@@ -74,6 +75,9 @@ LIBPROTOBUF_EXPORT std::wstring testonly_path_to_winpath(
 }  // namespace internal
 }  // namespace protobuf
 }  // namespace google
+#else  // _MSC_VER
+#define mkdir(name, mode) mkdir(name)
+#endif // !_MSC_VER
 
 #ifndef W_OK
 #define W_OK 02  // not defined by MSVC for whatever reason
@@ -91,7 +95,7 @@ LIBPROTOBUF_EXPORT std::wstring testonly_path_to_winpath(
 #define STDOUT_FILENO 1
 #endif
 
-#endif  // defined(_MSC_VER)
+#endif  // defined(_WIN32)
 
 #endif  // GOOGLE_PROTOBUF_STUBS_IO_WIN32_H__
 

--- a/src/google/protobuf/stubs/io_win32.h
+++ b/src/google/protobuf/stubs/io_win32.h
@@ -50,6 +50,8 @@
 #include <string>
 #include <google/protobuf/stubs/port.h>
 
+// Compilers on Windows other than MSVC (e.g. Cygwin, MinGW32) define the
+// following functions already, except for mkdir.
 #ifdef _MSC_VER
 namespace google {
 namespace protobuf {

--- a/src/google/protobuf/testing/file.cc
+++ b/src/google/protobuf/testing/file.cc
@@ -55,6 +55,9 @@ namespace protobuf {
 #define lstat stat
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
+#endif
+
+#ifdef _MSC_VER
 using google::protobuf::internal::win32::access;
 using google::protobuf::internal::win32::chdir;
 using google::protobuf::internal::win32::fopen;

--- a/src/google/protobuf/testing/googletest.cc
+++ b/src/google/protobuf/testing/googletest.cc
@@ -52,7 +52,7 @@
 namespace google {
 namespace protobuf {
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 // DO NOT include <io.h>, instead create functions in io_win32.{h,cc} and import
 // them like we do below.
 using google::protobuf::internal::win32::close;


### PR DESCRIPTION
Restrict the io_win32 change and only enable that for MSVC, because:
1) lots of the _w functions are not available on MinGW32 (possibly on cygwin either)
2) those platforms include <io.h> already via other common headers; using the functions in internal::win32 creates conflicts.

This is a temporary fix to make the build pass. We can revisit this if support on MinGW32 is required. Note that the pre-built protoc artifacts are built under mingw32. With this change, they won't use the long path support code and would rely on the platform APIs for path support.