### PR TITLE
Add CLI flag --schemas_out to turn descriptor set back to .protos

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -255,7 +255,8 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   bool InitializeDiskSourceTree(DiskSourceTree* source_tree);
 
   // Loads descriptor_set_in into the provided database
-  bool PopulateSimpleDescriptorDatabase(SimpleDescriptorDatabase* database);
+  bool PopulateSimpleDescriptorDatabase(SimpleDescriptorDatabase* database,
+                                        std::vector<std::string>* files);
 
   // Parses input_files_ into parsed_files
   bool ParseInputFiles(DescriptorPool* descriptor_pool,
@@ -277,6 +278,11 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   // Implements the --descriptor_set_out option.
   bool WriteDescriptorSet(
       const std::vector<const FileDescriptor*>& parsed_files);
+
+  // Implements the --schemas_out option.
+  bool GenerateSchemaFiles(
+      const std::vector<std::string>& filenames,
+      const DescriptorPool* descriptor_pool);
 
   // Implements the --dependency_out option
   bool GenerateDependencyManifestFile(
@@ -412,6 +418,10 @@ class LIBPROTOC_EXPORT CommandLineInterface {
   // If --dependency_out was given, this is the path to the file where the
   // dependency file will be written. Otherwise, empty.
   string dependency_out_name_;
+
+  // If --schemas_out was given, this is the path to the directory where
+  // schemas will be written. Ohterwise, empty.
+  string schemas_out_path_;
 
   // Path to a file that contains serialized AccessInfo which provides
   // relative hotness of fields per message. This helps protoc to generate


### PR DESCRIPTION
This is a proposed feature, on which I'm looking for comment. I haven't implemented tests yet, but will if folks like the idea.

The main use case I have is generating .proto schemas from another, canonical schema definition. Rather than writing out .proto strings myself, it seems safer/nicer to build a descriptor set object using standard setters and then use google/protobuf C++ code to turn that into .proto strings, and I'm not working in C++ so would like to be able to shell out to protoc.

Evidence that I'm not the only person who has wanted this feature: https://stackoverflow.com/questions/19418655/restoring-proto-file-from-descriptor-string-possible

I should be covered by the Stripe CLA, although the bot doesn't always seem to recognize that.