### PR TITLE
php: Added nanosecond support for Timestamp

### DIFF
--- a/php/ext/google/protobuf/protobuf.h
+++ b/php/ext/google/protobuf/protobuf.h
@@ -42,6 +42,10 @@
 #define MAX_LENGTH_OF_INT64 20
 #define SIZEOF_INT64 8
 
+/* From Chromium. */
+#define ARRAY_SIZE(x) \
+    ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
+
 // -----------------------------------------------------------------------------
 // PHP7 Wrappers
 // ----------------------------------------------------------------------------

--- a/php/src/Google/Protobuf/Timestamp.php
+++ b/php/src/Google/Protobuf/Timestamp.php
@@ -182,18 +182,19 @@ class Timestamp extends \Google\Protobuf\Internal\Message
      */
     public function fromDateTime(\DateTime $datetime)
     {
-        $this->seconds = $datetime->format('U');
-        $this->nanos = 0;
+        $this->seconds = $datetime->getTimestamp();
+        $this->nanos = 1000 * $datetime->format('u');
     }
 
     /**
-     * Converts Timestamp to PHP DateTime. Nano second is ignored.
+     * Converts Timestamp to PHP DateTime.
      *
      * @return \DateTime $datetime
      */
     public function toDateTime()
     {
-        return \DateTime::createFromFormat('U', $this->seconds);
+        $time = sprintf('%s.%06d', $this->seconds, $this->nanos / 1000);
+        return \DateTime::createFromFormat('U.u', $time);
     }
 }
 

--- a/php/tests/compatibility_test.sh
+++ b/php/tests/compatibility_test.sh
@@ -124,6 +124,7 @@ sed -i.bak '/php_implementation_test.php/d' phpunit.xml
 sed -i.bak '/generated_phpdoc_test.php/d' phpunit.xml
 sed -i.bak 's/generated_phpdoc_test.php//g' tests/test.sh
 sed -i.bak '/memory_leak_test.php/d' tests/test.sh
+sed -i.bak '/^    public function testTimestamp()$/,/^    }$/d' tests/well_known_test.php
 for t in "${tests[@]}"
 do
   remove_error_test tests/$t

--- a/php/tests/memory_leak_test.php
+++ b/php/tests/memory_leak_test.php
@@ -152,7 +152,7 @@ date_default_timezone_set('UTC');
 $from = new DateTime('2011-01-01T15:03:01.012345UTC');
 $timestamp->fromDateTime($from);
 assert($from->format('U') == $timestamp->getSeconds());
-assert(0 == $timestamp->getNanos());
+assert(1000 * $from->format('u') == $timestamp->getNanos());
 
 $to = $timestamp->toDateTime();
 assert(\DateTime::class == get_class($to));

--- a/php/tests/well_known_test.php
+++ b/php/tests/well_known_test.php
@@ -312,11 +312,12 @@ class WellKnownTest extends TestBase {
         $from = new DateTime('2011-01-01T15:03:01.012345UTC');
         $timestamp->fromDateTime($from);
         $this->assertEquals($from->format('U'), $timestamp->getSeconds());
-        $this->assertSame(0, $timestamp->getNanos());
+        $this->assertEquals(1000 * $from->format('u'), $timestamp->getNanos());
 
         $to = $timestamp->toDateTime();
         $this->assertSame(\DateTime::class, get_class($to));
         $this->assertSame($from->format('U'), $to->format('U'));
+        $this->assertSame($from->format('u'), $to->format('u'));
     }
 
     public function testType()


### PR DESCRIPTION
This PR adds support for the nanoseconds field of the wellknown `Timestamp` type for PHP 5.6 and later.
The accuracy will be in the order of microseconds though, as that's the highest resolution PHP supports.

---

I hope this PR fullfills all necessary preconditions to be merged, but if it doesn't (e.g. because the `Timestamp` class is generated automatically), I'd be glad to help get this feature implemented whatever is necessary for that to happen. 🙂