### PR TITLE
Work around wingdi.h defining ERROR as 0

### DIFF
--- a/src/google/protobuf/stubs/logging.h
+++ b/src/google/protobuf/stubs/logging.h
@@ -59,6 +59,19 @@ enum LogLevel {
 #else
   LOGLEVEL_DFATAL = LOGLEVEL_FATAL
 #endif
+
+#ifdef _WIN32
+  // wingdi.h defines ERROR to be 0, so `GOOGLE_LOG(ERROR, ...)` expands
+  // into `GOOGLE_LOG(0, ...)` which then expands into
+  // `someGoogleLogging(LOGLEVEL_0, ...)`. This is not ideal, because the
+  // GOOGLE_LOG macro expects to expand itself into
+  // `someGoogleLogging(LOGLEVEL_ERROR, ...)` instead. The workaround to
+  // get everything building is to simply define LOGLEVEL_0 as
+  // LOGLEVEL_ERROR and also define ERROR the same way that the Windows
+  // SDK does for consistency.
+#define ERROR 0
+  , LOGLEVEL_0 = LOGLEVEL_ERROR
+#endif
 };
 
 class StringPiece;


### PR DESCRIPTION
Without this fix, we get build errors like these on Windows when bundling protobuf in Firefox:

```
src/google/protobuf/stubs/strutil.cc(351): error C2039: 'LOGLEVEL_0': is not a member of 'google::protobuf'
src/google/protobuf/stubs/strutil.cc(60): note: see declaration of 'google::protobuf'
src/google/protobuf/stubs/strutil.cc(351): error C2065: 'LOGLEVEL_0': undeclared identifier
```