### PR TITLE
Fixing immutable/mutable type conversion in parser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -800,6 +800,8 @@ python_EXTRA_DIST=                                                           \
   python/google/protobuf/internal/more_extensions_dynamic.proto              \
   python/google/protobuf/internal/more_messages.proto                        \
   python/google/protobuf/internal/packed_field_test.proto                    \
+  python/google/protobuf/internal/parsing_test.proto                         \
+  python/google/protobuf/internal/parsing_test.py                            \
   python/google/protobuf/internal/proto_builder_test.py                      \
   python/google/protobuf/internal/python_message.py                          \
   python/google/protobuf/internal/python_protobuf.cc                         \

--- a/python/google/protobuf/internal/parsing_test.proto
+++ b/python/google/protobuf/internal/parsing_test.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package google.protobuf.internal;
+
+message BytesDecoderTest
+{
+    bytes bar = 1;
+}

--- a/python/google/protobuf/internal/parsing_test.py
+++ b/python/google/protobuf/internal/parsing_test.py
@@ -1,0 +1,59 @@
+#! /usr/bin/env python
+#
+# Protocol Buffers - Google's data interchange format
+# Copyright 2008 Google Inc.  All rights reserved.
+# https://developers.google.com/protocol-buffers/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import six
+
+from google.protobuf.internal.parsing_test_pb2 import BytesDecoderTest
+
+try:
+    import unittest2 as unittest  # PY26
+except ImportError:
+    import unittest
+
+
+class ParsingBytearrayTestCase(unittest.TestCase):
+    def test_stable_type(self):
+        foo = BytesDecoderTest(bar=six.binary_type(b'test'))
+        self.assertIsInstance(foo.bar, six.binary_type)
+
+        with self.assertRaises(TypeError):
+            invalid_foo = BytesDecoderTest(bar=bytearray(b'should_fail'))
+
+        data = foo.SerializeToString()
+        self.assertIsInstance(data, six.binary_type)
+
+        data_array = bytearray(data)
+        foo.ParseFromString(data_array)
+        self.assertIsInstance(foo.bar, six.binary_type)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -1078,9 +1078,10 @@ def _AddSerializePartialToStringMethod(message_descriptor, cls):
 def _AddMergeFromStringMethod(message_descriptor, cls):
   """Helper for _AddMessageMethods()."""
   def MergeFromString(self, serialized):
-    length = len(serialized)
+    buffer = six.binary_type(serialized)
+    length = len(buffer)
     try:
-      if self._InternalParse(serialized, 0, length) != length:
+      if self._InternalParse(buffer, 0, length) != length:
         # The only reason _InternalParse would return early is if it
         # encountered an end-group tag.
         raise message_mod.DecodeError('Unexpected end-group tag.')

--- a/python/google/protobuf/internal/python_message.py
+++ b/python/google/protobuf/internal/python_message.py
@@ -1078,6 +1078,8 @@ def _AddSerializePartialToStringMethod(message_descriptor, cls):
 def _AddMergeFromStringMethod(message_descriptor, cls):
   """Helper for _AddMessageMethods()."""
   def MergeFromString(self, serialized):
+    if not hasattr(serialized, "__getitem__"):
+      raise TypeError('the input is not indexable')
     buffer = six.binary_type(serialized)
     length = len(buffer)
     try:

--- a/python/setup.py
+++ b/python/setup.py
@@ -95,6 +95,7 @@ def GenerateUnittestProtos():
   generate_proto("../src/google/protobuf/unittest_proto3_arena.proto", False)
   generate_proto("../src/google/protobuf/util/json_format_proto3.proto", False)
   generate_proto("google/protobuf/internal/any_test.proto", False)
+  generate_proto("google/protobuf/internal/parsing_test.proto", False)
   generate_proto("google/protobuf/internal/descriptor_pool_test1.proto", False)
   generate_proto("google/protobuf/internal/descriptor_pool_test2.proto", False)
   generate_proto("google/protobuf/internal/factory_test1.proto", False)


### PR DESCRIPTION
This PR solves the problem described in issue #3954.

If the input to the parser is a mutable `bytearray`, an error is triggered in python2 and the type of the attributes is incorrect in python3.

A unit test is also added to reproduce the problem:
> python/google/protobuf/internal/parsing_test.py

Without the fix, the corresponding problems are triggered in python 2 / 3.

Python2 unit test failure:

> 
> Error
> Traceback (most recent call last):
>   File "/home/lenij/anaconda3/envs/p2/lib/python2.7/unittest/case.py", line 329, in run
>     testMethod()
>   File "/home/lenij/crypto/protobuf/python/google/protobuf/internal/parsing_test.py", line 54, in test_stable_type
>     foo.ParseFromString(data_array)
>   File "/home/lenij/crypto/protobuf/python/google/protobuf/message.py", line 185, in ParseFromString
>     self.MergeFromString(serialized)
>   File "/home/lenij/crypto/protobuf/python/google/protobuf/internal/python_message.py", line 1091, in MergeFromString
>     raise message_mod.DecodeError('Truncated message.')
> DecodeError: Truncated message.

Python3 unit test failure:

> Failure
> Traceback (most recent call last):
>   File "/home/lenij/anaconda3/envs/qrl3/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
>     yield
>   File "/home/lenij/anaconda3/envs/qrl3/lib/python3.6/unittest/case.py", line 605, in run
>     testMethod()
>   File "/home/lenij/crypto/protobuf/python/google/protobuf/internal/parsing_test.py", line 55, in test_stable_type
>     self.assertIsInstance(foo.bar, six.binary_type)
>   File "/home/lenij/anaconda3/envs/qrl3/lib/python3.6/unittest/case.py", line 1245, in assertIsInstance
>     self.fail(self._formatMessage(msg, standardMsg))
>   File "/home/lenij/anaconda3/envs/qrl3/lib/python3.6/unittest/case.py", line 670, in fail
>     raise self.failureException(msg)
> AssertionError: bytearray(b'test') is not an instance of <class 'bytes'>
> 

