### PR TITLE
Adds Dockerfile to build Protobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Building Protobuf via Docker
+# ----------------------------
+#
+# Create the build container:
+# ```bash
+# docker build -t protobuf .
+# ```
+#
+# Run the build container (mounts repo to `/protobuf`, which is the work dir):
+# ```bash
+# docker run -it --rm --name protobuf -v `pwd`:/protobuf -w /protobuf protobuf
+# ```
+
+FROM ubuntu:xenial
+
+RUN apt-get update && \
+    apt-get install -yq autoconf automake libtool curl make g++ unzip
+
+CMD ./autogen.sh && \
+    ./configure && \
+    make && \
+    make check && \
+    make install && \
+    ldconfig


### PR DESCRIPTION
Adds Dockerfile which creates a container to build Protobuf. Rather than worrying about Windows, OSX, or various Linux distros, developers *should* be able to quickly build Protobuf in a consistent cross-platform fashion. The build container installs dependencies required to build Protobuf and runs the configuration and make scripts unless the Docker CMD is overridden.

I need some help:
I ran through the config and make scripts successfully on my Mac, but `make` is failing on Ubuntu 16 and 14 (LTS) with the following error:

```
google/protobuf/stubs/.libs/io_win32.o: file not recognized: File format not recognized
collect2: error: ld returned 1 exit status
Makefile:2425: recipe for target 'libprotobuf.la' failed
make[2]: *** [libprotobuf.la] Error 1
make[2]: Leaving directory '/protobuf/src'
Makefile:1545: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/protobuf'
Makefile:1452: recipe for target 'all' failed
make: *** [all] Error 2
```

Any idea why this has happened? 

Thank you for the consideration and assistance.