### PR TITLE
Don't pass -lpthread and -lm on Windows

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -44,9 +44,11 @@ config_setting(
     },
 )
 
-# Android builds do not need to link in a separate pthread library.
+# Android and Windows builds do not need to link in a separate pthread library.
 LINK_OPTS = select({
     ":android": [],
+    ":windows": [],
+    ":windows_msvc": [],
     "//conditions:default": ["-lpthread", "-lm"],
 })
 


### PR DESCRIPTION
These flags are ignored by cl.exe and have no effect, but add noise to the build logs.