### PR TITLE
Explicitly propagate the status of Flush().

### DIFF
--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -170,12 +170,12 @@ size_t Message::SpaceUsedLong() const {
 
 bool Message::SerializeToFileDescriptor(int file_descriptor) const {
   io::FileOutputStream output(file_descriptor);
-  return SerializeToZeroCopyStream(&output);
+  return SerializeToZeroCopyStream(&output) && output.Flush();
 }
 
 bool Message::SerializePartialToFileDescriptor(int file_descriptor) const {
   io::FileOutputStream output(file_descriptor);
-  return SerializePartialToZeroCopyStream(&output);
+  return SerializePartialToZeroCopyStream(&output) && output.Flush();
 }
 
 bool Message::SerializeToOstream(std::ostream* output) const {


### PR DESCRIPTION
Before the change, an implicit Flush() will be triggered in the
destructor of the input stream. However, the return code of Flush() is
discarded. This change makes sure when Flush() fails, we will
return false.

Fixes #3715 