### PR TITLE
Allow roundtrip of FLT_MIN/MAX in JSON convention.

### DIFF
--- a/src/google/protobuf/util/internal/datapiece.cc
+++ b/src/google/protobuf/util/internal/datapiece.cc
@@ -106,8 +106,22 @@ StatusOr<float> DoubleToFloat(double before) {
   } else if (!MathLimits<double>::IsFinite(before)) {
     // Converting a double +inf/-inf to float should just work.
     return static_cast<float>(before);
-  } else if (before > std::numeric_limits<float>::max() ||
-             before < -std::numeric_limits<float>::max()) {
+  } else if (before > std::numeric_limits<float>::max()) {
+    // We accept values that are slightly larger than FLT_MAX or slightly
+    // smaller than FLT_MIN because converting FLT_MAX/FLT_MIN to text may
+    // result in these values due to round-up/down.
+    if (before <= 3.4028235e+38) {
+      return std::numeric_limits<float>::max();
+    }
+    // Double value outside of the range of float.
+    return InvalidArgument(DoubleAsString(before));
+  } else if (before < -std::numeric_limits<float>::max()) {
+    // We accept values that are slightly larger than FLT_MAX or slightly
+    // smaller than FLT_MIN because converting FLT_MAX/FLT_MIN to text may
+    // result in these values due to round-up/down.
+    if (before >= -3.4028235e+38) {
+      return -std::numeric_limits<float>::max();
+    }
     // Double value outside of the range of float.
     return InvalidArgument(DoubleAsString(before));
   } else {

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -332,6 +332,16 @@ TEST_F(JsonUtilTest, TestDynamicMessage) {
   EXPECT_EQ(ToJson(generated, options), ToJson(*message, options));
 }
 
+TEST_F(JsonUtilTest, FloatValueRoundTrip) {
+  TestMessage m;
+  m.add_repeated_float_value(std::numeric_limits<float>::max());
+  m.add_repeated_float_value(-std::numeric_limits<float>::max());
+
+  string json = ToJson(m, JsonPrintOptions());
+  Status status = JsonStringToMessage(json, &m, JsonParseOptions());
+  ASSERT_TRUE(status.ok()) << status.ToString();
+}
+
 typedef std::pair<char*, int> Segment;
 // A ZeroCopyOutputStream that writes to multiple buffers.
 class SegmentedZeroCopyOutputStream : public io::ZeroCopyOutputStream {


### PR DESCRIPTION
Fixes https://github.com/google/protobuf/issues/3615