### PR TITLE
Remove unreferenced 'GPBMessageSignatureProtocol' class.

### DIFF
--- a/objectivec/GPBRootObject.m
+++ b/objectivec/GPBRootObject.m
@@ -43,6 +43,14 @@
 - (const char *)singletonNameC;
 @end
 
+// We need some object to conform to the MessageSignatureProtocol to make sure
+// the selectors in it are recorded in our Objective C runtime information.
+// GPBMessage is arguably the more "obvious" choice, but given that all messages
+// inherit from GPBMessage, conflicts seem likely, so we are using GPBRootObject
+// instead.
+@interface GPBRootObject () <GPBMessageSignatureProtocol>
+@end
+
 @implementation GPBRootObject
 
 // Taken from http://www.burtleburtle.net/bob/hash/doobs.html

--- a/objectivec/GPBUtilities.m
+++ b/objectivec/GPBUtilities.m
@@ -1216,8 +1216,11 @@ void GPBSetMessageMapField(GPBMessage *self, GPBFieldDescriptor *field,
 const char *GPBMessageEncodingForSelector(SEL selector, BOOL instanceSel) {
   Protocol *protocol =
       objc_getProtocol(GPBStringifySymbol(GPBMessageSignatureProtocol));
+  NSCAssert(protocol, @"Missing GPBMessageSignatureProtocol");
   struct objc_method_description description =
       protocol_getMethodDescription(protocol, selector, NO, instanceSel);
+  NSCAssert(description.name != Nil && description.types != nil,
+            @"Missing method for selector %@", NSStringFromSelector(selector));
   return description.types;
 }
 
@@ -1911,13 +1914,3 @@ BOOL GPBClassHasSel(Class aClass, SEL sel) {
   free(methodList);
   return result;
 }
-
-#pragma mark - GPBMessageSignatureProtocol
-
-// A series of selectors that are used solely to get @encoding values
-// for them by the dynamic protobuf runtime code. An object using the protocol
-// needs to be declared for the protocol to be valid at runtime.
-@interface GPBMessageSignatureProtocol : NSObject<GPBMessageSignatureProtocol>
-@end
-@implementation GPBMessageSignatureProtocol
-@end

--- a/objectivec/GPBUtilities_PackagePrivate.h
+++ b/objectivec/GPBUtilities_PackagePrivate.h
@@ -309,7 +309,8 @@ NSString *GPBDecodeTextFormatName(const uint8_t *decodeData, int32_t key,
 
 // A series of selectors that are used solely to get @encoding values
 // for them by the dynamic protobuf runtime code. See
-// GPBMessageEncodingForSelector for details.
+// GPBMessageEncodingForSelector for details. GPBRootObject conforms to
+// the protocol so that it is encoded in the Objective C runtime.
 @protocol GPBMessageSignatureProtocol
 @optional
 


### PR DESCRIPTION
Remove unreferenced 'GPBMessageSignatureProtocol' class that is just taking up
space in the Objective C runtime information by hanging the protocol it needs to
declare off of GPBRootObject instead.

Small binary size reduction, but more importantly a removal of a class that
appears to be unused when statically analyzed.