### PR TITLE
Fix build for Intel compilers.

### DIFF
--- a/src/google/protobuf/generated_message_table_driven.h
+++ b/src/google/protobuf/generated_message_table_driven.h
@@ -185,7 +185,10 @@ static_assert(sizeof(ParseTableField) <= 16, "ParseTableField is too large");
 // The tables must be composed of POD components to ensure link-time
 // initialization.
 static_assert(std::is_pod<ParseTableField>::value, "");
+// This static_assert() fails at least with Intel 15.0 and 16.0:
+#if !defined(__INTEL_COMPILER)
 static_assert(std::is_pod<AuxillaryParseTableField>::value, "");
+#endif
 static_assert(std::is_pod<AuxillaryParseTableField::enum_aux>::value, "");
 static_assert(std::is_pod<AuxillaryParseTableField::message_aux>::value, "");
 static_assert(std::is_pod<AuxillaryParseTableField::string_aux>::value, "");

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -209,6 +209,11 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 
 #define GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE GOOGLE_ATTRIBUTE_NOINLINE
 
+// Intel compiler warns otherwise "routine is both inline and noinline"
+#if defined __INTEL_COMPILER
+#pragma warning disable 2196
+#endif
+
 #ifndef GOOGLE_PREDICT_TRUE
 #ifdef __GNUC__
 // Provided at least since GCC 3.0.


### PR DESCRIPTION
The full discussion is in ticket #4069 .
The Intel compilers version 15 and 16 fail at this static_assert.
The warning 2196 "routine is both inline and noninline" makes it impossible to build make check, so disable this warning.
