### PR TITLE
Add #ifdef AtomicWord typedef to fix build on OpenBSD/i386

### DIFF
--- a/src/google/protobuf/stubs/atomicops.h
+++ b/src/google/protobuf/stubs/atomicops.h
@@ -82,7 +82,11 @@ namespace internal {
 
 // Use AtomicWord for a machine-sized pointer.  It will use the Atomic32 or
 // Atomic64 routines below, depending on your architecture.
+#if defined(__OpenBSD__) && !defined(GOOGLE_PROTOBUF_ARCH_64_BIT)
+typedef Atomic32 AtomicWord;
+#else
 typedef intptr_t AtomicWord;
+#endif
 
 // Atomically execute:
 //      result = *ptr;


### PR DESCRIPTION
This is a patch that Firefox carries in order to successfully build protobuf on 32-bit OpenBSD.

It originally comes from <https://bugzilla.mozilla.org/show_bug.cgi?id=1192556>.