### PR TITLE
Clarify default value behavior in JSON conversion.

### DIFF
--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -56,10 +56,10 @@ struct JsonPrintOptions {
   // Whether to add spaces, line breaks and indentation to make the JSON output
   // easy to read.
   bool add_whitespace;
-  // Whether to always print primitive fields. By default primitive fields with
-  // default values will be omitted in JSON joutput. For example, an int32 field
-  // set to 0 will be omitted. Set this flag to true will override the default
-  // behavior and print primitive fields regardless of their values.
+  // Whether to always print primitive fields. By default proto3 primitive
+  // fields with default values will be omitted in JSON output. For example, an
+  // int32 field set to 0 will be omitted. Set this flag to true will override
+  // the default behavior and print primitive fields regardless of their values.
   bool always_print_primitive_fields;
   // Whether to always print enums as ints. By default they are rendered as
   // strings.


### PR DESCRIPTION
Make it clear default value is only omitted for proto3.

Fixes https://github.com/google/protobuf/issues/2880