### PR TITLE
Remove cmp for python3

### DIFF
--- a/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/message_test.py
+++ b/python/compatibility_tests/v2.5.0/tests/google/protobuf/internal/message_test.py
@@ -55,11 +55,6 @@ from google.protobuf.internal import api_implementation
 from google.protobuf.internal import test_util
 from google.protobuf import message
 
-try:
-  cmp                                    # Python 2
-except NameError:
-  cmp = lambda(x, y): (x > y) - (x < y)  # Python 3
-
 # Python pre-2.6 does not have isinf() or isnan() functions, so we have
 # to provide our own.
 def isnan(val):

--- a/python/google/protobuf/internal/message_test.py
+++ b/python/google/protobuf/internal/message_test.py
@@ -56,10 +56,6 @@ try:
   import unittest2 as unittest  # PY26
 except ImportError:
   import unittest
-try:
-  cmp                                    # Python 2
-except NameError:
-  cmp = lambda(x, y): (x > y) - (x < y)  # Python 3
 
 from google.protobuf import map_unittest_pb2
 from google.protobuf import unittest_pb2


### PR DESCRIPTION
It is a revert for #3517 because Jenknins show syntax errors:
https://grpc-testing.appspot.com/job/protobuf_pull_request/1479/testReport/junit/(root)/python/python/