### PR TITLE
Fix warnings 'forcing value to bool' in VisualStudio 

### DIFF
--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -157,7 +157,7 @@ struct LIBPROTOBUF_EXPORT FieldMetadata {
 
 inline bool IsPresent(const void* base, uint32 hasbit) {
   const uint32* has_bits_array = static_cast<const uint32*>(base);
-  return has_bits_array[hasbit / 32] & (1u << (hasbit & 31));
+  return (has_bits_array[hasbit / 32] & (1u << (hasbit & 31))) != 0;
 }
 
 inline bool IsOneofPresent(const void* base, uint32 offset, uint32 tag) {

--- a/src/google/protobuf/io/coded_stream.h
+++ b/src/google/protobuf/io/coded_stream.h
@@ -867,11 +867,11 @@ class LIBPROTOBUF_EXPORT CodedOutputStream {
   bool IsSerializationDeterministic() const {
     return serialization_deterministic_is_overridden_ ?
         serialization_deterministic_override_ :
-        default_serialization_deterministic_;
+        default_serialization_deterministic_ != 0;
   }
 
   static bool IsDefaultSerializationDeterministic() {
-    return google::protobuf::internal::Acquire_Load(&default_serialization_deterministic_);
+    return google::protobuf::internal::Acquire_Load(&default_serialization_deterministic_) != 0;
   }
 
  private:


### PR DESCRIPTION
This fixes following warnings in VisualStudio:
https://msdn.microsoft.com/en-us/library/b6801kcy.aspx 

Tested with VisualStudio 2013.

coded_stream.h(870): warning C4800: 'google::protobuf::internal::AtomicWord' : forcing value to bool 'true' or 'false' (performance warning)
coded_stream.h(874): warning C4800: 'google::protobuf::internal::Atomic32' : forcing value to bool 'true' or 'false' (performance warning)
generated_message_util.h(160): warning C4800: 'const google::protobuf::uint32' : forcing value to bool 'true' or 'false' (performance warning)