### PR TITLE
add optional goJsonFlags (default=",omitempty") to FieldOptions

### DIFF
--- a/src/google/protobuf/descriptor.proto
+++ b/src/google/protobuf/descriptor.proto
@@ -576,6 +576,8 @@ message FieldOptions {
   // For Google-internal migration only. Do not use.
   optional bool weak = 10 [default=false];
 
+  // For defining json flags in generated Go structs, either removing default "omitempty" flag, or adding new flags
+  optional string goJsonFlags = 11 [default=",omitempty"];
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;


### PR DESCRIPTION
Our usecase right now, is that we marshal the message to json in Go (using generated go struct), and unmarshal that json in a dynamic-typed language like Lua, and unmarshal it into a generic data structure (table in Lua), but we need the zero/empty values in the json. So in short, we want the "omitempty" json flag be removed from go structs, by setting `[goJsonFlags=""]` in proto file.

But this option can be also used for completely excluding this param from json: `[goJsonFlags="-"]`
Or changing the param name in json: `[goJsonFlags="anotherName,omitempty"]`

The default value for this param (`default=",omitempty"`) makes it backward-compatible.
