### PR TITLE
Add lite option to java_out

### DIFF
--- a/src/google/protobuf/compiler/java/java_generator.cc
+++ b/src/google/protobuf/compiler/java/java_generator.cc
@@ -81,6 +81,8 @@ bool JavaGenerator::Generate(const FileDescriptor* file,
       file_options.generate_mutable_code = true;
     } else if (options[i].first == "shared") {
       file_options.generate_shared_code = true;
+    } else if (options[i].first == "lite") {
+      file_options.enforce_lite = true;
     } else if (options[i].first == "annotate_code") {
       file_options.annotate_code = true;
     } else if (options[i].first == "annotation_list_file") {


### PR DESCRIPTION
**Background**

https://github.com/google/protobuf/blob/v3.0.0-beta-3/CHANGES.txt#L120 claims that 

> A new "lite" generator parameter was introduced in the protoc for C++ and
    Java for Proto3 syntax messages.

However, this is only enabled for C++. The Java generator options are hooked up to support the "lite" generator parameter, but the parameter parsing code is not there.

**Change**

Add the code to parse the "lite" parameter for java code generation, modeled after the C++ code generator.

**Test**

Tested with a simple proto message like so:

```
syntax = "proto3";

package test;

message Test {
  int32 value = 1;
}
```

Ran these commands and verified the output is correct:

Enforce lite code generation:

```
./src/protoc --java_out=lite:. test.proto
```

Default code generation (controlled by optimize_for option per file):

```
./src/protoc --java_out=. test.proto
```