### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/php/tests/array_test.php
+++ b/php/tests/array_test.php
@@ -6,8 +6,9 @@ use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestMessage;
 use Foo\TestMessage_Sub;
+use PHPUnit\Framework\TestCase;
 
-class RepeatedFieldTest extends PHPUnit_Framework_TestCase
+class RepeatedFieldTest extends TestCase
 {
 
     #########################################################

--- a/php/tests/map_field_test.php
+++ b/php/tests/map_field_test.php
@@ -6,8 +6,9 @@ use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\MapField;
 use Foo\TestMessage;
 use Foo\TestMessage_Sub;
+use PHPUnit\Framework\TestCase;
 
-class MapFieldTest extends PHPUnit_Framework_TestCase {
+class MapFieldTest extends TestCase {
 
     #########################################################
     # Test int32 field.

--- a/php/tests/test_base.php
+++ b/php/tests/test_base.php
@@ -3,8 +3,9 @@
 use Foo\TestMessage;
 use Foo\TestEnum;
 use Foo\TestMessage_Sub;
+use PHPUnit\Framework\TestCase;
 
-class TestBase extends PHPUnit_Framework_TestCase
+class TestBase extends TestCase
 {
 
     public function setFields(TestMessage $m)

--- a/php/tests/undefined_test.php
+++ b/php/tests/undefined_test.php
@@ -6,8 +6,9 @@ use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\GPBType;
 use Foo\TestMessage;
 use Foo\TestMessage_Sub;
+use PHPUnit\Framework\TestCase;
 
-class UndefinedTest extends PHPUnit_Framework_TestCase
+class UndefinedTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).