### PR TITLE
Update switch's fallthrough for GCC 7

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -237,7 +237,11 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 #define GOOGLE_SAFE_CONCURRENT_WRITES_END()
 #endif
 
-#if defined(__clang__) && defined(__has_cpp_attribute) \
+#if __cplusplus > 201402L && __has_cpp_attribute(fallthrough)
+# define GOOGLE_FALLTHROUGH_INTENDED [[fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+# define GOOGLE_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#elif defined(__clang__) && defined(__has_cpp_attribute) \
     && !defined(GOOGLE_PROTOBUF_OS_APPLE)
 # if defined(GOOGLE_PROTOBUF_OS_NACL) || defined(EMSCRIPTEN) || \
      __has_cpp_attribute(clang::fallthrough)


### PR DESCRIPTION
Implicit fallthrough throws an warning on GCC 7 with -Wextra.

The current code already supports the explicit attribute using
GOOGLE_FALLTHROUGH_INTENDED at specific configuration with clang.

This commit supports the C++17 new attribute [[fallthrough]] and the GNU
version, [[gnu:fallthrough]].

I kept the current rules to enable the attribute when compiling with clang.