### PR TITLE
Work around a bug in clang's static analyzer

### DIFF
--- a/src/google/protobuf/metadata_lite.h
+++ b/src/google/protobuf/metadata_lite.h
@@ -150,8 +150,11 @@ class InternalMetadataWithArenaBase {
   GOOGLE_ATTRIBUTE_NOINLINE T* mutable_unknown_fields_slow() {
     Arena* my_arena = arena();
     Container* container = Arena::Create<Container>(my_arena);
+    // Two-step assignment works around a bug in clang's static analyzer:
+    // https://bugs.llvm.org/show_bug.cgi?id=34198.
+    ptr_ = container;
     ptr_ = reinterpret_cast<void*>(
-        reinterpret_cast<intptr_t>(container) | kTagContainer);
+        reinterpret_cast<intptr_t>(ptr_) | kTagContainer);
     container->arena = my_arena;
     return &(container->unknown_fields);
   }


### PR DESCRIPTION
Due to https://bugs.llvm.org/show_bug.cgi?id=34198, clang's static
analyzer emits diagnostics about leaking `container`. Doing this
assignment in two steps works around this.

In particular, this code is making the static analyzer we run in The
Wonderful World of Android sad.