### PR TITLE
Drop Python 3.3 from testing & add Python 3.5, 3.6

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34}-{cpp,python}
+    py{26,27,34,35,36}-{cpp,python}
 
 [testenv]
 usedevelop=true

--- a/tests.sh
+++ b/tests.sh
@@ -235,8 +235,9 @@ internal_install_python_deps() {
     sudo apt-add-repository -y ppa:fkrull/deadsnakes
     sudo apt-get update -qq
     sudo apt-get install -y python2.6 python2.6-dev
-    sudo apt-get install -y python3.3 python3.3-dev
     sudo apt-get install -y python3.4 python3.4-dev
+    sudo apt-get install -y python3.5 python3.5-dev
+    sudo apt-get install -y python3.6 python3.6-dev
   fi
 }
 
@@ -278,7 +279,7 @@ build_python() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34\}-python
+    envlist=py\{26,27,34,35,36\}-python
   else
     envlist=py27-python
   fi
@@ -294,7 +295,7 @@ build_python_cpp() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34\}-cpp
+    envlist=py\{26,27,34,35,36\}-cpp
   else
     envlist=py27-cpp
   fi


### PR DESCRIPTION
Python 3.3 goes [EOL](https://docs.python.org/devguide/index.html#branchstatus) next month.