### PR TITLE
for generated pb.cc files, avoid __FILE__ in VERIFY_VERSION macro call

### DIFF
--- a/src/google/protobuf/any.pb.cc
+++ b/src/google/protobuf/any.pb.cc
@@ -92,7 +92,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/any");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _Any_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -130,7 +130,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/api");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   ::google::protobuf::protobuf_google_2fprotobuf_2fsource_5fcontext_2eproto::InitDefaults();

--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -767,7 +767,7 @@ void FileGenerator::GenerateBuildDescriptors(io::Printer* printer) {
   // -----------------------------------------------------------------
 
   // Now generate the InitDefaultsImpl() function.
-  // pass "FirstMessageName" or "FileName.pb.cc" to VerifyVersion()
+  // pass basename of .proto file to VerifyVersion()
   // rather than __FILE__, which might include entire path string in binary.
   string message_or_file_name = (message_generators_.size() == 0 ? file_->name() : ClassName(message_generators_[0]->descriptor_, false));
   printer->Print(
@@ -775,7 +775,7 @@ void FileGenerator::GenerateBuildDescriptors(io::Printer* printer) {
       "  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR(\"$name$\");\n\n"
       // Force initialization of primitive values we depend on.
       "  ::google::protobuf::internal::InitProtobufDefaults();\n",
-      "name", message_or_file_name);
+      "name", StripProto(file_->name()));
 
   printer->Indent();
 

--- a/src/google/protobuf/compiler/cpp/cpp_file.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_file.cc
@@ -767,11 +767,15 @@ void FileGenerator::GenerateBuildDescriptors(io::Printer* printer) {
   // -----------------------------------------------------------------
 
   // Now generate the InitDefaultsImpl() function.
+  // pass "FirstMessageName" or "FileName.pb.cc" to VerifyVersion()
+  // rather than __FILE__, which might include entire path string in binary.
+  string message_or_file_name = (message_generators_.size() == 0 ? file_->name() : ClassName(message_generators_[0]->descriptor_, false));
   printer->Print(
       "void TableStruct::InitDefaultsImpl() {\n"
-      "  GOOGLE_PROTOBUF_VERIFY_VERSION;\n\n"
+      "  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR(\"$name$\");\n\n"
       // Force initialization of primitive values we depend on.
-      "  ::google::protobuf::internal::InitProtobufDefaults();\n");
+      "  ::google::protobuf::internal::InitProtobufDefaults();\n",
+      "name", message_or_file_name);
 
   printer->Indent();
 

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -153,7 +153,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/compiler/plugin");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   ::google::protobuf::protobuf_google_2fprotobuf_2fdescriptor_2eproto::InitDefaults();

--- a/src/google/protobuf/compiler/profile.pb.cc
+++ b/src/google/protobuf/compiler/profile.pb.cc
@@ -131,7 +131,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/compiler/profile");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _FieldAccessInfo_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -607,7 +607,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/descriptor");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _FileDescriptorSet_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/duration.pb.cc
+++ b/src/google/protobuf/duration.pb.cc
@@ -92,7 +92,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/duration");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _Duration_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/empty.pb.cc
+++ b/src/google/protobuf/empty.pb.cc
@@ -90,7 +90,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/empty");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _Empty_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/field_mask.pb.cc
+++ b/src/google/protobuf/field_mask.pb.cc
@@ -91,7 +91,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/field_mask");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _FieldMask_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/source_context.pb.cc
+++ b/src/google/protobuf/source_context.pb.cc
@@ -91,7 +91,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/source_context");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _SourceContext_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -137,7 +137,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/struct");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _Struct_FieldsEntry_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -132,10 +132,19 @@ std::string LIBPROTOBUF_EXPORT VersionString(int version);
 // to use the protobuf library) to verify that the version you link against
 // matches the headers you compiled against.  If a version mismatch is
 // detected, the process will abort.
+// NOTE: This macro called by InitDefaultsImpl in all .pb.cc files.
+
+#ifdef NDEBUG
+#define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
+  ::google::protobuf::internal::VerifyVersion(                            \
+    GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
+    "" /* filename omitted when NDEBUG defined */ )
+#else // NDEBUG
 #define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
   ::google::protobuf::internal::VerifyVersion(                            \
     GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
     __FILE__)
+#endif // NDEBUG
 
 
 // ===================================================================

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -128,23 +128,20 @@ std::string LIBPROTOBUF_EXPORT VersionString(int version);
 
 }  // namespace internal
 
+#define GOOGLE_PROTOBUF_VERIFY_VERSION_FOR(_MSG_OR_FILE_NAME)             \
+  ::google::protobuf::internal::VerifyVersion(                            \
+    GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
+    (_MSG_OR_FILE_NAME) )
+
 // Place this macro in your main() function (or somewhere before you attempt
 // to use the protobuf library) to verify that the version you link against
 // matches the headers you compiled against.  If a version mismatch is
 // detected, the process will abort.
-// NOTE: This macro called by InitDefaultsImpl in all .pb.cc files.
+// NOTE: uses __FILE__ macro, so the compiled binary will contain string
+// of source filename (potentially entire path).
 
-#ifdef NDEBUG
 #define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
-  ::google::protobuf::internal::VerifyVersion(                            \
-    GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
-    "" /* filename omitted when NDEBUG defined */ )
-#else // NDEBUG
-#define GOOGLE_PROTOBUF_VERIFY_VERSION                                    \
-  ::google::protobuf::internal::VerifyVersion(                            \
-    GOOGLE_PROTOBUF_VERSION, GOOGLE_PROTOBUF_MIN_LIBRARY_VERSION,         \
-    __FILE__)
-#endif // NDEBUG
+           GOOGLE_PROTOBUF_VERIFY_VERSION_FOR(__FILE__)
 
 
 // ===================================================================

--- a/src/google/protobuf/timestamp.pb.cc
+++ b/src/google/protobuf/timestamp.pb.cc
@@ -92,7 +92,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/timestamp");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _Timestamp_default_instance_.DefaultConstruct();

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -165,7 +165,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/type");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   ::google::protobuf::protobuf_google_2fprotobuf_2fany_2eproto::InitDefaults();

--- a/src/google/protobuf/wrappers.pb.cc
+++ b/src/google/protobuf/wrappers.pb.cc
@@ -195,7 +195,7 @@ void TableStruct::Shutdown() {
 }
 
 void TableStruct::InitDefaultsImpl() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  GOOGLE_PROTOBUF_VERIFY_VERSION_FOR("google/protobuf/wrappers");
 
   ::google::protobuf::internal::InitProtobufDefaults();
   _DoubleValue_default_instance_.DefaultConstruct();


### PR DESCRIPTION
Currently, whether generated .pb.cc files are built in release or debug mode, the source filenames are included as strings in the resulting binary.

This is because protoc-cpp adds a call to the GOOGLE_PROTOBUF_VERIFY_VERSION macro in the InitDefaultsImpl function of every generated C++ protobuf message file.  That macro contains the __FILE__ macro.  Therefore, if you have a source file named MySpecialMessage.pb.cc, runnings *strings* on the resulting .o or .a or executable will reveal all the source file names.  If you are using CMAKE for your build, it will include the absolute path of all .pb.cc files (e.g. "/Users/bob/dev/blah/generated/MySpecialMessage.pb.cc").

This change follows the behavior of the assert macro, which will omit __FILE__ when NDEBUG is defined.