### PR TITLE
Move parse frame array to the Map object

### DIFF
--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -280,11 +280,6 @@ rb_data_type_t MapParseFrame_type = {
   { MapParseFrame_mark, MapParseFrame_free, NULL },
 };
 
-// Array of Ruby objects wrapping map_parse_frame_t.
-// We don't allow multiple concurrent decodes, so we assume that this global
-// variable is specific to the "current" decode.
-VALUE map_parse_frames;
-
 static map_parse_frame_t* map_push_frame(VALUE map,
                                          const map_handlerdata_t* handlerdata) {
   map_parse_frame_t* frame = ALLOC(map_parse_frame_t);
@@ -293,14 +288,10 @@ static map_parse_frame_t* map_push_frame(VALUE map,
   native_slot_init(handlerdata->key_field_type, &frame->key_storage);
   native_slot_init(handlerdata->value_field_type, &frame->value_storage);
 
-  rb_ary_push(map_parse_frames,
+  Map_push_frame(map,
               TypedData_Wrap_Struct(rb_cObject, &MapParseFrame_type, frame));
 
   return frame;
-}
-
-static void map_pop_frame() {
-  rb_ary_pop(map_parse_frames);
 }
 
 // Handler to begin a map entry: allocates a temporary frame. This is the
@@ -336,7 +327,7 @@ static bool endmap_handler(void *closure, const void *hd, upb_status* s) {
       &frame->value_storage);
 
   Map_index_set(frame->map, key, value);
-  map_pop_frame();
+  Map_pop_frame(frame->map);
 
   return true;
 }
@@ -775,10 +766,6 @@ VALUE Message_decode(VALUE klass, VALUE data) {
   msg_rb = rb_class_new_instance(0, NULL, msgklass);
   TypedData_Get_Struct(msg_rb, MessageHeader, &Message_type, msg);
 
-  // We generally expect this to be clear already, but clear it in case parsing
-  // previously got interrupted somehow.
-  rb_ary_clear(map_parse_frames);
-
   {
     const upb_pbdecodermethod* method = msgdef_decodermethod(desc);
     const upb_handlers* h = upb_pbdecodermethod_desthandlers(method);
@@ -822,10 +809,6 @@ VALUE Message_decode_json(VALUE klass, VALUE data) {
 
   msg_rb = rb_class_new_instance(0, NULL, msgklass);
   TypedData_Get_Struct(msg_rb, MessageHeader, &Message_type, msg);
-
-  // We generally expect this to be clear already, but clear it in case parsing
-  // previously got interrupted somehow.
-  rb_ary_clear(map_parse_frames);
 
   {
     const upb_json_parsermethod* method = msgdef_jsonparsermethod(desc);

--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -288,7 +288,7 @@ static map_parse_frame_t* map_push_frame(VALUE map,
   native_slot_init(handlerdata->key_field_type, &frame->key_storage);
   native_slot_init(handlerdata->value_field_type, &frame->value_storage);
 
-  Map_push_frame(map,
+  Map_set_frame(map,
               TypedData_Wrap_Struct(rb_cObject, &MapParseFrame_type, frame));
 
   return frame;
@@ -327,7 +327,7 @@ static bool endmap_handler(void *closure, const void *hd, upb_status* s) {
       &frame->value_storage);
 
   Map_index_set(frame->map, key, value);
-  Map_pop_frame(frame->map);
+  Map_set_frame(frame->map, Qnil);
 
   return true;
 }

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -146,6 +146,7 @@ void Map_mark(void* _self) {
   Map* self = _self;
 
   rb_gc_mark(self->value_type_class);
+  rb_gc_mark(self->parse_frames);
 
   if (self->value_type == UPB_TYPE_STRING ||
       self->value_type == UPB_TYPE_BYTES ||
@@ -172,6 +173,16 @@ VALUE Map_alloc(VALUE klass) {
   memset(self, 0, sizeof(Map));
   self->value_type_class = Qnil;
   return TypedData_Wrap_Struct(klass, &Map_type, self);
+}
+
+VALUE Map_push_frame(VALUE map, VALUE val) {
+  Map* self = ruby_to_Map(map);
+  return rb_ary_push(self->parse_frames, val);
+}
+
+VALUE Map_pop_frame(VALUE map) {
+  Map* self = ruby_to_Map(map);
+  return rb_ary_pop(self->parse_frames);
 }
 
 static bool needs_typeclass(upb_fieldtype_t type) {
@@ -227,6 +238,7 @@ VALUE Map_init(int argc, VALUE* argv, VALUE _self) {
 
   self->key_type = ruby_to_fieldtype(argv[0]);
   self->value_type = ruby_to_fieldtype(argv[1]);
+  self->parse_frames = rb_ary_new();
 
   // Check that the key type is an allowed type.
   switch (self->key_type) {

--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -146,7 +146,7 @@ void Map_mark(void* _self) {
   Map* self = _self;
 
   rb_gc_mark(self->value_type_class);
-  rb_gc_mark(self->parse_frames);
+  rb_gc_mark(self->parse_frame);
 
   if (self->value_type == UPB_TYPE_STRING ||
       self->value_type == UPB_TYPE_BYTES ||
@@ -175,14 +175,10 @@ VALUE Map_alloc(VALUE klass) {
   return TypedData_Wrap_Struct(klass, &Map_type, self);
 }
 
-VALUE Map_push_frame(VALUE map, VALUE val) {
+VALUE Map_set_frame(VALUE map, VALUE val) {
   Map* self = ruby_to_Map(map);
-  return rb_ary_push(self->parse_frames, val);
-}
-
-VALUE Map_pop_frame(VALUE map) {
-  Map* self = ruby_to_Map(map);
-  return rb_ary_pop(self->parse_frames);
+  self->parse_frame = val;
+  return val;
 }
 
 static bool needs_typeclass(upb_fieldtype_t type) {
@@ -238,7 +234,7 @@ VALUE Map_init(int argc, VALUE* argv, VALUE _self) {
 
   self->key_type = ruby_to_fieldtype(argv[0]);
   self->value_type = ruby_to_fieldtype(argv[1]);
-  self->parse_frames = rb_ary_new();
+  self->parse_frame = Qnil;
 
   // Check that the key type is an allowed type.
   switch (self->key_type) {

--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -112,6 +112,4 @@ void Init_protobuf_c() {
 
   upb_def_to_ruby_obj_map = rb_hash_new();
   rb_gc_register_address(&upb_def_to_ruby_obj_map);
-  map_parse_frames = rb_ary_new();
-  rb_gc_register_address(&map_parse_frames);
 }

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -395,7 +395,7 @@ typedef struct {
   upb_fieldtype_t key_type;
   upb_fieldtype_t value_type;
   VALUE value_type_class;
-  VALUE parse_frames;
+  VALUE parse_frame;
   upb_strtable table;
 } Map;
 
@@ -404,8 +404,7 @@ void Map_free(void* self);
 VALUE Map_alloc(VALUE klass);
 VALUE Map_init(int argc, VALUE* argv, VALUE self);
 void Map_register(VALUE module);
-VALUE Map_push_frame(VALUE self, VALUE val);
-VALUE Map_pop_frame(VALUE self);
+VALUE Map_set_frame(VALUE self, VALUE val);
 
 extern const rb_data_type_t Map_type;
 extern VALUE cMap;

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -166,8 +166,6 @@ extern VALUE cBuilder;
 extern VALUE cError;
 extern VALUE cParseError;
 
-extern VALUE map_parse_frames;
-
 // We forward-declare all of the Ruby method implementations here because we
 // sometimes call the methods directly across .c files, rather than going
 // through Ruby's method dispatching (e.g. during message parse). It's cleaner
@@ -397,6 +395,7 @@ typedef struct {
   upb_fieldtype_t key_type;
   upb_fieldtype_t value_type;
   VALUE value_type_class;
+  VALUE parse_frames;
   upb_strtable table;
 } Map;
 
@@ -405,6 +404,8 @@ void Map_free(void* self);
 VALUE Map_alloc(VALUE klass);
 VALUE Map_init(int argc, VALUE* argv, VALUE self);
 void Map_register(VALUE module);
+VALUE Map_push_frame(VALUE self, VALUE val);
+VALUE Map_pop_frame(VALUE self);
 
 extern const rb_data_type_t Map_type;
 extern VALUE cMap;


### PR DESCRIPTION
This makes the frame stack per-parser, and per-thread.  Fixes #3250