### PR TITLE
Prefer system distributed binaries/libraries.

### DIFF
--- a/python/release/wheel/protobuf_optimized_pip.sh
+++ b/python/release/wheel/protobuf_optimized_pip.sh
@@ -47,6 +47,9 @@ cd $DIR/protobuf-${PROTOBUF_VERSION}
 sed -i '/AC_PROG_OBJC/d' configure.ac
 sed -i 's/conformance\/Makefile//g' configure.ac
 
+# Use the /usr/bin/autoconf and related tools to pick the correct aclocal macros
+export PATH="/usr/bin:$PATH"
+
 # Build protoc
 ./autogen.sh
 CXXFLAGS="-fPIC -g -O2" ./configure


### PR DESCRIPTION
It seems like the image has a /usr/local/bin/autoconf installed, which
doesn't recognize/work with the yum installed libtools. Putting
distributed binaries/libraries first solves the problem