### PR TITLE
json_util: Don't call memcpy() on a NULL `buffer_`.

### DIFF
--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -61,9 +61,11 @@ void ZeroCopyStreamByteSink::Append(const char* bytes, size_t len) {
       buffer_size_ -= len;
       return;
     }
-    memcpy(buffer_, bytes, buffer_size_);
-    bytes += buffer_size_;
-    len -= buffer_size_;
+    if (buffer_size_ > 0) {
+      memcpy(buffer_, bytes, buffer_size_);
+      bytes += buffer_size_;
+      len -= buffer_size_;
+    }
     if (!stream_->Next(&buffer_, &buffer_size_)) {
       // There isn't a way for ByteSink to report errors.
       buffer_size_ = 0;

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -179,7 +179,7 @@ namespace internal {
 class LIBPROTOBUF_EXPORT ZeroCopyStreamByteSink : public strings::ByteSink {
  public:
   explicit ZeroCopyStreamByteSink(io::ZeroCopyOutputStream* stream)
-      : stream_(stream), buffer_size_(0) {}
+      : stream_(stream), buffer_(nullptr), buffer_size_(0) {}
   ~ZeroCopyStreamByteSink();
 
   virtual void Append(const char* bytes, size_t len);


### PR DESCRIPTION
Fixes Clang undefined behavior error:

```
external/protobuf_bzl/src/google/protobuf/util/json_util.cc:64:12: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/protobuf_bzl/src/google/protobuf/util/json_util.cc:64:12 in 
```