### PR TITLE
Calling reflected c'tors no longer breaks MergeFrom.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -100,3 +100,5 @@ Patch contributors:
   Andrew Paprocki <andrew@ishiboo.com>
     * Fixed minor IBM xlC compiler build issues
     * Added atomicops for AIX (POWER)
+  Yonatan Zunger <zunger@humu.com>
+    * Fixed python proto issue with reflected classes breaking descriptors.

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -1208,8 +1208,17 @@ def _AddMergeFromMethod(cls):
   LABEL_REPEATED = _FieldDescriptor.LABEL_REPEATED
   CPPTYPE_MESSAGE = _FieldDescriptor.CPPTYPE_MESSAGE
 
+  def __IsInstance(msg, cls):
+      """Check if msg is an instance of class, handling protos correctly."""
+      if isinstance(msg, cls):
+          return True
+      if hasattr(msg, "DESCRIPTOR") and hasattr(
+              cls, "DESCRIPTOR") and msg.DESCRIPTOR == cls.DESCRIPTOR:
+          return True
+      return False
+
   def MergeFrom(self, msg):
-    if not isinstance(msg, cls):
+    if not __IsInstance(msg, cls):
       raise TypeError(
           "Parameter to MergeFrom() must be instance of same class: "
           'expected %s got %s.' % (cls.__name__, msg.__class__.__name__))

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -50,26 +50,22 @@ this file*.
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
-from io import BytesIO
 import struct
 import sys
 import weakref
+from io import BytesIO
 
 import six
 
-# We use "as" to avoid name collisions with variables.
-from google.protobuf.internal import api_implementation
-from google.protobuf.internal import containers
-from google.protobuf.internal import decoder
-from google.protobuf.internal import encoder
-from google.protobuf.internal import enum_type_wrapper
-from google.protobuf.internal import message_listener as message_listener_mod
-from google.protobuf.internal import type_checkers
-from google.protobuf.internal import well_known_types
-from google.protobuf.internal import wire_format
 from google.protobuf import descriptor as descriptor_mod
 from google.protobuf import message as message_mod
 from google.protobuf import text_format
+from google.protobuf.internal import message_listener as message_listener_mod
+# We use "as" to avoid name collisions with variables.
+from google.protobuf.internal import (api_implementation, containers, decoder,
+                                      encoder, enum_type_wrapper,
+                                      type_checkers, well_known_types,
+                                      wire_format)
 
 _FieldDescriptor = descriptor_mod.FieldDescriptor
 _AnyFullTypeName = 'google.protobuf.Any'
@@ -1208,17 +1204,8 @@ def _AddMergeFromMethod(cls):
   LABEL_REPEATED = _FieldDescriptor.LABEL_REPEATED
   CPPTYPE_MESSAGE = _FieldDescriptor.CPPTYPE_MESSAGE
 
-  def __IsInstance(msg, cls):
-      """Check if msg is an instance of class, handling protos correctly."""
-      if isinstance(msg, cls):
-          return True
-      if hasattr(msg, "DESCRIPTOR") and hasattr(
-              cls, "DESCRIPTOR") and msg.DESCRIPTOR == cls.DESCRIPTOR:
-          return True
-      return False
-
   def MergeFrom(self, msg):
-    if not __IsInstance(msg, cls):
+    if not isinstance(msg, cls):
       raise TypeError(
           "Parameter to MergeFrom() must be instance of same class: "
           'expected %s got %s.' % (cls.__name__, msg.__class__.__name__))

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -50,22 +50,26 @@ this file*.
 
 __author__ = 'robinson@google.com (Will Robinson)'
 
+from io import BytesIO
 import struct
 import sys
 import weakref
-from io import BytesIO
 
 import six
 
+# We use "as" to avoid name collisions with variables.
+from google.protobuf.internal import api_implementation
+from google.protobuf.internal import containers
+from google.protobuf.internal import decoder
+from google.protobuf.internal import encoder
+from google.protobuf.internal import enum_type_wrapper
+from google.protobuf.internal import message_listener as message_listener_mod
+from google.protobuf.internal import type_checkers
+from google.protobuf.internal import well_known_types
+from google.protobuf.internal import wire_format
 from google.protobuf import descriptor as descriptor_mod
 from google.protobuf import message as message_mod
 from google.protobuf import text_format
-from google.protobuf.internal import message_listener as message_listener_mod
-# We use "as" to avoid name collisions with variables.
-from google.protobuf.internal import (api_implementation, containers, decoder,
-                                      encoder, enum_type_wrapper,
-                                      type_checkers, well_known_types,
-                                      wire_format)
 
 _FieldDescriptor = descriptor_mod.FieldDescriptor
 _AnyFullTypeName = 'google.protobuf.Any'

--- a/python/google/protobuf/internal/reflection_test.py
+++ b/python/google/protobuf/internal/reflection_test.py
@@ -47,6 +47,7 @@ try:
 except ImportError:
   import unittest
 
+from google.protobuf import map_unittest_pb2
 from google.protobuf import unittest_import_pb2
 from google.protobuf import unittest_mset_pb2
 from google.protobuf import unittest_pb2
@@ -1479,6 +1480,30 @@ class ReflectionTest(BaseTestCase):
     # Merge into message2.  This should not instantiate the field is message2.
     message2.MergeFrom(message1)
     self.assertFalse(message2.HasField('optional_nested_message'))
+
+  def testReflectionDoesntBreakMerging(self):
+    """Test that building a class from reflection doesn't break merging."""
+    # Instantiate a TestMap from the generated class. (We use this class
+    # because copying a MessageMap relies on the map value's descriptor's
+    # concrete class, unlike most other copies, and is especially bug-prone)
+    proto = map_unittest_pb2.TestMap()
+    proto.map_string_nested_message["one"].c = 1234
+
+    print "First: %s" % proto
+
+    # Instantiate one from reflection
+    generated = reflection.MakeClass(proto.DESCRIPTOR)()
+    generated.map_string_nested_message["two"].c = 2345
+
+    print "Second: %s" % generated
+    print "Third: %s" % proto
+
+    # The concrete class of their shared descriptor has changed! Make sure
+    # we can still assign copies.
+    proto2 = map_unittest_pb2.TestMap()
+    proto2.MergeFrom(proto)
+    self.assertEqual(proto.map_string_nested_message["one"],
+                     proto2.map_string_nested_message["one"])
 
   def testCopyFromSingularField(self):
     # Test copy with just a singular field.

--- a/python/google/protobuf/reflection.py
+++ b/python/google/protobuf/reflection.py
@@ -48,9 +48,8 @@ this file*.
 __author__ = 'robinson@google.com (Will Robinson)'
 
 
-from google.protobuf.internal import api_implementation
 from google.protobuf import message
-
+from google.protobuf.internal import api_implementation
 
 if api_implementation.Type() == 'cpp':
   from google.protobuf.pyext import cpp_message as message_impl
@@ -106,6 +105,9 @@ def MakeClass(descriptor):
   Returns:
     The Message class object described by the descriptor.
   """
+  if hasattr(descriptor, '_concrete_class'):
+      return descriptor._concrete_class
+
   if descriptor in MESSAGE_CLASS_CACHE:
     return MESSAGE_CLASS_CACHE[descriptor]
 

--- a/python/google/protobuf/reflection.py
+++ b/python/google/protobuf/reflection.py
@@ -48,8 +48,8 @@ this file*.
 __author__ = 'robinson@google.com (Will Robinson)'
 
 
-from google.protobuf import message
 from google.protobuf.internal import api_implementation
+from google.protobuf import message
 
 if api_implementation.Type() == 'cpp':
   from google.protobuf.pyext import cpp_message as message_impl

--- a/python/google/protobuf/reflection.py
+++ b/python/google/protobuf/reflection.py
@@ -51,6 +51,7 @@ __author__ = 'robinson@google.com (Will Robinson)'
 from google.protobuf.internal import api_implementation
 from google.protobuf import message
 
+
 if api_implementation.Type() == 'cpp':
   from google.protobuf.pyext import cpp_message as message_impl
 else:

--- a/src/google/protobuf/map_unittest.proto
+++ b/src/google/protobuf/map_unittest.proto
@@ -61,6 +61,11 @@ message TestMap {
   map<int32   , ForeignMessage> map_int32_foreign_message = 17;
   map<string  , ForeignMessage> map_string_foreign_message = 18;
   map<int32   , TestAllTypes> map_int32_all_types = 19;
+
+  message NestedMessage {
+    int32 c = 1;
+  }
+  map<string  , NestedMessage> map_string_nested_message = 20;
 }
 
 message TestMapSubmessage {


### PR DESCRIPTION
Hey everyone,

I came across a nasty little bug with Python reflection, with a simple workaround. The problem can be triggered by a map whose value is a nested message.

*Problem description:* Both the constructors of protoc-generated messages and of reflection-generated messages (GeneratedProtocolMessageType.__init__) set descriptor._concrete_class to themselves. Unfortunately, if you access a class both directly and through reflection, they try to do this to the same descriptor, and hilarity ensues.

A way to manifest this problem is to print a protobuf (constructed normally) containing a map whose value is a nested (not foreign) type. When the printer reaches the map field, it will call value.GetEntryClass()(key=...) on the MapMessage object, which in turn calls descriptor._concrete_class(); the constructor then tries to MergeFrom on the output of that, merging the contents of the value field from the class being printed into what was made by the concrete class. But if the generated class has ever been constructed, descriptor._concrete_class() will now return one of *those*, and MergeFrom will throw a TypeError because it's trying to merge two different classes!

*A hypothetical hard fix:* would be to have multiple concrete classes available in the descriptor and switch through them based on something or other.

*A much easier fix:* There are really two bugs here: the fact that both classes are modifying the same descriptor, and the fact that MergeFrom is testing class match incorrectly. Specifically, MergeFrom should work fine if you are trying to merge a generated class into a compiled class or vice-versa. Therefore, a much better fix is to replace the isinstance() check on python_message.py:1212 with a check that also allows it to pass if the two classes are protos whose descriptor matches.

There do not appear to be any other points in the protobuf code that require such a change; the only other dubious uses of isinstance() are in the two equality checks (_AddEqualsMethod.__eq__ and _ExtensionDict.__eq__), where it's arguable that returning false when comparing generated and non-generated messages is reasonable. (Although you could argue the other way; proto equality has always been a contentious subject)

This pull request contains the fix and a unittest which reproduces the core issue.,