### PR TITLE
Upgrading dotnet to 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       language: csharp
       dist: trusty
       sudo: required
-      dotnet: 1.0.1
+      dotnet: 1.0.4
       mono: none
     # This test is kept on travis because it doesn't play nicely with other
     # tests on jenkins running in parallel.


### PR DESCRIPTION
This PR solves issue #3961.
Many PRs are failing because c# unit tests in travis cannot install dotnet-1.0.1
This version is not available anymore for trusty.

```
root@035bb8b9f40f:/# apt-cache search dotnet
libgtk-dotnet3.0-cil - GTK.NET library
libgtk-dotnet3.0-cil-dev - GTK.NET library - development files
dotnet-dev-1.0.4 - .NET Core SDK 1.0.4
dotnet-dev-1.1.4 - .NET Core SDK 1.1.4
dotnet-dev-1.1.5 - .NET Core SDK 1.1.5
```

Upgrading dotnet to 1.0.4