### PR TITLE
bazel: Add proto_library rules for well known types. Fixes #2763

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "com_google_protobuf")
+
 new_git_repository(
     name = "googletest",
     build_file = "gmock.BUILD",


### PR DESCRIPTION
Adds a proto_library rule for each well known type proto:

```
$ bazel query "filter(\".*_proto$\", \"...\")"
//:wrappers_proto
//:timestamp_proto
//:struct_proto
//:field_mask_proto
//:empty_proto
//:duration_proto
//:compiler_plugin_proto
//:descriptor_proto
//:api_proto
//:type_proto
//:source_context_proto
//:any_proto
```

Bazel users can reference these proto_library rules for their own
language specific rules i.e.

```
java_proto_library(
  name = "any_java_proto",
  deps = ["@com_google_protobuf//:any_proto"],
)
```

Also set the workspace name to `"com_google_protobuf"`, as proto_library
rules reference protobuf that way.