### PR TITLE
rename duplicate testMessageSetNullFail function

### DIFF
--- a/php/tests/undefined_test.php
+++ b/php/tests/undefined_test.php
@@ -909,7 +909,7 @@ class UndefinedTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException PHPUnit_Framework_Error
      */
-    public function testMessageSetNullFail()
+    public function testMessageSetNullFailMap()
     {
        $arr =
            new MapField(GPBType::INT32, GPBType::MESSAGE, TestMessage::class);


### PR DESCRIPTION
the testMessageSetNullFail function was declared twice.
So I renamed one to testMessageSetNullFailMap