### PR TITLE
remove -lpthread for Android based on PLATFORM=android define

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -44,9 +44,19 @@ config_setting(
     },
 )
 
+# Android build need not always use //external:android/crosstool
+# for example one can use --android_crosstool_top too.
+config_setting(
+    name = "android_platform",
+    values = {
+      "define": "PLATFORM=android",
+    },
+)
+
 # Android and Windows builds do not need to link in a separate pthread library.
 LINK_OPTS = select({
     ":android": [],
+    ":android_platform": [],
     ":windows": [],
     ":windows_msvc": [],
     "//conditions:default": ["-lpthread", "-lm"],


### PR DESCRIPTION
This is needed because not all Android builds use //external:android/crosstool
For example one can use --android_crosstool_top too.

Without this:
external/android_ndk/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: cannot find -lpthread
external/android_ndk/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: cannot find -lpthread
external/android_ndk/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: cannot find -lpthread
clang: error: linker command failed with exit code 1 (use -v to see invocation)

With this and passing --define PLATFORM=android,  protobuf compiles fine.