### PR TITLE
Ruby: make .to_json method play nice with builtin json module

### DIFF
--- a/ruby/lib/google/protobuf/message_exts.rb
+++ b/ruby/lib/google/protobuf/message_exts.rb
@@ -40,7 +40,7 @@ module Google
       module ClassMethods
       end
 
-      def to_json
+      def to_json(_opts=nil)
         self.class.encode_json(self)
       end
 


### PR DESCRIPTION
Generated Ruby message objects implement a convenience `to_json` method that return a JSON-formatted string for that message.

However, that `to_json` method doesn't play nice with native Ruby's [`json` module](http://ruby-doc.org/stdlib-2.4.0/libdoc/json/rdoc/JSON.html), specially in the case of nesting a protobuf message into a data structure like an Array or a Hash. Take this example program:

```ruby
require 'json'
require 'google/protobuf'

Google::Protobuf::DescriptorPool.generated_pool.build do
  add_message 'MyMessage' do
    optional :str, :string, 1
  end
end

MyMessage = Google::Protobuf::DescriptorPool.generated_pool.lookup('MyMessage').msgclass

message = MyMessage.new(str: 'foobar')

puts(message.to_json) # => {"str":"foobar"}
puts([message].to_json) # ArgumentError: wrong number of arguments (given 1, expected 0)
puts({message: message}.to_json) # ArgumentError: wrong number of arguments (given 1, expected 0)
```

This PR simply adds an optional argument to the `to_json` method of these generated classes. This argument is completely ignored, but makes it possible to nest protobuf objects into Ruby data structures and then serialize everything with a `to_json` call.

With this patch, the above code runs and yields:

```
{"str":"foobar"}
[{"str":"foobar"}]
{"message":{"str":"foobar"}}
```

😸 