### PR TITLE
remove the parens from the cmp() lambda definition

### DIFF
--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/message_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/message_test.py
@@ -56,9 +56,9 @@ from google.protobuf.internal import test_util
 from google.protobuf import message
 
 try:
-  cmp                                    # Python 2
+  cmp                                   # Python 2
 except NameError:
-  cmp = lambda(x, y): (x > y) - (x < y)  # Python 3
+  cmp = lambda x, y: (x > y) - (x < y)  # Python 3
 
 # Python pre-2.6 does not have isinf() or isnan() functions, so we have
 # to provide our own.

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -57,9 +57,9 @@ try:
 except ImportError:
   import unittest
 try:
-  cmp                                    # Python 2
+  cmp                                   # Python 2
 except NameError:
-  cmp = lambda(x, y): (x > y) - (x < y)  # Python 3
+  cmp = lambda x, y: (x > y) - (x < y)  # Python 3
 
 from google.protobuf import map_unittest_pb2
 from google.protobuf import unittest_pb2


### PR DESCRIPTION
Fixes a mistake that I made in #3517

See https://github.com/PythonCharmers/python-future/pull/298