### PR TITLE
Adding Release_CompareAndSwap 64-bit variant

### DIFF
--- a/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+++ b/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
@@ -146,6 +146,14 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
   return __atomic_load_n(ptr, __ATOMIC_RELAXED);
 }
 
+inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
 #endif // defined(__LP64__)
 
 }  // namespace internal


### PR DESCRIPTION
While building Protobuf v3.5.0 (latest stable) facing an issue:  undefined reference to `google::protobuf::internal::Release_CompareAndSwap(long volatile*, long, long)' 

Need to add 64-bit version for function : Release_CompareAndSwap

 I had already raised an issue here : https://github.com/google/protobuf/issues/3937 