### PR TITLE
Add Vcpkg to C++ installation instructions for Windows

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -184,6 +184,16 @@ In the downloads section, download the zip file protoc-$VERSION-win32.zip.
 It contains the protoc binary as well as public proto files of protobuf
 library.
 
+Protobuf and its dependencies can be installed directly by using `vcpkg`:
+
+    >vcpkg install protobuf protobuf:x64-windows
+
+If zlib support is desired, you'll also need to install the zlib feature:
+
+    >vcpkg install protobuf[zlib] protobuf[zlib]:x64-windows
+
+See https://github.com/Microsoft/vcpkg for more information.
+
 To build from source using Microsoft Visual C++, see [cmake/README.md](../cmake/README.md).
 
 To build from source using Cygwin or MinGW, follow the Unix installation


### PR DESCRIPTION
Fixes issue #1154 by noting that `vcpkg` contains protobuf. Potential improvements: also remark how to use `vcpkg` to get dependencies when building from source via CMake.