### PR TITLE
fixes issue #3750

### DIFF
--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -150,6 +150,10 @@ if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
   get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_DEBUG)
 endif()
+if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
+    IMPORTED_LOCATION_NOCONFIG)
+endif()
 
 # Version info variable
 set(Protobuf_VERSION "@protobuf_VERSION@")


### PR DESCRIPTION
In protobuf-module.cmake: in addition to checking for release or debug
variants of protoc's location we should also check the configuration "noconfig".