### PR TITLE
Move namespace closing brace inside the header guard block

### DIFF
--- a/src/google/protobuf/util/internal/json_escaping.h
+++ b/src/google/protobuf/util/internal/json_escaping.h
@@ -86,6 +86,6 @@ class JsonEscaping {
 }  // namespace converter
 }  // namespace util
 }  // namespace protobuf
+}  // namespace google
 
 #endif  // NET_PROTO2_UTIL_CONVERTER_STRINGS_JSON_ESCAPING_H_
-}  // namespace google


### PR DESCRIPTION
This doesn't seem to cause problems when it's only included once, but it fails to build as part of the Firefox unified builds.