### PR TITLE
Simplify getter/setter method implementations

### DIFF
--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -2998,7 +2998,7 @@ typedef struct ResolveIvarAccessorMethodResult {
   SEL encodingSelector;
 } ResolveIvarAccessorMethodResult;
 
-static void ResolveIvarGet(GPBFieldDescriptor *field,
+static void ResolveIvarGet(__unsafe_unretained GPBFieldDescriptor *field,
                            ResolveIvarAccessorMethodResult *result) {
   GPBDataType fieldDataType = GPBGetFieldDataType(field);
   switch (fieldDataType) {
@@ -3040,7 +3040,7 @@ static void ResolveIvarGet(GPBFieldDescriptor *field,
   }
 }
 
-static void ResolveIvarSet(GPBFieldDescriptor *field,
+static void ResolveIvarSet(__unsafe_unretained GPBFieldDescriptor *field,
                            GPBFileSyntax syntax,
                            ResolveIvarAccessorMethodResult *result) {
   GPBDataType fieldDataType = GPBGetFieldDataType(field);
@@ -3086,7 +3086,12 @@ static void ResolveIvarSet(GPBFieldDescriptor *field,
   // no need for checks here to see if has*/setHas* are allowed.
 
   ResolveIvarAccessorMethodResult result = {NULL, NULL};
-  for (GPBFieldDescriptor *field in descriptor->fields_) {
+
+  
+  // |field| can be __unsafe_unretained because they are created at startup
+  // and are essentially global. No need to pay for retain/release when
+  // they are captured in blocks.
+  for (__unsafe_unretained GPBFieldDescriptor *field in descriptor->fields_) {
     BOOL isMapOrArray = GPBFieldIsMapOrArray(field);
     if (!isMapOrArray) {
       // Single fields.

--- a/objectivec/GPBMessage.m
+++ b/objectivec/GPBMessage.m
@@ -2998,6 +2998,9 @@ typedef struct ResolveIvarAccessorMethodResult {
   SEL encodingSelector;
 } ResolveIvarAccessorMethodResult;
 
+// |field| can be __unsafe_unretained because they are created at startup
+// and are essentially global. No need to pay for retain/release when
+// they are captured in blocks.
 static void ResolveIvarGet(__unsafe_unretained GPBFieldDescriptor *field,
                            ResolveIvarAccessorMethodResult *result) {
   GPBDataType fieldDataType = GPBGetFieldDataType(field);
@@ -3040,6 +3043,7 @@ static void ResolveIvarGet(__unsafe_unretained GPBFieldDescriptor *field,
   }
 }
 
+// See comment about __unsafe_unretained on ResolveIvarGet.
 static void ResolveIvarSet(__unsafe_unretained GPBFieldDescriptor *field,
                            GPBFileSyntax syntax,
                            ResolveIvarAccessorMethodResult *result) {
@@ -3084,13 +3088,9 @@ static void ResolveIvarSet(__unsafe_unretained GPBFieldDescriptor *field,
   // NOTE: hasOrCountSel_/setHasSel_ will be NULL if the field for the given
   // message should not have has support (done in GPBDescriptor.m), so there is
   // no need for checks here to see if has*/setHas* are allowed.
-
   ResolveIvarAccessorMethodResult result = {NULL, NULL};
 
-  
-  // |field| can be __unsafe_unretained because they are created at startup
-  // and are essentially global. No need to pay for retain/release when
-  // they are captured in blocks.
+  // See comment about __unsafe_unretained on ResolveIvarGet.
   for (__unsafe_unretained GPBFieldDescriptor *field in descriptor->fields_) {
     BOOL isMapOrArray = GPBFieldIsMapOrArray(field);
     if (!isMapOrArray) {


### PR DESCRIPTION
Remove unnecessary retain/releases for GPBFieldDescriptors when
creating implementations with blocks. The descriptors do not need
to be memory managed because they are essentially global constructs
that are guaranteed to be around the lifetime of the app.