### PR TITLE
When initializing a message, skip a field if value is nil

### DIFF
--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -249,6 +249,10 @@ int Message_initialize_kwarg(VALUE key, VALUE val, VALUE _self) {
              "Unknown field name '%s' in initialization map entry.", name);
   }
 
+  if (TYPE(val) == T_NIL) {
+    return 0;
+  }
+
   if (is_map_field(f)) {
     VALUE map;
 

--- a/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
+++ b/ruby/src/main/java/com/google/protobuf/jruby/RubyMessage.java
@@ -86,6 +86,8 @@ public class RubyMessage extends RubyObject {
                         throw runtime.newTypeError("Expected string or symbols as hash keys in initialization map.");
                     final Descriptors.FieldDescriptor fieldDescriptor = findField(context, key);
 
+                    if (value.isNil()) return;
+
                     if (Utils.isMapEntry(fieldDescriptor)) {
                         if (!(value instanceof RubyHash))
                             throw runtime.newArgumentError("Expected Hash object as initializer value for map field '" +  key.asJavaString() + "'.");

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -212,6 +212,15 @@ module BasicTest
       assert_equal ['foo', 'bar'], m.repeated_string
     end
 
+    def test_ctor_nil_args
+      m = TestMessage.new(:optional_enum => nil, :optional_int32 => nil, :optional_string => nil, :optional_msg => nil)
+
+      assert_equal :Default, m.optional_enum
+      assert_equal 0, m.optional_int32
+      assert_equal "", m.optional_string
+      assert_nil m.optional_msg
+    end
+
     def test_embeddedmsg_hash_init
       m = TestEmbeddedMessageParent.new(:child_msg => {sub_child: {optional_int32: 1}},
                                         :number => 2,


### PR DESCRIPTION
This is mostly in the same vein as https://github.com/google/protobuf/pull/3627 for Ruby.

It allows doing: `MyMessage.new(string_field: nil)` and `string_field` is treated as a default. It makes it easier to construct protos when you're building up the options across multiple files, or from JSON where a nil value isn't necessarily a bad thing.