### PR TITLE
BUILD,globs: ignore *.pb.{h,cc} in the source tree

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -111,7 +111,12 @@ cc_library(
         "src/google/protobuf/stubs/time.cc",
         "src/google/protobuf/wire_format_lite.cc",
     ],
-    hdrs = glob(["src/google/protobuf/**/*.h"]),
+    hdrs = glob(
+        ["src/google/protobuf/**/*.h"],
+        exclude = [
+            "src/google/protobuf/**/*.pb.h",
+        ],
+    ),
     copts = COPTS,
     includes = ["src/"],
     linkopts = LINK_OPTS,
@@ -178,7 +183,12 @@ cc_library(
         "src/google/protobuf/wire_format.cc",
         "src/google/protobuf/wrappers.pb.cc",
     ],
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = glob(
+        ["src/**/*.h"],
+        exclude = [
+            "src/**/*.pb.h",
+        ],
+    ),
     copts = COPTS,
     includes = ["src/"],
     linkopts = LINK_OPTS,
@@ -192,7 +202,12 @@ cc_library(
 # TODO(keveman): Remove this target once the support gets added to Bazel.
 cc_library(
     name = "protobuf_headers",
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = glob(
+        ["src/**/*.h"],
+        exclude = [
+            "src/**/*.pb.h",
+        ],
+    ),
     includes = ["src/"],
     visibility = ["//visibility:public"],
 )
@@ -583,12 +598,17 @@ cc_test(
     copts = COPTS,
     data = [
         ":test_plugin",
-    ] + glob([
-        "src/google/protobuf/**/*",
-        # Files for csharp_bootstrap_unittest.cc.
-        "conformance/**/*",
-        "csharp/src/**/*",
-    ]),
+    ] + glob(
+        [
+            "src/google/protobuf/**/*",
+            # Files for csharp_bootstrap_unittest.cc.
+            "conformance/**/*",
+            "csharp/src/**/*",
+        ],
+        exclude = [
+            "src/**/*.pb.h",
+            "src/**/*.pb.cc",
+        ]),
     includes = [
         "src/",
     ],
@@ -675,10 +695,15 @@ cc_binary(
 
 cc_binary(
     name = "python/google/protobuf/pyext/_message.so",
-    srcs = glob([
-        "python/google/protobuf/pyext/*.cc",
-        "python/google/protobuf/pyext/*.h",
-    ]),
+    srcs = glob(
+        [
+            "python/google/protobuf/pyext/*.cc",
+            "python/google/protobuf/pyext/*.h",
+        ],
+        exclude = [
+            "python/google/protobuf/pyext/*.pb.h",
+            "python/google/protobuf/pyext/*.pb.cc",
+        ]),
     copts = COPTS + [
         "-DGOOGLE_PROTOBUF_HAS_ONEOF=1",
     ] + select({


### PR DESCRIPTION
The globs were picking up such files and created
dependency cycles so I could no longer build
//:protoc on Windows.

This is what happened:

1. I built the tests with CMake. As part of that,
   CMake generated header files in the source
   tree, such as
   "src/google/protobuf/unittest_lite.pb.cc"

2. I attempted to build "//:protoc" with Bazel:

2.1. As part of loading the BUILD file, Bazel
     expanded glob() statements in the
     "protobuf" cc_library's hdrs attribute.

2.2. The result of glob() expansion is a list of
     labels, and the expanded list included
     "src/google/protobuf/unittest_lite.pb.cc"

2.3. After glob() expansion, Bazel parsed all rule
     definitions. It found the
     "cc_test_protos_genproto" rule which
     generates a file called
     "src/google/protobuf/unittest_lite.pb.cc"

2.4. Because Bazel can't tell from a label whether
     it refers to a source file or a generated
     file or a rule -- after all, srcs=["foo.cc"]
     could refer to either the source file
     "foo.cc", or the generated file "foo.cc", or
     the rule called "foo.cc" -- Bazel didn't
     realise that it should depend on the source
     file "unittest_lite.pb.cc", not on the output
     file "unittest_lite.pb.cc". (Or that it
     should error out because of the ambiguity.)

2.5. Building the generated file
     "unittest_lite.pb.cc" however involves
     running the protocol compiler, which involes
     building ":protoc", which depends on the
     ":protobuf" rule, thus we now have a
     dependency cycle.

3. It made debugging more difficult that the
   .gitignore file includes a pattern to match the
   CMake-generated headers, so I didn't see any
   new files in "git status", so I initially ruled
   out globs as the source of the problem.

Takeaway:
- Bazel should error out if labels are ambiguous.
- As a workaround, the glob() should use exclude
  statements. This commit adds that.