### PR TITLE
Remove unhelpful build warnings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,6 +24,8 @@ COPTS = select({
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
         "-Wno-unused-function",
+        # Prevents ISO C++ const string assignment warnings for pyext sources.
+        "-Wno-writable-strings",
     ],
 })
 


### PR DESCRIPTION
-Wno-writable-strings removes 230 "ISO C++11 does not allow conversion from
string literal to 'char *'" warnings from TensorFlow test / build output.
These happen because pyext/ sources pass string literals to Python C API data
structures, e.g. PyGetSetDef, which for some reason were designed to not have
the const qualifier.