### PR TITLE
Suppress VS2017 compiler/linker warnings

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -135,12 +135,15 @@ endif (protobuf_BUILD_SHARED_LIBS)
 if (MSVC)
   # Build with multiple processes
   add_definitions(/MP)
-  add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305 /wd4309)
+  add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305 /wd4309 /wd4065 /wd4506 /wd4307 /wd4334)
   # Allow big object
   add_definitions(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})
   string(REPLACE "/" "\\" PROTOBUF_BINARY_WIN32_PATH ${protobuf_BINARY_DIR})
   configure_file(extract_includes.bat.in extract_includes.bat)
+  
+  # Suppress linker warnings about files with no symbols defined.
+  set(CMAKE_STATIC_LINKER_FLAGS /ignore:4221)
 endif (MSVC)
 
 get_filename_component(protobuf_source_dir ${protobuf_SOURCE_DIR} PATH)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -135,7 +135,23 @@ endif (protobuf_BUILD_SHARED_LIBS)
 if (MSVC)
   # Build with multiple processes
   add_definitions(/MP)
-  add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305 /wd4309 /wd4065 /wd4506 /wd4307 /wd4334)
+  # MSVC warning suppressions
+  add_definitions(
+    /wd4018 # 'expression' : signed/unsigned mismatch
+    /wd4065 # switch statement contains 'default' but no 'case' labels
+    /wd4146 # unary minus operator applied to unsigned type, result still unsigned
+    /wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+    /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+    /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+    /wd4305 # 'identifier' : truncation from 'type1' to 'type2'
+    /wd4307 # 'operator' : integral constant overflow
+    /wd4309 # 'conversion' : truncation of constant value
+    /wd4334 # 'operator' : result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+    /wd4355 # 'this' : used in base member initializer list
+    /wd4506 # no definition for inline function 'function'
+    /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
+    /wd4996 # The compiler encountered a deprecated declaration.
+  )
   # Allow big object
   add_definitions(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})


### PR DESCRIPTION
VS2017 warns about a few additional things, for example, files that
define no symbols (which is typically the result of a platform specific
ifdef not applying on Windows).

Suppress these warnings so the build is clean on VS2017.