### PR TITLE
Handle srcs in generated files by cd'ing in and out

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -913,3 +913,30 @@ objc_library(
     non_arc_srcs = OBJC_SRCS,
     visibility = ["//visibility:public"],
 )
+
+################################################################################
+# Test generated proto support
+################################################################################
+
+genrule(
+    name = "generated_protos",
+    srcs = ["src/google/protobuf/unittest_import.proto"],
+    outs = ["unittest_gen.proto"],
+    cmd = "cat $(SRCS) | sed 's|google/|src/google/|' >  $(OUTS)"
+)
+
+proto_library(
+    name = "generated_protos_proto",
+    srcs = ["unittest_gen.proto"],
+)
+
+
+py_proto_library(
+    name = "generated_protos_py",
+    srcs = [
+        "unittest_gen.proto",
+        "src/google/protobuf/unittest_import_public.proto",
+    ],
+    default_runtime = "",
+    protoc = ":protoc",
+)

--- a/BUILD
+++ b/BUILD
@@ -927,9 +927,11 @@ genrule(
 
 proto_library(
     name = "generated_protos_proto",
-    srcs = ["unittest_gen.proto"],
+    srcs = [
+        "unittest_gen.proto",
+        "src/google/protobuf/unittest_import_public.proto",
+    ],
 )
-
 
 py_proto_library(
     name = "generated_protos_py",

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -72,7 +72,7 @@ def _proto_gen_impl(ctx):
   deps = []
   deps += ctx.files.srcs
   source_dir = _SourceDir(ctx)
-  gen_dir = _GenDir(ctx)
+  gen_dir = _GenDir(ctx).rstrip('/')
   if source_dir:
     import_flags = ["-I" + source_dir, "-I" + gen_dir]
   else:
@@ -94,7 +94,7 @@ def _proto_gen_impl(ctx):
   for src in srcs:
     args = []
 
-    in_gen_dir = src.root.path == gen_dir.rstrip('/')
+    in_gen_dir = src.root.path == gen_dir
     if in_gen_dir:
       import_flags_real = []
       for f in depset(import_flags):
@@ -148,8 +148,10 @@ def _proto_gen_impl(ctx):
             "cd %s" % src.dirname,
             "${CMD}",
             "cd -",
-            "mv %s/%s %s" % (gen_dir, out.basename, out.path)
         ])
+        generated_out = '/'.join([gen_dir,  out.basename])
+        if generated_out != out.path:
+            command += ";mv %s %s" % (generated_out, out.path)
         ctx.action(
             inputs=inputs + [ctx.executable.protoc],
             outputs=[out],

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -94,7 +94,7 @@ def _proto_gen_impl(ctx):
   for src, out in zip(srcs, ctx.outputs.outs):
     args = []
 
-    in_gen_dir = src.root.path == gen_dir
+    in_gen_dir = src.root.path == gen_dir.rstrip('/')
     if in_gen_dir:
       import_flags_real = []
       for f in depset(import_flags):


### PR DESCRIPTION
The change:
* Each source file is compiled separately now
* If a source file is generated, we cd into its folder so protoc can see it, then move it out

The downside is that a separate protoc call is made per file now, which is a small decrease in performance. An optimization can be made to combine all non-generated files into a single call.

I tried a few approaches over the past 2 days, all of them failed for some reason or another (mostly because bazel is super uptight about things):
* Explicitly create an intermediate file and move it (only for generated inputs): Fails because bazel refuses to let me create a `File()` that isn't relative to my package. protoc will output the file into `bazel-out/.../genfiles/bazel_out/.../genfiles/<path>/<filename>_pb2.py` but the closest I could get was a declared file (via `ctx.actions.declare_file()`) that was `bazel-out/.../genfiles/<path>/bazel_out/.../genfiles/<path>/...` and that's got <path> in there twice and you can't change the filename at all, ever, in any way, from Skylark.
* A single protoc call. Figuring out where things are output and need to be moved to is a mess and you're better off with the performance hit if you don't want to mess up the sandbox too much.

Fixes #1314 and fixes #1313