### PR TITLE
fix implicit fallthrough in gcc 7

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -243,6 +243,8 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
      __has_cpp_attribute(clang::fallthrough)
 #  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]
 # endif
+#elif defined(__GNUC__) && __GNUC__ > 6
+# define GOOGLE_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
 #endif
 
 #ifndef GOOGLE_FALLTHROUGH_INTENDED


### PR DESCRIPTION
fixes #3700