### PR TITLE
Add _file_desc_by_toplevel_extension back

### DIFF
--- a/python/google/protobuf/descriptor_pool.py
+++ b/python/google/protobuf/descriptor_pool.py
@@ -127,6 +127,9 @@ class DescriptorPool(object):
     self._service_descriptors = {}
     self._file_descriptors = {}
     self._toplevel_extensions = {}
+    # TODO(jieluo): Remove _file_desc_by_toplevel_extension after
+    # maybe year 2020 for compatibility issue (with 3.4.1 only).
+    self._file_desc_by_toplevel_extension = {}
     # We store extensions in two two-level mappings: The first key is the
     # descriptor of the message being extended, the second key is the extension
     # full name or its tag number.
@@ -252,6 +255,12 @@ class DescriptorPool(object):
     """
 
     self._AddFileDescriptor(file_desc)
+    # TODO(jieluo): This is a temporary solution for FieldDescriptor.file.
+    # FieldDescriptor.file is added in code gen. Remove this solution after
+    # maybe 2020 for compatibility reason (with 3.4.1 only).
+    for extension in file_desc.extensions_by_name.values():
+      self._file_desc_by_toplevel_extension[
+          extension.full_name] = file_desc
 
   def _AddFileDescriptor(self, file_desc):
     """Adds a FileDescriptor to the pool, non-recursively.
@@ -331,7 +340,7 @@ class DescriptorPool(object):
       pass
 
     try:
-      return self._toplevel_extensions[symbol].file
+      return self._file_desc_by_toplevel_extension[symbol]
     except KeyError:
       pass
 


### PR DESCRIPTION
Add _file_desc_by_toplevel_extension back for compatibility issue with 3.4.1.

_file_desc_by_toplevel_extension is a temporary solution for FieldDescriptor.file.
FieldDescriptor.file was added in code gen. However, we need to keep it for some time for compatibility reason (with 3.4.1 only). May try to remove it after 2 years.