### PR TITLE
Change C# reflection to avoid using expression trees

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,7 @@ csharp_EXTRA_DIST=                                                           \
   csharp/src/Google.Protobuf/Collections/ProtobufEqualityComparers.cs        \
   csharp/src/Google.Protobuf/Collections/ReadOnlyDictionary.cs               \
   csharp/src/Google.Protobuf/Collections/RepeatedField.cs                    \
+  csharp/src/Google.Protobuf/Compatibility/MethodInfoExtensions.cs           \
   csharp/src/Google.Protobuf/Compatibility/PropertyInfoExtensions.cs         \
   csharp/src/Google.Protobuf/Compatibility/StreamExtensions.cs               \
   csharp/src/Google.Protobuf/Compatibility/TypeExtensions.cs                 \

--- a/csharp/src/Google.Protobuf/Compatibility/MethodInfoExtensions.cs
+++ b/csharp/src/Google.Protobuf/Compatibility/MethodInfoExtensions.cs
@@ -1,0 +1,47 @@
+﻿#region Copyright notice and license
+// Protocol Buffers - Google's data interchange format
+// Copyright 2017 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+#if NET35
+using System;
+using System.Reflection;
+
+namespace Google.Protobuf.Compatibility
+{
+    // .NET Core (at least netstandard1.0) doesn't have Delegate.CreateDelegate, and .NET 3.5 doesn't have
+    // MethodInfo.CreateDelegate. Proxy from one to the other on .NET 3.5...
+    internal static class MethodInfoExtensions
+    {
+        internal static Delegate CreateDelegate(this MethodInfo method, Type type) =>
+            Delegate.CreateDelegate(type, method);
+    }
+}
+#endif

--- a/csharp/src/Google.Protobuf/Reflection/OneofAccessor.cs
+++ b/csharp/src/Google.Protobuf/Reflection/OneofAccessor.cs
@@ -52,7 +52,7 @@ namespace Google.Protobuf.Reflection
                 throw new ArgumentException("Cannot read from property");
             }
             this.descriptor = descriptor;
-            caseDelegate = ReflectionUtil.CreateFuncIMessageT<int>(caseProperty.GetGetMethod());
+            caseDelegate = ReflectionUtil.CreateFuncIMessageInt32(caseProperty.GetGetMethod());
 
             this.descriptor = descriptor;
             clearDelegate = ReflectionUtil.CreateActionIMessage(clearMethod);

--- a/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
@@ -56,32 +56,40 @@ namespace Google.Protobuf.Reflection
         internal static readonly Type[] EmptyTypes = new Type[0];
 
         /// <summary>
-        /// Creates a delegate which will cast the argument to the appropriate method target type,
+        /// Creates a delegate which will cast the argument to the type that declares the method,
         /// call the method on it, then convert the result to object.
         /// </summary>
+        /// <param name="method">The method to create a delegate for, which must be declared in an IMessage
+        /// implementation.</param>
         internal static Func<IMessage, object> CreateFuncIMessageObject(MethodInfo method) =>
             GetReflectionHelper(method.DeclaringType, method.ReturnType).CreateFuncIMessageObject(method);
 
         /// <summary>
-        /// Creates a delegate which will cast the argument to the appropriate method target type,
+        /// Creates a delegate which will cast the argument to the type that declares the method,
         /// call the method on it, then convert the result to the specified type. The method is expected
         /// to actually return an enum (because of where we're calling it - for oneof cases). Sometimes that
         /// means we need some extra work to perform conversions.
         /// </summary>
+        /// <param name="method">The method to create a delegate for, which must be declared in an IMessage
+        /// implementation.</param>
         internal static Func<IMessage, int> CreateFuncIMessageInt32(MethodInfo method) =>
             GetReflectionHelper(method.DeclaringType, method.ReturnType).CreateFuncIMessageInt32(method);
 
         /// <summary>
         /// Creates a delegate which will execute the given method after casting the first argument to
-        /// the target type of the method, and the second argument to the first parameter type of the method.
+        /// the type that declares the method, and the second argument to the first parameter type of the method.
         /// </summary>
+        /// <param name="method">The method to create a delegate for, which must be declared in an IMessage
+        /// implementation.</param>
         internal static Action<IMessage, object> CreateActionIMessageObject(MethodInfo method) =>
             GetReflectionHelper(method.DeclaringType, method.GetParameters()[0].ParameterType).CreateActionIMessageObject(method);
 
         /// <summary>
         /// Creates a delegate which will execute the given method after casting the first argument to
-        /// the target type of the method.
+        /// type that declares the method.
         /// </summary>
+        /// <param name="method">The method to create a delegate for, which must be declared in an IMessage
+        /// implementation.</param>
         internal static Action<IMessage> CreateActionIMessage(MethodInfo method) =>
             GetReflectionHelper(method.DeclaringType, typeof(object)).CreateActionIMessage(method);
 

--- a/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
@@ -33,6 +33,10 @@
 using System;
 using System.Reflection;
 
+#if NET35
+using Google.Protobuf.Compatibility;
+#endif
+
 namespace Google.Protobuf.Reflection
 {
     /// <summary>


### PR DESCRIPTION
This should work on Unity, Mono and .NET 3.5 as far as I'm aware.
It won't work on platforms where reflection itself is prohibited,
but that's a non-starter basically.

Creating a PR to start with, but I'd like to test it in other environments before merging.
Once this is in, we can look at potentially officially supporting .NET 3.5 and Unity (#644).