### PR TITLE
Add backslach to make class explict in global namespace

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1111,7 +1111,7 @@ class Message
         }
         try {
             $this->mergeFromJsonArray($array);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new GPBDecodeException($e->getMessage());
         }
     }


### PR DESCRIPTION
Fix #3944 