### PR TITLE
Fix go example test.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,12 +22,12 @@ clean:
 	rmdir com 2>/dev/null || true
 
 protoc_middleman: addressbook.proto
-	protoc --cpp_out=. --java_out=. --python_out=. addressbook.proto
+	protoc $$PROTO_PATH --cpp_out=. --java_out=. --python_out=. addressbook.proto
 	@touch protoc_middleman
 
 protoc_middleman_go: addressbook.proto
-	mkdir tutorial # make directory for go package
-	protoc --go_out=tutorial addressbook.proto
+	mkdir -p tutorial # make directory for go package
+	protoc $$PROTO_PATH --go_out=tutorial addressbook.proto
 	@touch protoc_middleman_go
 
 add_person_cpp: add_person.cc protoc_middleman

--- a/tests.sh
+++ b/tests.sh
@@ -129,7 +129,7 @@ build_golang() {
   export PATH="$GOPATH/bin:$PATH"
   go get github.com/golang/protobuf/protoc-gen-go
 
-  cd examples && make gotest && cd ..
+  cd examples && PROTO_PATH="-I../src -I." make gotest && cd ..
 }
 
 use_java() {


### PR DESCRIPTION
It was broken when I introduced well known types into example addressbook.proto in https://github.com/google/protobuf/pull/3613

This PR fixes it by adding the needed import path.