### PR TITLE
Make Status::error_message() return const string&.

### DIFF
--- a/src/google/protobuf/stubs/status.h
+++ b/src/google/protobuf/stubs/status.h
@@ -88,7 +88,7 @@ class LIBPROTOBUF_EXPORT Status {
   int error_code() const {
     return error_code_;
   }
-  StringPiece error_message() const {
+  const string& error_message() const {
     return error_message_;
   }
 

--- a/src/google/protobuf/stubs/status_test.cc
+++ b/src/google/protobuf/stubs/status_test.cc
@@ -65,15 +65,15 @@ TEST(Status, CheckOK) {
 TEST(Status, ErrorMessage) {
   util::Status status(util::error::INVALID_ARGUMENT, "");
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ("", status.error_message().ToString());
+  EXPECT_EQ("", status.error_message());
   EXPECT_EQ("INVALID_ARGUMENT", status.ToString());
   status = util::Status(util::error::INVALID_ARGUMENT, "msg");
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ("msg", status.error_message().ToString());
+  EXPECT_EQ("msg", status.error_message());
   EXPECT_EQ("INVALID_ARGUMENT:msg", status.ToString());
   status = util::Status(util::error::OK, "msg");
   EXPECT_TRUE(status.ok());
-  EXPECT_EQ("", status.error_message().ToString());
+  EXPECT_EQ("", status.error_message());
   EXPECT_EQ("OK", status.ToString());
 }
 


### PR DESCRIPTION
This change should be safe for most users thanks to the automatic construction of StringPiece out of std::string&.