### PR TITLE
Add #include <vector> to work around problems on Android

### DIFF
--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -48,6 +48,7 @@
 #ifndef _SHARED_PTR_H
 #include <google/protobuf/stubs/shared_ptr.h>
 #endif
+#include <vector>
 #include <string>
 #include <iosfwd>
 #include <google/protobuf/io/zero_copy_stream.h>


### PR DESCRIPTION
Compiling Firefox with libc++ and GCC 4.9 on Android runs into a problem. The protobuf #includes and libc++ result in preprocessed code that looks something like:

```
/* via <iterator> */

namespace std {
namespace __1 {
}
using namespace __1 __attribute__((__strong__));
}

namespace std { namespace __1 {
template <class _Iter>
class __wrap_iter
{
  ...
  template <class _Tp, class _Alloc> friend class vector;
  ...
};

} // namespace __1
} // namespace std
```

```
/* via <vector> */

namespace std { namespace __1 {

template <class _Tp, class _Alloc>
class _LIBCPP_TYPE_VIS_ONLY vector : ...
{ ... };

} // namespace __1
} // namespace std
```

and the problem is that GCC doesn't understand that the forward declaration of vector inside `__wrap_iter` is forward-declaring the actual vector class; it thinks it's declaring something else.

Hacking `<iterator>` to include `_LIBCPP_TYPE_VIS_ONLY` for the forward declaration doesn't help.  What does help is including `<vector>` earlier than `<iterator>`, so the `__wrap_iter` forward declaration picks up the correct definition of `std::vector`, and makes everything happy.

The patch originally comes from <https://bugzilla.mozilla.org/show_bug.cgi?id=1186561>.