### PR TITLE
Include .cc and .h files in Python source distribution

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -4,6 +4,9 @@ exclude google/protobuf/internal/*_test.py
 exclude google/protobuf/internal/*.proto
 exclude google/protobuf/internal/test_util.py
 
+recursive-include google *.cc
+recursive-include google *.h
+
 recursive-exclude google *_test.py
 recursive-exclude google *_test.proto
 recursive-exclude google unittest*_pb2.py


### PR DESCRIPTION
If you try to build from the source distribution on PyPI and use the cpp implementation it currently fails with this error when you try to use it:

```
exceptions.ImportError, dynamic module does not define init function (init_message)
```

Part of the problem is the source distribution is missing the .cc and .h files for the Python extension. I'm able to build the extension from the source distribution after making this change.