### PR TITLE
Update comments for Timestamp JSON format.

### DIFF
--- a/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
+++ b/csharp/src/Google.Protobuf/WellKnownTypes/Timestamp.cs
@@ -101,7 +101,9 @@ namespace Google.Protobuf.WellKnownTypes {
   /// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
   /// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
   /// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-  /// is required, though only UTC (as indicated by "Z") is presently supported.
+  /// is required. A proto3 JSON serializer should always use UTC (as indicated by
+  /// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+  /// able to accept both UTC and other timezones (as indicated by an offset).
   ///
   /// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
   /// 01:30 UTC on January 15, 2017.

--- a/objectivec/google/protobuf/Timestamp.pbobjc.h
+++ b/objectivec/google/protobuf/Timestamp.pbobjc.h
@@ -115,7 +115,9 @@ typedef GPB_ENUM(GPBTimestamp_FieldNumber) {
  * {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
  * seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
  * are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
- * is required, though only UTC (as indicated by "Z") is presently supported.
+ * is required. A proto3 JSON serializer should always use UTC (as indicated by
+ * "Z") when printing the Timestamp type and a proto3 JSON parser should be
+ * able to accept both UTC and other timezones (as indicated by an offset).
  *
  * For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
  * 01:30 UTC on January 15, 2017.

--- a/src/google/protobuf/timestamp.proto
+++ b/src/google/protobuf/timestamp.proto
@@ -103,7 +103,9 @@ option objc_class_prefix = "GPB";
 // {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
 // seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
 // are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-// is required, though only UTC (as indicated by "Z") is presently supported.
+// is required. A proto3 JSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// able to accept both UTC and other timezones (as indicated by an offset).
 //
 // For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
 // 01:30 UTC on January 15, 2017.


### PR DESCRIPTION
Clarify that JSON parser are required to accept both UTC and other
timezone offsets.

Fixes https://github.com/google/protobuf/issues/3093