### PR TITLE
Backport #3858 to 3.5.x branch

### DIFF
--- a/csharp/src/Google.Protobuf/MessageExtensions.cs
+++ b/csharp/src/Google.Protobuf/MessageExtensions.cs
@@ -54,6 +54,22 @@ namespace Google.Protobuf
         }
 
         /// <summary>
+        /// Merges data from the given byte array slice into an existing message.
+        /// </summary>
+        /// <param name="message">The message to merge the data into.</param>
+        /// <param name="data">The data containing the slice to merge, which must be protobuf-encoded binary data.</param>
+        /// <param name="offset">The offset of the slice to merge.</param>
+        /// <param name="length">The length of the slice to merge.</param>
+        public static void MergeFrom(this IMessage message, byte[] data, int offset, int length)
+        {
+            ProtoPreconditions.CheckNotNull(message, "message");
+            ProtoPreconditions.CheckNotNull(data, "data");
+            CodedInputStream input = new CodedInputStream(data, offset, length);
+            message.MergeFrom(input);
+            input.CheckReadEndOfStreamTag();
+        }
+
+        /// <summary>
         /// Merges data from the given byte string into an existing message.
         /// </summary>
         /// <param name="message">The message to merge the data into.</param>

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -71,6 +71,21 @@ namespace Google.Protobuf
         }
 
         /// <summary>
+        /// Parses a message from a byte array slice.
+        /// </summary>
+        /// <param name="data">The byte array containing the message. Must not be null.</param>
+        /// <param name="offset">The offset of the slice to parse.</param>
+        /// <param name="length">The length of the slice to parse.</param>
+        /// <returns>The newly parsed message.</returns>
+        public IMessage ParseFrom(byte[] data, int offset, int length)
+        {
+            ProtoPreconditions.CheckNotNull(data, "data");
+            IMessage message = factory();
+            message.MergeFrom(data, offset, length);
+            return message;
+        }
+
+        /// <summary>
         /// Parses a message from the given byte string.
         /// </summary>
         /// <param name="data">The data to parse.</param>

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -64,7 +64,6 @@ namespace Google.Protobuf
         /// <returns>The newly parsed message.</returns>
         public IMessage ParseFrom(byte[] data)
         {
-            ProtoPreconditions.CheckNotNull(data, "data");
             IMessage message = factory();
             message.MergeFrom(data);
             return message;
@@ -79,7 +78,6 @@ namespace Google.Protobuf
         /// <returns>The newly parsed message.</returns>
         public IMessage ParseFrom(byte[] data, int offset, int length)
         {
-            ProtoPreconditions.CheckNotNull(data, "data");
             IMessage message = factory();
             message.MergeFrom(data, offset, length);
             return message;
@@ -92,7 +90,6 @@ namespace Google.Protobuf
         /// <returns>The parsed message.</returns>
         public IMessage ParseFrom(ByteString data)
         {
-            ProtoPreconditions.CheckNotNull(data, "data");
             IMessage message = factory();
             message.MergeFrom(data);
             return message;
@@ -206,7 +203,6 @@ namespace Google.Protobuf
         /// <returns>The newly parsed message.</returns>
         public new T ParseFrom(byte[] data)
         {
-            ProtoPreconditions.CheckNotNull(data, "data");
             T message = factory();
             message.MergeFrom(data);
             return message;
@@ -219,7 +215,6 @@ namespace Google.Protobuf
         /// <returns>The parsed message.</returns>
         public new T ParseFrom(ByteString data)
         {
-            ProtoPreconditions.CheckNotNull(data, "data");
             T message = factory();
             message.MergeFrom(data);
             return message;

--- a/csharp/src/Google.Protobuf/MessageParser.cs
+++ b/csharp/src/Google.Protobuf/MessageParser.cs
@@ -209,6 +209,20 @@ namespace Google.Protobuf
         }
 
         /// <summary>
+        /// Parses a message from a byte array slice.
+        /// </summary>
+        /// <param name="data">The byte array containing the message. Must not be null.</param>
+        /// <param name="offset">The offset of the slice to parse.</param>
+        /// <param name="length">The length of the slice to parse.</param>
+        /// <returns>The newly parsed message.</returns>
+        public new T ParseFrom(byte[] data, int offset, int length)
+        {
+            T message = factory();
+            message.MergeFrom(data, offset, length);
+            return message;
+        }
+
+        /// <summary>
         /// Parses a message from the given byte string.
         /// </summary>
         /// <param name="data">The data to parse.</param>


### PR DESCRIPTION
Backports https://github.com/google/protobuf/pull/3858.

Can we still squeeze this into 3.5 release? (some gRPC C# parsing optimizations depend on this being released).