### PR TITLE
Converting tags to immutable hashable types

### DIFF
--- a/python/google/protobuf/internal/decoder.py
+++ b/python/google/protobuf/internal/decoder.py
@@ -181,7 +181,7 @@ def ReadTag(buffer, pos):
   while six.indexbytes(buffer, pos) & 0x80:
     pos += 1
   pos += 1
-  return (buffer[start:pos], pos)
+  return (six.binary_type(buffer[start:pos]), pos)
 
 
 # --------------------------------------------------------------------

--- a/python/google/protobuf/internal/encoder.py
+++ b/python/google/protobuf/internal/encoder.py
@@ -418,7 +418,7 @@ def _VarintBytes(value):
 def TagBytes(field_number, wire_type):
   """Encode the given tag and return the bytes.  Only called at startup."""
 
-  return _VarintBytes(wire_format.PackTag(field_number, wire_type))
+  return six.binary_type( _VarintBytes(wire_format.PackTag(field_number, wire_type)) )
 
 # --------------------------------------------------------------------
 # As with sizers (see above), we have a number of common encoder


### PR DESCRIPTION
In a Raspberry Pi, tags are not hashable if data is passed as byterray, however, running in Ubuntu this is not a problem.

This PR addresses the problem as described in:
https://github.com/google/protobuf/issues/3734

