### PR TITLE
Prefer using compiler built-in endianness definitions.

### DIFF
--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -113,7 +113,9 @@
 #include <climits>
 #include <string>
 #include <utility>
-#ifdef _MSC_VER
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+  #define PROTOBUF_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#elif defined(_MSC_VER)
   // Assuming windows is always little-endian.
   #if !defined(PROTOBUF_DISABLE_LITTLE_ENDIAN_OPT_FOR_TEST)
     #define PROTOBUF_LITTLE_ENDIAN 1

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -47,7 +47,9 @@
 #include <google/protobuf/stubs/platform_macros.h>
 
 #undef PROTOBUF_LITTLE_ENDIAN
-#ifdef _WIN32
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+  #define PROTOBUF_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#elif defined(_WIN32)
   // Assuming windows is always little-endian.
   // TODO(xiaofeng): The PROTOBUF_LITTLE_ENDIAN is not only used for
   // optimization but also for correctness. We should define an


### PR DESCRIPTION
In order to make Protobuf build and work on CloudABI, a sandboxed
UNIX-like runtime environment, we have to extend the endianness
detection code. Instead of adding code specific to CloudABI, let's
change this to simply use definitions that are documented by GCC and
Clang, so that any other operating system/runtime may benefit.