### PR TITLE
Create containing directory before generating well_known_types_embed.cc

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -525,6 +525,7 @@ js_well_known_types_sources =                                  \
 	google/protobuf/compiler/js/well_known_types/timestamp.js
 # We have to cd to $(srcdir) so that out-of-tree builds work properly.
 google/protobuf/compiler/js/well_known_types_embed.cc: js_embed$(EXEEXT) $(js_well_known_types_sources)
+	mkdir -p `dirname $@` && \
 	oldpwd=`pwd` && cd $(srcdir) && \
 	$$oldpwd/js_embed$(EXEEXT) $(js_well_known_types_sources) > $$oldpwd/$@
 


### PR DESCRIPTION
This fixes the following build error:

oldpwd=`pwd` && cd .../protobuf/src && \
$oldpwd/js_embed google/protobuf/compiler/js/well_known_types/any.js google/protobuf/compiler/js/well_known_types/struct.js google/protobuf/compiler/js/well_known_types/timestamp.js > $oldpwd/google/protobuf/compiler/js/well_known_types_embed.cc
/bin/bash: line 1: .../protobuf/target/src/google/protobuf/compiler/js/well_known_types_embed.cc: No such file or directory
Makefile:8201: recipe for target 'google/protobuf/compiler/js/well_known_types_embed.cc' failed

which is observed during the cross-compilation since the version 3.2.