### PR TITLE
Fix the PHP extension building in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ autom4te.cache
 
 # downloaded files
 gmock
+php-sdk
 
 # in-tree configure-generated files
 Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -594,6 +594,7 @@ php_EXTRA_DIST=                                                       \
   php/ext/google/protobuf/storage.c                                   \
   php/ext/google/protobuf/map.c                                       \
   php/ext/google/protobuf/config.m4                                   \
+  php/ext/google/protobuf/config.w32                                  \
   php/ext/google/protobuf/upb.c                                       \
   php/ext/google/protobuf/protobuf.c                                  \
   php/src/phpdoc.dist.xml                                             \

--- a/Makefile.am
+++ b/Makefile.am
@@ -686,6 +686,7 @@ php_EXTRA_DIST=                                                       \
   php/tests/proto/test_service.proto                                  \
   php/tests/proto/test_service_namespace.proto                        \
   php/tests/test.sh                                                   \
+  php/tests/test.bat                                                  \
   php/tests/test_base.php                                             \
   php/tests/test_util.php                                             \
   php/tests/well_known_test.php                                       \

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -36,6 +36,9 @@ goto :EOF
 
 :build_php
 echo Preparing environment
+call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+
 echo Downloading PHP SDK
 curl -L -o php-sdk.zip https://github.com/OSTC/php-sdk-binary-tools/archive/php-sdk-2.0.9.zip || goto :error
 7z x php-sdk.zip

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -2,6 +2,7 @@ setlocal
 
 IF %language%==cpp GOTO build_cpp
 IF %language%==csharp GOTO build_csharp
+IF %language%==php GOTO build_php
 
 echo Unsupported language %language%. Exiting.
 goto :error
@@ -29,6 +30,37 @@ echo Testing C#
 dotnet run -c %configuration% -f netcoreapp1.0 -p Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 dotnet run -c %configuration% -f net451 -p Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 
+goto :EOF
+
+
+:build_php
+echo Preparing environment
+echo Downloading PHP SDK
+curl -L -o php-sdk.zip https://github.com/OSTC/php-sdk-binary-tools/archive/php-sdk-2.0.9.zip
+7z x php-sdk.zip
+del /Q php-sdk.zip
+ren php-sdk-binary-tools-php-sdk-2.0.9 php-sdk
+cd php-sdk
+bin\phpsdk_setvars.bat
+bin\phpsdk_buildtree.bat phpdev
+curl -L -o php-src.zip https://github.com/php/php-src/archive/php-7.1.8.zip
+7z x php-src.zip
+del /Q php-src.zip
+ren php-src-php-7.1.8 php-7.1.8
+move php-7.1.8 phpdev\vc14\x64\php-7.1.8
+cd phpdev\vc14\x64\php-7.1.8
+set PHP_SDK_VC=vc14
+phpsdk_deps --update --branch 7.1
+mkdir ..\pecl\protobuf
+xcopy ..\..\..\..\..\php\ext\google\protobuf ..\pecl\protobuf
+echo Building Protobuf Extension for PHP
+buildconf
+configure --disable-all --enable-cli --enable-protobuf=shared --disable-zts
+nmake
+
+goto :EOF
+
+echo Builing PHP
 goto :EOF
 
 :error

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ environment:
 
     - language: php
       image: Visual Studio 2015
+      BUILD_DLL: ON
+      UNICODE: ON
 
 # Our build scripts run tests automatically; we don't want AppVeyor
 # to try to detect them itself.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ environment:
     - language: csharp
       image: Visual Studio 2017
 
+    - language: php
+      image: Visual Studio 2015
+
 # Our build scripts run tests automatically; we don't want AppVeyor
 # to try to detect them itself.
 test: off

--- a/php/ext/google/protobuf/config.w32
+++ b/php/ext/google/protobuf/config.w32
@@ -1,0 +1,10 @@
+ARG_ENABLE("protobuf", "protobuf", "yes");
+
+if (PHP_PROTOBUF == "yes") {
+
+  EXTENSION(
+    "protobuf",
+    "array.c def.c encode_decode.c map.c message.c protobuf.c storage.c type_check.c upb.c utf8.c");
+    AC_DEFINE('HAVE_PROTOBUF', 1, 'Have protobuf');
+
+}

--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -38,9 +38,11 @@
 
 #define PHP_PROTOBUF_EXTNAME "protobuf"
 #define PHP_PROTOBUF_VERSION "3.3.2"
-
 #define MAX_LENGTH_OF_INT64 20
 #define SIZEOF_INT64 8
+
+extern zend_module_entry protobuf_module_entry;
+#define phpext_protobuf_ptr &protobuf_module_entry
 
 // -----------------------------------------------------------------------------
 // PHP7 Wrappers
@@ -431,6 +433,11 @@ typedef struct Oneof Oneof;
 // -----------------------------------------------------------------------------
 
 ZEND_BEGIN_MODULE_GLOBALS(protobuf)
+#if defined(_MSC_VER)
+// GCC permits a C structure to have no members, but MSVC not.
+// https://gcc.gnu.org/onlinedocs/gcc/Empty-Structures.html
+  int member;
+#endif
 ZEND_END_MODULE_GLOBALS(protobuf)
 
 // Init module and PHP classes.

--- a/php/ext/google/protobuf/storage.c
+++ b/php/ext/google/protobuf/storage.c
@@ -29,7 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
-#include <protobuf.h>
+#include "protobuf.h"
 #include <Zend/zend.h>
 
 #include "utf8.h"
@@ -991,7 +991,10 @@ void layout_merge(MessageLayout* layout, MessageHeader* from,
           layout->fields[upb_fielddef_index(field)].case_offset;
       // For a oneof, check that this field is actually present -- skip all the
       // below if not.
-      if (DEREF((message_data(from) + oneof_case_offset), uint32_t) !=
+      // Adding to a void* is a GCC extension, so in MSVC, we have to cast the
+      // pointer to a char*.
+      // See: http://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html
+      if (DEREF(((char*)message_data(from) + oneof_case_offset), uint32_t) !=
           upb_fielddef_number(field)) {
         continue;
       }

--- a/php/ext/google/protobuf/upb.c
+++ b/php/ext/google/protobuf/upb.c
@@ -11,6 +11,13 @@ typedef struct {
   char str[1];  /* Null-terminated string data follows. */
 } str_t;
 
+#if defined(_MSC_VER)
+inline int __builtin_ctzll(unsigned long long x) {
+  unsigned long index;
+  return (int)(_BitScanForward64(&index, x) ? index : 64);
+}
+#endif
+
 static str_t *newstr(const char *data, size_t len) {
   str_t *ret = upb_gmalloc(sizeof(*ret) + len);
   if (!ret) return NULL;
@@ -4300,11 +4307,13 @@ static bool atomic_dec(uint32_t *a) { return __sync_sub_and_fetch(a, 1) == 0; }
 
 #elif defined(WIN32) /*-------------------------------------------------------*/
 
-#include <Windows.h>
+#include <windows.h>
 
-static void atomic_inc(upb_atomic_t *a) { InterlockedIncrement(&a->val); }
-static bool atomic_dec(upb_atomic_t *a) {
-  return InterlockedDecrement(&a->val) == 0;
+static void atomic_inc(uint32_t *a) { 
+  InterlockedIncrement(&a); 
+}
+static bool atomic_dec(uint32_t *a) {
+  return InterlockedDecrement(&a) == 0;
 }
 
 #else

--- a/php/ext/google/protobuf/upb.h
+++ b/php/ext/google/protobuf/upb.h
@@ -123,7 +123,7 @@ template <int N> class InlinedEnvironment;
 #define UPB_NORETURN
 #endif
 
-#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L || defined(_MSC_VER)
 /* C99/C++11 versions. */
 #include <stdio.h>
 #define _upb_snprintf snprintf

--- a/php/tests/test.bat
+++ b/php/tests/test.bat
@@ -1,0 +1,17 @@
+@echo off
+REM The test.bat is unavailable yet.
+
+set tests=array_test.php encode_decode_test.php generated_class_test.php generated_phpdoc_test.php map_field_test.php well_known_test.php generated_service_test.php descriptors_test.php
+
+(for %%a in (%tests%) do (
+  echo ****************************
+  echo *    %%a
+  echo ****************************
+  php -dextension=%PHP_BINARY_PATH%\ext\php_mbstring.dll -dextension=%PHP_RELEASE_PATH%\php_protobuf.dll %PHP_RELEASE_PATH%\phpunit.phar --bootstrap autoload.php %%a
+))
+
+exit /b 0
+
+REM export ZEND_DONT_UNLOAD_MODULES=1
+REM export USE_ZEND_ALLOC=0
+REM valgrind --leak-check=yes php -dextension=../ext/google/protobuf/modules/protobuf.so memory_leak_test.php


### PR DESCRIPTION
Instruction: Follow the guideline "Building PECL extensions" in https://wiki.php.net/internals/windows/stepbystepbuild, copy all files in ``php/ext/google/protobuf/`` to ``phpdev\vc14\x64\pecl\protobuf``, and configure with ``configure --disable-all --enable-cli --enable-protobuf=shared --disable-zts``

![image](https://user-images.githubusercontent.com/2398785/29300267-0cc74368-81a7-11e7-842f-1da6e3aa2c88.png)

![image](https://user-images.githubusercontent.com/2398785/29300216-c3c291d6-81a6-11e7-8a3d-3451b7d19346.png)
![image](https://user-images.githubusercontent.com/2398785/29300278-108fa5c6-81a7-11e7-8806-271fa72c96e4.png)



This PR just fixed building on Windows, anyway, there're lots of warning when I compiling it and if I call any function like ``\Google\Protobuf\Internal\DescriptorPool::internalAddGeneratedFile``, it will still crash PHP.