### PR TITLE
Fix out-of-tree build for cmake

### DIFF
--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -72,7 +72,6 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -92,6 +91,7 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
+  ${protobuf_BINARY_DIR}/well_known_types_embed.cc		# This file is generated, therefore is in different directory
 )
 
 set(libprotoc_headers
@@ -209,9 +209,9 @@ set(js_well_known_types_sources
 )
 add_executable(js_embed ${protobuf_source_dir}/src/google/protobuf/compiler/js/embed.cc)
 add_custom_command(
-  OUTPUT ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+  OUTPUT ${protobuf_BINARY_DIR}/well_known_types_embed.cc
   DEPENDS js_embed ${js_well_known_types_sources}
-  COMMAND js_embed ${js_well_known_types_sources} > ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+  COMMAND js_embed ${js_well_known_types_sources} > ${protobuf_BINARY_DIR}/well_known_types_embed.cc
 )
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -72,6 +72,7 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_message_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/javanano/javanano_primitive_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
+  ${protobuf_BINARY_DIR}/well_known_types_embed.cc		# This file is generated, therefore is in different directory
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -91,7 +92,6 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
-  ${protobuf_BINARY_DIR}/well_known_types_embed.cc		# This file is generated, therefore is in different directory
 )
 
 set(libprotoc_headers

--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -96,12 +96,13 @@ set_cmake_value() {
       print \$0;
       len = split(values, vlist, \" \");
       for (i = 1; i <= len; ++i) {
-	    if (vlist[i] != \"google/protobuf/compiler/js/well_known_types_embed.cc\") {
-           printf(\"  %s%s\\n\", prefix, vlist[i]);
-		} else {
-           printf(\"  \${protobuf_BINARY_DIR}/well_known_types_embed.cc\t\t# This file is generated, therefore is in different directory\\n\");
-	    }
-
+        if (vlist[i] != \"google/protobuf/compiler/js/well_known_types_embed.cc\") {
+          # Most of the files is in directory prefix
+          printf(\"  %s%s\\n\", prefix, vlist[i]);
+        } else {
+          # but well_known_types_embed.cc is generated and should be out-of-sources
+          printf(\"  \${protobuf_BINARY_DIR}/well_known_types_embed.cc\t\t# This file is generated, therefore is in different directory\\n\");
+        }
       }
       next;
     }

--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -96,7 +96,12 @@ set_cmake_value() {
       print \$0;
       len = split(values, vlist, \" \");
       for (i = 1; i <= len; ++i) {
-        printf(\"  %s%s\\n\", prefix, vlist[i]);
+	    if (vlist[i] != \"google/protobuf/compiler/js/well_known_types_embed.cc\") {
+           printf(\"  %s%s\\n\", prefix, vlist[i]);
+		} else {
+           printf(\"  \${protobuf_BINARY_DIR}/well_known_types_embed.cc\t\t# This file is generated, therefore is in different directory\\n\");
+	    }
+
       }
       next;
     }


### PR DESCRIPTION
File well_known_types_embed.cc is generated in the same place where are source code and this does not allow us make our sources read-only