### PR TITLE
Fixing -Wexpansion-to-defined Clang warning

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -256,8 +256,11 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 # define GOOGLE_PROTOBUF_USE_UNALIGNED 0
 #else
 // x86 and x86-64 can perform unaligned loads/stores directly.
-# define GOOGLE_PROTOBUF_USE_UNALIGNED defined(_M_X64) || \
-     defined(__x86_64__) || defined(_M_IX86) || defined(__i386__)
+# if defined(_M_X64) || defined(__x86_64__) || defined(_M_IX86) || defined(__i386__)
+#  define GOOGLE_PROTOBUF_USE_UNALIGNED 1
+# else
+#  define GOOGLE_PROTOBUF_USE_UNALIGNED 0
+# endif
 #endif
 
 #if GOOGLE_PROTOBUF_USE_UNALIGNED


### PR DESCRIPTION
Clang 6.0.0 (trunk 310909) was producing the following warning:

> src/google/protobuf/stubs/port.h:263:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
> src/google/protobuf/stubs/port.h:260:49: note: expanded from macro 'GOOGLE_PROTOBUF_USE_UNALIGNED'
>      defined(__x86_64__) || defined(_M_IX86) || defined(__i386__)

This change intends to resolve the warning (and undefined behavior).