### PR TITLE
Correct PHP JSON_BIGINT_AS_STRING parameter and decode as an object

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -718,7 +718,7 @@ class Message
                         throw new GPBDecodeException("Expect message.");
                     }
 
-                    $submsg->mergeFromJsonArray($value);
+                    $submsg->mergeFromJsonObject($value);
                 }
                 return $submsg;
             case GPBType::ENUM:
@@ -842,9 +842,9 @@ class Message
         }
     }
 
-    private function mergeFromJsonArray($array)
+    private function mergeFromJsonObject($object)
     {
-        foreach ($array as $key => $value) {
+        foreach ($object as $key => $value) {
             $field = $this->desc->getFieldByJsonName($key);
             if (is_null($field)) {
                 $field = $this->desc->getFieldByName($key);
@@ -913,13 +913,13 @@ class Message
      */
     public function parseFromJsonStream($input)
     {
-        $array = json_decode($input->getData(), JSON_BIGINT_AS_STRING);
-        if (is_null($array)) {
+        $object = json_decode($input->getData(), false, 512, JSON_BIGINT_AS_STRING);
+        if (is_null($object)) {
             throw new GPBDecodeException(
                 "Cannot decode json string.");
         }
         try {
-            $this->mergeFromJsonArray($array);
+            $this->mergeFromJsonObject($object);
         } catch (Exception $e) {
             throw new GPBDecodeException($e->getMessage());
         }

--- a/php/tests/autoload.php
+++ b/php/tests/autoload.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once('../vendor/autoload.php');
+
 function getGeneratedFiles($dir, &$results = array())
 {
     $files = scandir($dir);

--- a/php/tests/encode_decode_test.php
+++ b/php/tests/encode_decode_test.php
@@ -450,4 +450,13 @@ class EncodeDecodeTest extends TestBase
         $to->mergeFromJsonString($data);
         $this->expectFields($to);
     }
+
+    public function testJsonEncodeNumericalStringMapKey()
+    {
+        $from = new TestMessage();
+        $from->setMapStringString(["0" => "a"]);
+        $data = $from->serializeToJsonString();
+        $to = new TestMessage();
+        $to->mergeFromJsonString($data);
+    }
 }

--- a/php/tests/test.sh
+++ b/php/tests/test.sh
@@ -12,10 +12,16 @@ tests=( array_test.php encode_decode_test.php generated_class_test.php generated
 
 for t in "${tests[@]}"
 do
-  echo "****************************"
-  echo "* $t"
-  echo "****************************"
+  echo "************************************"
+  echo "* $t - Extension"
+  echo "************************************"
   php -dextension=../ext/google/protobuf/modules/protobuf.so `which phpunit` --bootstrap autoload.php $t
+  echo ""
+
+  echo "************************************"
+  echo "* $t - PHP"
+  echo "************************************"
+  php `which phpunit` --bootstrap autoload.php $t
   echo ""
 done
 


### PR DESCRIPTION
This fixes the placement of the `JSON_BIGINT_AS_STRING` option passed to `json_decode`, this is being passed as the `$assoc` parameter which decodes the JSON as an associative array.

I've changed the JSON to be decoded as as object rather as an array. This fixes an issue where the keys to a Protobuf map could be a numerical string, which then become integers when decoded as an associative array causing `expected string`

```php
$data = '{"1001": true, "foo": true}';

var_dump(json_decode($data, true));
// array(2) {
//   [1001]=>
//   bool(true)
//   ["foo"]=>
//   bool(true)
// }

var_dump(json_decode($data));
// object(stdClass)#1 (2) {
//   ["1001"]=>
//   bool(true)
//   ["foo"]=>
//   bool(true)
// }
```