### PR TITLE
Fix undefined memory management found by Clang's sanitizers.

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -4309,8 +4309,10 @@ FileDescriptor* DescriptorBuilder::BuildFileImpl(
     result->dependencies_once_ = tables_->AllocateOnceDynamic();
     result->dependencies_names_ =
         tables_->AllocateArray<const string*>(proto.dependency_size());
-    memset(result->dependencies_names_, 0,
-           sizeof(*result->dependencies_names_) * proto.dependency_size());
+    if (proto.dependency_size() > 0) {
+      memset(result->dependencies_names_, 0,
+             sizeof(*result->dependencies_names_) * proto.dependency_size());
+    }
   } else {
     result->dependencies_once_ = NULL;
     result->dependencies_names_ = NULL;

--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -1244,10 +1244,12 @@ class TextFormat::Printer::TextGenerator
     while (size > buffer_size_) {
       // Data exceeds space in the buffer.  Copy what we can and request a
       // new buffer.
-      memcpy(buffer_, data, buffer_size_);
-      data += buffer_size_;
-      size -= buffer_size_;
-      void* void_buffer;
+      if (buffer_size_ > 0) {
+        memcpy(buffer_, data, buffer_size_);
+        data += buffer_size_;
+        size -= buffer_size_;
+      }
+      void* void_buffer = NULL;
       failed_ = !output_->Next(&void_buffer, &buffer_size_);
       if (failed_) return;
       buffer_ = reinterpret_cast<char*>(void_buffer);

--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -61,9 +61,11 @@ void ZeroCopyStreamByteSink::Append(const char* bytes, size_t len) {
       buffer_size_ -= len;
       return;
     }
-    memcpy(buffer_, bytes, buffer_size_);
-    bytes += buffer_size_;
-    len -= buffer_size_;
+    if (buffer_size_ > 0) {
+      memcpy(buffer_, bytes, buffer_size_);
+      bytes += buffer_size_;
+      len -= buffer_size_;
+    }
     if (!stream_->Next(&buffer_, &buffer_size_)) {
       // There isn't a way for ByteSink to report errors.
       buffer_size_ = 0;

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -179,7 +179,7 @@ namespace internal {
 class LIBPROTOBUF_EXPORT ZeroCopyStreamByteSink : public strings::ByteSink {
  public:
   explicit ZeroCopyStreamByteSink(io::ZeroCopyOutputStream* stream)
-      : stream_(stream), buffer_size_(0) {}
+      : stream_(stream), buffer_(NULL), buffer_size_(0) {}
   ~ZeroCopyStreamByteSink();
 
   virtual void Append(const char* bytes, size_t len);


### PR DESCRIPTION
See https://github.com/google/protobuf/issues/3752 for context.