### PR TITLE
Update port.h

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -263,7 +263,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 # endif
 #endif
 
-#if GOOGLE_PROTOBUF_USE_UNALIGNED
+#ifdef GOOGLE_PROTOBUF_USE_UNALIGNED
 
 #define GOOGLE_UNALIGNED_LOAD16(_p) (*reinterpret_cast<const uint16 *>(_p))
 #define GOOGLE_UNALIGNED_LOAD32(_p) (*reinterpret_cast<const uint32 *>(_p))


### PR DESCRIPTION
Fix following build errors:  

```
error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
 #if GOOGLE_PROTOBUF_USE_UNALIGNED
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```