### PR TITLE
Add Python 3.5, 3.6 && drop Python 2.6

### DIFF
--- a/jenkins/docker/Dockerfile
+++ b/jenkins/docker/Dockerfile
@@ -217,6 +217,13 @@ RUN apt-get install -y \
   # -- For javascript -- \
   npm
 
+##################
+# Python 3.5 3.6 dependencies.
+RUN apt-get clean && apt-get update && apt-get install -y --force-yes \
+  python3.5-dev \
+  python3.6-dev \
+  && apt-get clean
+
 # On Debian/Ubuntu, nodejs binary is named 'nodejs' because the name 'node'
 # is taken by another legacy binary. We don't have that legacy binary and
 # npm expects the binary to be named 'node', so we just create a symbol

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34}-{cpp,python}
+    py{26,27,33,34,35,36}-{cpp,python}
 
 [testenv]
 usedevelop=true

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,33,34,35,36}-{cpp,python}
+    py{27,33,34,35,36}-{cpp,python}
 
 [testenv]
 usedevelop=true

--- a/tests.sh
+++ b/tests.sh
@@ -234,7 +234,6 @@ internal_install_python_deps() {
     sudo apt-get install -y python-software-properties # for apt-add-repository
     sudo apt-add-repository -y ppa:fkrull/deadsnakes
     sudo apt-get update -qq
-    sudo apt-get install -y python2.6 python2.6-dev
     sudo apt-get install -y python3.3 python3.3-dev
     sudo apt-get install -y python3.4 python3.4-dev
     sudo apt-get install -y python3.5 python3.5-dev
@@ -280,7 +279,7 @@ build_python() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34,35,36\}-python
+    envlist=py\{27,33,34,35,36\}-python
   else
     envlist=py27-python
   fi
@@ -294,9 +293,9 @@ build_python_cpp() {
   export LD_LIBRARY_PATH=../src/.libs # for Linux
   export DYLD_LIBRARY_PATH=../src/.libs # for OS X
   cd python
-  # Only test Python 2.6/3.x on Linux
+  # Only test Python 3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34,35,36\}-cpp
+    envlist=py\{27,33,34,35,36\}-cpp
   else
     envlist=py27-cpp
   fi

--- a/tests.sh
+++ b/tests.sh
@@ -237,6 +237,8 @@ internal_install_python_deps() {
     sudo apt-get install -y python2.6 python2.6-dev
     sudo apt-get install -y python3.3 python3.3-dev
     sudo apt-get install -y python3.4 python3.4-dev
+    sudo apt-get install -y python3.5 python3.5-dev
+    sudo apt-get install -y python3.6 python3.6-dev
   fi
 }
 
@@ -278,7 +280,7 @@ build_python() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34\}-python
+    envlist=py\{26,27,33,34,35,36\}-python
   else
     envlist=py27-python
   fi
@@ -294,7 +296,7 @@ build_python_cpp() {
   cd python
   # Only test Python 2.6/3.x on Linux
   if [ $(uname -s) == "Linux" ]; then
-    envlist=py\{26,27,33,34\}-cpp
+    envlist=py\{26,27,33,34,35,36\}-cpp
   else
     envlist=py27-cpp
   fi


### PR DESCRIPTION
Jenkins complains for python 2.6
DEPRECATION: Python 2.6 is no longer supported by the Python core team
ERROR: InvocationError: '/tmp/protobuf/protobuf/python/.tox/py26-cpp/bin/python setup.py -q build_py'
https://grpc-testing.appspot.com/job/protobuf_pull_request/1502/testReport/junit/(root)/python_cpp/python_cpp/