### PR TITLE
POC: improved the generated C++ code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Google
+Standard: Cpp11
+---
+Language: Cpp

--- a/src/google/protobuf/any_test.cc
+++ b/src/google/protobuf/any_test.cc
@@ -39,7 +39,7 @@ TEST(AnyTest, TestPackAndUnpack) {
   protobuf_unittest::TestAny submessage;
   submessage.set_int32_value(12345);
   protobuf_unittest::TestAny message;
-  message.mutable_any_value()->PackFrom(submessage);
+  message.mutable_any_value().PackFrom(submessage);
 
   string data = message.SerializeAsString();
 
@@ -56,7 +56,7 @@ TEST(AnyTest, TestPackAndUnpackAny) {
   google::protobuf::Any any;
   any.PackFrom(submessage);
   protobuf_unittest::TestAny message;
-  message.mutable_any_value()->PackFrom(any);
+  message.mutable_any_value().PackFrom(any);
 
   string data = message.SerializeAsString();
 
@@ -77,7 +77,7 @@ TEST(AnyTest, TestIs) {
   EXPECT_FALSE(any.Is<google::protobuf::Any>());
 
   protobuf_unittest::TestAny message;
-  message.mutable_any_value()->PackFrom(any);
+  message.mutable_any_value().PackFrom(any);
   ASSERT_TRUE(message.ParseFromString(message.SerializeAsString()));
   EXPECT_FALSE(message.any_value().Is<protobuf_unittest::TestAny>());
   EXPECT_TRUE(message.any_value().Is<google::protobuf::Any>());

--- a/src/google/protobuf/api.pb.cc
+++ b/src/google/protobuf/api.pb.cc
@@ -402,7 +402,7 @@ bool Api::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_source_context()));
+               input, &mutable_source_context()));
         } else {
           goto handle_unusual;
         }
@@ -712,7 +712,7 @@ void Api::MergeFrom(const Api& from) {
     version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.version_);
   }
   if (from.has_source_context()) {
-    mutable_source_context()->::google::protobuf::SourceContext::MergeFrom(from.source_context());
+    mutable_source_context().::google::protobuf::SourceContext::MergeFrom(from.source_context());
   }
   if (from.syntax() != 0) {
     set_syntax(from.syntax());

--- a/src/google/protobuf/api.pb.h
+++ b/src/google/protobuf/api.pb.h
@@ -171,9 +171,9 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   int methods_size() const;
   void clear_methods();
   static const int kMethodsFieldNumber = 2;
-  ::google::protobuf::Method* mutable_methods(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Method >*
-      mutable_methods();
+  ::google::protobuf::Method& methods(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Method >&
+      methods();
   const ::google::protobuf::Method& methods(int index) const;
   ::google::protobuf::Method* add_methods();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Method >&
@@ -183,9 +183,9 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 3;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -195,9 +195,9 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   int mixins_size() const;
   void clear_mixins();
   static const int kMixinsFieldNumber = 6;
-  ::google::protobuf::Mixin* mutable_mixins(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Mixin >*
-      mutable_mixins();
+  ::google::protobuf::Mixin& mixins(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Mixin >&
+      mixins();
   const ::google::protobuf::Mixin& mixins(int index) const;
   ::google::protobuf::Mixin* add_mixins();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Mixin >&
@@ -237,7 +237,7 @@ class LIBPROTOBUF_EXPORT Api : public ::google::protobuf::Message /* @@protoc_in
   static const int kSourceContextFieldNumber = 5;
   const ::google::protobuf::SourceContext& source_context() const;
   ::google::protobuf::SourceContext* release_source_context();
-  ::google::protobuf::SourceContext* mutable_source_context();
+  ::google::protobuf::SourceContext& mutable_source_context();
   void set_allocated_source_context(::google::protobuf::SourceContext* source_context);
 
   // .google.protobuf.Syntax syntax = 7;
@@ -353,9 +353,9 @@ class LIBPROTOBUF_EXPORT Method : public ::google::protobuf::Message /* @@protoc
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 6;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -633,14 +633,14 @@ inline int Api::methods_size() const {
 inline void Api::clear_methods() {
   methods_.Clear();
 }
-inline ::google::protobuf::Method* Api::mutable_methods(int index) {
+inline ::google::protobuf::Method& Api::methods(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Api.methods)
-  return methods_.Mutable(index);
+  return *methods_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Method >*
-Api::mutable_methods() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Method >&
+Api::methods() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Api.methods)
-  return &methods_;
+  return methods_;
 }
 inline const ::google::protobuf::Method& Api::methods(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Api.methods)
@@ -660,14 +660,14 @@ Api::methods() const {
 inline int Api::options_size() const {
   return options_.size();
 }
-inline ::google::protobuf::Option* Api::mutable_options(int index) {
+inline ::google::protobuf::Option& Api::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Api.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-Api::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+Api::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Api.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& Api::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Api.options)
@@ -753,14 +753,14 @@ inline ::google::protobuf::SourceContext* Api::release_source_context() {
   source_context_ = NULL;
   return temp;
 }
-inline ::google::protobuf::SourceContext* Api::mutable_source_context() {
+inline ::google::protobuf::SourceContext& Api::mutable_source_context() {
   
   if (source_context_ == NULL) {
     source_context_ = ::google::protobuf::Arena::Create< ::google::protobuf::SourceContext >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Api.source_context)
-  return source_context_;
+  return *source_context_;
 }
 inline void Api::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -788,14 +788,14 @@ inline int Api::mixins_size() const {
 inline void Api::clear_mixins() {
   mixins_.Clear();
 }
-inline ::google::protobuf::Mixin* Api::mutable_mixins(int index) {
+inline ::google::protobuf::Mixin& Api::mixins(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Api.mixins)
-  return mixins_.Mutable(index);
+  return *mixins_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Mixin >*
-Api::mutable_mixins() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Mixin >&
+Api::mixins() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Api.mixins)
-  return &mixins_;
+  return mixins_;
 }
 inline const ::google::protobuf::Mixin& Api::mixins(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Api.mixins)
@@ -1020,14 +1020,14 @@ inline void Method::set_response_streaming(bool value) {
 inline int Method::options_size() const {
   return options_.size();
 }
-inline ::google::protobuf::Option* Method::mutable_options(int index) {
+inline ::google::protobuf::Option& Method::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Method.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-Method::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+Method::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Method.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& Method::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Method.options)

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -649,7 +649,7 @@ void CommandLineInterface::MemoryOutputStream::UpdateMetadata(
     is_text_format = true;
   }
   for (int i = 0; i < metadata.annotation_size(); ++i) {
-    GeneratedCodeInfo::Annotation* annotation = metadata.mutable_annotation(i);
+    GeneratedCodeInfo::Annotation* annotation = &metadata.annotation(i);
     if (annotation->begin() >= insertion_offset) {
       annotation->set_begin(annotation->begin() + insertion_length);
       annotation->set_end(annotation->end() + insertion_length);
@@ -1840,7 +1840,7 @@ bool CommandLineInterface::GenerateDependencyManifestFile(
                               false,
                               false,
                               &already_seen,
-                              file_set.mutable_file());
+                              &file_set.file());
   }
 
   std::vector<string> output_filenames;
@@ -1921,11 +1921,11 @@ bool CommandLineInterface::GeneratePluginOutput(
     GetTransitiveDependencies(parsed_files[i],
                               true,  // Include json_name for plugins.
                               true,  // Include source code info.
-                              &already_seen, request.mutable_proto_file());
+                              &already_seen, &request.proto_file());
   }
 
   google::protobuf::compiler::Version* version =
-      request.mutable_compiler_version();
+      &request.mutable_compiler_version();
   version->set_major(GOOGLE_PROTOBUF_VERSION / 1000000);
   version->set_minor(GOOGLE_PROTOBUF_VERSION / 1000 % 1000);
   version->set_patch(GOOGLE_PROTOBUF_VERSION % 1000);
@@ -2078,7 +2078,7 @@ bool CommandLineInterface::WriteDescriptorSet(
     GetTransitiveDependencies(parsed_files[i],
                               true,  // Include json_name
                               source_info_in_descriptor_set_,
-                              &already_seen, file_set.mutable_file());
+                              &already_seen, &file_set.file());
   }
 
   int fd;

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -1446,8 +1446,8 @@ TEST_F(CommandLineInterfaceTest, WriteTransitiveDescriptorSet) {
   if (HasFatalFailure()) return;
   EXPECT_EQ(2, descriptor_set.file_size());
   if (descriptor_set.file(0).name() == "bar.proto") {
-    std::swap(descriptor_set.mutable_file()->mutable_data()[0],
-              descriptor_set.mutable_file()->mutable_data()[1]);
+    std::swap(descriptor_set.file().mutable_data()[0],
+              descriptor_set.file().mutable_data()[1]);
   }
   EXPECT_EQ("foo.proto", descriptor_set.file(0).name());
   EXPECT_EQ("bar.proto", descriptor_set.file(1).name());
@@ -1477,8 +1477,8 @@ TEST_F(CommandLineInterfaceTest, WriteTransitiveDescriptorSetWithSourceInfo) {
   if (HasFatalFailure()) return;
   EXPECT_EQ(2, descriptor_set.file_size());
   if (descriptor_set.file(0).name() == "bar.proto") {
-    std::swap(descriptor_set.mutable_file()->mutable_data()[0],
-              descriptor_set.mutable_file()->mutable_data()[1]);
+    std::swap(descriptor_set.file().mutable_data()[0],
+              descriptor_set.file().mutable_data()[1]);
   }
   EXPECT_EQ("foo.proto", descriptor_set.file(0).name());
   EXPECT_EQ("bar.proto", descriptor_set.file(1).name());

--- a/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_enum_field.cc
@@ -268,8 +268,8 @@ GenerateAccessorDeclarations(io::Printer* printer) const {
       "$deprecated_attr$const ::google::protobuf::RepeatedField<int>& $name$() const;\n");
   printer->Annotate("name", descriptor_);
   printer->Print(variables_,
-                 "$deprecated_attr$::google::protobuf::RepeatedField<int>* "
-                 "${$mutable_$name$$}$();\n");
+                 "$deprecated_attr$::google::protobuf::RepeatedField<int>& "
+                 "$name$();\n");
   printer->Annotate("{", "}", descriptor_);
 }
 
@@ -303,10 +303,10 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     "  // @@protoc_insertion_point(field_list:$full_name$)\n"
     "  return $name$_;\n"
     "}\n"
-    "inline ::google::protobuf::RepeatedField<int>*\n"
-    "$classname$::mutable_$name$() {\n"
+    "inline ::google::protobuf::RepeatedField<int>&\n"
+    "$classname$::$name$() {\n"
     "  // @@protoc_insertion_point(field_mutable_list:$full_name$)\n"
-    "  return &$name$_;\n"
+    "  return $name$_;\n"
     "}\n");
 }
 
@@ -373,7 +373,7 @@ GenerateMergeFromCodedStreamWithPacking(io::Printer* printer) const {
         "       $number$,\n"
         "       NULL,\n"
         "       NULL,\n"
-        "       this->mutable_$name$())));\n");
+        "       &this->$name$())));\n");
     } else if (UseUnknownFieldSet(descriptor_->file(), options_)) {
       printer->Print(variables_,
         "DO_((::google::protobuf::internal::WireFormat::ReadPackedEnumPreserveUnknowns(\n"
@@ -381,7 +381,7 @@ GenerateMergeFromCodedStreamWithPacking(io::Printer* printer) const {
         "       $number$,\n"
         "       $type$_IsValid,\n"
         "       mutable_unknown_fields(),\n"
-        "       this->mutable_$name$())));\n");
+        "       &this->$name$())));\n");
     } else {
       printer->Print(variables_,
         "DO_((::google::protobuf::internal::"
@@ -390,7 +390,7 @@ GenerateMergeFromCodedStreamWithPacking(io::Printer* printer) const {
         "       $number$,\n"
         "       $type$_IsValid,\n"
         "       &unknown_fields_stream,\n"
-        "       this->mutable_$name$())));\n");
+        "       &this->$name$())));\n");
     }
   } else {
     printer->Print(variables_,

--- a/src/google/protobuf/compiler/cpp/cpp_map_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_map_field.cc
@@ -130,9 +130,10 @@ GenerateAccessorDeclarations(io::Printer* printer) const {
       "$deprecated_attr$const ::google::protobuf::Map< $key_cpp$, $val_cpp$ >&\n"
       "    $name$() const;\n");
   printer->Annotate("name", descriptor_);
-  printer->Print(variables_,
-                 "$deprecated_attr$::google::protobuf::Map< $key_cpp$, $val_cpp$ >*\n"
-                 "    ${$mutable_$name$$}$();\n");
+  printer->Print(
+      variables_,
+      "$deprecated_attr$::google::protobuf::Map< $key_cpp$, $val_cpp$ >&\n"
+      "    $name$();\n");
   printer->Annotate("{", "}", descriptor_);
 }
 
@@ -144,10 +145,10 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
       "  // @@protoc_insertion_point(field_map:$full_name$)\n"
       "  return $name$_.GetMap();\n"
       "}\n"
-      "inline ::google::protobuf::Map< $key_cpp$, $val_cpp$ >*\n"
-      "$classname$::mutable_$name$() {\n"
+      "inline ::google::protobuf::Map< $key_cpp$, $val_cpp$ >&\n"
+      "$classname$::$name$() {\n"
       "  // @@protoc_insertion_point(field_mutable_map:$full_name$)\n"
-      "  return $name$_.MutableMap();\n"
+      "  return *$name$_.MutableMap();\n"
       "}\n");
 }
 
@@ -209,7 +210,7 @@ GenerateMergeFromCodedStream(io::Printer* printer) const {
         "  DO_(::google::protobuf::internal::WireFormatLite::ReadString(input, &data));\n"
         "  DO_(entry->ParseFromString(data));\n"
         "  if ($val_cpp$_IsValid(*entry->mutable_value())) {\n"
-        "    (*mutable_$name$())[entry->key()] =\n"
+        "    $name$()[entry->key()] =\n"
         "        static_cast< $val_cpp$ >(*entry->mutable_value());\n"
         "  } else {\n");
     if (HasDescriptorMethods(descriptor_->file(), options_)) {

--- a/src/google/protobuf/compiler/cpp/cpp_message_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message_field.cc
@@ -139,7 +139,7 @@ GenerateAccessorDeclarations(io::Printer* printer) const {
   printer->Print(variables_, "$deprecated_attr$$type$* $release_name$();\n");
   printer->Annotate("release_name", descriptor_);
   printer->Print(variables_,
-                 "$deprecated_attr$$type$* ${$mutable_$name$$}$();\n");
+                 "$deprecated_attr$$type$& mutable_$name$();\n");
   printer->Annotate("{", "}", descriptor_);
   printer->Print(variables_,
                  "$deprecated_attr$void ${$set_allocated_$name$$}$"
@@ -268,7 +268,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   }
 
   printer->Print(variables_,
-    "inline $type$* $classname$::mutable_$name$() {\n"
+    "inline $type$& $classname$::mutable_$name$() {\n"
     "$type_reference_function$"
     "  $set_hasbit$\n"
     "  if ($name$_ == NULL) {\n");
@@ -283,7 +283,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   printer->Print(variables_,
     "  }\n"
     "  // @@protoc_insertion_point(field_mutable:$full_name$)\n"
-    "  return $casted_member$;\n"
+    "  return *$casted_member$;\n"
     "}\n");
 
   // We handle the most common case inline, and delegate less common cases to
@@ -380,7 +380,7 @@ GenerateMergingCode(io::Printer* printer) const {
       "    from._internal_$name$());\n");
   } else {
     printer->Print(variables_,
-      "mutable_$name$()->$type$::MergeFrom(from.$name$());\n");
+      "mutable_$name$().$type$::MergeFrom(from.$name$());\n");
   }
 }
 
@@ -424,11 +424,11 @@ GenerateMergeFromCodedStream(io::Printer* printer) const {
   } else if (descriptor_->type() == FieldDescriptor::TYPE_MESSAGE) {
     printer->Print(variables_,
       "DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(\n"
-      "     input, mutable_$name$()));\n");
+      "     input, &mutable_$name$()));\n");
   } else {
     printer->Print(variables_,
       "DO_(::google::protobuf::internal::WireFormatLite::ReadGroup(\n"
-      "      $number$, input, mutable_$name$()));\n");
+      "      $number$, input, &mutable_$name$()));\n");
   }
 }
 
@@ -561,7 +561,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   }
 
   printer->Print(variables_,
-    "inline $type$* $classname$::mutable_$name$() {\n"
+    "inline $type$& $classname$::mutable_$name$() {\n"
     "  if (!has_$name$()) {\n"
     "    clear_$oneof_name$();\n"
     "    set_has_$name$();\n"
@@ -569,7 +569,7 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     "        GetArenaNoVirtual());\n"
     "  }\n"
     "  // @@protoc_insertion_point(field_mutable:$full_name$)\n"
-    "  return $field_member$;\n"
+    "  return *$field_member$;\n"
     "}\n");
 }
 
@@ -643,11 +643,11 @@ GenerateDependentAccessorDeclarations(io::Printer* printer) const {
 void RepeatedMessageFieldGenerator::
 GenerateAccessorDeclarations(io::Printer* printer) const {
   printer->Print(variables_,
-                 "$deprecated_attr$$type$* ${$mutable_$name$$}$(int index);\n");
+                 "$deprecated_attr$$type$& $name$(int index);\n");
   printer->Annotate("{", "}", descriptor_);
   printer->Print(variables_,
-                 "$deprecated_attr$::google::protobuf::RepeatedPtrField< $type$ >*\n"
-                 "    ${$mutable_$name$$}$();\n");
+                 "$deprecated_attr$::google::protobuf::RepeatedPtrField< $type$ >&\n"
+                 "    $name$();\n");
   printer->Annotate("{", "}", descriptor_);
 
   printer->Print(variables_,
@@ -688,17 +688,17 @@ GenerateDependentInlineAccessorDefinitions(io::Printer* printer) const {
 void RepeatedMessageFieldGenerator::
 GenerateInlineAccessorDefinitions(io::Printer* printer) const {
   printer->Print(variables_,
-    "inline $type$* $classname$::mutable_$name$(int index) {\n"
+    "inline $type$& $classname$::$name$(int index) {\n"
     // TODO(dlj): move insertion points
     "  // @@protoc_insertion_point(field_mutable:$full_name$)\n"
     "$type_reference_function$"
-    "  return $name$_.Mutable(index);\n"
+    "  return *$name$_.Mutable(index);\n"
     "}\n"
-    "inline ::google::protobuf::RepeatedPtrField< $type$ >*\n"
-    "$classname$::mutable_$name$() {\n"
+    "inline ::google::protobuf::RepeatedPtrField< $type$ >&\n"
+    "$classname$::$name$() {\n"
     "  // @@protoc_insertion_point(field_mutable_list:$full_name$)\n"
     "$type_reference_function$"
-    "  return &$name$_;\n"
+    "  return $name$_;\n"
     "}\n");
 
   if (options_.safe_boundary_check) {

--- a/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_primitive_field.cc
@@ -301,8 +301,8 @@ GenerateAccessorDeclarations(io::Printer* printer) const {
                  "    $name$() const;\n");
   printer->Annotate("name", descriptor_);
   printer->Print(variables_,
-                 "$deprecated_attr$::google::protobuf::RepeatedField< $type$ >*\n"
-                 "    ${$mutable_$name$$}$();\n");
+                 "$deprecated_attr$::google::protobuf::RepeatedField< $type$ >&\n"
+                 "    $name$();\n");
   printer->Annotate("{", "}", descriptor_);
 }
 
@@ -326,10 +326,10 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     "  // @@protoc_insertion_point(field_list:$full_name$)\n"
     "  return $name$_;\n"
     "}\n"
-    "inline ::google::protobuf::RepeatedField< $type$ >*\n"
-    "$classname$::mutable_$name$() {\n"
+    "inline ::google::protobuf::RepeatedField< $type$ >&\n"
+    "$classname$::$name$() {\n"
     "  // @@protoc_insertion_point(field_mutable_list:$full_name$)\n"
-    "  return &$name$_;\n"
+    "  return $name$_;\n"
     "}\n");
 }
 
@@ -363,7 +363,7 @@ GenerateMergeFromCodedStream(io::Printer* printer) const {
   printer->Print(variables_,
     "DO_((::google::protobuf::internal::WireFormatLite::$repeated_reader$<\n"
     "         $type$, $wire_format_field_type$>(\n"
-    "       $tag_size$, $tag$u, input, this->mutable_$name$())));\n");
+    "       $tag_size$, $tag$u, input, &this->$name$())));\n");
 }
 
 void RepeatedPrimitiveFieldGenerator::
@@ -371,7 +371,7 @@ GenerateMergeFromCodedStreamWithPacking(io::Printer* printer) const {
   printer->Print(variables_,
     "DO_((::google::protobuf::internal::WireFormatLite::$packed_reader$<\n"
     "         $type$, $wire_format_field_type$>(\n"
-    "       input, this->mutable_$name$())));\n");
+    "       input, &this->$name$())));\n");
 }
 
 void RepeatedPrimitiveFieldGenerator::

--- a/src/google/protobuf/compiler/cpp/cpp_string_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_string_field.cc
@@ -899,8 +899,8 @@ GenerateAccessorDeclarations(io::Printer* printer) const {
       "const;\n");
   printer->Annotate("name", descriptor_);
   printer->Print(variables_,
-                 "$deprecated_attr$::google::protobuf::RepeatedPtrField< ::std::string>* "
-                 "${$mutable_$name$$}$()"
+                 "$deprecated_attr$::google::protobuf::RepeatedPtrField< ::std::string>& "
+                 "$name$()"
                  ";\n");
   printer->Annotate("{", "}", descriptor_);
 
@@ -983,10 +983,10 @@ GenerateInlineAccessorDefinitions(io::Printer* printer) const {
     "  // @@protoc_insertion_point(field_list:$full_name$)\n"
     "  return $name$_;\n"
     "}\n"
-    "inline ::google::protobuf::RepeatedPtrField< ::std::string>*\n"
-    "$classname$::mutable_$name$() {\n"
+    "inline ::google::protobuf::RepeatedPtrField< ::std::string>&\n"
+    "$classname$::$name$() {\n"
     "  // @@protoc_insertion_point(field_mutable_list:$full_name$)\n"
-    "  return &$name$_;\n"
+    "  return $name$_;\n"
     "}\n");
 }
 

--- a/src/google/protobuf/compiler/cpp/cpp_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_unittest.cc
@@ -292,7 +292,7 @@ TEST(GeneratedMessageTest, ReleaseMessage) {
   EXPECT_EQ(NULL, message.release_optional_nested_message());
   EXPECT_FALSE(message.has_optional_nested_message());
 
-  message.mutable_optional_nested_message()->set_bb(1);
+  message.mutable_optional_nested_message().set_bb(1);
   google::protobuf::scoped_ptr<unittest::TestAllTypes::NestedMessage> nest(
       message.release_optional_nested_message());
   EXPECT_FALSE(message.has_optional_nested_message());
@@ -327,7 +327,7 @@ TEST(GeneratedMessageTest, SetAllocatedMessage) {
 
   EXPECT_FALSE(message.has_optional_nested_message());
 
-  message.mutable_optional_nested_message()->set_bb(1);
+  message.mutable_optional_nested_message().set_bb(1);
   EXPECT_TRUE(message.has_optional_nested_message());
 
   message.set_allocated_optional_nested_message(NULL);
@@ -335,7 +335,7 @@ TEST(GeneratedMessageTest, SetAllocatedMessage) {
   EXPECT_EQ(&unittest::TestAllTypes::NestedMessage::default_instance(),
             &message.optional_nested_message());
 
-  message.mutable_optional_nested_message()->set_bb(1);
+  message.mutable_optional_nested_message().set_bb(1);
   unittest::TestAllTypes::NestedMessage* nest =
       message.release_optional_nested_message();
   ASSERT_TRUE(nest != NULL);
@@ -523,7 +523,7 @@ TEST(GeneratedMessageTest, SwapWithOther) {
 
   message1.set_optional_int32(123);
   message1.set_optional_string("abc");
-  message1.mutable_optional_nested_message()->set_bb(1);
+  message1.mutable_optional_nested_message().set_bb(1);
   message1.set_optional_nested_enum(unittest::TestAllTypes::FOO);
   message1.add_repeated_int32(1);
   message1.add_repeated_int32(2);
@@ -536,7 +536,7 @@ TEST(GeneratedMessageTest, SwapWithOther) {
 
   message2.set_optional_int32(456);
   message2.set_optional_string("def");
-  message2.mutable_optional_nested_message()->set_bb(2);
+  message2.mutable_optional_nested_message().set_bb(2);
   message2.set_optional_nested_enum(unittest::TestAllTypes::BAR);
   message2.add_repeated_int32(3);
   message2.add_repeated_string("c");
@@ -836,17 +836,17 @@ TEST(GeneratedMessageTest, RequiredForeign) {
   message.mutable_optional_message();
   EXPECT_FALSE(message.IsInitialized());
 
-  message.mutable_optional_message()->set_a(1);
-  message.mutable_optional_message()->set_b(2);
-  message.mutable_optional_message()->set_c(3);
+  message.mutable_optional_message().set_a(1);
+  message.mutable_optional_message().set_b(2);
+  message.mutable_optional_message().set_c(3);
   EXPECT_TRUE(message.IsInitialized());
 
   message.add_repeated_message();
   EXPECT_FALSE(message.IsInitialized());
 
-  message.mutable_repeated_message(0)->set_a(1);
-  message.mutable_repeated_message(0)->set_b(2);
-  message.mutable_repeated_message(0)->set_c(3);
+  message.repeated_message(0).set_a(1);
+  message.repeated_message(0).set_b(2);
+  message.repeated_message(0).set_c(3);
   EXPECT_TRUE(message.IsInitialized());
 }
 
@@ -857,9 +857,8 @@ TEST(GeneratedMessageTest, ForeignNested) {
 
   // If this compiles and runs without crashing, it must work.  We have
   // nothing more to test.
-  unittest::TestAllTypes::NestedMessage* nested =
-    message.mutable_foreign_nested();
-  nested->set_bb(1);
+  auto& nested = message.mutable_foreign_nested();
+  nested.set_bb(1);
 }
 
 TEST(GeneratedMessageTest, ReallyLargeTagNumber) {
@@ -882,8 +881,8 @@ TEST(GeneratedMessageTest, ReallyLargeTagNumber) {
 TEST(GeneratedMessageTest, MutualRecursion) {
   // Test that mutually-recursive message types work.
   unittest::TestMutualRecursionA message;
-  unittest::TestMutualRecursionA* nested = message.mutable_bb()->mutable_a();
-  unittest::TestMutualRecursionA* nested2 = nested->mutable_bb()->mutable_a();
+  unittest::TestMutualRecursionA* nested = &message.mutable_bb().mutable_a();
+  unittest::TestMutualRecursionA* nested2 = &nested->mutable_bb().mutable_a();
 
   // Again, if the above compiles and runs, that's all we really have to
   // test, but just for run we'll check that the system didn't somehow come
@@ -907,7 +906,7 @@ TEST(GeneratedMessageTest, CamelCaseFieldNames) {
   message.set_primitivefield(2);
   message.set_stringfield("foo");
   message.set_enumfield(unittest::FOREIGN_FOO);
-  message.mutable_messagefield()->set_c(6);
+  message.mutable_messagefield().set_c(6);
 
   message.add_repeatedprimitivefield(8);
   message.add_repeatedstringfield("qux");
@@ -973,7 +972,7 @@ TEST(GeneratedMessageTest, TestOptimizedForSize) {
 
   protobuf_unittest::TestOptimizedForSize message, message2;
   message.set_i(1);
-  message.mutable_msg()->set_c(2);
+  message.mutable_msg().set_c(2);
   message2.CopyFrom(message);
   EXPECT_EQ(1, message2.i());
   EXPECT_EQ(2, message2.msg().c());
@@ -984,8 +983,8 @@ TEST(GeneratedMessageTest, TestEmbedOptimizedForSize) {
   // for size.
 
   protobuf_unittest::TestEmbedOptimizedForSize message, message2;
-  message.mutable_optional_message()->set_i(1);
-  message.add_repeated_message()->mutable_msg()->set_c(2);
+  message.mutable_optional_message().set_i(1);
+  message.add_repeated_message()->mutable_msg().set_c(2);
   string data;
   message.SerializeToString(&data);
   ASSERT_TRUE(message2.ParseFromString(data));
@@ -1610,11 +1609,11 @@ TEST_F(OneofTest, SettingOneFieldClearsOthers) {
   EXPECT_TRUE(message.has_foo_enum());
   TestUtil::ExpectAtMostOneFieldSetInOneof(message);
 
-  message.mutable_foo_message()->set_qux_int(234);
+  message.mutable_foo_message().set_qux_int(234);
   EXPECT_TRUE(message.has_foo_message());
   TestUtil::ExpectAtMostOneFieldSetInOneof(message);
 
-  message.mutable_foogroup()->set_a(345);
+  message.mutable_foogroup().set_a(345);
   EXPECT_TRUE(message.has_foogroup());
   TestUtil::ExpectAtMostOneFieldSetInOneof(message);
 
@@ -1637,9 +1636,9 @@ TEST_F(OneofTest, EnumCases) {
   ExpectEnumCasesWork(message);
   message.set_foo_enum(unittest::TestOneof2::FOO);
   ExpectEnumCasesWork(message);
-  message.mutable_foo_message()->set_qux_int(234);
+  message.mutable_foo_message().set_qux_int(234);
   ExpectEnumCasesWork(message);
-  message.mutable_foogroup()->set_a(345);
+  message.mutable_foogroup().set_a(345);
   ExpectEnumCasesWork(message);
 }
 
@@ -1753,7 +1752,7 @@ TEST_F(OneofTest, SetMessage) {
             &unittest::TestOneof2_NestedMessage::default_instance());
   EXPECT_EQ(message.foo_message().qux_int(), 0);
 
-  message.mutable_foo_message()->set_qux_int(234);
+  message.mutable_foo_message().set_qux_int(234);
   EXPECT_TRUE(message.has_foo_message());
   EXPECT_EQ(message.foo_message().qux_int(), 234);
   message.clear_foo_message();
@@ -1768,7 +1767,7 @@ TEST_F(OneofTest, ReleaseMessage) {
   EXPECT_EQ(NULL, message.release_foo_message());
   EXPECT_FALSE(message.has_foo_message());
 
-  message.mutable_foo_message()->set_qux_int(1);
+  message.mutable_foo_message().set_qux_int(1);
   EXPECT_TRUE(message.has_foo_message());
   google::protobuf::scoped_ptr<unittest::TestOneof2_NestedMessage> mes(
       message.release_foo_message());
@@ -1786,7 +1785,7 @@ TEST_F(OneofTest, SetAllocatedMessage) {
 
   EXPECT_FALSE(message.has_foo_message());
 
-  message.mutable_foo_message()->set_qux_int(1);
+  message.mutable_foo_message().set_qux_int(1);
   EXPECT_TRUE(message.has_foo_message());
 
   message.set_allocated_foo_message(NULL);
@@ -1794,7 +1793,7 @@ TEST_F(OneofTest, SetAllocatedMessage) {
   EXPECT_EQ(&message.foo_message(),
             &unittest::TestOneof2_NestedMessage::default_instance());
 
-  message.mutable_foo_message()->set_qux_int(1);
+  message.mutable_foo_message().set_qux_int(1);
   unittest::TestOneof2_NestedMessage* mes = message.release_foo_message();
   ASSERT_TRUE(mes != NULL);
   EXPECT_FALSE(message.has_foo_message());
@@ -1875,7 +1874,7 @@ TEST_F(OneofTest, SwapBothHasFields) {
 
   message1.set_foo_string("FOO");
   EXPECT_TRUE(message1.has_foo_string());
-  message2.mutable_foo_message()->set_qux_int(1);
+  message2.mutable_foo_message().set_qux_int(1);
   EXPECT_TRUE(message2.has_foo_message());
 
   message1.Swap(&message2);
@@ -1913,7 +1912,7 @@ TEST_F(OneofTest, CopyFrom) {
 
 TEST_F(OneofTest, CopyAssignmentOperator) {
   unittest::TestOneof2 message1;
-  message1.mutable_foo_message()->set_qux_int(123);
+  message1.mutable_foo_message().set_qux_int(123);
   EXPECT_TRUE(message1.has_foo_message());
 
   unittest::TestOneof2 message2;
@@ -1929,7 +1928,7 @@ TEST_F(OneofTest, UpcastCopyFrom) {
   // Test the CopyFrom method that takes in the generic const Message&
   // parameter.
   unittest::TestOneof2 message1, message2;
-  message1.mutable_foogroup()->set_a(123);
+  message1.mutable_foogroup().set_a(123);
   EXPECT_TRUE(message1.has_foogroup());
 
   const Message* source = implicit_cast<const Message*>(&message1);
@@ -2005,7 +2004,7 @@ TEST_F(OneofTest, SerializationToArray) {
   {
     unittest::TestOneof2 message1, message2;
     string data;
-    message1.mutable_foo_message()->set_qux_int(234);
+    message1.mutable_foo_message().set_qux_int(234);
     int size = message1.ByteSize();
     data.resize(size);
     uint8* start = reinterpret_cast<uint8*>(string_as_array(&data));
@@ -2019,7 +2018,7 @@ TEST_F(OneofTest, SerializationToArray) {
   {
     unittest::TestOneof2 message1, message2;
     string data;
-    message1.mutable_foogroup()->set_a(345);
+    message1.mutable_foogroup().set_a(345);
     int size = message1.ByteSize();
     data.resize(size);
     uint8* start = reinterpret_cast<uint8*>(string_as_array(&data));
@@ -2126,7 +2125,7 @@ TEST_F(OneofTest, SerializationToStream) {
   {
     unittest::TestOneof2 message1, message2;
     string data;
-    message1.mutable_foo_message()->set_qux_int(234);
+    message1.mutable_foo_message().set_qux_int(234);
     int size = message1.ByteSize();
     data.resize(size);
 
@@ -2147,7 +2146,7 @@ TEST_F(OneofTest, SerializationToStream) {
   {
     unittest::TestOneof2 message1, message2;
     string data;
-    message1.mutable_foogroup()->set_a(345);
+    message1.mutable_foogroup().set_a(345);
     int size = message1.ByteSize();
     data.resize(size);
 
@@ -2194,13 +2193,13 @@ TEST_F(OneofTest, MergeFrom) {
   EXPECT_TRUE(message2.has_foo_enum());
   EXPECT_EQ(message2.foo_enum(), unittest::TestOneof2::FOO);
 
-  message1.mutable_foo_message()->set_qux_int(234);
+  message1.mutable_foo_message().set_qux_int(234);
   message2.MergeFrom(message1);
   TestUtil::ExpectAtMostOneFieldSetInOneof(message2);
   EXPECT_TRUE(message2.has_foo_message());
   EXPECT_EQ(message2.foo_message().qux_int(), 234);
 
-  message1.mutable_foogroup()->set_a(345);
+  message1.mutable_foogroup().set_a(345);
   message2.MergeFrom(message1);
   TestUtil::ExpectAtMostOneFieldSetInOneof(message2);
   EXPECT_TRUE(message2.has_foogroup());

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1933,10 +1933,10 @@ void SortMessages(DescriptorProto *descriptor_proto) {
   int size = descriptor_proto->nested_type_size();
   // recursively sort; we can't guarantee the order of nested messages either
   for (int i = 0; i < size; ++i) {
-    SortMessages(descriptor_proto->mutable_nested_type(i));
+    SortMessages(&descriptor_proto->nested_type(i));
   }
   DescriptorProto **data =
-    descriptor_proto->mutable_nested_type()->mutable_data();
+    descriptor_proto->nested_type().mutable_data();
   std::sort(data, data + size, CompareDescriptorNames());
 }
 
@@ -1945,10 +1945,10 @@ void SortMessages(FileDescriptorProto *file_descriptor_proto) {
   int size = file_descriptor_proto->message_type_size();
   // recursively sort; we can't guarantee the order of nested messages either
   for (int i = 0; i < size; ++i) {
-    SortMessages(file_descriptor_proto->mutable_message_type(i));
+    SortMessages(&file_descriptor_proto->message_type(i));
   }
   DescriptorProto **data =
-    file_descriptor_proto->mutable_message_type()->mutable_data();
+    file_descriptor_proto->message_type().mutable_data();
   std::sort(data, data + size, CompareDescriptorNames());
 }
 
@@ -1958,18 +1958,18 @@ void StripFieldTypeName(DescriptorProto* proto) {
     string type_name = proto->field(i).type_name();
     string::size_type pos = type_name.find_last_of(".");
     if (pos != string::npos) {
-      proto->mutable_field(i)->mutable_type_name()->assign(
+      proto->field(i).mutable_type_name()->assign(
           type_name.begin() + pos + 1, type_name.end());
     }
   }
   for (int i = 0; i < proto->nested_type_size(); ++i) {
-    StripFieldTypeName(proto->mutable_nested_type(i));
+    StripFieldTypeName(&proto->nested_type(i));
   }
 }
 
 void StripFieldTypeName(FileDescriptorProto* file_proto) {
   for (int i = 0; i < file_proto->message_type_size(); ++i) {
-    StripFieldTypeName(file_proto->mutable_message_type(i));
+    StripFieldTypeName(&file_proto->message_type(i));
   }
 }
 

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -865,21 +865,18 @@ void GenerateAddFileToPool(const FileDescriptor* file, bool is_descriptor,
     file->CopyTo(file_proto);
 
     // Filter out descriptor.proto as it cannot be depended on for now.
-    RepeatedPtrField<string>* dependency = file_proto->mutable_dependency();
-    for (RepeatedPtrField<string>::iterator it = dependency->begin();
-         it != dependency->end(); ++it) {
+    for (auto it = file_proto->dependency().begin();
+         it != file_proto->dependency().end(); ++it) {
       if (*it != kDescriptorFile) {
-        dependency->erase(it);
+        file_proto->dependency().erase(it);
         break;
       }
     }
 
     // Filter out all extensions, since we do not support extension yet.
     file_proto->clear_extension();
-    RepeatedPtrField<DescriptorProto>* message_type =
-        file_proto->mutable_message_type();
-    for (RepeatedPtrField<DescriptorProto>::iterator it = message_type->begin();
-         it != message_type->end(); ++it) {
+    for (auto it = file_proto->message_type().begin();
+         it != file_proto->message_type().end(); ++it) {
       it->clear_extension();
     }
 

--- a/src/google/protobuf/compiler/plugin.pb.cc
+++ b/src/google/protobuf/compiler/plugin.pb.cc
@@ -788,7 +788,7 @@ bool CodeGeneratorRequest::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_compiler_version()));
+               input, &mutable_compiler_version()));
         } else {
           goto handle_unusual;
         }
@@ -1010,7 +1010,7 @@ void CodeGeneratorRequest::MergeFrom(const CodeGeneratorRequest& from) {
       parameter_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.parameter_);
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_compiler_version()->::google::protobuf::compiler::Version::MergeFrom(from.compiler_version());
+      mutable_compiler_version().::google::protobuf::compiler::Version::MergeFrom(from.compiler_version());
     }
   }
 }

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -361,15 +361,15 @@ class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message
   void add_file_to_generate(const char* value);
   void add_file_to_generate(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& file_to_generate() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_file_to_generate();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& file_to_generate();
 
   // repeated .google.protobuf.FileDescriptorProto proto_file = 15;
   int proto_file_size() const;
   void clear_proto_file();
   static const int kProtoFileFieldNumber = 15;
-  ::google::protobuf::FileDescriptorProto* mutable_proto_file(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >*
-      mutable_proto_file();
+  ::google::protobuf::FileDescriptorProto& proto_file(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
+      proto_file();
   const ::google::protobuf::FileDescriptorProto& proto_file(int index) const;
   ::google::protobuf::FileDescriptorProto* add_proto_file();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
@@ -396,7 +396,7 @@ class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message
   static const int kCompilerVersionFieldNumber = 3;
   const ::google::protobuf::compiler::Version& compiler_version() const;
   ::google::protobuf::compiler::Version* release_compiler_version();
-  ::google::protobuf::compiler::Version* mutable_compiler_version();
+  ::google::protobuf::compiler::Version& mutable_compiler_version();
   void set_allocated_compiler_version(::google::protobuf::compiler::Version* compiler_version);
 
   // @@protoc_insertion_point(class_scope:google.protobuf.compiler.CodeGeneratorRequest)
@@ -675,9 +675,9 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Messag
   int file_size() const;
   void clear_file();
   static const int kFileFieldNumber = 15;
-  ::google::protobuf::compiler::CodeGeneratorResponse_File* mutable_file(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::compiler::CodeGeneratorResponse_File >*
-      mutable_file();
+  ::google::protobuf::compiler::CodeGeneratorResponse_File& file(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::compiler::CodeGeneratorResponse_File >&
+      file();
   const ::google::protobuf::compiler::CodeGeneratorResponse_File& file(int index) const;
   ::google::protobuf::compiler::CodeGeneratorResponse_File* add_file();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::compiler::CodeGeneratorResponse_File >&
@@ -924,10 +924,10 @@ CodeGeneratorRequest::file_to_generate() const {
   // @@protoc_insertion_point(field_list:google.protobuf.compiler.CodeGeneratorRequest.file_to_generate)
   return file_to_generate_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-CodeGeneratorRequest::mutable_file_to_generate() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+CodeGeneratorRequest::file_to_generate() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.compiler.CodeGeneratorRequest.file_to_generate)
-  return &file_to_generate_;
+  return file_to_generate_;
 }
 
 // optional string parameter = 2;
@@ -997,14 +997,14 @@ inline void CodeGeneratorRequest::set_allocated_parameter(::std::string* paramet
 inline int CodeGeneratorRequest::proto_file_size() const {
   return proto_file_.size();
 }
-inline ::google::protobuf::FileDescriptorProto* CodeGeneratorRequest::mutable_proto_file(int index) {
+inline ::google::protobuf::FileDescriptorProto& CodeGeneratorRequest::proto_file(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.compiler.CodeGeneratorRequest.proto_file)
-  return proto_file_.Mutable(index);
+  return *proto_file_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >*
-CodeGeneratorRequest::mutable_proto_file() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
+CodeGeneratorRequest::proto_file() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.compiler.CodeGeneratorRequest.proto_file)
-  return &proto_file_;
+  return proto_file_;
 }
 inline const ::google::protobuf::FileDescriptorProto& CodeGeneratorRequest::proto_file(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.compiler.CodeGeneratorRequest.proto_file)
@@ -1047,14 +1047,14 @@ inline ::google::protobuf::compiler::Version* CodeGeneratorRequest::release_comp
   compiler_version_ = NULL;
   return temp;
 }
-inline ::google::protobuf::compiler::Version* CodeGeneratorRequest::mutable_compiler_version() {
+inline ::google::protobuf::compiler::Version& CodeGeneratorRequest::mutable_compiler_version() {
   set_has_compiler_version();
   if (compiler_version_ == NULL) {
     compiler_version_ = ::google::protobuf::Arena::Create< ::google::protobuf::compiler::Version >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.compiler.CodeGeneratorRequest.compiler_version)
-  return compiler_version_;
+  return *compiler_version_;
 }
 inline void CodeGeneratorRequest::set_allocated_compiler_version(::google::protobuf::compiler::Version* compiler_version) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -1342,14 +1342,14 @@ inline int CodeGeneratorResponse::file_size() const {
 inline void CodeGeneratorResponse::clear_file() {
   file_.Clear();
 }
-inline ::google::protobuf::compiler::CodeGeneratorResponse_File* CodeGeneratorResponse::mutable_file(int index) {
+inline ::google::protobuf::compiler::CodeGeneratorResponse_File& CodeGeneratorResponse::file(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.compiler.CodeGeneratorResponse.file)
-  return file_.Mutable(index);
+  return *file_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::compiler::CodeGeneratorResponse_File >*
-CodeGeneratorResponse::mutable_file() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::compiler::CodeGeneratorResponse_File >&
+CodeGeneratorResponse::file() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.compiler.CodeGeneratorResponse.file)
-  return &file_;
+  return file_;
 }
 inline const ::google::protobuf::compiler::CodeGeneratorResponse_File& CodeGeneratorResponse::file(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.compiler.CodeGeneratorResponse.file)

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -2028,7 +2028,7 @@ void FileDescriptor::CopyTo(FileDescriptorProto* proto) const {
   }
 
   if (&options() != &FileOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2039,17 +2039,17 @@ void FileDescriptor::CopyJsonNameTo(FileDescriptorProto* proto) const {
     return;
   }
   for (int i = 0; i < message_type_count(); i++) {
-    message_type(i)->CopyJsonNameTo(proto->mutable_message_type(i));
+    message_type(i)->CopyJsonNameTo(&proto->message_type(i));
   }
   for (int i = 0; i < extension_count(); i++) {
-    extension(i)->CopyJsonNameTo(proto->mutable_extension(i));
+    extension(i)->CopyJsonNameTo(&proto->extension(i));
   }
 }
 
 void FileDescriptor::CopySourceCodeInfoTo(FileDescriptorProto* proto) const {
   if (source_code_info_ &&
       source_code_info_ != &SourceCodeInfo::default_instance()) {
-    proto->mutable_source_code_info()->CopyFrom(*source_code_info_);
+    proto->mutable_source_code_info() = *source_code_info_;
   }
 }
 
@@ -2074,7 +2074,7 @@ void Descriptor::CopyTo(DescriptorProto* proto) const {
     range->set_end(extension_range(i)->end);
     const ExtensionRangeOptions* options = extension_range(i)->options_;
     if (options != &ExtensionRangeOptions::default_instance()) {
-      range->mutable_options()->CopyFrom(*options);
+      range->mutable_options() = *options;
     }
   }
   for (int i = 0; i < extension_count(); i++) {
@@ -2090,7 +2090,7 @@ void Descriptor::CopyTo(DescriptorProto* proto) const {
   }
 
   if (&options() != &MessageOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2102,13 +2102,13 @@ void Descriptor::CopyJsonNameTo(DescriptorProto* proto) const {
     return;
   }
   for (int i = 0; i < field_count(); i++) {
-    field(i)->CopyJsonNameTo(proto->mutable_field(i));
+    field(i)->CopyJsonNameTo(&proto->field(i));
   }
   for (int i = 0; i < nested_type_count(); i++) {
-    nested_type(i)->CopyJsonNameTo(proto->mutable_nested_type(i));
+    nested_type(i)->CopyJsonNameTo(&proto->nested_type(i));
   }
   for (int i = 0; i < extension_count(); i++) {
-    extension(i)->CopyJsonNameTo(proto->mutable_extension(i));
+    extension(i)->CopyJsonNameTo(&proto->extension(i));
   }
 }
 
@@ -2160,7 +2160,7 @@ void FieldDescriptor::CopyTo(FieldDescriptorProto* proto) const {
   }
 
   if (&options() != &FieldOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2171,7 +2171,7 @@ void FieldDescriptor::CopyJsonNameTo(FieldDescriptorProto* proto) const {
 void OneofDescriptor::CopyTo(OneofDescriptorProto* proto) const {
   proto->set_name(name());
   if (&options() != &OneofOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2191,7 +2191,7 @@ void EnumDescriptor::CopyTo(EnumDescriptorProto* proto) const {
   }
 
   if (&options() != &EnumOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2200,7 +2200,7 @@ void EnumValueDescriptor::CopyTo(EnumValueDescriptorProto* proto) const {
   proto->set_number(number());
 
   if (&options() != &EnumValueOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2212,7 +2212,7 @@ void ServiceDescriptor::CopyTo(ServiceDescriptorProto* proto) const {
   }
 
   if (&options() != &ServiceOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 }
 
@@ -2230,7 +2230,7 @@ void MethodDescriptor::CopyTo(MethodDescriptorProto* proto) const {
   proto->mutable_output_type()->append(output_type()->full_name());
 
   if (&options() != &MethodOptions::default_instance()) {
-    proto->mutable_options()->CopyFrom(options());
+    proto->mutable_options() = options();
   }
 
   if (client_streaming_) {

--- a/src/google/protobuf/descriptor.pb.cc
+++ b/src/google/protobuf/descriptor.pb.cc
@@ -2149,7 +2149,7 @@ bool FileDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -2161,7 +2161,7 @@ bool FileDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(74u /* 74 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_source_code_info()));
+               input, &mutable_source_code_info()));
         } else {
           goto handle_unusual;
         }
@@ -2174,13 +2174,13 @@ bool FileDescriptorProto::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(80u /* 80 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 80u, input, this->mutable_public_dependency())));
+                 1, 80u, input, &this->public_dependency())));
         } else if (
             static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(82u /* 82 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitiveNoInline<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_public_dependency())));
+                 input, &this->public_dependency())));
         } else {
           goto handle_unusual;
         }
@@ -2193,13 +2193,13 @@ bool FileDescriptorProto::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(88u /* 88 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 88u, input, this->mutable_weak_dependency())));
+                 1, 88u, input, &this->weak_dependency())));
         } else if (
             static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(90u /* 90 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitiveNoInline<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_weak_dependency())));
+                 input, &this->weak_dependency())));
         } else {
           goto handle_unusual;
         }
@@ -2633,10 +2633,10 @@ void FileDescriptorProto::MergeFrom(const FileDescriptorProto& from) {
       set_syntax(from.syntax());
     }
     if (cached_has_bits & 0x00000008u) {
-      mutable_options()->::google::protobuf::FileOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::FileOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000010u) {
-      mutable_source_code_info()->::google::protobuf::SourceCodeInfo::MergeFrom(from.source_code_info());
+      mutable_source_code_info().::google::protobuf::SourceCodeInfo::MergeFrom(from.source_code_info());
     }
   }
 }
@@ -2870,7 +2870,7 @@ bool DescriptorProto_ExtensionRange::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -3024,7 +3024,7 @@ void DescriptorProto_ExtensionRange::MergeFrom(const DescriptorProto_ExtensionRa
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 7u) {
     if (cached_has_bits & 0x00000001u) {
-      mutable_options()->::google::protobuf::ExtensionRangeOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::ExtensionRangeOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000002u) {
       start_ = from.start_;
@@ -3651,7 +3651,7 @@ bool DescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -4075,7 +4075,7 @@ void DescriptorProto::MergeFrom(const DescriptorProto& from) {
       set_name(from.name());
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_options()->::google::protobuf::MessageOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::MessageOptions::MergeFrom(from.options());
     }
   }
 }
@@ -4766,7 +4766,7 @@ bool FieldDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -5143,7 +5143,7 @@ void FieldDescriptorProto::MergeFrom(const FieldDescriptorProto& from) {
       set_json_name(from.json_name());
     }
     if (cached_has_bits & 0x00000020u) {
-      mutable_options()->::google::protobuf::FieldOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::FieldOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000040u) {
       number_ = from.number_;
@@ -5377,7 +5377,7 @@ bool OneofDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -5528,7 +5528,7 @@ void OneofDescriptorProto::MergeFrom(const OneofDescriptorProto& from) {
       set_name(from.name());
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_options()->::google::protobuf::OneofOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::OneofOptions::MergeFrom(from.options());
     }
   }
 }
@@ -6079,7 +6079,7 @@ bool EnumDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -6346,7 +6346,7 @@ void EnumDescriptorProto::MergeFrom(const EnumDescriptorProto& from) {
       set_name(from.name());
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_options()->::google::protobuf::EnumOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::EnumOptions::MergeFrom(from.options());
     }
   }
 }
@@ -6579,7 +6579,7 @@ bool EnumValueDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -6747,7 +6747,7 @@ void EnumValueDescriptorProto::MergeFrom(const EnumValueDescriptorProto& from) {
       set_name(from.name());
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_options()->::google::protobuf::EnumValueOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::EnumValueOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000004u) {
       number_ = from.number_;
@@ -6978,7 +6978,7 @@ bool ServiceDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -7158,7 +7158,7 @@ void ServiceDescriptorProto::MergeFrom(const ServiceDescriptorProto& from) {
       set_name(from.name());
     }
     if (cached_has_bits & 0x00000002u) {
-      mutable_options()->::google::protobuf::ServiceOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::ServiceOptions::MergeFrom(from.options());
     }
   }
 }
@@ -7436,7 +7436,7 @@ bool MethodDescriptorProto::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_options()));
+               input, &mutable_options()));
         } else {
           goto handle_unusual;
         }
@@ -7707,7 +7707,7 @@ void MethodDescriptorProto::MergeFrom(const MethodDescriptorProto& from) {
       set_output_type(from.output_type());
     }
     if (cached_has_bits & 0x00000008u) {
-      mutable_options()->::google::protobuf::MethodOptions::MergeFrom(from.options());
+      mutable_options().::google::protobuf::MethodOptions::MergeFrom(from.options());
     }
     if (cached_has_bits & 0x00000010u) {
       client_streaming_ = from.client_streaming_;
@@ -12722,13 +12722,13 @@ bool SourceCodeInfo_Location::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_path())));
+                 input, &this->path())));
         } else if (
             static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 10u, input, this->mutable_path())));
+                 1, 10u, input, &this->path())));
         } else {
           goto handle_unusual;
         }
@@ -12741,13 +12741,13 @@ bool SourceCodeInfo_Location::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_span())));
+                 input, &this->span())));
         } else if (
             static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(16u /* 16 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 18u, input, this->mutable_span())));
+                 1, 18u, input, &this->span())));
         } else {
           goto handle_unusual;
         }
@@ -13520,13 +13520,13 @@ bool GeneratedCodeInfo_Annotation::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 input, this->mutable_path())));
+                 input, &this->path())));
         } else if (
             static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
                    ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
-                 1, 10u, input, this->mutable_path())));
+                 1, 10u, input, &this->path())));
         } else {
           goto handle_unusual;
         }

--- a/src/google/protobuf/descriptor.pb.h
+++ b/src/google/protobuf/descriptor.pb.h
@@ -492,9 +492,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorSet : public ::google::protobuf::Message 
   int file_size() const;
   void clear_file();
   static const int kFileFieldNumber = 1;
-  ::google::protobuf::FileDescriptorProto* mutable_file(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >*
-      mutable_file();
+  ::google::protobuf::FileDescriptorProto& file(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
+      file();
   const ::google::protobuf::FileDescriptorProto& file(int index) const;
   ::google::protobuf::FileDescriptorProto* add_file();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
@@ -640,15 +640,15 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   void add_dependency(const char* value);
   void add_dependency(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& dependency() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_dependency();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& dependency();
 
   // repeated .google.protobuf.DescriptorProto message_type = 4;
   int message_type_size() const;
   void clear_message_type();
   static const int kMessageTypeFieldNumber = 4;
-  ::google::protobuf::DescriptorProto* mutable_message_type(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >*
-      mutable_message_type();
+  ::google::protobuf::DescriptorProto& message_type(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
+      message_type();
   const ::google::protobuf::DescriptorProto& message_type(int index) const;
   ::google::protobuf::DescriptorProto* add_message_type();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
@@ -658,9 +658,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   int enum_type_size() const;
   void clear_enum_type();
   static const int kEnumTypeFieldNumber = 5;
-  ::google::protobuf::EnumDescriptorProto* mutable_enum_type(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >*
-      mutable_enum_type();
+  ::google::protobuf::EnumDescriptorProto& enum_type(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
+      enum_type();
   const ::google::protobuf::EnumDescriptorProto& enum_type(int index) const;
   ::google::protobuf::EnumDescriptorProto* add_enum_type();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
@@ -670,9 +670,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   int service_size() const;
   void clear_service();
   static const int kServiceFieldNumber = 6;
-  ::google::protobuf::ServiceDescriptorProto* mutable_service(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::ServiceDescriptorProto >*
-      mutable_service();
+  ::google::protobuf::ServiceDescriptorProto& service(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::ServiceDescriptorProto >&
+      service();
   const ::google::protobuf::ServiceDescriptorProto& service(int index) const;
   ::google::protobuf::ServiceDescriptorProto* add_service();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::ServiceDescriptorProto >&
@@ -682,9 +682,9 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   int extension_size() const;
   void clear_extension();
   static const int kExtensionFieldNumber = 7;
-  ::google::protobuf::FieldDescriptorProto* mutable_extension(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-      mutable_extension();
+  ::google::protobuf::FieldDescriptorProto& extension(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+      extension();
   const ::google::protobuf::FieldDescriptorProto& extension(int index) const;
   ::google::protobuf::FieldDescriptorProto* add_extension();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
@@ -699,8 +699,8 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   void add_public_dependency(::google::protobuf::int32 value);
   const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
       public_dependency() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_public_dependency();
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      public_dependency();
 
   // repeated int32 weak_dependency = 11;
   int weak_dependency_size() const;
@@ -711,8 +711,8 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   void add_weak_dependency(::google::protobuf::int32 value);
   const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
       weak_dependency() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_weak_dependency();
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      weak_dependency();
 
   // optional string name = 1;
   bool has_name() const;
@@ -792,7 +792,7 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   static const int kOptionsFieldNumber = 8;
   const ::google::protobuf::FileOptions& options() const;
   ::google::protobuf::FileOptions* release_options();
-  ::google::protobuf::FileOptions* mutable_options();
+  ::google::protobuf::FileOptions& mutable_options();
   void set_allocated_options(::google::protobuf::FileOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::FileOptions* options);
@@ -804,7 +804,7 @@ class LIBPROTOBUF_EXPORT FileDescriptorProto : public ::google::protobuf::Messag
   static const int kSourceCodeInfoFieldNumber = 9;
   const ::google::protobuf::SourceCodeInfo& source_code_info() const;
   ::google::protobuf::SourceCodeInfo* release_source_code_info();
-  ::google::protobuf::SourceCodeInfo* mutable_source_code_info();
+  ::google::protobuf::SourceCodeInfo& mutable_source_code_info();
   void set_allocated_source_code_info(::google::protobuf::SourceCodeInfo* source_code_info);
   void unsafe_arena_set_allocated_source_code_info(
       ::google::protobuf::SourceCodeInfo* source_code_info);
@@ -957,7 +957,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto_ExtensionRange : public ::google::proto
   static const int kOptionsFieldNumber = 3;
   const ::google::protobuf::ExtensionRangeOptions& options() const;
   ::google::protobuf::ExtensionRangeOptions* release_options();
-  ::google::protobuf::ExtensionRangeOptions* mutable_options();
+  ::google::protobuf::ExtensionRangeOptions& mutable_options();
   void set_allocated_options(::google::protobuf::ExtensionRangeOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::ExtensionRangeOptions* options);
@@ -1251,9 +1251,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int field_size() const;
   void clear_field();
   static const int kFieldFieldNumber = 2;
-  ::google::protobuf::FieldDescriptorProto* mutable_field(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-      mutable_field();
+  ::google::protobuf::FieldDescriptorProto& field(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+      field();
   const ::google::protobuf::FieldDescriptorProto& field(int index) const;
   ::google::protobuf::FieldDescriptorProto* add_field();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
@@ -1263,9 +1263,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int nested_type_size() const;
   void clear_nested_type();
   static const int kNestedTypeFieldNumber = 3;
-  ::google::protobuf::DescriptorProto* mutable_nested_type(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >*
-      mutable_nested_type();
+  ::google::protobuf::DescriptorProto& nested_type(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
+      nested_type();
   const ::google::protobuf::DescriptorProto& nested_type(int index) const;
   ::google::protobuf::DescriptorProto* add_nested_type();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
@@ -1275,9 +1275,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int enum_type_size() const;
   void clear_enum_type();
   static const int kEnumTypeFieldNumber = 4;
-  ::google::protobuf::EnumDescriptorProto* mutable_enum_type(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >*
-      mutable_enum_type();
+  ::google::protobuf::EnumDescriptorProto& enum_type(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
+      enum_type();
   const ::google::protobuf::EnumDescriptorProto& enum_type(int index) const;
   ::google::protobuf::EnumDescriptorProto* add_enum_type();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
@@ -1287,9 +1287,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int extension_range_size() const;
   void clear_extension_range();
   static const int kExtensionRangeFieldNumber = 5;
-  ::google::protobuf::DescriptorProto_ExtensionRange* mutable_extension_range(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ExtensionRange >*
-      mutable_extension_range();
+  ::google::protobuf::DescriptorProto_ExtensionRange& extension_range(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ExtensionRange >&
+      extension_range();
   const ::google::protobuf::DescriptorProto_ExtensionRange& extension_range(int index) const;
   ::google::protobuf::DescriptorProto_ExtensionRange* add_extension_range();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ExtensionRange >&
@@ -1299,9 +1299,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int extension_size() const;
   void clear_extension();
   static const int kExtensionFieldNumber = 6;
-  ::google::protobuf::FieldDescriptorProto* mutable_extension(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-      mutable_extension();
+  ::google::protobuf::FieldDescriptorProto& extension(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+      extension();
   const ::google::protobuf::FieldDescriptorProto& extension(int index) const;
   ::google::protobuf::FieldDescriptorProto* add_extension();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
@@ -1311,9 +1311,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int oneof_decl_size() const;
   void clear_oneof_decl();
   static const int kOneofDeclFieldNumber = 8;
-  ::google::protobuf::OneofDescriptorProto* mutable_oneof_decl(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::OneofDescriptorProto >*
-      mutable_oneof_decl();
+  ::google::protobuf::OneofDescriptorProto& oneof_decl(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::OneofDescriptorProto >&
+      oneof_decl();
   const ::google::protobuf::OneofDescriptorProto& oneof_decl(int index) const;
   ::google::protobuf::OneofDescriptorProto* add_oneof_decl();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::OneofDescriptorProto >&
@@ -1323,9 +1323,9 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   int reserved_range_size() const;
   void clear_reserved_range();
   static const int kReservedRangeFieldNumber = 9;
-  ::google::protobuf::DescriptorProto_ReservedRange* mutable_reserved_range(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ReservedRange >*
-      mutable_reserved_range();
+  ::google::protobuf::DescriptorProto_ReservedRange& reserved_range(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ReservedRange >&
+      reserved_range();
   const ::google::protobuf::DescriptorProto_ReservedRange& reserved_range(int index) const;
   ::google::protobuf::DescriptorProto_ReservedRange* add_reserved_range();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ReservedRange >&
@@ -1351,7 +1351,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   void add_reserved_name(const char* value);
   void add_reserved_name(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& reserved_name() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_reserved_name();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& reserved_name();
 
   // optional string name = 1;
   bool has_name() const;
@@ -1383,7 +1383,7 @@ class LIBPROTOBUF_EXPORT DescriptorProto : public ::google::protobuf::Message /*
   static const int kOptionsFieldNumber = 7;
   const ::google::protobuf::MessageOptions& options() const;
   ::google::protobuf::MessageOptions* release_options();
-  ::google::protobuf::MessageOptions* mutable_options();
+  ::google::protobuf::MessageOptions& mutable_options();
   void set_allocated_options(::google::protobuf::MessageOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::MessageOptions* options);
@@ -1526,9 +1526,9 @@ class LIBPROTOBUF_EXPORT ExtensionRangeOptions : public ::google::protobuf::Mess
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -1869,7 +1869,7 @@ class LIBPROTOBUF_EXPORT FieldDescriptorProto : public ::google::protobuf::Messa
   static const int kOptionsFieldNumber = 8;
   const ::google::protobuf::FieldOptions& options() const;
   ::google::protobuf::FieldOptions* release_options();
-  ::google::protobuf::FieldOptions* mutable_options();
+  ::google::protobuf::FieldOptions& mutable_options();
   void set_allocated_options(::google::protobuf::FieldOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::FieldOptions* options);
@@ -2082,7 +2082,7 @@ class LIBPROTOBUF_EXPORT OneofDescriptorProto : public ::google::protobuf::Messa
   static const int kOptionsFieldNumber = 2;
   const ::google::protobuf::OneofOptions& options() const;
   ::google::protobuf::OneofOptions* release_options();
-  ::google::protobuf::OneofOptions* mutable_options();
+  ::google::protobuf::OneofOptions& mutable_options();
   void set_allocated_options(::google::protobuf::OneofOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::OneofOptions* options);
@@ -2358,9 +2358,9 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   int value_size() const;
   void clear_value();
   static const int kValueFieldNumber = 2;
-  ::google::protobuf::EnumValueDescriptorProto* mutable_value(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValueDescriptorProto >*
-      mutable_value();
+  ::google::protobuf::EnumValueDescriptorProto& value(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValueDescriptorProto >&
+      value();
   const ::google::protobuf::EnumValueDescriptorProto& value(int index) const;
   ::google::protobuf::EnumValueDescriptorProto* add_value();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValueDescriptorProto >&
@@ -2370,9 +2370,9 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   int reserved_range_size() const;
   void clear_reserved_range();
   static const int kReservedRangeFieldNumber = 4;
-  ::google::protobuf::EnumDescriptorProto_EnumReservedRange* mutable_reserved_range(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto_EnumReservedRange >*
-      mutable_reserved_range();
+  ::google::protobuf::EnumDescriptorProto_EnumReservedRange& reserved_range(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto_EnumReservedRange >&
+      reserved_range();
   const ::google::protobuf::EnumDescriptorProto_EnumReservedRange& reserved_range(int index) const;
   ::google::protobuf::EnumDescriptorProto_EnumReservedRange* add_reserved_range();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto_EnumReservedRange >&
@@ -2398,7 +2398,7 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   void add_reserved_name(const char* value);
   void add_reserved_name(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& reserved_name() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_reserved_name();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& reserved_name();
 
   // optional string name = 1;
   bool has_name() const;
@@ -2430,7 +2430,7 @@ class LIBPROTOBUF_EXPORT EnumDescriptorProto : public ::google::protobuf::Messag
   static const int kOptionsFieldNumber = 3;
   const ::google::protobuf::EnumOptions& options() const;
   ::google::protobuf::EnumOptions* release_options();
-  ::google::protobuf::EnumOptions* mutable_options();
+  ::google::protobuf::EnumOptions& mutable_options();
   void set_allocated_options(::google::protobuf::EnumOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::EnumOptions* options);
@@ -2594,7 +2594,7 @@ class LIBPROTOBUF_EXPORT EnumValueDescriptorProto : public ::google::protobuf::M
   static const int kOptionsFieldNumber = 3;
   const ::google::protobuf::EnumValueOptions& options() const;
   ::google::protobuf::EnumValueOptions* release_options();
-  ::google::protobuf::EnumValueOptions* mutable_options();
+  ::google::protobuf::EnumValueOptions& mutable_options();
   void set_allocated_options(::google::protobuf::EnumValueOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::EnumValueOptions* options);
@@ -2739,9 +2739,9 @@ class LIBPROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Mes
   int method_size() const;
   void clear_method();
   static const int kMethodFieldNumber = 2;
-  ::google::protobuf::MethodDescriptorProto* mutable_method(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::MethodDescriptorProto >*
-      mutable_method();
+  ::google::protobuf::MethodDescriptorProto& method(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::MethodDescriptorProto >&
+      method();
   const ::google::protobuf::MethodDescriptorProto& method(int index) const;
   ::google::protobuf::MethodDescriptorProto* add_method();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::MethodDescriptorProto >&
@@ -2777,7 +2777,7 @@ class LIBPROTOBUF_EXPORT ServiceDescriptorProto : public ::google::protobuf::Mes
   static const int kOptionsFieldNumber = 3;
   const ::google::protobuf::ServiceOptions& options() const;
   ::google::protobuf::ServiceOptions* release_options();
-  ::google::protobuf::ServiceOptions* mutable_options();
+  ::google::protobuf::ServiceOptions& mutable_options();
   void set_allocated_options(::google::protobuf::ServiceOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::ServiceOptions* options);
@@ -2987,7 +2987,7 @@ class LIBPROTOBUF_EXPORT MethodDescriptorProto : public ::google::protobuf::Mess
   static const int kOptionsFieldNumber = 4;
   const ::google::protobuf::MethodOptions& options() const;
   ::google::protobuf::MethodOptions* release_options();
-  ::google::protobuf::MethodOptions* mutable_options();
+  ::google::protobuf::MethodOptions& mutable_options();
   void set_allocated_options(::google::protobuf::MethodOptions* options);
   void unsafe_arena_set_allocated_options(
       ::google::protobuf::MethodOptions* options);
@@ -3176,9 +3176,9 @@ class LIBPROTOBUF_EXPORT FileOptions : public ::google::protobuf::Message /* @@p
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -3627,9 +3627,9 @@ class LIBPROTOBUF_EXPORT MessageOptions : public ::google::protobuf::Message /* 
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -3858,9 +3858,9 @@ class LIBPROTOBUF_EXPORT FieldOptions : public ::google::protobuf::Message /* @@
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4053,9 +4053,9 @@ class LIBPROTOBUF_EXPORT OneofOptions : public ::google::protobuf::Message /* @@
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4188,9 +4188,9 @@ class LIBPROTOBUF_EXPORT EnumOptions : public ::google::protobuf::Message /* @@p
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4343,9 +4343,9 @@ class LIBPROTOBUF_EXPORT EnumValueOptions : public ::google::protobuf::Message /
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4488,9 +4488,9 @@ class LIBPROTOBUF_EXPORT ServiceOptions : public ::google::protobuf::Message /* 
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4661,9 +4661,9 @@ class LIBPROTOBUF_EXPORT MethodOptions : public ::google::protobuf::Message /* @
   int uninterpreted_option_size() const;
   void clear_uninterpreted_option();
   static const int kUninterpretedOptionFieldNumber = 999;
-  ::google::protobuf::UninterpretedOption* mutable_uninterpreted_option(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-      mutable_uninterpreted_option();
+  ::google::protobuf::UninterpretedOption& uninterpreted_option(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+      uninterpreted_option();
   const ::google::protobuf::UninterpretedOption& uninterpreted_option(int index) const;
   ::google::protobuf::UninterpretedOption* add_uninterpreted_option();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
@@ -4977,9 +4977,9 @@ class LIBPROTOBUF_EXPORT UninterpretedOption : public ::google::protobuf::Messag
   int name_size() const;
   void clear_name();
   static const int kNameFieldNumber = 2;
-  ::google::protobuf::UninterpretedOption_NamePart* mutable_name(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption_NamePart >*
-      mutable_name();
+  ::google::protobuf::UninterpretedOption_NamePart& name(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption_NamePart >&
+      name();
   const ::google::protobuf::UninterpretedOption_NamePart& name(int index) const;
   ::google::protobuf::UninterpretedOption_NamePart* add_name();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption_NamePart >&
@@ -5225,8 +5225,8 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Me
   void add_path(::google::protobuf::int32 value);
   const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
       path() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_path();
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      path();
 
   // repeated int32 span = 2 [packed = true];
   int span_size() const;
@@ -5237,8 +5237,8 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Me
   void add_span(::google::protobuf::int32 value);
   const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
       span() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_span();
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      span();
 
   // repeated string leading_detached_comments = 6;
   int leading_detached_comments_size() const;
@@ -5260,7 +5260,7 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo_Location : public ::google::protobuf::Me
   void add_leading_detached_comments(const char* value);
   void add_leading_detached_comments(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& leading_detached_comments() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_leading_detached_comments();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& leading_detached_comments();
 
   // optional string leading_comments = 3;
   bool has_leading_comments() const;
@@ -5446,9 +5446,9 @@ class LIBPROTOBUF_EXPORT SourceCodeInfo : public ::google::protobuf::Message /* 
   int location_size() const;
   void clear_location();
   static const int kLocationFieldNumber = 1;
-  ::google::protobuf::SourceCodeInfo_Location* mutable_location(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::SourceCodeInfo_Location >*
-      mutable_location();
+  ::google::protobuf::SourceCodeInfo_Location& location(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::SourceCodeInfo_Location >&
+      location();
   const ::google::protobuf::SourceCodeInfo_Location& location(int index) const;
   ::google::protobuf::SourceCodeInfo_Location* add_location();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::SourceCodeInfo_Location >&
@@ -5583,8 +5583,8 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo_Annotation : public ::google::protobu
   void add_path(::google::protobuf::int32 value);
   const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
       path() const;
-  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-      mutable_path();
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      path();
 
   // optional string source_file = 2;
   bool has_source_file() const;
@@ -5760,9 +5760,9 @@ class LIBPROTOBUF_EXPORT GeneratedCodeInfo : public ::google::protobuf::Message 
   int annotation_size() const;
   void clear_annotation();
   static const int kAnnotationFieldNumber = 1;
-  ::google::protobuf::GeneratedCodeInfo_Annotation* mutable_annotation(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::GeneratedCodeInfo_Annotation >*
-      mutable_annotation();
+  ::google::protobuf::GeneratedCodeInfo_Annotation& annotation(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::GeneratedCodeInfo_Annotation >&
+      annotation();
   const ::google::protobuf::GeneratedCodeInfo_Annotation& annotation(int index) const;
   ::google::protobuf::GeneratedCodeInfo_Annotation* add_annotation();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::GeneratedCodeInfo_Annotation >&
@@ -5799,14 +5799,14 @@ inline int FileDescriptorSet::file_size() const {
 inline void FileDescriptorSet::clear_file() {
   file_.Clear();
 }
-inline ::google::protobuf::FileDescriptorProto* FileDescriptorSet::mutable_file(int index) {
+inline ::google::protobuf::FileDescriptorProto& FileDescriptorSet::file(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorSet.file)
-  return file_.Mutable(index);
+  return *file_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >*
-FileDescriptorSet::mutable_file() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FileDescriptorProto >&
+FileDescriptorSet::file() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorSet.file)
-  return &file_;
+  return file_;
 }
 inline const ::google::protobuf::FileDescriptorProto& FileDescriptorSet::file(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorSet.file)
@@ -6059,10 +6059,10 @@ FileDescriptorProto::dependency() const {
   // @@protoc_insertion_point(field_list:google.protobuf.FileDescriptorProto.dependency)
   return dependency_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-FileDescriptorProto::mutable_dependency() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+FileDescriptorProto::dependency() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.dependency)
-  return &dependency_;
+  return dependency_;
 }
 
 // repeated int32 public_dependency = 10;
@@ -6089,10 +6089,10 @@ FileDescriptorProto::public_dependency() const {
   // @@protoc_insertion_point(field_list:google.protobuf.FileDescriptorProto.public_dependency)
   return public_dependency_;
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-FileDescriptorProto::mutable_public_dependency() {
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+FileDescriptorProto::public_dependency() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.public_dependency)
-  return &public_dependency_;
+  return public_dependency_;
 }
 
 // repeated int32 weak_dependency = 11;
@@ -6119,10 +6119,10 @@ FileDescriptorProto::weak_dependency() const {
   // @@protoc_insertion_point(field_list:google.protobuf.FileDescriptorProto.weak_dependency)
   return weak_dependency_;
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-FileDescriptorProto::mutable_weak_dependency() {
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+FileDescriptorProto::weak_dependency() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.weak_dependency)
-  return &weak_dependency_;
+  return weak_dependency_;
 }
 
 // repeated .google.protobuf.DescriptorProto message_type = 4;
@@ -6132,14 +6132,14 @@ inline int FileDescriptorProto::message_type_size() const {
 inline void FileDescriptorProto::clear_message_type() {
   message_type_.Clear();
 }
-inline ::google::protobuf::DescriptorProto* FileDescriptorProto::mutable_message_type(int index) {
+inline ::google::protobuf::DescriptorProto& FileDescriptorProto::message_type(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.message_type)
-  return message_type_.Mutable(index);
+  return *message_type_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >*
-FileDescriptorProto::mutable_message_type() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
+FileDescriptorProto::message_type() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.message_type)
-  return &message_type_;
+  return message_type_;
 }
 inline const ::google::protobuf::DescriptorProto& FileDescriptorProto::message_type(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.message_type)
@@ -6162,14 +6162,14 @@ inline int FileDescriptorProto::enum_type_size() const {
 inline void FileDescriptorProto::clear_enum_type() {
   enum_type_.Clear();
 }
-inline ::google::protobuf::EnumDescriptorProto* FileDescriptorProto::mutable_enum_type(int index) {
+inline ::google::protobuf::EnumDescriptorProto& FileDescriptorProto::enum_type(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.enum_type)
-  return enum_type_.Mutable(index);
+  return *enum_type_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >*
-FileDescriptorProto::mutable_enum_type() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
+FileDescriptorProto::enum_type() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.enum_type)
-  return &enum_type_;
+  return enum_type_;
 }
 inline const ::google::protobuf::EnumDescriptorProto& FileDescriptorProto::enum_type(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.enum_type)
@@ -6192,14 +6192,14 @@ inline int FileDescriptorProto::service_size() const {
 inline void FileDescriptorProto::clear_service() {
   service_.Clear();
 }
-inline ::google::protobuf::ServiceDescriptorProto* FileDescriptorProto::mutable_service(int index) {
+inline ::google::protobuf::ServiceDescriptorProto& FileDescriptorProto::service(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.service)
-  return service_.Mutable(index);
+  return *service_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::ServiceDescriptorProto >*
-FileDescriptorProto::mutable_service() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::ServiceDescriptorProto >&
+FileDescriptorProto::service() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.service)
-  return &service_;
+  return service_;
 }
 inline const ::google::protobuf::ServiceDescriptorProto& FileDescriptorProto::service(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.service)
@@ -6222,14 +6222,14 @@ inline int FileDescriptorProto::extension_size() const {
 inline void FileDescriptorProto::clear_extension() {
   extension_.Clear();
 }
-inline ::google::protobuf::FieldDescriptorProto* FileDescriptorProto::mutable_extension(int index) {
+inline ::google::protobuf::FieldDescriptorProto& FileDescriptorProto::extension(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.extension)
-  return extension_.Mutable(index);
+  return *extension_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-FileDescriptorProto::mutable_extension() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+FileDescriptorProto::extension() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileDescriptorProto.extension)
-  return &extension_;
+  return extension_;
 }
 inline const ::google::protobuf::FieldDescriptorProto& FileDescriptorProto::extension(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileDescriptorProto.extension)
@@ -6282,14 +6282,14 @@ inline ::google::protobuf::FileOptions* FileDescriptorProto::unsafe_arena_releas
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::FileOptions* FileDescriptorProto::mutable_options() {
+inline ::google::protobuf::FileOptions& FileDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::FileOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void FileDescriptorProto::set_allocated_options(::google::protobuf::FileOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -6348,14 +6348,14 @@ inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::unsafe_arena_rel
   source_code_info_ = NULL;
   return temp;
 }
-inline ::google::protobuf::SourceCodeInfo* FileDescriptorProto::mutable_source_code_info() {
+inline ::google::protobuf::SourceCodeInfo& FileDescriptorProto::mutable_source_code_info() {
   set_has_source_code_info();
   if (source_code_info_ == NULL) {
     source_code_info_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::SourceCodeInfo >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileDescriptorProto.source_code_info)
-  return source_code_info_;
+  return *source_code_info_;
 }
 inline void FileDescriptorProto::set_allocated_source_code_info(::google::protobuf::SourceCodeInfo* source_code_info) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -6551,14 +6551,14 @@ inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::ExtensionRangeOptions* DescriptorProto_ExtensionRange::mutable_options() {
+inline ::google::protobuf::ExtensionRangeOptions& DescriptorProto_ExtensionRange::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::ExtensionRangeOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.ExtensionRange.options)
-  return options_;
+  return *options_;
 }
 inline void DescriptorProto_ExtensionRange::set_allocated_options(::google::protobuf::ExtensionRangeOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -6728,14 +6728,14 @@ inline int DescriptorProto::field_size() const {
 inline void DescriptorProto::clear_field() {
   field_.Clear();
 }
-inline ::google::protobuf::FieldDescriptorProto* DescriptorProto::mutable_field(int index) {
+inline ::google::protobuf::FieldDescriptorProto& DescriptorProto::field(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.field)
-  return field_.Mutable(index);
+  return *field_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-DescriptorProto::mutable_field() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+DescriptorProto::field() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.field)
-  return &field_;
+  return field_;
 }
 inline const ::google::protobuf::FieldDescriptorProto& DescriptorProto::field(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.field)
@@ -6758,14 +6758,14 @@ inline int DescriptorProto::extension_size() const {
 inline void DescriptorProto::clear_extension() {
   extension_.Clear();
 }
-inline ::google::protobuf::FieldDescriptorProto* DescriptorProto::mutable_extension(int index) {
+inline ::google::protobuf::FieldDescriptorProto& DescriptorProto::extension(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.extension)
-  return extension_.Mutable(index);
+  return *extension_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >*
-DescriptorProto::mutable_extension() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::FieldDescriptorProto >&
+DescriptorProto::extension() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.extension)
-  return &extension_;
+  return extension_;
 }
 inline const ::google::protobuf::FieldDescriptorProto& DescriptorProto::extension(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.extension)
@@ -6788,14 +6788,14 @@ inline int DescriptorProto::nested_type_size() const {
 inline void DescriptorProto::clear_nested_type() {
   nested_type_.Clear();
 }
-inline ::google::protobuf::DescriptorProto* DescriptorProto::mutable_nested_type(int index) {
+inline ::google::protobuf::DescriptorProto& DescriptorProto::nested_type(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.nested_type)
-  return nested_type_.Mutable(index);
+  return *nested_type_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >*
-DescriptorProto::mutable_nested_type() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto >&
+DescriptorProto::nested_type() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.nested_type)
-  return &nested_type_;
+  return nested_type_;
 }
 inline const ::google::protobuf::DescriptorProto& DescriptorProto::nested_type(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.nested_type)
@@ -6818,14 +6818,14 @@ inline int DescriptorProto::enum_type_size() const {
 inline void DescriptorProto::clear_enum_type() {
   enum_type_.Clear();
 }
-inline ::google::protobuf::EnumDescriptorProto* DescriptorProto::mutable_enum_type(int index) {
+inline ::google::protobuf::EnumDescriptorProto& DescriptorProto::enum_type(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.enum_type)
-  return enum_type_.Mutable(index);
+  return *enum_type_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >*
-DescriptorProto::mutable_enum_type() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto >&
+DescriptorProto::enum_type() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.enum_type)
-  return &enum_type_;
+  return enum_type_;
 }
 inline const ::google::protobuf::EnumDescriptorProto& DescriptorProto::enum_type(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.enum_type)
@@ -6848,14 +6848,14 @@ inline int DescriptorProto::extension_range_size() const {
 inline void DescriptorProto::clear_extension_range() {
   extension_range_.Clear();
 }
-inline ::google::protobuf::DescriptorProto_ExtensionRange* DescriptorProto::mutable_extension_range(int index) {
+inline ::google::protobuf::DescriptorProto_ExtensionRange& DescriptorProto::extension_range(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.extension_range)
-  return extension_range_.Mutable(index);
+  return *extension_range_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ExtensionRange >*
-DescriptorProto::mutable_extension_range() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ExtensionRange >&
+DescriptorProto::extension_range() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.extension_range)
-  return &extension_range_;
+  return extension_range_;
 }
 inline const ::google::protobuf::DescriptorProto_ExtensionRange& DescriptorProto::extension_range(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.extension_range)
@@ -6878,14 +6878,14 @@ inline int DescriptorProto::oneof_decl_size() const {
 inline void DescriptorProto::clear_oneof_decl() {
   oneof_decl_.Clear();
 }
-inline ::google::protobuf::OneofDescriptorProto* DescriptorProto::mutable_oneof_decl(int index) {
+inline ::google::protobuf::OneofDescriptorProto& DescriptorProto::oneof_decl(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.oneof_decl)
-  return oneof_decl_.Mutable(index);
+  return *oneof_decl_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::OneofDescriptorProto >*
-DescriptorProto::mutable_oneof_decl() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::OneofDescriptorProto >&
+DescriptorProto::oneof_decl() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.oneof_decl)
-  return &oneof_decl_;
+  return oneof_decl_;
 }
 inline const ::google::protobuf::OneofDescriptorProto& DescriptorProto::oneof_decl(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.oneof_decl)
@@ -6938,14 +6938,14 @@ inline ::google::protobuf::MessageOptions* DescriptorProto::unsafe_arena_release
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::MessageOptions* DescriptorProto::mutable_options() {
+inline ::google::protobuf::MessageOptions& DescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::MessageOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void DescriptorProto::set_allocated_options(::google::protobuf::MessageOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -6974,14 +6974,14 @@ inline int DescriptorProto::reserved_range_size() const {
 inline void DescriptorProto::clear_reserved_range() {
   reserved_range_.Clear();
 }
-inline ::google::protobuf::DescriptorProto_ReservedRange* DescriptorProto::mutable_reserved_range(int index) {
+inline ::google::protobuf::DescriptorProto_ReservedRange& DescriptorProto::reserved_range(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.DescriptorProto.reserved_range)
-  return reserved_range_.Mutable(index);
+  return *reserved_range_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ReservedRange >*
-DescriptorProto::mutable_reserved_range() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::DescriptorProto_ReservedRange >&
+DescriptorProto::reserved_range() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.reserved_range)
-  return &reserved_range_;
+  return reserved_range_;
 }
 inline const ::google::protobuf::DescriptorProto_ReservedRange& DescriptorProto::reserved_range(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.DescriptorProto.reserved_range)
@@ -7060,10 +7060,10 @@ DescriptorProto::reserved_name() const {
   // @@protoc_insertion_point(field_list:google.protobuf.DescriptorProto.reserved_name)
   return reserved_name_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-DescriptorProto::mutable_reserved_name() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+DescriptorProto::reserved_name() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.DescriptorProto.reserved_name)
-  return &reserved_name_;
+  return reserved_name_;
 }
 
 // -------------------------------------------------------------------
@@ -7077,14 +7077,14 @@ inline int ExtensionRangeOptions::uninterpreted_option_size() const {
 inline void ExtensionRangeOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* ExtensionRangeOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& ExtensionRangeOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.ExtensionRangeOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-ExtensionRangeOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+ExtensionRangeOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.ExtensionRangeOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& ExtensionRangeOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.ExtensionRangeOptions.uninterpreted_option)
@@ -7664,14 +7664,14 @@ inline ::google::protobuf::FieldOptions* FieldDescriptorProto::unsafe_arena_rele
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::FieldOptions* FieldDescriptorProto::mutable_options() {
+inline ::google::protobuf::FieldOptions& FieldDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::FieldOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.FieldDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void FieldDescriptorProto::set_allocated_options(::google::protobuf::FieldOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -7819,14 +7819,14 @@ inline ::google::protobuf::OneofOptions* OneofDescriptorProto::unsafe_arena_rele
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::OneofOptions* OneofDescriptorProto::mutable_options() {
+inline ::google::protobuf::OneofOptions& OneofDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::OneofOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.OneofDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void OneofDescriptorProto::set_allocated_options(::google::protobuf::OneofOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -7996,14 +7996,14 @@ inline int EnumDescriptorProto::value_size() const {
 inline void EnumDescriptorProto::clear_value() {
   value_.Clear();
 }
-inline ::google::protobuf::EnumValueDescriptorProto* EnumDescriptorProto::mutable_value(int index) {
+inline ::google::protobuf::EnumValueDescriptorProto& EnumDescriptorProto::value(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumDescriptorProto.value)
-  return value_.Mutable(index);
+  return *value_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValueDescriptorProto >*
-EnumDescriptorProto::mutable_value() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValueDescriptorProto >&
+EnumDescriptorProto::value() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumDescriptorProto.value)
-  return &value_;
+  return value_;
 }
 inline const ::google::protobuf::EnumValueDescriptorProto& EnumDescriptorProto::value(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.EnumDescriptorProto.value)
@@ -8056,14 +8056,14 @@ inline ::google::protobuf::EnumOptions* EnumDescriptorProto::unsafe_arena_releas
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::EnumOptions* EnumDescriptorProto::mutable_options() {
+inline ::google::protobuf::EnumOptions& EnumDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::EnumOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void EnumDescriptorProto::set_allocated_options(::google::protobuf::EnumOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -8092,14 +8092,14 @@ inline int EnumDescriptorProto::reserved_range_size() const {
 inline void EnumDescriptorProto::clear_reserved_range() {
   reserved_range_.Clear();
 }
-inline ::google::protobuf::EnumDescriptorProto_EnumReservedRange* EnumDescriptorProto::mutable_reserved_range(int index) {
+inline ::google::protobuf::EnumDescriptorProto_EnumReservedRange& EnumDescriptorProto::reserved_range(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumDescriptorProto.reserved_range)
-  return reserved_range_.Mutable(index);
+  return *reserved_range_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto_EnumReservedRange >*
-EnumDescriptorProto::mutable_reserved_range() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumDescriptorProto_EnumReservedRange >&
+EnumDescriptorProto::reserved_range() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumDescriptorProto.reserved_range)
-  return &reserved_range_;
+  return reserved_range_;
 }
 inline const ::google::protobuf::EnumDescriptorProto_EnumReservedRange& EnumDescriptorProto::reserved_range(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.EnumDescriptorProto.reserved_range)
@@ -8178,10 +8178,10 @@ EnumDescriptorProto::reserved_name() const {
   // @@protoc_insertion_point(field_list:google.protobuf.EnumDescriptorProto.reserved_name)
   return reserved_name_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-EnumDescriptorProto::mutable_reserved_name() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+EnumDescriptorProto::reserved_name() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumDescriptorProto.reserved_name)
-  return &reserved_name_;
+  return reserved_name_;
 }
 
 // -------------------------------------------------------------------
@@ -8334,14 +8334,14 @@ inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::unsafe_ar
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::EnumValueOptions* EnumValueDescriptorProto::mutable_options() {
+inline ::google::protobuf::EnumValueOptions& EnumValueDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::EnumValueOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumValueDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void EnumValueDescriptorProto::set_allocated_options(::google::protobuf::EnumValueOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -8459,14 +8459,14 @@ inline int ServiceDescriptorProto::method_size() const {
 inline void ServiceDescriptorProto::clear_method() {
   method_.Clear();
 }
-inline ::google::protobuf::MethodDescriptorProto* ServiceDescriptorProto::mutable_method(int index) {
+inline ::google::protobuf::MethodDescriptorProto& ServiceDescriptorProto::method(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.ServiceDescriptorProto.method)
-  return method_.Mutable(index);
+  return *method_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::MethodDescriptorProto >*
-ServiceDescriptorProto::mutable_method() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::MethodDescriptorProto >&
+ServiceDescriptorProto::method() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.ServiceDescriptorProto.method)
-  return &method_;
+  return method_;
 }
 inline const ::google::protobuf::MethodDescriptorProto& ServiceDescriptorProto::method(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.ServiceDescriptorProto.method)
@@ -8519,14 +8519,14 @@ inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::unsafe_arena_
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::ServiceOptions* ServiceDescriptorProto::mutable_options() {
+inline ::google::protobuf::ServiceOptions& ServiceDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::ServiceOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.ServiceDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void ServiceDescriptorProto::set_allocated_options(::google::protobuf::ServiceOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -8844,14 +8844,14 @@ inline ::google::protobuf::MethodOptions* MethodDescriptorProto::unsafe_arena_re
   options_ = NULL;
   return temp;
 }
-inline ::google::protobuf::MethodOptions* MethodDescriptorProto::mutable_options() {
+inline ::google::protobuf::MethodOptions& MethodDescriptorProto::mutable_options() {
   set_has_options();
   if (options_ == NULL) {
     options_ = ::google::protobuf::Arena::CreateMessage< ::google::protobuf::MethodOptions >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.MethodDescriptorProto.options)
-  return options_;
+  return *options_;
 }
 inline void MethodDescriptorProto::set_allocated_options(::google::protobuf::MethodOptions* options) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -9853,14 +9853,14 @@ inline int FileOptions::uninterpreted_option_size() const {
 inline void FileOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* FileOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& FileOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FileOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-FileOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+FileOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FileOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& FileOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FileOptions.uninterpreted_option)
@@ -9983,14 +9983,14 @@ inline int MessageOptions::uninterpreted_option_size() const {
 inline void MessageOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* MessageOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& MessageOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.MessageOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-MessageOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+MessageOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.MessageOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& MessageOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.MessageOptions.uninterpreted_option)
@@ -10163,14 +10163,14 @@ inline int FieldOptions::uninterpreted_option_size() const {
 inline void FieldOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* FieldOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& FieldOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.FieldOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-FieldOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+FieldOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FieldOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& FieldOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.FieldOptions.uninterpreted_option)
@@ -10197,14 +10197,14 @@ inline int OneofOptions::uninterpreted_option_size() const {
 inline void OneofOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* OneofOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& OneofOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.OneofOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-OneofOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+OneofOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.OneofOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& OneofOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.OneofOptions.uninterpreted_option)
@@ -10279,14 +10279,14 @@ inline int EnumOptions::uninterpreted_option_size() const {
 inline void EnumOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* EnumOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& EnumOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-EnumOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+EnumOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& EnumOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.EnumOptions.uninterpreted_option)
@@ -10337,14 +10337,14 @@ inline int EnumValueOptions::uninterpreted_option_size() const {
 inline void EnumValueOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* EnumValueOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& EnumValueOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumValueOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-EnumValueOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+EnumValueOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumValueOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& EnumValueOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.EnumValueOptions.uninterpreted_option)
@@ -10395,14 +10395,14 @@ inline int ServiceOptions::uninterpreted_option_size() const {
 inline void ServiceOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* ServiceOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& ServiceOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.ServiceOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-ServiceOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+ServiceOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.ServiceOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& ServiceOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.ServiceOptions.uninterpreted_option)
@@ -10478,14 +10478,14 @@ inline int MethodOptions::uninterpreted_option_size() const {
 inline void MethodOptions::clear_uninterpreted_option() {
   uninterpreted_option_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption* MethodOptions::mutable_uninterpreted_option(int index) {
+inline ::google::protobuf::UninterpretedOption& MethodOptions::uninterpreted_option(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.MethodOptions.uninterpreted_option)
-  return uninterpreted_option_.Mutable(index);
+  return *uninterpreted_option_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >*
-MethodOptions::mutable_uninterpreted_option() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption >&
+MethodOptions::uninterpreted_option() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.MethodOptions.uninterpreted_option)
-  return &uninterpreted_option_;
+  return uninterpreted_option_;
 }
 inline const ::google::protobuf::UninterpretedOption& MethodOptions::uninterpreted_option(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.MethodOptions.uninterpreted_option)
@@ -10625,14 +10625,14 @@ inline int UninterpretedOption::name_size() const {
 inline void UninterpretedOption::clear_name() {
   name_.Clear();
 }
-inline ::google::protobuf::UninterpretedOption_NamePart* UninterpretedOption::mutable_name(int index) {
+inline ::google::protobuf::UninterpretedOption_NamePart& UninterpretedOption::name(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.UninterpretedOption.name)
-  return name_.Mutable(index);
+  return *name_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption_NamePart >*
-UninterpretedOption::mutable_name() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::UninterpretedOption_NamePart >&
+UninterpretedOption::name() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.UninterpretedOption.name)
-  return &name_;
+  return name_;
 }
 inline const ::google::protobuf::UninterpretedOption_NamePart& UninterpretedOption::name(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.UninterpretedOption.name)
@@ -11003,10 +11003,10 @@ SourceCodeInfo_Location::path() const {
   // @@protoc_insertion_point(field_list:google.protobuf.SourceCodeInfo.Location.path)
   return path_;
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-SourceCodeInfo_Location::mutable_path() {
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+SourceCodeInfo_Location::path() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.SourceCodeInfo.Location.path)
-  return &path_;
+  return path_;
 }
 
 // repeated int32 span = 2 [packed = true];
@@ -11033,10 +11033,10 @@ SourceCodeInfo_Location::span() const {
   // @@protoc_insertion_point(field_list:google.protobuf.SourceCodeInfo.Location.span)
   return span_;
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-SourceCodeInfo_Location::mutable_span() {
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+SourceCodeInfo_Location::span() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.SourceCodeInfo.Location.span)
-  return &span_;
+  return span_;
 }
 
 // optional string leading_comments = 3;
@@ -11272,10 +11272,10 @@ SourceCodeInfo_Location::leading_detached_comments() const {
   // @@protoc_insertion_point(field_list:google.protobuf.SourceCodeInfo.Location.leading_detached_comments)
   return leading_detached_comments_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-SourceCodeInfo_Location::mutable_leading_detached_comments() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+SourceCodeInfo_Location::leading_detached_comments() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.SourceCodeInfo.Location.leading_detached_comments)
-  return &leading_detached_comments_;
+  return leading_detached_comments_;
 }
 
 // -------------------------------------------------------------------
@@ -11289,14 +11289,14 @@ inline int SourceCodeInfo::location_size() const {
 inline void SourceCodeInfo::clear_location() {
   location_.Clear();
 }
-inline ::google::protobuf::SourceCodeInfo_Location* SourceCodeInfo::mutable_location(int index) {
+inline ::google::protobuf::SourceCodeInfo_Location& SourceCodeInfo::location(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.SourceCodeInfo.location)
-  return location_.Mutable(index);
+  return *location_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::SourceCodeInfo_Location >*
-SourceCodeInfo::mutable_location() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::SourceCodeInfo_Location >&
+SourceCodeInfo::location() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.SourceCodeInfo.location)
-  return &location_;
+  return location_;
 }
 inline const ::google::protobuf::SourceCodeInfo_Location& SourceCodeInfo::location(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.SourceCodeInfo.location)
@@ -11340,10 +11340,10 @@ GeneratedCodeInfo_Annotation::path() const {
   // @@protoc_insertion_point(field_list:google.protobuf.GeneratedCodeInfo.Annotation.path)
   return path_;
 }
-inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
-GeneratedCodeInfo_Annotation::mutable_path() {
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+GeneratedCodeInfo_Annotation::path() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.GeneratedCodeInfo.Annotation.path)
-  return &path_;
+  return path_;
 }
 
 // optional string source_file = 2;
@@ -11490,14 +11490,14 @@ inline int GeneratedCodeInfo::annotation_size() const {
 inline void GeneratedCodeInfo::clear_annotation() {
   annotation_.Clear();
 }
-inline ::google::protobuf::GeneratedCodeInfo_Annotation* GeneratedCodeInfo::mutable_annotation(int index) {
+inline ::google::protobuf::GeneratedCodeInfo_Annotation& GeneratedCodeInfo::annotation(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.GeneratedCodeInfo.annotation)
-  return annotation_.Mutable(index);
+  return *annotation_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::GeneratedCodeInfo_Annotation >*
-GeneratedCodeInfo::mutable_annotation() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::GeneratedCodeInfo_Annotation >&
+GeneratedCodeInfo::annotation() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.GeneratedCodeInfo.annotation)
-  return &annotation_;
+  return annotation_;
 }
 inline const ::google::protobuf::GeneratedCodeInfo_Annotation& GeneratedCodeInfo::annotation(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.GeneratedCodeInfo.annotation)

--- a/src/google/protobuf/descriptor_unittest.cc
+++ b/src/google/protobuf/descriptor_unittest.cc
@@ -662,7 +662,7 @@ class DescriptorTest : public testing::Test {
     AddField(entry, "value", 2,
              FieldDescriptorProto::LABEL_OPTIONAL,
              FieldDescriptorProto::TYPE_INT32);
-    entry->mutable_options()->set_map_entry(true);
+    entry->mutable_options().set_map_entry(true);
 
     AddField(message3, "map_int32_int32", 1,
              FieldDescriptorProto::LABEL_REPEATED,
@@ -1009,17 +1009,17 @@ class OneofDescriptorTest : public testing::Test {
     AddField(oneof_message, "b", 2,
              FieldDescriptorProto::LABEL_OPTIONAL,
              FieldDescriptorProto::TYPE_STRING);
-    oneof_message->mutable_field(1)->set_oneof_index(0);
+    oneof_message->field(1).set_oneof_index(0);
     AddField(oneof_message, "c", 3,
              FieldDescriptorProto::LABEL_OPTIONAL,
              FieldDescriptorProto::TYPE_MESSAGE);
-    oneof_message->mutable_field(2)->set_oneof_index(0);
-    oneof_message->mutable_field(2)->set_type_name("TestOneof");
+    oneof_message->field(2).set_oneof_index(0);
+    oneof_message->field(2).set_type_name("TestOneof");
 
     AddField(oneof_message, "d", 4,
              FieldDescriptorProto::LABEL_OPTIONAL,
              FieldDescriptorProto::TYPE_FLOAT);
-    oneof_message->mutable_field(3)->set_oneof_index(1);
+    oneof_message->field(3).set_oneof_index(1);
 
     // Build the descriptors and get the pointers.
     baz_file_ = pool_.BuildFile(baz_file);
@@ -2561,7 +2561,7 @@ TEST_F(MiscTest, FieldOptions) {
              FieldDescriptorProto::LABEL_OPTIONAL,
              FieldDescriptorProto::TYPE_INT32);
 
-  FieldOptions* options = bar_proto->mutable_options();
+  FieldOptions* options = &bar_proto->mutable_options();
   options->set_ctype(FieldOptions::CORD);
 
   // Build the descriptors and get the pointers.
@@ -3451,7 +3451,7 @@ TEST(CustomOptions, OptionsWithRequiredEnums) {
       "  } "
       "  aggregate_value: 'value: NEW_VALUE' "
       "}",
-      test_message_type->mutable_options()));
+      &test_message_type->mutable_options()));
 
   // Add the file descriptor to the pool.
   ASSERT_TRUE(pool.BuildFile(file_proto) != NULL);
@@ -5721,7 +5721,7 @@ TEST_F(ValidationErrorTest, MapEntryExtensionRange) {
       "extension_range { "
       "  start: 10 end: 20 "
       "} ",
-      file_proto.mutable_message_type(0)->mutable_nested_type(0));
+      &file_proto.message_type(0).nested_type(0));
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
@@ -5732,7 +5732,7 @@ TEST_F(ValidationErrorTest, MapEntryExtension) {
       "extension { "
       "  name: 'foo_ext' extendee: '.Bar' number: 5"
       "} ",
-      file_proto.mutable_message_type(0)->mutable_nested_type(0));
+      &file_proto.message_type(0).nested_type(0));
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
@@ -5743,7 +5743,7 @@ TEST_F(ValidationErrorTest, MapEntryNestedType) {
       "nested_type { "
       "  name: 'Bar' "
       "} ",
-      file_proto.mutable_message_type(0)->mutable_nested_type(0));
+      &file_proto.message_type(0).nested_type(0));
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
@@ -5755,7 +5755,7 @@ TEST_F(ValidationErrorTest, MapEntryEnumTypes) {
       "  name: 'BarEnum' "
       "  value { name: 'BAR_BAR' number:0 } "
       "} ",
-      file_proto.mutable_message_type(0)->mutable_nested_type(0));
+      &file_proto.message_type(0).nested_type(0));
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
@@ -5769,16 +5769,16 @@ TEST_F(ValidationErrorTest, MapEntryExtraField) {
       "  type: TYPE_INT32 "
       "  number: 3 "
       "} ",
-      file_proto.mutable_message_type(0)->mutable_nested_type(0));
+      &file_proto.message_type(0).nested_type(0));
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
 TEST_F(ValidationErrorTest, MapEntryMessageName) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  file_proto.mutable_message_type(0)->mutable_nested_type(0)->set_name(
+  file_proto.message_type(0).nested_type(0).set_name(
       "OtherMapEntry");
-  file_proto.mutable_message_type(0)->mutable_field(0)->set_type_name(
+  file_proto.message_type(0).field(0).set_type_name(
       "OtherMapEntry");
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5786,7 +5786,7 @@ TEST_F(ValidationErrorTest, MapEntryMessageName) {
 TEST_F(ValidationErrorTest, MapEntryNoneRepeatedMapEntry) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  file_proto.mutable_message_type(0)->mutable_field(0)->set_label(
+  file_proto.message_type(0).field(0).set_label(
       FieldDescriptorProto::LABEL_OPTIONAL);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5796,17 +5796,17 @@ TEST_F(ValidationErrorTest, MapEntryDifferentContainingType) {
   FillValidMapEntry(&file_proto);
   // Move the nested MapEntry message into the top level, which should not pass
   // the validation.
-  file_proto.mutable_message_type()->AddAllocated(
-      file_proto.mutable_message_type(0)->mutable_nested_type()->ReleaseLast());
+  file_proto.message_type().AddAllocated(
+      file_proto.message_type(0).nested_type().ReleaseLast());
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
 
 TEST_F(ValidationErrorTest, MapEntryKeyName) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_name("Key");
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5814,9 +5814,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyName) {
 TEST_F(ValidationErrorTest, MapEntryKeyLabel) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_label(FieldDescriptorProto::LABEL_REQUIRED);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5824,9 +5824,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyLabel) {
 TEST_F(ValidationErrorTest, MapEntryKeyNumber) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_number(3);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5834,9 +5834,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyNumber) {
 TEST_F(ValidationErrorTest, MapEntryValueName) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* value = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(1);
+  FieldDescriptorProto* value = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(1);
   value->set_name("Value");
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5844,9 +5844,9 @@ TEST_F(ValidationErrorTest, MapEntryValueName) {
 TEST_F(ValidationErrorTest, MapEntryValueLabel) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* value = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(1);
+  FieldDescriptorProto* value = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(1);
   value->set_label(FieldDescriptorProto::LABEL_REQUIRED);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5854,9 +5854,9 @@ TEST_F(ValidationErrorTest, MapEntryValueLabel) {
 TEST_F(ValidationErrorTest, MapEntryValueNumber) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* value = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(1);
+  FieldDescriptorProto* value = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(1);
   value->set_number(3);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryErrorMessage);
 }
@@ -5864,9 +5864,9 @@ TEST_F(ValidationErrorTest, MapEntryValueNumber) {
 TEST_F(ValidationErrorTest, MapEntryKeyTypeFloat) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_type(FieldDescriptorProto::TYPE_FLOAT);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryKeyTypeErrorMessage);
 }
@@ -5874,9 +5874,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyTypeFloat) {
 TEST_F(ValidationErrorTest, MapEntryKeyTypeDouble) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_type(FieldDescriptorProto::TYPE_DOUBLE);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryKeyTypeErrorMessage);
 }
@@ -5884,9 +5884,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyTypeDouble) {
 TEST_F(ValidationErrorTest, MapEntryKeyTypeBytes) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->set_type(FieldDescriptorProto::TYPE_BYTES);
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryKeyTypeErrorMessage);
 }
@@ -5894,9 +5894,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyTypeBytes) {
 TEST_F(ValidationErrorTest, MapEntryKeyTypeEnum) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->clear_type();
   key->set_type_name("BarEnum");
   EnumDescriptorProto* enum_proto = file_proto.add_enum_type();
@@ -5909,7 +5909,7 @@ TEST_F(ValidationErrorTest, MapEntryKeyTypeEnum) {
                       "be enum types.\n");
   // Enum keys are not allowed in proto3 as well.
   // Get rid of extensions for proto3 to make it proto3 compatible.
-  file_proto.mutable_message_type()->RemoveLast();
+  file_proto.message_type().RemoveLast();
   file_proto.set_syntax("proto3");
   BuildFileWithErrors(file_proto.DebugString(),
                       "foo.proto: Foo.foo_map: TYPE: Key in map fields cannot "
@@ -5920,9 +5920,9 @@ TEST_F(ValidationErrorTest, MapEntryKeyTypeEnum) {
 TEST_F(ValidationErrorTest, MapEntryKeyTypeMessage) {
   FileDescriptorProto file_proto;
   FillValidMapEntry(&file_proto);
-  FieldDescriptorProto* key = file_proto.mutable_message_type(0)
-      ->mutable_nested_type(0)
-      ->mutable_field(0);
+  FieldDescriptorProto* key = &file_proto.message_type(0)
+      .nested_type(0)
+      .field(0);
   key->clear_type();
   key->set_type_name(".Bar");
   BuildFileWithErrors(file_proto.DebugString(), kMapEntryKeyTypeErrorMessage);
@@ -5938,7 +5938,7 @@ TEST_F(ValidationErrorTest, MapEntryConflictsWithField) {
       "  label: LABEL_OPTIONAL "
       "  number: 100 "
       "}",
-      file_proto.mutable_message_type(0));
+      &file_proto.message_type(0));
   BuildFileWithErrors(
       file_proto.DebugString(),
       "foo.proto: Foo.FooMapEntry: NAME: \"FooMapEntry\" is already defined in "
@@ -5955,7 +5955,7 @@ TEST_F(ValidationErrorTest, MapEntryConflictsWithMessage) {
       "nested_type { "
       "  name: 'FooMapEntry' "
       "}",
-      file_proto.mutable_message_type(0));
+      &file_proto.message_type(0));
   BuildFileWithErrors(
       file_proto.DebugString(),
       "foo.proto: Foo.FooMapEntry: NAME: \"FooMapEntry\" is already defined in "
@@ -5972,7 +5972,7 @@ TEST_F(ValidationErrorTest, MapEntryConflictsWithEnum) {
       "  name: 'FooMapEntry' "
       "  value { name: 'ENTRY_FOO' number: 0 }"
       "}",
-      file_proto.mutable_message_type(0));
+      &file_proto.message_type(0));
   BuildFileWithErrors(
       file_proto.DebugString(),
       "foo.proto: Foo.FooMapEntry: NAME: \"FooMapEntry\" is already defined in "
@@ -6058,7 +6058,7 @@ TEST_F(ValidationErrorTest, MapEntryConflictsWithOneof) {
       "  oneof_index: 0 "
       "  number: 100 "
       "} ",
-      file_proto.mutable_message_type(0));
+      &file_proto.message_type(0));
   BuildFileWithErrors(
       file_proto.DebugString(),
       "foo.proto: Foo.FooMapEntry: NAME: \"FooMapEntry\" is already defined in "
@@ -7030,7 +7030,7 @@ TEST_F(SourceLocationTest, GetSourceLocation_BogusSourceCodeInfo) {
   file_desc->CopyTo(&proto);  // Note, this discards the SourceCodeInfo.
   EXPECT_FALSE(proto.has_source_code_info());
   SourceCodeInfo_Location *loc_msg =
-      proto.mutable_source_code_info()->add_location();
+      proto.mutable_source_code_info().add_location();
   loc_msg->add_path(1);
   loc_msg->add_path(2);
   loc_msg->add_path(3);

--- a/src/google/protobuf/extension_set_unittest.cc
+++ b/src/google/protobuf/extension_set_unittest.cc
@@ -1132,17 +1132,17 @@ TEST(ExtensionSetTest, DynamicExtensions) {
       unittest::TestDynamicExtensions::descriptor();
   DescriptorProto template_descriptor_proto;
   template_descriptor->CopyTo(&template_descriptor_proto);
-  dynamic_proto.mutable_message_type()->MergeFrom(
+  dynamic_proto.message_type().MergeFrom(
       template_descriptor_proto.nested_type());
-  dynamic_proto.mutable_enum_type()->MergeFrom(
+  dynamic_proto.enum_type().MergeFrom(
       template_descriptor_proto.enum_type());
-  dynamic_proto.mutable_extension()->MergeFrom(
+  dynamic_proto.extension().MergeFrom(
       template_descriptor_proto.field());
 
   // For each extension that we added...
   for (int i = 0; i < dynamic_proto.extension_size(); i++) {
     // Set its extendee to TestAllExtensions.
-    FieldDescriptorProto* extension = dynamic_proto.mutable_extension(i);
+    FieldDescriptorProto* extension = &dynamic_proto.extension(i);
     extension->set_extendee(
         unittest::TestAllExtensions::descriptor()->full_name());
 

--- a/src/google/protobuf/extension_set_unittest.cc
+++ b/src/google/protobuf/extension_set_unittest.cc
@@ -1174,8 +1174,8 @@ TEST(ExtensionSetTest, DynamicExtensions) {
     message.set_enum_extension(unittest::FOREIGN_BAR);
     message.set_dynamic_enum_extension(
         unittest::TestDynamicExtensions::DYNAMIC_BAZ);
-    message.mutable_message_extension()->set_c(456);
-    message.mutable_dynamic_message_extension()->set_dynamic_field(789);
+    message.mutable_message_extension().set_c(456);
+    message.mutable_dynamic_message_extension().set_dynamic_field(789);
     message.add_repeated_extension("foo");
     message.add_repeated_extension("bar");
     message.add_packed_extension(12);

--- a/src/google/protobuf/field_mask.pb.h
+++ b/src/google/protobuf/field_mask.pb.h
@@ -171,7 +171,7 @@ class LIBPROTOBUF_EXPORT FieldMask : public ::google::protobuf::Message /* @@pro
   void add_paths(const char* value);
   void add_paths(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& paths() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_paths();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& paths();
 
   // @@protoc_insertion_point(class_scope:google.protobuf.FieldMask)
  private:
@@ -256,10 +256,10 @@ FieldMask::paths() const {
   // @@protoc_insertion_point(field_list:google.protobuf.FieldMask.paths)
   return paths_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-FieldMask::mutable_paths() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+FieldMask::paths() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.FieldMask.paths)
-  return &paths_;
+  return paths_;
 }
 
 #ifdef __GNUC__

--- a/src/google/protobuf/generated_message_reflection_unittest.cc
+++ b/src/google/protobuf/generated_message_reflection_unittest.cc
@@ -217,11 +217,11 @@ TEST(GeneratedMessageReflectionTest, SwapUnknown) {
 TEST(GeneratedMessageReflectionTest, SwapFields) {
   unittest::TestAllTypes message1, message2;
   message1.set_optional_double(12.3);
-  message1.mutable_repeated_int32()->Add(10);
-  message1.mutable_repeated_int32()->Add(20);
+  message1.repeated_int32().Add(10);
+  message1.repeated_int32().Add(20);
 
   message2.set_optional_string("hello");
-  message2.mutable_repeated_int64()->Add(30);
+  message2.repeated_int64().Add(30);
 
   std::vector<const FieldDescriptor*> fields;
   const Descriptor* descriptor = message1.GetDescriptor();
@@ -359,7 +359,7 @@ TEST(GeneratedMessageReflectionTest, ReleaseLast) {
   TestUtil::SetAllFields(&message);
   ASSERT_EQ(2, message.repeated_foreign_message_size());
   const protobuf_unittest::ForeignMessage* expected =
-      message.mutable_repeated_foreign_message(1);
+      &message.repeated_foreign_message(1);
   google::protobuf::scoped_ptr<Message> released(message.GetReflection()->ReleaseLast(
       &message, descriptor->FindFieldByName("repeated_foreign_message")));
   EXPECT_EQ(expected, released.get());

--- a/src/google/protobuf/lite_unittest.cc
+++ b/src/google/protobuf/lite_unittest.cc
@@ -192,9 +192,9 @@ TEST(Lite, AllLite5) {
 
 #undef ASSIGN_REPEATED_FIELD
 #define ASSIGN_REPEATED_GROUP(FIELD)                \
-  msg1 = generator.add_##FIELD()->mutable_field1(); \
-  msg2 = generator.add_##FIELD()->mutable_field1(); \
-  msg3 = generator.add_##FIELD()->mutable_field1(); \
+  msg1 = &generator.add_##FIELD()->mutable_field1(); \
+  msg2 = &generator.add_##FIELD()->mutable_field1(); \
+  msg3 = &generator.add_##FIELD()->mutable_field1(); \
   AssignParsingMergeMessages(msg1, msg2, msg3)
 
     ASSIGN_REPEATED_GROUP(group1);
@@ -452,7 +452,7 @@ TEST(Lite, AllLite18) {
 
     // Creates a TestAllTypes with default value
     google::protobuf::TestUtilLite::ExpectClear(
-        (*message.mutable_map_int32_message())[0]);
+        message.map_int32_message()[0]);
   }
 }
 
@@ -480,8 +480,8 @@ TEST(Lite, AllLite20) {
     // CopyFromMessageMap
     protobuf_unittest::TestMessageMapLite message1, message2;
 
-    (*message1.mutable_map_int32_message())[0].add_repeated_int32(100);
-    (*message2.mutable_map_int32_message())[0].add_repeated_int32(101);
+    message1.map_int32_message()[0].add_repeated_int32(100);
+    message2.map_int32_message()[0].add_repeated_int32(101);
 
     message1.CopyFrom(message2);
 
@@ -581,12 +581,12 @@ TEST(Lite, AllLite26) {
     google::protobuf::MapLiteTestUtil::SetMapFields(&message1);
 
     // This field will test merging into an empty spot.
-    (*message2.mutable_map_int32_int32())[1] = 1;
-    message1.mutable_map_int32_int32()->erase(1);
+    message2.map_int32_int32()[1] = 1;
+    message1.map_int32_int32().erase(1);
 
     // This tests overwriting.
-    (*message2.mutable_map_int32_double())[1] = 1;
-    (*message1.mutable_map_int32_double())[1] = 2;
+    message2.map_int32_double()[1] = 1;
+    message1.map_int32_double()[1] = 2;
 
     message1.MergeFrom(message2);
     google::protobuf::MapLiteTestUtil::ExpectMapFieldsSet(message1);
@@ -600,8 +600,8 @@ TEST(Lite, AllLite27) {
     // MergeFromMessageMap
     protobuf_unittest::TestMessageMapLite message1, message2;
 
-    (*message1.mutable_map_int32_message())[0].add_repeated_int32(100);
-    (*message2.mutable_map_int32_message())[0].add_repeated_int32(101);
+    message1.map_int32_message()[0].add_repeated_int32(100);
+    message2.map_int32_message()[0].add_repeated_int32(101);
 
     message1.MergeFrom(message2);
 
@@ -660,9 +660,9 @@ TEST(Lite, AllLite32) {
   {
     // Proto2UnknownEnum
     protobuf_unittest::TestEnumMapPlusExtraLite from;
-    (*from.mutable_known_map_field())[0] =
+    from.known_map_field()[0] =
         protobuf_unittest::E_PROTO2_MAP_ENUM_FOO_LITE;
-    (*from.mutable_unknown_map_field())[0] =
+    from.unknown_map_field()[0] =
         protobuf_unittest::E_PROTO2_MAP_ENUM_EXTRA_LITE;
     string data;
     from.SerializeToString(&data);
@@ -820,13 +820,13 @@ TEST(Lite, AllLite41) {
     protobuf_unittest::TestRequiredMessageMapLite map_message;
 
     // Add an uninitialized message.
-    (*map_message.mutable_map_field())[0];
+    map_message.map_field()[0];
     EXPECT_FALSE(map_message.IsInitialized());
 
     // Initialize uninitialized message
-    (*map_message.mutable_map_field())[0].set_a(0);
-    (*map_message.mutable_map_field())[0].set_b(0);
-    (*map_message.mutable_map_field())[0].set_c(0);
+    map_message.map_field()[0].set_a(0);
+    map_message.map_field()[0].set_b(0);
+    map_message.map_field()[0].set_c(0);
     EXPECT_TRUE(map_message.IsInitialized());
   }
 }
@@ -925,7 +925,7 @@ TEST(Lite, AllLite44) {
   // Submessage
   {
     protobuf_unittest::TestOneofParsingLite original;
-    original.mutable_oneof_submessage()->set_optional_int32(5);
+    original.mutable_oneof_submessage().set_optional_int32(5);
     string serialized;
     EXPECT_TRUE(original.SerializeToString(&serialized));
     protobuf_unittest::TestOneofParsingLite parsed;

--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -1015,17 +1015,16 @@ TEST_F(MapFieldReflectionTest, RegularFields) {
   const Reflection* refl = message.GetReflection();
   const Descriptor* desc = message.GetDescriptor();
 
-  Map<int32, int32>* map_int32_int32 = message.mutable_map_int32_int32();
-  Map<int32, double>* map_int32_double = message.mutable_map_int32_double();
-  Map<string, string>* map_string_string = message.mutable_map_string_string();
-  Map<int32, ForeignMessage>* map_int32_foreign_message =
-      message.mutable_map_int32_foreign_message();
+  auto& map_int32_int32 = message.map_int32_int32();
+  auto& map_int32_double = message.map_int32_double();
+  auto& map_string_string = message.map_string_string();
+  auto& map_int32_foreign_message = message.map_int32_foreign_message();
 
   for (int i = 0; i < 10; ++i) {
-    (*map_int32_int32)[i] = Func(i, 1);
-    (*map_int32_double)[i] = Func(i, 2);
-    (*map_string_string)[StrFunc(i, 1)] = StrFunc(i, 5);
-    (*map_int32_foreign_message)[i].set_c(Func(i, 6));
+    map_int32_int32[i] = Func(i, 1);
+    map_int32_double[i] = Func(i, 2);
+    map_string_string[StrFunc(i, 1)] = StrFunc(i, 5);
+    map_int32_foreign_message[i].set_c(Func(i, 6));
   }
 
   // Get FieldDescriptors for all the fields of interest.
@@ -1206,11 +1205,10 @@ TEST_F(MapFieldReflectionTest, RepeatedFieldRefForRegularFields) {
   const Reflection* refl = message.GetReflection();
   const Descriptor* desc = message.GetDescriptor();
 
-  Map<int32, int32>* map_int32_int32 = message.mutable_map_int32_int32();
-  Map<int32, double>* map_int32_double = message.mutable_map_int32_double();
-  Map<string, string>* map_string_string = message.mutable_map_string_string();
-  Map<int32, ForeignMessage>* map_int32_foreign_message =
-      message.mutable_map_int32_foreign_message();
+  auto map_int32_int32 = &message.map_int32_int32();
+  auto map_int32_double = &message.map_int32_double();
+  auto map_string_string = &message.map_string_string();
+  auto map_int32_foreign_message = &message.map_int32_foreign_message();
 
   for (int i = 0; i < 10; ++i) {
     (*map_int32_int32)[i] = Func(i, 1);
@@ -1697,18 +1695,18 @@ TEST_F(MapFieldReflectionTest, RepeatedFieldRefMergeFromAndSwap) {
   // Set-up message content.
   TestMap m0, m1, m2;
   for (int i = 0; i < 10; ++i) {
-    (*m0.mutable_map_int32_int32())[i] = Func(i, 1);
-    (*m0.mutable_map_int32_double())[i] = Func(i, 2);
-    (*m0.mutable_map_string_string())[StrFunc(i, 1)] = StrFunc(i, 5);
-    (*m0.mutable_map_int32_foreign_message())[i].set_c(Func(i, 6));
-    (*m1.mutable_map_int32_int32())[i + 10] = Func(i, 11);
-    (*m1.mutable_map_int32_double())[i + 10] = Func(i, 12);
-    (*m1.mutable_map_string_string())[StrFunc(i + 10, 1)] = StrFunc(i, 15);
-    (*m1.mutable_map_int32_foreign_message())[i + 10].set_c(Func(i, 16));
-    (*m2.mutable_map_int32_int32())[i + 20] = Func(i, 21);
-    (*m2.mutable_map_int32_double())[i + 20] = Func(i, 22);
-    (*m2.mutable_map_string_string())[StrFunc(i + 20, 1)] = StrFunc(i, 25);
-    (*m2.mutable_map_int32_foreign_message())[i + 20].set_c(Func(i, 26));
+    m0.map_int32_int32()[i] = Func(i, 1);
+    m0.map_int32_double()[i] = Func(i, 2);
+    m0.map_string_string()[StrFunc(i, 1)] = StrFunc(i, 5);
+    m0.map_int32_foreign_message()[i].set_c(Func(i, 6));
+    m1.map_int32_int32()[i + 10] = Func(i, 11);
+    m1.map_int32_double()[i + 10] = Func(i, 12);
+    m1.map_string_string()[StrFunc(i + 10, 1)] = StrFunc(i, 15);
+    m1.map_int32_foreign_message()[i + 10].set_c(Func(i, 16));
+    m2.map_int32_int32()[i + 20] = Func(i, 21);
+    m2.map_int32_double()[i + 20] = Func(i, 22);
+    m2.map_string_string()[StrFunc(i + 20, 1)] = StrFunc(i, 25);
+    m2.map_int32_foreign_message()[i + 20].set_c(Func(i, 26));
   }
 
   const Reflection* refl = m0.GetReflection();
@@ -1881,7 +1879,7 @@ TEST(GeneratedMapFieldTest, SetMapFieldsInitialized) {
 TEST(GeneratedMapFieldTest, Proto2SetMapFieldsInitialized) {
   unittest::TestEnumMap message;
   EXPECT_EQ(unittest::PROTO2_MAP_ENUM_FOO,
-            (*message.mutable_known_map_field())[0]);
+            message.known_map_field()[0]);
 }
 
 TEST(GeneratedMapFieldTest, Clear) {
@@ -1896,7 +1894,7 @@ TEST(GeneratedMapFieldTest, ClearMessageMap) {
   unittest::TestMessageMap message;
 
   // Creates a TestAllTypes with default value
-  TestUtil::ExpectClear((*message.mutable_map_int32_message())[0]);
+  TestUtil::ExpectClear(message.map_int32_message()[0]);
 }
 
 TEST(GeneratedMapFieldTest, CopyFrom) {
@@ -1914,8 +1912,8 @@ TEST(GeneratedMapFieldTest, CopyFrom) {
 TEST(GeneratedMapFieldTest, CopyFromMessageMap) {
   unittest::TestMessageMap message1, message2;
 
-  (*message1.mutable_map_int32_message())[0].add_repeated_int32(100);
-  (*message2.mutable_map_int32_message())[0].add_repeated_int32(101);
+  message1.map_int32_message()[0].add_repeated_int32(100);
+  message2.map_int32_message()[0].add_repeated_int32(101);
 
   message1.CopyFrom(message2);
 
@@ -2089,12 +2087,12 @@ TEST(GeneratedMapFieldTest, NonEmptyMergeFrom) {
   MapTestUtil::SetMapFields(&message1);
 
   // This field will test merging into an empty spot.
-  (*message2.mutable_map_int32_int32())[1] = 1;
-  message1.mutable_map_int32_int32()->erase(1);
+  message2.map_int32_int32()[1] = 1;
+  message1.map_int32_int32().erase(1);
 
   // This tests overwriting.
-  (*message2.mutable_map_int32_double())[1] = 1;
-  (*message1.mutable_map_int32_double())[1] = 2;
+  message2.map_int32_double()[1] = 1;
+  message1.map_int32_double()[1] = 2;
 
   message1.MergeFrom(message2);
   MapTestUtil::ExpectMapFieldsSet(message1);
@@ -2103,8 +2101,8 @@ TEST(GeneratedMapFieldTest, NonEmptyMergeFrom) {
 TEST(GeneratedMapFieldTest, MergeFromMessageMap) {
   unittest::TestMessageMap message1, message2;
 
-  (*message1.mutable_map_int32_message())[0].add_repeated_int32(100);
-  (*message2.mutable_map_int32_message())[0].add_repeated_int32(101);
+  message1.map_int32_message()[0].add_repeated_int32(100);
+  message2.map_int32_message()[0].add_repeated_int32(101);
 
   message1.MergeFrom(message2);
 
@@ -2166,8 +2164,8 @@ TEST(GeneratedMapFieldTest, SameTypeMaps) {
 
 TEST(GeneratedMapFieldTest, Proto2UnknownEnum) {
   unittest::TestEnumMapPlusExtra from;
-  (*from.mutable_known_map_field())[0] = unittest::E_PROTO2_MAP_ENUM_FOO;
-  (*from.mutable_unknown_map_field())[0] = unittest::E_PROTO2_MAP_ENUM_EXTRA;
+  from.known_map_field()[0] = unittest::E_PROTO2_MAP_ENUM_FOO;
+  from.unknown_map_field()[0] = unittest::E_PROTO2_MAP_ENUM_EXTRA;
   string data;
   from.SerializeToString(&data);
 
@@ -2231,14 +2229,14 @@ TEST(GeneratedMapFieldTest, DuplicatedKeyWireFormat) {
   with_dummy4.set_b(0);
   with_dummy4.set_c(0);
   with_dummy4.set_dummy4(11);
-  (*map_message.mutable_map_field())[key] = with_dummy4;
+  map_message.map_field()[key] = with_dummy4;
   string s = map_message.SerializeAsString();
   unittest::TestRequired with_dummy5;
   with_dummy5.set_a(0);
   with_dummy5.set_b(0);
   with_dummy5.set_c(0);
   with_dummy5.set_dummy5(12);
-  (*map_message.mutable_map_field())[key] = with_dummy5;
+  map_message.map_field()[key] = with_dummy5;
   string both = s + map_message.SerializeAsString();
   // We don't expect a merge now.  The "second one wins."
   ASSERT_TRUE(map_message.ParseFromString(both));
@@ -2363,13 +2361,13 @@ TEST(GeneratedMapFieldTest, IsInitialized) {
   unittest::TestRequiredMessageMap map_message;
 
   // Add an uninitialized message.
-  (*map_message.mutable_map_field())[0];
+  map_message.map_field()[0];
   EXPECT_FALSE(map_message.IsInitialized());
 
   // Initialize uninitialized message
-  (*map_message.mutable_map_field())[0].set_a(0);
-  (*map_message.mutable_map_field())[0].set_b(0);
-  (*map_message.mutable_map_field())[0].set_c(0);
+  map_message.map_field()[0].set_a(0);
+  map_message.map_field()[0].set_b(0);
+  map_message.map_field()[0].set_c(0);
   EXPECT_TRUE(map_message.IsInitialized());
 }
 
@@ -2382,7 +2380,7 @@ TEST(GeneratedMapFieldTest, MessagesMustMerge) {
   with_dummy4.set_dummy4(98);
 
   EXPECT_TRUE(with_dummy4.IsInitialized());
-  (*map_message.mutable_map_field())[0] = with_dummy4;
+  map_message.map_field()[0] = with_dummy4;
   EXPECT_TRUE(map_message.IsInitialized());
   string s = map_message.SerializeAsString();
 
@@ -2759,7 +2757,7 @@ TEST_F(MapFieldInDynamicMessageTest, MapSpaceUsed) {
 
 TEST_F(MapFieldInDynamicMessageTest, RecursiveMap) {
   TestRecursiveMapMessage from;
-  (*from.mutable_a())[""];
+  from.a()[""];
   string data = from.SerializeAsString();
   google::protobuf::scoped_ptr<Message> to(
       factory_.GetPrototype(recursive_map_descriptor_)->New());
@@ -2895,13 +2893,13 @@ TEST(ReflectionOpsForMapFieldTest, IsInitialized) {
   unittest::TestRequiredMessageMap map_message;
 
   // Add an uninitialized message.
-  (*map_message.mutable_map_field())[0];
+  map_message.map_field()[0];
   EXPECT_FALSE(ReflectionOps::IsInitialized(map_message));
 
   // Initialize uninitialized message
-  (*map_message.mutable_map_field())[0].set_a(0);
-  (*map_message.mutable_map_field())[0].set_b(0);
-  (*map_message.mutable_map_field())[0].set_c(0);
+  map_message.map_field()[0].set_a(0);
+  map_message.map_field()[0].set_b(0);
+  map_message.map_field()[0].set_c(0);
   EXPECT_TRUE(ReflectionOps::IsInitialized(map_message));
 }
 
@@ -3115,8 +3113,7 @@ TEST(MapSerializationTest, Deterministic) {
   const int kIters = 25;
   protobuf_unittest::TestMaps t;
   protobuf_unittest::TestIntIntMap inner;
-  (*inner.mutable_m())[0] = (*inner.mutable_m())[10] =
-      (*inner.mutable_m())[-200] = 0;
+  inner.m()[0] = inner.m()[10] = inner.m()[-200] = 0;
   uint64 frog = 9;
   const uint64 multiplier = 0xa29cd16f;
   for (int i = 0; i < kIters; i++) {
@@ -3126,18 +3123,18 @@ TEST(MapSerializationTest, Deterministic) {
     const uint64 u64 = frog * static_cast<uint64>(187321);
     const bool b = i32 > 0;
     const string s = ConstructKey(frog);
-    (*inner.mutable_m())[i] = i32;
-    (*t.mutable_m_int32())[i32] = (*t.mutable_m_sint32())[i32] =
-        (*t.mutable_m_sfixed32())[i32] = inner;
-    (*t.mutable_m_uint32())[u32] = (*t.mutable_m_fixed32())[u32] = inner;
-    (*t.mutable_m_int64())[i64] = (*t.mutable_m_sint64())[i64] =
-        (*t.mutable_m_sfixed64())[i64] = inner;
-    (*t.mutable_m_uint64())[u64] = (*t.mutable_m_fixed64())[u64] = inner;
-    (*t.mutable_m_bool())[b] = inner;
-    (*t.mutable_m_string())[s] = inner;
-    (*t.mutable_m_string())[s + string(1 << (u32 % static_cast<uint32>(9)),
+    inner.m()[i] = i32;
+    t.m_int32()[i32] = t.m_sint32()[i32] =
+        t.m_sfixed32()[i32] = inner;
+    t.m_uint32()[u32] = t.m_fixed32()[u32] = inner;
+    t.m_int64()[i64] = t.m_sint64()[i64] =
+        t.m_sfixed64()[i64] = inner;
+    t.m_uint64()[u64] = t.m_fixed64()[u64] = inner;
+    t.m_bool()[b] = inner;
+    t.m_string()[s] = inner;
+    t.m_string()[s + string(1 << (u32 % static_cast<uint32>(9)),
                                        b)] = inner;
-    inner.mutable_m()->erase(i);
+    inner.m().erase(i);
     frog = frog * multiplier + i;
     frog ^= (frog >> 41);
   }
@@ -3153,7 +3150,7 @@ TEST(MapSerializationTest, DeterministicSubmessage) {
       TestSourceDir() + "/google/protobuf/testdata/" + filename,
       &golden, true));
   t.ParseFromString(golden);
-  *(p.mutable_m()) = t;
+  p.mutable_m() = t;
   std::vector<string> v;
   // Use multiple attempts to increase the chance of a failure if something is
   // buggy.  For example, each separate copy of a map might use a different
@@ -3273,7 +3270,7 @@ TEST(ArenaTest, StringMapNoLeak) {
   while (data.capacity() <= original_capacity) {
     data.append("a");
   }
-  (*message->mutable_map_string_string())[data] = data;
+  message->map_string_string()[data] = data;
   // We rely on heap checkers to detect memory leak for us.
   ASSERT_FALSE(message == NULL);
 }
@@ -3290,14 +3287,14 @@ TEST(ArenaTest, IsInitialized) {
 
   unittest::TestArenaMap* message =
       Arena::CreateMessage<unittest::TestArenaMap>(&arena);
-  EXPECT_EQ(0, (*message->mutable_map_int32_int32())[0]);
+  EXPECT_EQ(0, message->map_int32_int32()[0]);
 }
 
 #if LANG_CXX11
 TEST(MoveTest, MoveConstructorWorks) {
   Map<int32, TestAllTypes> original_map;
-  original_map[42].mutable_optional_nested_message()->set_bb(42);
-  original_map[43].mutable_optional_nested_message()->set_bb(43);
+  original_map[42].mutable_optional_nested_message().set_bb(42);
+  original_map[43].mutable_optional_nested_message().set_bb(43);
   const auto* nested_msg42_ptr = &original_map[42].optional_nested_message();
   const auto* nested_msg43_ptr = &original_map[43].optional_nested_message();
 
@@ -3314,8 +3311,8 @@ TEST(MoveTest, MoveConstructorWorks) {
 
 TEST(MoveTest, MoveAssignmentWorks) {
   Map<int32, TestAllTypes> original_map;
-  original_map[42].mutable_optional_nested_message()->set_bb(42);
-  original_map[43].mutable_optional_nested_message()->set_bb(43);
+  original_map[42].mutable_optional_nested_message().set_bb(42);
+  original_map[43].mutable_optional_nested_message().set_bb(43);
   const auto* nested_msg42_ptr = &original_map[42].optional_nested_message();
   const auto* nested_msg43_ptr = &original_map[43].optional_nested_message();
 

--- a/src/google/protobuf/map_test_util_impl.h
+++ b/src/google/protobuf/map_test_util_impl.h
@@ -108,130 +108,130 @@ template <typename EnumType, EnumType enum_value0,
           EnumType enum_value1, typename MapMessage>
 void MapTestUtilImpl::SetMapFields(MapMessage* message) {
   // Add first element.
-  (*message->mutable_map_int32_int32())[0] = 0;
-  (*message->mutable_map_int64_int64())[0] = 0;
-  (*message->mutable_map_uint32_uint32())[0] = 0;
-  (*message->mutable_map_uint64_uint64())[0] = 0;
-  (*message->mutable_map_sint32_sint32())[0] = 0;
-  (*message->mutable_map_sint64_sint64())[0] = 0;
-  (*message->mutable_map_fixed32_fixed32())[0] = 0;
-  (*message->mutable_map_fixed64_fixed64())[0] = 0;
-  (*message->mutable_map_sfixed32_sfixed32())[0] = 0;
-  (*message->mutable_map_sfixed64_sfixed64())[0] = 0;
-  (*message->mutable_map_int32_float())[0] = 0.0;
-  (*message->mutable_map_int32_double())[0] = 0.0;
-  (*message->mutable_map_bool_bool())[0] = false;
-  (*message->mutable_map_string_string())["0"] = "0";
-  (*message->mutable_map_int32_bytes())[0] = "0";
-  (*message->mutable_map_int32_enum())[0] = enum_value0;
-  (*message->mutable_map_int32_foreign_message())[0].set_c(0);
+  message->map_int32_int32()[0] = 0;
+  message->map_int64_int64()[0] = 0;
+  message->map_uint32_uint32()[0] = 0;
+  message->map_uint64_uint64()[0] = 0;
+  message->map_sint32_sint32()[0] = 0;
+  message->map_sint64_sint64()[0] = 0;
+  message->map_fixed32_fixed32()[0] = 0;
+  message->map_fixed64_fixed64()[0] = 0;
+  message->map_sfixed32_sfixed32()[0] = 0;
+  message->map_sfixed64_sfixed64()[0] = 0;
+  message->map_int32_float()[0] = 0.0;
+  message->map_int32_double()[0] = 0.0;
+  message->map_bool_bool()[0] = false;
+  message->map_string_string()["0"] = "0";
+  message->map_int32_bytes()[0] = "0";
+  message->map_int32_enum()[0] = enum_value0;
+  message->map_int32_foreign_message()[0].set_c(0);
 
   // Add second element
-  (*message->mutable_map_int32_int32())[1] = 1;
-  (*message->mutable_map_int64_int64())[1] = 1;
-  (*message->mutable_map_uint32_uint32())[1] = 1;
-  (*message->mutable_map_uint64_uint64())[1] = 1;
-  (*message->mutable_map_sint32_sint32())[1] = 1;
-  (*message->mutable_map_sint64_sint64())[1] = 1;
-  (*message->mutable_map_fixed32_fixed32())[1] = 1;
-  (*message->mutable_map_fixed64_fixed64())[1] = 1;
-  (*message->mutable_map_sfixed32_sfixed32())[1] = 1;
-  (*message->mutable_map_sfixed64_sfixed64())[1] = 1;
-  (*message->mutable_map_int32_float())[1] = 1.0;
-  (*message->mutable_map_int32_double())[1] = 1.0;
-  (*message->mutable_map_bool_bool())[1] = true;
-  (*message->mutable_map_string_string())["1"] = "1";
-  (*message->mutable_map_int32_bytes())[1] = "1";
-  (*message->mutable_map_int32_enum())[1] = enum_value1;
-  (*message->mutable_map_int32_foreign_message())[1].set_c(1);
+  message->map_int32_int32()[1] = 1;
+  message->map_int64_int64()[1] = 1;
+  message->map_uint32_uint32()[1] = 1;
+  message->map_uint64_uint64()[1] = 1;
+  message->map_sint32_sint32()[1] = 1;
+  message->map_sint64_sint64()[1] = 1;
+  message->map_fixed32_fixed32()[1] = 1;
+  message->map_fixed64_fixed64()[1] = 1;
+  message->map_sfixed32_sfixed32()[1] = 1;
+  message->map_sfixed64_sfixed64()[1] = 1;
+  message->map_int32_float()[1] = 1.0;
+  message->map_int32_double()[1] = 1.0;
+  message->map_bool_bool()[1] = true;
+  message->map_string_string()["1"] = "1";
+  message->map_int32_bytes()[1] = "1";
+  message->map_int32_enum()[1] = enum_value1;
+  message->map_int32_foreign_message()[1].set_c(1);
 }
 
 template <typename EnumType, EnumType enum_value0,
           EnumType enum_value1, typename MapMessage>
 void MapTestUtilImpl::SetArenaMapFields(MapMessage* message) {
   // Add first element.
-  (*message->mutable_map_int32_int32())[0] = 0;
-  (*message->mutable_map_int64_int64())[0] = 0;
-  (*message->mutable_map_uint32_uint32())[0] = 0;
-  (*message->mutable_map_uint64_uint64())[0] = 0;
-  (*message->mutable_map_sint32_sint32())[0] = 0;
-  (*message->mutable_map_sint64_sint64())[0] = 0;
-  (*message->mutable_map_fixed32_fixed32())[0] = 0;
-  (*message->mutable_map_fixed64_fixed64())[0] = 0;
-  (*message->mutable_map_sfixed32_sfixed32())[0] = 0;
-  (*message->mutable_map_sfixed64_sfixed64())[0] = 0;
-  (*message->mutable_map_int32_float())[0] = 0.0;
-  (*message->mutable_map_int32_double())[0] = 0.0;
-  (*message->mutable_map_bool_bool())[0] = false;
-  (*message->mutable_map_string_string())["0"] = "0";
-  (*message->mutable_map_int32_bytes())[0] = "0";
-  (*message->mutable_map_int32_enum())[0] = enum_value0;
-  (*message->mutable_map_int32_foreign_message())[0].set_c(0);
-  (*message->mutable_map_int32_foreign_message_no_arena())[0].set_c(0);
+  message->map_int32_int32()[0] = 0;
+  message->map_int64_int64()[0] = 0;
+  message->map_uint32_uint32()[0] = 0;
+  message->map_uint64_uint64()[0] = 0;
+  message->map_sint32_sint32()[0] = 0;
+  message->map_sint64_sint64()[0] = 0;
+  message->map_fixed32_fixed32()[0] = 0;
+  message->map_fixed64_fixed64()[0] = 0;
+  message->map_sfixed32_sfixed32()[0] = 0;
+  message->map_sfixed64_sfixed64()[0] = 0;
+  message->map_int32_float()[0] = 0.0;
+  message->map_int32_double()[0] = 0.0;
+  message->map_bool_bool()[0] = false;
+  message->map_string_string()["0"] = "0";
+  message->map_int32_bytes()[0] = "0";
+  message->map_int32_enum()[0] = enum_value0;
+  message->map_int32_foreign_message()[0].set_c(0);
+  message->map_int32_foreign_message_no_arena()[0].set_c(0);
 
   // Add second element
-  (*message->mutable_map_int32_int32())[1] = 1;
-  (*message->mutable_map_int64_int64())[1] = 1;
-  (*message->mutable_map_uint32_uint32())[1] = 1;
-  (*message->mutable_map_uint64_uint64())[1] = 1;
-  (*message->mutable_map_sint32_sint32())[1] = 1;
-  (*message->mutable_map_sint64_sint64())[1] = 1;
-  (*message->mutable_map_fixed32_fixed32())[1] = 1;
-  (*message->mutable_map_fixed64_fixed64())[1] = 1;
-  (*message->mutable_map_sfixed32_sfixed32())[1] = 1;
-  (*message->mutable_map_sfixed64_sfixed64())[1] = 1;
-  (*message->mutable_map_int32_float())[1] = 1.0;
-  (*message->mutable_map_int32_double())[1] = 1.0;
-  (*message->mutable_map_bool_bool())[1] = true;
-  (*message->mutable_map_string_string())["1"] = "1";
-  (*message->mutable_map_int32_bytes())[1] = "1";
-  (*message->mutable_map_int32_enum())[1] = enum_value1;
-  (*message->mutable_map_int32_foreign_message())[1].set_c(1);
-  (*message->mutable_map_int32_foreign_message_no_arena())[1].set_c(1);
+  message->map_int32_int32()[1] = 1;
+  message->map_int64_int64()[1] = 1;
+  message->map_uint32_uint32()[1] = 1;
+  message->map_uint64_uint64()[1] = 1;
+  message->map_sint32_sint32()[1] = 1;
+  message->map_sint64_sint64()[1] = 1;
+  message->map_fixed32_fixed32()[1] = 1;
+  message->map_fixed64_fixed64()[1] = 1;
+  message->map_sfixed32_sfixed32()[1] = 1;
+  message->map_sfixed64_sfixed64()[1] = 1;
+  message->map_int32_float()[1] = 1.0;
+  message->map_int32_double()[1] = 1.0;
+  message->map_bool_bool()[1] = true;
+  message->map_string_string()["1"] = "1";
+  message->map_int32_bytes()[1] = "1";
+  message->map_int32_enum()[1] = enum_value1;
+  message->map_int32_foreign_message()[1].set_c(1);
+  message->map_int32_foreign_message_no_arena()[1].set_c(1);
 }
 
 template <typename MapMessage>
 void MapTestUtilImpl::SetMapFieldsInitialized(MapMessage* message) {
   // Add first element using bracket operator, which should assign default
   // value automatically.
-  (*message->mutable_map_int32_int32())[0];
-  (*message->mutable_map_int64_int64())[0];
-  (*message->mutable_map_uint32_uint32())[0];
-  (*message->mutable_map_uint64_uint64())[0];
-  (*message->mutable_map_sint32_sint32())[0];
-  (*message->mutable_map_sint64_sint64())[0];
-  (*message->mutable_map_fixed32_fixed32())[0];
-  (*message->mutable_map_fixed64_fixed64())[0];
-  (*message->mutable_map_sfixed32_sfixed32())[0];
-  (*message->mutable_map_sfixed64_sfixed64())[0];
-  (*message->mutable_map_int32_float())[0];
-  (*message->mutable_map_int32_double())[0];
-  (*message->mutable_map_bool_bool())[0];
-  (*message->mutable_map_string_string())["0"];
-  (*message->mutable_map_int32_bytes())[0];
-  (*message->mutable_map_int32_enum())[0];
-  (*message->mutable_map_int32_foreign_message())[0];
+  message->map_int32_int32()[0];
+  message->map_int64_int64()[0];
+  message->map_uint32_uint32()[0];
+  message->map_uint64_uint64()[0];
+  message->map_sint32_sint32()[0];
+  message->map_sint64_sint64()[0];
+  message->map_fixed32_fixed32()[0];
+  message->map_fixed64_fixed64()[0];
+  message->map_sfixed32_sfixed32()[0];
+  message->map_sfixed64_sfixed64()[0];
+  message->map_int32_float()[0];
+  message->map_int32_double()[0];
+  message->map_bool_bool()[0];
+  message->map_string_string()["0"];
+  message->map_int32_bytes()[0];
+  message->map_int32_enum()[0];
+  message->map_int32_foreign_message()[0];
 }
 
 template <typename EnumType, EnumType enum_value, typename MapMessage>
 void MapTestUtilImpl::ModifyMapFields(MapMessage* message) {
-  (*message->mutable_map_int32_int32())[1] = 2;
-  (*message->mutable_map_int64_int64())[1] = 2;
-  (*message->mutable_map_uint32_uint32())[1] = 2;
-  (*message->mutable_map_uint64_uint64())[1] = 2;
-  (*message->mutable_map_sint32_sint32())[1] = 2;
-  (*message->mutable_map_sint64_sint64())[1] = 2;
-  (*message->mutable_map_fixed32_fixed32())[1] = 2;
-  (*message->mutable_map_fixed64_fixed64())[1] = 2;
-  (*message->mutable_map_sfixed32_sfixed32())[1] = 2;
-  (*message->mutable_map_sfixed64_sfixed64())[1] = 2;
-  (*message->mutable_map_int32_float())[1] = 2.0;
-  (*message->mutable_map_int32_double())[1] = 2.0;
-  (*message->mutable_map_bool_bool())[1] = false;
-  (*message->mutable_map_string_string())["1"] = "2";
-  (*message->mutable_map_int32_bytes())[1] = "2";
-  (*message->mutable_map_int32_enum())[1] = enum_value;
-  (*message->mutable_map_int32_foreign_message())[1].set_c(2);
+  message->map_int32_int32()[1] = 2;
+  message->map_int64_int64()[1] = 2;
+  message->map_uint32_uint32()[1] = 2;
+  message->map_uint64_uint64()[1] = 2;
+  message->map_sint32_sint32()[1] = 2;
+  message->map_sint64_sint64()[1] = 2;
+  message->map_fixed32_fixed32()[1] = 2;
+  message->map_fixed64_fixed64()[1] = 2;
+  message->map_sfixed32_sfixed32()[1] = 2;
+  message->map_sfixed64_sfixed64()[1] = 2;
+  message->map_int32_float()[1] = 2.0;
+  message->map_int32_double()[1] = 2.0;
+  message->map_bool_bool()[1] = false;
+  message->map_string_string()["1"] = "2";
+  message->map_int32_bytes()[1] = "2";
+  message->map_int32_enum()[1] = enum_value;
+  message->map_int32_foreign_message()[1].set_c(2);
 }
 
 template <typename MapMessage>

--- a/src/google/protobuf/message_unittest.cc
+++ b/src/google/protobuf/message_unittest.cc
@@ -452,9 +452,9 @@ TEST(MessageTest, ParsingMerge) {
 
 #undef ASSIGN_REPEATED_FIELD
 #define ASSIGN_REPEATED_GROUP(FIELD)                \
-  msg1 = generator.add_##FIELD()->mutable_field1(); \
-  msg2 = generator.add_##FIELD()->mutable_field1(); \
-  msg3 = generator.add_##FIELD()->mutable_field1(); \
+  msg1 = &generator.add_##FIELD()->mutable_field1(); \
+  msg2 = &generator.add_##FIELD()->mutable_field1(); \
+  msg3 = &generator.add_##FIELD()->mutable_field1(); \
   AssignParsingMergeMessages(msg1, msg2, msg3)
 
   ASSIGN_REPEATED_GROUP(group1);
@@ -540,11 +540,11 @@ TEST(MessageTest, MergeFrom) {
 TEST(MessageTest, IsInitialized) {
   protobuf_unittest::TestIsInitialized msg;
   EXPECT_TRUE(msg.IsInitialized());
-  protobuf_unittest::TestIsInitialized::SubMessage* sub_message = msg.mutable_sub_message();
+  auto& sub_message = msg.mutable_sub_message();
   EXPECT_TRUE(msg.IsInitialized());
-  protobuf_unittest::TestIsInitialized::SubMessage::SubGroup* sub_group = sub_message->mutable_subgroup();
+  auto& sub_group = sub_message.mutable_subgroup();
   EXPECT_FALSE(msg.IsInitialized());
-  sub_group->set_i(1);
+  sub_group.set_i(1);
   EXPECT_TRUE(msg.IsInitialized());
 }
 

--- a/src/google/protobuf/no_field_presence_test.cc
+++ b/src/google/protobuf/no_field_presence_test.cc
@@ -115,14 +115,14 @@ void FillValues(proto2_nofieldpresence_unittest::TestAllTypes* m) {
   m->set_optional_bool(true);
   m->set_optional_string("asdf");
   m->set_optional_bytes("jkl;");
-  m->mutable_optional_nested_message()->set_bb(42);
-  m->mutable_optional_foreign_message()->set_c(43);
-  m->mutable_optional_proto2_message()->set_optional_int32(44);
+  m->mutable_optional_nested_message().set_bb(42);
+  m->mutable_optional_foreign_message().set_c(43);
+  m->mutable_optional_proto2_message().set_optional_int32(44);
   m->set_optional_nested_enum(
       proto2_nofieldpresence_unittest::TestAllTypes_NestedEnum_BAZ);
   m->set_optional_foreign_enum(
       proto2_nofieldpresence_unittest::FOREIGN_BAZ);
-  m->mutable_optional_lazy_message()->set_bb(45);
+  m->mutable_optional_lazy_message().set_bb(45);
   m->add_repeated_int32(100);
   m->add_repeated_int64(101);
   m->add_repeated_uint32(102);
@@ -148,7 +148,7 @@ void FillValues(proto2_nofieldpresence_unittest::TestAllTypes* m) {
   m->add_repeated_lazy_message()->set_bb(49);
 
   m->set_oneof_uint32(1);
-  m->mutable_oneof_nested_message()->set_bb(50);
+  m->mutable_oneof_nested_message().set_bb(50);
   m->set_oneof_string("test");  // only this one remains set
 }
 
@@ -254,7 +254,7 @@ TEST(NoFieldPresenceTest, MessageFieldPresenceTest) {
   // present.
   EXPECT_EQ(0, message.optional_nested_message().bb());
   EXPECT_EQ(false, message.has_optional_nested_message());
-  message.mutable_optional_nested_message()->set_bb(42);
+  message.mutable_optional_nested_message().set_bb(42);
   EXPECT_EQ(true, message.has_optional_nested_message());
   message.clear_optional_nested_message();
   EXPECT_EQ(false, message.has_optional_nested_message());
@@ -265,7 +265,7 @@ TEST(NoFieldPresenceTest, MessageFieldPresenceTest) {
   // present.
   EXPECT_EQ(0, message.optional_lazy_message().bb());
   EXPECT_EQ(false, message.has_optional_lazy_message());
-  message.mutable_optional_lazy_message()->set_bb(42);
+  message.mutable_optional_lazy_message().set_bb(42);
   EXPECT_EQ(true, message.has_optional_lazy_message());
   message.clear_optional_lazy_message();
   EXPECT_EQ(false, message.has_optional_lazy_message());
@@ -370,12 +370,12 @@ TEST(NoFieldPresenceTest, ReflectionClearFieldTest) {
   r->ClearField(&message, field_string);
   EXPECT_EQ("", message.optional_string());
 
-  message.mutable_optional_nested_message()->set_bb(1234);
+  message.mutable_optional_nested_message().set_bb(1234);
   r->ClearField(&message, field_message);
   EXPECT_FALSE(message.has_optional_nested_message());
   EXPECT_EQ(0, message.optional_nested_message().bb());
 
-  message.mutable_optional_lazy_message()->set_bb(42);
+  message.mutable_optional_lazy_message().set_bb(42);
   r->ClearField(&message, field_lazy);
   EXPECT_FALSE(message.has_optional_lazy_message());
   EXPECT_EQ(0, message.optional_lazy_message().bb());
@@ -405,7 +405,7 @@ TEST(NoFieldPresenceTest, HasFieldOneofsTest) {
   EXPECT_EQ(false, r->HasField(message, desc_oneof_uint32));
   EXPECT_EQ(false, r->HasField(message, desc_oneof_nested_message));
   EXPECT_EQ(true, r->HasField(message, desc_oneof_string));
-  message.mutable_oneof_nested_message()->set_bb(42);
+  message.mutable_oneof_nested_message().set_bb(42);
   EXPECT_EQ(false, r->HasField(message, desc_oneof_uint32));
   EXPECT_EQ(true, r->HasField(message, desc_oneof_nested_message));
   EXPECT_EQ(false, r->HasField(message, desc_oneof_string));
@@ -486,11 +486,11 @@ TEST(NoFieldPresenceTest, IsInitializedTest) {
   proto2_nofieldpresence_unittest::TestProto2Required message;
 
   EXPECT_EQ(true, message.IsInitialized());
-  message.mutable_proto2()->set_a(1);
+  message.mutable_proto2().set_a(1);
   EXPECT_EQ(false, message.IsInitialized());
-  message.mutable_proto2()->set_b(1);
+  message.mutable_proto2().set_b(1);
   EXPECT_EQ(false, message.IsInitialized());
-  message.mutable_proto2()->set_c(1);
+  message.mutable_proto2().set_c(1);
   EXPECT_EQ(true, message.IsInitialized());
 }
 
@@ -507,7 +507,7 @@ TEST(NoFieldPresenceTest, LazyMessageFieldHasBit) {
   EXPECT_EQ(false, message.has_optional_lazy_message());
   EXPECT_EQ(false, r->HasField(message, field));
 
-  message.mutable_optional_lazy_message()->set_bb(42);
+  message.mutable_optional_lazy_message().set_bb(42);
   EXPECT_EQ(true, message.has_optional_lazy_message());
   EXPECT_EQ(true, r->HasField(message, field));
 

--- a/src/google/protobuf/proto3_arena_lite_unittest.cc
+++ b/src/google/protobuf/proto3_arena_lite_unittest.cc
@@ -53,13 +53,13 @@ void SetAllFields(TestAllTypes* m) {
   m->set_optional_int32(100);
   m->set_optional_string("asdf");
   m->set_optional_bytes("jkl;");
-  m->mutable_optional_nested_message()->set_bb(42);
-  m->mutable_optional_foreign_message()->set_c(43);
+  m->mutable_optional_nested_message().set_bb(42);
+  m->mutable_optional_foreign_message().set_c(43);
   m->set_optional_nested_enum(
       proto3_arena_lite_unittest::TestAllTypes_NestedEnum_BAZ);
   m->set_optional_foreign_enum(
       proto3_arena_lite_unittest::FOREIGN_BAZ);
-  m->mutable_optional_lazy_message()->set_bb(45);
+  m->mutable_optional_lazy_message().set_bb(45);
   m->add_repeated_int32(100);
   m->add_repeated_string("asdf");
   m->add_repeated_bytes("jkl;");
@@ -72,7 +72,7 @@ void SetAllFields(TestAllTypes* m) {
   m->add_repeated_lazy_message()->set_bb(49);
 
   m->set_oneof_uint32(1);
-  m->mutable_oneof_nested_message()->set_bb(50);
+  m->mutable_oneof_nested_message().set_bb(50);
   m->set_oneof_string("test");  // only this one remains set
 }
 
@@ -153,7 +153,7 @@ TEST(Proto3ArenaLiteTest, SetAllocatedMessage) {
 TEST(Proto3ArenaLiteTest, ReleaseMessage) {
   Arena arena;
   TestAllTypes* arena_message = Arena::CreateMessage<TestAllTypes>(&arena);
-  arena_message->mutable_optional_nested_message()->set_bb(118);
+  arena_message->mutable_optional_nested_message().set_bb(118);
   google::protobuf::scoped_ptr<TestAllTypes::NestedMessage> nested(
       arena_message->release_optional_nested_message());
   EXPECT_EQ(118, nested->bb());

--- a/src/google/protobuf/proto3_arena_unittest.cc
+++ b/src/google/protobuf/proto3_arena_unittest.cc
@@ -53,13 +53,13 @@ void SetAllFields(TestAllTypes* m) {
   m->set_optional_int32(100);
   m->set_optional_string("asdf");
   m->set_optional_bytes("jkl;");
-  m->mutable_optional_nested_message()->set_bb(42);
-  m->mutable_optional_foreign_message()->set_c(43);
+  m->mutable_optional_nested_message().set_bb(42);
+  m->mutable_optional_foreign_message().set_c(43);
   m->set_optional_nested_enum(
       proto3_arena_unittest::TestAllTypes_NestedEnum_BAZ);
   m->set_optional_foreign_enum(
       proto3_arena_unittest::FOREIGN_BAZ);
-  m->mutable_optional_lazy_message()->set_bb(45);
+  m->mutable_optional_lazy_message().set_bb(45);
   m->add_repeated_int32(100);
   m->add_repeated_string("asdf");
   m->add_repeated_bytes("jkl;");
@@ -72,7 +72,7 @@ void SetAllFields(TestAllTypes* m) {
   m->add_repeated_lazy_message()->set_bb(49);
 
   m->set_oneof_uint32(1);
-  m->mutable_oneof_nested_message()->set_bb(50);
+  m->mutable_oneof_nested_message().set_bb(50);
   m->set_oneof_string("test");  // only this one remains set
 }
 
@@ -197,7 +197,7 @@ TEST(Proto3ArenaTest, SetAllocatedMessage) {
 TEST(Proto3ArenaTest, ReleaseMessage) {
   Arena arena;
   TestAllTypes* arena_message = Arena::CreateMessage<TestAllTypes>(&arena);
-  arena_message->mutable_optional_nested_message()->set_bb(118);
+  arena_message->mutable_optional_nested_message().set_bb(118);
   google::protobuf::scoped_ptr<TestAllTypes::NestedMessage> nested(
       arena_message->release_optional_nested_message());
   EXPECT_EQ(118, nested->bb());
@@ -207,7 +207,7 @@ TEST(Proto3ArenaTest, MessageFieldClear) {
   // GitHub issue #310: https://github.com/google/protobuf/issues/310
   Arena arena;
   TestAllTypes* arena_message = Arena::CreateMessage<TestAllTypes>(&arena);
-  arena_message->mutable_optional_nested_message()->set_bb(118);
+  arena_message->mutable_optional_nested_message().set_bb(118);
   // This should not crash, but prior to the bugfix, it tried to use `operator
   // delete` the nested message (which is on the arena):
   arena_message->Clear();
@@ -221,7 +221,7 @@ TEST(Proto3ArenaTest, MessageFieldClearViaReflection) {
   const FieldDescriptor* msg_field = d->FindFieldByName(
       "optional_nested_message");
 
-  message->mutable_optional_nested_message()->set_bb(1);
+  message->mutable_optional_nested_message().set_bb(1);
   r->ClearField(message, msg_field);
   EXPECT_FALSE(message->has_optional_nested_message());
   EXPECT_EQ(0, message->optional_nested_message().bb());

--- a/src/google/protobuf/proto3_lite_unittest.cc
+++ b/src/google/protobuf/proto3_lite_unittest.cc
@@ -53,13 +53,13 @@ void SetAllFields(TestAllTypes* m) {
   m->set_optional_int32(100);
   m->set_optional_string("asdf");
   m->set_optional_bytes("jkl;");
-  m->mutable_optional_nested_message()->set_bb(42);
-  m->mutable_optional_foreign_message()->set_c(43);
+  m->mutable_optional_nested_message().set_bb(42);
+  m->mutable_optional_foreign_message().set_c(43);
   m->set_optional_nested_enum(
       proto3_lite_unittest::TestAllTypes_NestedEnum_BAZ);
   m->set_optional_foreign_enum(
       proto3_lite_unittest::FOREIGN_BAZ);
-  m->mutable_optional_lazy_message()->set_bb(45);
+  m->mutable_optional_lazy_message().set_bb(45);
   m->add_repeated_int32(100);
   m->add_repeated_string("asdf");
   m->add_repeated_bytes("jkl;");
@@ -72,7 +72,7 @@ void SetAllFields(TestAllTypes* m) {
   m->add_repeated_lazy_message()->set_bb(49);
 
   m->set_oneof_uint32(1);
-  m->mutable_oneof_nested_message()->set_bb(50);
+  m->mutable_oneof_nested_message().set_bb(50);
   m->set_oneof_string("test");  // only this one remains set
 }
 

--- a/src/google/protobuf/reflection_ops_unittest.cc
+++ b/src/google/protobuf/reflection_ops_unittest.cc
@@ -274,14 +274,11 @@ TEST(ReflectionOpsTest, DiscardUnknownFields) {
   TestUtil::SetAllFields(&message);
 
   // Set some unknown fields in message.
-  message.mutable_unknown_fields()
-        ->AddVarint(123456, 654321);
-  message.mutable_optional_nested_message()
-        ->mutable_unknown_fields()
-        ->AddVarint(123456, 654321);
-  message.mutable_repeated_nested_message(0)
-        ->mutable_unknown_fields()
-        ->AddVarint(123456, 654321);
+  message.mutable_unknown_fields()->AddVarint(123456, 654321);
+  message.mutable_optional_nested_message().mutable_unknown_fields()->AddVarint(
+      123456, 654321);
+  message.repeated_nested_message(0).mutable_unknown_fields()->AddVarint(
+      123456, 654321);
 
   EXPECT_EQ(1, message.unknown_fields().field_count());
   EXPECT_EQ(1, message.optional_nested_message()
@@ -359,9 +356,9 @@ TEST(ReflectionOpsTest, ForeignIsInitialized) {
   EXPECT_FALSE(ReflectionOps::IsInitialized(message));
 
   // Initialize it.  Now we're initialized.
-  message.mutable_optional_message()->set_a(1);
-  message.mutable_optional_message()->set_b(2);
-  message.mutable_optional_message()->set_c(3);
+  message.mutable_optional_message().set_a(1);
+  message.mutable_optional_message().set_b(2);
+  message.mutable_optional_message().set_c(3);
   EXPECT_TRUE(ReflectionOps::IsInitialized(message));
 
   // Add a repeated version of the message.  No longer initialized.
@@ -415,7 +412,7 @@ TEST(ReflectionOpsTest, OneofIsInitialized) {
 
   message.mutable_foo_message();
   EXPECT_FALSE(ReflectionOps::IsInitialized(message));
-  message.mutable_foo_message()->set_required_double(0.1);
+  message.mutable_foo_message().set_required_double(0.1);
   EXPECT_TRUE(ReflectionOps::IsInitialized(message));
 }
 

--- a/src/google/protobuf/repeated_field_unittest.cc
+++ b/src/google/protobuf/repeated_field_unittest.cc
@@ -1681,7 +1681,7 @@ class RepeatedFieldInsertionIteratorsTest : public testing::Test {
     fibonacci.push_back(5);
     fibonacci.push_back(8);
     std::copy(fibonacci.begin(), fibonacci.end(),
-              RepeatedFieldBackInserter(protobuffer.mutable_repeated_int32()));
+              RepeatedFieldBackInserter(&protobuffer.repeated_int32()));
 
     halves.push_back(1.0);
     halves.push_back(0.5);
@@ -1689,7 +1689,7 @@ class RepeatedFieldInsertionIteratorsTest : public testing::Test {
     halves.push_back(0.125);
     halves.push_back(0.0625);
     std::copy(halves.begin(), halves.end(),
-              RepeatedFieldBackInserter(protobuffer.mutable_repeated_double()));
+              RepeatedFieldBackInserter(&protobuffer.repeated_double()));
 
     words.push_back("Able");
     words.push_back("was");
@@ -1699,13 +1699,13 @@ class RepeatedFieldInsertionIteratorsTest : public testing::Test {
     words.push_back("saw");
     words.push_back("Elba");
     std::copy(words.begin(), words.end(),
-              RepeatedFieldBackInserter(protobuffer.mutable_repeated_string()));
+              RepeatedFieldBackInserter(&protobuffer.repeated_string()));
 
     nesteds[0].set_bb(17);
     nesteds[1].set_bb(4711);
     std::copy(&nesteds[0], &nesteds[2],
               RepeatedFieldBackInserter(
-                  protobuffer.mutable_repeated_nested_message()));
+                  &protobuffer.repeated_nested_message()));
 
     nested_ptrs.push_back(new Nested);
     nested_ptrs.back()->set_bb(170);
@@ -1713,7 +1713,7 @@ class RepeatedFieldInsertionIteratorsTest : public testing::Test {
     nested_ptrs.back()->set_bb(47110);
     std::copy(nested_ptrs.begin(), nested_ptrs.end(),
               RepeatedFieldBackInserter(
-                  protobuffer.mutable_repeated_nested_message()));
+                  &protobuffer.repeated_nested_message()));
   }
 
   virtual void TearDown() {
@@ -1753,9 +1753,9 @@ TEST_F(RepeatedFieldInsertionIteratorsTest, Words2) {
   words.push_back("of");
   words.push_back("six");
   words.push_back("pence");
-  protobuffer.mutable_repeated_string()->Clear();
+  protobuffer.repeated_string().Clear();
   std::copy(words.begin(), words.end(), RepeatedPtrFieldBackInserter(
-      protobuffer.mutable_repeated_string()));
+      &protobuffer.repeated_string()));
   ASSERT_EQ(words.size(), protobuffer.repeated_string_size());
   for (int i = 0; i < words.size(); ++i)
     EXPECT_EQ(words.at(i), protobuffer.repeated_string(i));
@@ -1784,7 +1784,7 @@ TEST_F(RepeatedFieldInsertionIteratorsTest,
   TestAllTypes testproto;
   std::copy(data.begin(), data.end(),
             AllocatedRepeatedPtrFieldBackInserter(
-                testproto.mutable_repeated_nested_message()));
+                &testproto.repeated_nested_message()));
   EXPECT_EQ(testproto.DebugString(), goldenproto.DebugString());
 }
 
@@ -1801,8 +1801,9 @@ TEST_F(RepeatedFieldInsertionIteratorsTest,
     *new_data = "name-" + SimpleItoa(i);
   }
   TestAllTypes testproto;
-  std::copy(data.begin(), data.end(), AllocatedRepeatedPtrFieldBackInserter(
-                                          testproto.mutable_repeated_string()));
+  std::copy(
+      data.begin(), data.end(),
+      AllocatedRepeatedPtrFieldBackInserter(&testproto.repeated_string()));
   EXPECT_EQ(testproto.DebugString(), goldenproto.DebugString());
 }
 
@@ -1821,7 +1822,7 @@ TEST_F(RepeatedFieldInsertionIteratorsTest,
   TestAllTypes testproto;
   std::copy(data.begin(), data.end(),
             UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
-                testproto.mutable_repeated_nested_message()));
+                &testproto.repeated_nested_message()));
   EXPECT_EQ(testproto.DebugString(), goldenproto.DebugString());
 }
 
@@ -1840,7 +1841,7 @@ TEST_F(RepeatedFieldInsertionIteratorsTest,
   TestAllTypes testproto;
   std::copy(data.begin(), data.end(),
             UnsafeArenaAllocatedRepeatedPtrFieldBackInserter(
-                testproto.mutable_repeated_string()));
+                &testproto.repeated_string()));
   EXPECT_EQ(testproto.DebugString(), goldenproto.DebugString());
 }
 
@@ -1850,7 +1851,7 @@ TEST_F(RepeatedFieldInsertionIteratorsTest, MoveStrings) {
   std::vector<string> copy = src;  // copy since move leaves in undefined state
   TestAllTypes testproto;
   std::move(copy.begin(), copy.end(),
-            RepeatedFieldBackInserter(testproto.mutable_repeated_string()));
+            RepeatedFieldBackInserter(&testproto.repeated_string()));
 
   ASSERT_THAT(testproto.repeated_string(), testing::ElementsAreArray(src));
 }
@@ -1866,7 +1867,7 @@ TEST_F(RepeatedFieldInsertionIteratorsTest, MoveProtos) {
   TestAllTypes testproto;
   std::move(
       copy.begin(), copy.end(),
-      RepeatedFieldBackInserter(testproto.mutable_repeated_nested_message()));
+      RepeatedFieldBackInserter(&testproto.repeated_nested_message()));
 
   ASSERT_EQ(src.size(), testproto.repeated_nested_message_size());
   for (int i = 0; i < src.size(); ++i) {

--- a/src/google/protobuf/struct.pb.cc
+++ b/src/google/protobuf/struct.pb.cc
@@ -707,11 +707,11 @@ Value::Value(const Value& from)
       break;
     }
     case kStructValue: {
-      mutable_struct_value()->::google::protobuf::Struct::MergeFrom(from.struct_value());
+      mutable_struct_value().::google::protobuf::Struct::MergeFrom(from.struct_value());
       break;
     }
     case kListValue: {
-      mutable_list_value()->::google::protobuf::ListValue::MergeFrom(from.list_value());
+      mutable_list_value().::google::protobuf::ListValue::MergeFrom(from.list_value());
       break;
     }
     case KIND_NOT_SET: {
@@ -886,7 +886,7 @@ bool Value::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_struct_value()));
+               input, &mutable_struct_value()));
         } else {
           goto handle_unusual;
         }
@@ -898,7 +898,7 @@ bool Value::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_list_value()));
+               input, &mutable_list_value()));
         } else {
           goto handle_unusual;
         }
@@ -1130,11 +1130,11 @@ void Value::MergeFrom(const Value& from) {
       break;
     }
     case kStructValue: {
-      mutable_struct_value()->::google::protobuf::Struct::MergeFrom(from.struct_value());
+      mutable_struct_value().::google::protobuf::Struct::MergeFrom(from.struct_value());
       break;
     }
     case kListValue: {
-      mutable_list_value()->::google::protobuf::ListValue::MergeFrom(from.list_value());
+      mutable_list_value().::google::protobuf::ListValue::MergeFrom(from.list_value());
       break;
     }
     case KIND_NOT_SET: {

--- a/src/google/protobuf/struct.pb.h
+++ b/src/google/protobuf/struct.pb.h
@@ -227,8 +227,8 @@ class LIBPROTOBUF_EXPORT Struct : public ::google::protobuf::Message /* @@protoc
   static const int kFieldsFieldNumber = 1;
   const ::google::protobuf::Map< ::std::string, ::google::protobuf::Value >&
       fields() const;
-  ::google::protobuf::Map< ::std::string, ::google::protobuf::Value >*
-      mutable_fields();
+  ::google::protobuf::Map< ::std::string, ::google::protobuf::Value >&
+      fields();
 
   // @@protoc_insertion_point(class_scope:google.protobuf.Struct)
  private:
@@ -416,7 +416,7 @@ class LIBPROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_
   static const int kStructValueFieldNumber = 5;
   const ::google::protobuf::Struct& struct_value() const;
   ::google::protobuf::Struct* release_struct_value();
-  ::google::protobuf::Struct* mutable_struct_value();
+  ::google::protobuf::Struct& mutable_struct_value();
   void set_allocated_struct_value(::google::protobuf::Struct* struct_value);
   void unsafe_arena_set_allocated_struct_value(
       ::google::protobuf::Struct* struct_value);
@@ -428,7 +428,7 @@ class LIBPROTOBUF_EXPORT Value : public ::google::protobuf::Message /* @@protoc_
   static const int kListValueFieldNumber = 6;
   const ::google::protobuf::ListValue& list_value() const;
   ::google::protobuf::ListValue* release_list_value();
-  ::google::protobuf::ListValue* mutable_list_value();
+  ::google::protobuf::ListValue& mutable_list_value();
   void set_allocated_list_value(::google::protobuf::ListValue* list_value);
   void unsafe_arena_set_allocated_list_value(
       ::google::protobuf::ListValue* list_value);
@@ -571,9 +571,9 @@ class LIBPROTOBUF_EXPORT ListValue : public ::google::protobuf::Message /* @@pro
   int values_size() const;
   void clear_values();
   static const int kValuesFieldNumber = 1;
-  ::google::protobuf::Value* mutable_values(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Value >*
-      mutable_values();
+  ::google::protobuf::Value& values(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Value >&
+      values();
   const ::google::protobuf::Value& values(int index) const;
   ::google::protobuf::Value* add_values();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Value >&
@@ -616,10 +616,10 @@ Struct::fields() const {
   // @@protoc_insertion_point(field_map:google.protobuf.Struct.fields)
   return fields_.GetMap();
 }
-inline ::google::protobuf::Map< ::std::string, ::google::protobuf::Value >*
-Struct::mutable_fields() {
+inline ::google::protobuf::Map< ::std::string, ::google::protobuf::Value >&
+Struct::fields() {
   // @@protoc_insertion_point(field_mutable_map:google.protobuf.Struct.fields)
-  return fields_.MutableMap();
+  return *fields_.MutableMap();
 }
 
 // -------------------------------------------------------------------
@@ -891,7 +891,7 @@ inline void Value::unsafe_arena_set_allocated_struct_value(::google::protobuf::S
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Value.struct_value)
 }
-inline ::google::protobuf::Struct* Value::mutable_struct_value() {
+inline ::google::protobuf::Struct& Value::mutable_struct_value() {
   if (!has_struct_value()) {
     clear_kind();
     set_has_struct_value();
@@ -899,7 +899,7 @@ inline ::google::protobuf::Struct* Value::mutable_struct_value() {
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Value.struct_value)
-  return kind_.struct_value_;
+  return *kind_.struct_value_;
 }
 
 // .google.protobuf.ListValue list_value = 6;
@@ -956,7 +956,7 @@ inline void Value::unsafe_arena_set_allocated_list_value(::google::protobuf::Lis
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:google.protobuf.Value.list_value)
 }
-inline ::google::protobuf::ListValue* Value::mutable_list_value() {
+inline ::google::protobuf::ListValue& Value::mutable_list_value() {
   if (!has_list_value()) {
     clear_kind();
     set_has_list_value();
@@ -964,7 +964,7 @@ inline ::google::protobuf::ListValue* Value::mutable_list_value() {
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Value.list_value)
-  return kind_.list_value_;
+  return *kind_.list_value_;
 }
 
 inline bool Value::has_kind() const {
@@ -987,14 +987,14 @@ inline int ListValue::values_size() const {
 inline void ListValue::clear_values() {
   values_.Clear();
 }
-inline ::google::protobuf::Value* ListValue::mutable_values(int index) {
+inline ::google::protobuf::Value& ListValue::values(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.ListValue.values)
-  return values_.Mutable(index);
+  return *values_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Value >*
-ListValue::mutable_values() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Value >&
+ListValue::values() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.ListValue.values)
-  return &values_;
+  return values_;
 }
 inline const ::google::protobuf::Value& ListValue::values(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.ListValue.values)

--- a/src/google/protobuf/test_util.cc
+++ b/src/google/protobuf/test_util.cc
@@ -75,12 +75,12 @@ void TestUtil::SetOptionalFields(unittest::TestAllTypes* message) {
   message->set_optional_string  ("115");
   message->set_optional_bytes   ("116");
 
-  message->mutable_optionalgroup                 ()->set_a(117);
-  message->mutable_optional_nested_message       ()->set_bb(118);
-  message->mutable_optional_foreign_message      ()->set_c(119);
-  message->mutable_optional_import_message       ()->set_d(120);
-  message->mutable_optional_public_import_message()->set_e(126);
-  message->mutable_optional_lazy_message         ()->set_bb(127);
+  message->mutable_optionalgroup                 ().set_a(117);
+  message->mutable_optional_nested_message       ().set_bb(118);
+  message->mutable_optional_foreign_message      ().set_c(119);
+  message->mutable_optional_import_message       ().set_d(120);
+  message->mutable_optional_public_import_message().set_e(126);
+  message->mutable_optional_lazy_message         ().set_bb(127);
 
   message->set_optional_nested_enum (unittest::TestAllTypes::BAZ);
   message->set_optional_foreign_enum(unittest::FOREIGN_BAZ      );
@@ -235,11 +235,11 @@ void TestUtil::ModifyRepeatedFields(unittest::TestAllTypes* message) {
   message->set_repeated_string  (1, "515");
   message->set_repeated_bytes   (1, "516");
 
-  message->mutable_repeatedgroup           (1)->set_a(517);
-  message->mutable_repeated_nested_message (1)->set_bb(518);
-  message->mutable_repeated_foreign_message(1)->set_c(519);
-  message->mutable_repeated_import_message (1)->set_d(520);
-  message->mutable_repeated_lazy_message   (1)->set_bb(527);
+  message->repeatedgroup           (1).set_a(517);
+  message->repeated_nested_message (1).set_bb(518);
+  message->repeated_foreign_message(1).set_c(519);
+  message->repeated_import_message (1).set_d(520);
+  message->repeated_lazy_message   (1).set_bb(527);
 
   message->set_repeated_nested_enum (1, unittest::TestAllTypes::FOO);
   message->set_repeated_foreign_enum(1, unittest::FOREIGN_FOO      );
@@ -260,7 +260,7 @@ void TestUtil::ModifyRepeatedFields(unittest::TestAllTypes* message) {
 // ------------------------------------------------------------------
 void TestUtil::SetOneofFields(unittest::TestAllTypes* message) {
   message->set_oneof_uint32(601);
-  message->mutable_oneof_nested_message()->set_bb(602);
+  message->mutable_oneof_nested_message().set_bb(602);
   message->set_oneof_string("603");
   message->set_oneof_bytes("604");
 }
@@ -2217,7 +2217,7 @@ void TestUtil::ExpectRepeatedExtensionsSwapped(
 }
 
 void TestUtil::SetOneof1(unittest::TestOneof2* message) {
-  message->mutable_foo_lazy_message()->set_qux_int(100);
+  message->mutable_foo_lazy_message().set_qux_int(100);
   message->set_bar_string("101");
   message->set_baz_int(102);
   message->set_baz_string("103");

--- a/src/google/protobuf/test_util_lite.cc
+++ b/src/google/protobuf/test_util_lite.cc
@@ -58,12 +58,12 @@ void TestUtilLite::SetAllFields(unittest::TestAllTypesLite* message) {
   message->set_optional_string  ("115");
   message->set_optional_bytes   ("116");
 
-  message->mutable_optionalgroup                 ()->set_a(117);
-  message->mutable_optional_nested_message       ()->set_bb(118);
-  message->mutable_optional_foreign_message      ()->set_c(119);
-  message->mutable_optional_import_message       ()->set_d(120);
-  message->mutable_optional_public_import_message()->set_e(126);
-  message->mutable_optional_lazy_message         ()->set_bb(127);
+  message->mutable_optionalgroup                 ().set_a(117);
+  message->mutable_optional_nested_message       ().set_bb(118);
+  message->mutable_optional_foreign_message      ().set_c(119);
+  message->mutable_optional_import_message       ().set_d(120);
+  message->mutable_optional_public_import_message().set_e(126);
+  message->mutable_optional_lazy_message         ().set_bb(127);
 
   message->set_optional_nested_enum (unittest::TestAllTypesLite::BAZ );
   message->set_optional_foreign_enum(unittest::FOREIGN_LITE_BAZ      );
@@ -151,7 +151,7 @@ void TestUtilLite::SetAllFields(unittest::TestAllTypesLite* message) {
 
 
   message->set_oneof_uint32(601);
-  message->mutable_oneof_nested_message()->set_bb(602);
+  message->mutable_oneof_nested_message().set_bb(602);
   message->set_oneof_string("603");
   message->set_oneof_bytes("604");
 }
@@ -175,11 +175,11 @@ void TestUtilLite::ModifyRepeatedFields(unittest::TestAllTypesLite* message) {
   message->set_repeated_string  (1, "515");
   message->set_repeated_bytes   (1, "516");
 
-  message->mutable_repeatedgroup           (1)->set_a(517);
-  message->mutable_repeated_nested_message (1)->set_bb(518);
-  message->mutable_repeated_foreign_message(1)->set_c(519);
-  message->mutable_repeated_import_message (1)->set_d(520);
-  message->mutable_repeated_lazy_message   (1)->set_bb(527);
+  message->repeatedgroup           (1).set_a(517);
+  message->repeated_nested_message (1).set_bb(518);
+  message->repeated_foreign_message(1).set_c(519);
+  message->repeated_import_message (1).set_d(520);
+  message->repeated_lazy_message   (1).set_bb(527);
 
   message->set_repeated_nested_enum (1, unittest::TestAllTypesLite::FOO );
   message->set_repeated_foreign_enum(1, unittest::FOREIGN_LITE_FOO      );

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -135,7 +135,7 @@ TEST_F(TextFormatExtensionsTest, Extensions) {
 TEST_F(TextFormatTest, ShortDebugString) {
   proto_.set_optional_int32(1);
   proto_.set_optional_string("hello");
-  proto_.mutable_optional_nested_message()->set_bb(2);
+  proto_.mutable_optional_nested_message().set_bb(2);
   proto_.mutable_optional_foreign_message();
 
   EXPECT_EQ("optional_int32: 1 optional_string: \"hello\" "
@@ -505,7 +505,7 @@ class CustomMessageFieldValuePrinter : public TextFormat::FieldValuePrinter {
 TEST_F(TextFormatTest, CustomPrinterForComments) {
   protobuf_unittest::TestAllTypes message;
   message.mutable_optional_nested_message();
-  message.mutable_optional_import_message()->set_d(42);
+  message.mutable_optional_import_message().set_d(42);
   message.add_repeated_nested_message();
   message.add_repeated_nested_message();
   message.add_repeated_import_message()->set_d(43);
@@ -547,7 +547,7 @@ class CustomMultilineCommentPrinter : public TextFormat::FieldValuePrinter {
 TEST_F(TextFormatTest, CustomPrinterForMultilineComments) {
   protobuf_unittest::TestAllTypes message;
   message.mutable_optional_nested_message();
-  message.mutable_optional_import_message()->set_d(42);
+  message.mutable_optional_import_message().set_d(42);
   TextFormat::Printer printer;
   CustomMessageFieldValuePrinter my_field_printer;
   printer.SetDefaultFieldValuePrinter(new CustomMultilineCommentPrinter());
@@ -1578,11 +1578,11 @@ const char TextFormatMessageSetTest::proto_debug_string_[] =
 TEST_F(TextFormatMessageSetTest, Serialize) {
   protobuf_unittest::TestMessageSetContainer proto;
   protobuf_unittest::TestMessageSetExtension1* item_a =
-    proto.mutable_message_set()->MutableExtension(
+    proto.mutable_message_set().MutableExtension(
       protobuf_unittest::TestMessageSetExtension1::message_set_extension);
   item_a->set_i(23);
   protobuf_unittest::TestMessageSetExtension2* item_b =
-    proto.mutable_message_set()->MutableExtension(
+    proto.mutable_message_set().MutableExtension(
       protobuf_unittest::TestMessageSetExtension2::message_set_extension);
   item_b->set_str("foo");
   EXPECT_EQ(proto_debug_string_, proto.DebugString());

--- a/src/google/protobuf/type.pb.cc
+++ b/src/google/protobuf/type.pb.cc
@@ -620,7 +620,7 @@ bool Type::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_source_context()));
+               input, &mutable_source_context()));
         } else {
           goto handle_unusual;
         }
@@ -885,7 +885,7 @@ void Type::MergeFrom(const Type& from) {
     set_name(from.name());
   }
   if (from.has_source_context()) {
-    mutable_source_context()->::google::protobuf::SourceContext::MergeFrom(from.source_context());
+    mutable_source_context().::google::protobuf::SourceContext::MergeFrom(from.source_context());
   }
   if (from.syntax() != 0) {
     set_syntax(from.syntax());
@@ -1819,7 +1819,7 @@ bool Enum::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_source_context()));
+               input, &mutable_source_context()));
         } else {
           goto handle_unusual;
         }
@@ -2055,7 +2055,7 @@ void Enum::MergeFrom(const Enum& from) {
     set_name(from.name());
   }
   if (from.has_source_context()) {
-    mutable_source_context()->::google::protobuf::SourceContext::MergeFrom(from.source_context());
+    mutable_source_context().::google::protobuf::SourceContext::MergeFrom(from.source_context());
   }
   if (from.syntax() != 0) {
     set_syntax(from.syntax());
@@ -2628,7 +2628,7 @@ bool Option::MergePartialFromCodedStream(
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
-               input, mutable_value()));
+               input, &mutable_value()));
         } else {
           goto handle_unusual;
         }
@@ -2773,7 +2773,7 @@ void Option::MergeFrom(const Option& from) {
     set_name(from.name());
   }
   if (from.has_value()) {
-    mutable_value()->::google::protobuf::Any::MergeFrom(from.value());
+    mutable_value().::google::protobuf::Any::MergeFrom(from.value());
   }
 }
 

--- a/src/google/protobuf/type.pb.h
+++ b/src/google/protobuf/type.pb.h
@@ -280,9 +280,9 @@ class LIBPROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_i
   int fields_size() const;
   void clear_fields();
   static const int kFieldsFieldNumber = 2;
-  ::google::protobuf::Field* mutable_fields(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Field >*
-      mutable_fields();
+  ::google::protobuf::Field& fields(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Field >&
+      fields();
   const ::google::protobuf::Field& fields(int index) const;
   ::google::protobuf::Field* add_fields();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Field >&
@@ -308,15 +308,15 @@ class LIBPROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_i
   void add_oneofs(const char* value);
   void add_oneofs(const char* value, size_t size);
   const ::google::protobuf::RepeatedPtrField< ::std::string>& oneofs() const;
-  ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_oneofs();
+  ::google::protobuf::RepeatedPtrField< ::std::string>& oneofs();
 
   // repeated .google.protobuf.Option options = 4;
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 4;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -351,7 +351,7 @@ class LIBPROTOBUF_EXPORT Type : public ::google::protobuf::Message /* @@protoc_i
   static const int kSourceContextFieldNumber = 5;
   const ::google::protobuf::SourceContext& source_context() const;
   ::google::protobuf::SourceContext* release_source_context();
-  ::google::protobuf::SourceContext* mutable_source_context();
+  ::google::protobuf::SourceContext& mutable_source_context();
   void set_allocated_source_context(::google::protobuf::SourceContext* source_context);
   void unsafe_arena_set_allocated_source_context(
       ::google::protobuf::SourceContext* source_context);
@@ -574,9 +574,9 @@ class LIBPROTOBUF_EXPORT Field : public ::google::protobuf::Message /* @@protoc_
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 9;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -829,9 +829,9 @@ class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_i
   int enumvalue_size() const;
   void clear_enumvalue();
   static const int kEnumvalueFieldNumber = 2;
-  ::google::protobuf::EnumValue* mutable_enumvalue(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValue >*
-      mutable_enumvalue();
+  ::google::protobuf::EnumValue& enumvalue(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValue >&
+      enumvalue();
   const ::google::protobuf::EnumValue& enumvalue(int index) const;
   ::google::protobuf::EnumValue* add_enumvalue();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValue >&
@@ -841,9 +841,9 @@ class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_i
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 3;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -878,7 +878,7 @@ class LIBPROTOBUF_EXPORT Enum : public ::google::protobuf::Message /* @@protoc_i
   static const int kSourceContextFieldNumber = 4;
   const ::google::protobuf::SourceContext& source_context() const;
   ::google::protobuf::SourceContext* release_source_context();
-  ::google::protobuf::SourceContext* mutable_source_context();
+  ::google::protobuf::SourceContext& mutable_source_context();
   void set_allocated_source_context(::google::protobuf::SourceContext* source_context);
   void unsafe_arena_set_allocated_source_context(
       ::google::protobuf::SourceContext* source_context);
@@ -1010,9 +1010,9 @@ class LIBPROTOBUF_EXPORT EnumValue : public ::google::protobuf::Message /* @@pro
   int options_size() const;
   void clear_options();
   static const int kOptionsFieldNumber = 3;
-  ::google::protobuf::Option* mutable_options(int index);
-  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-      mutable_options();
+  ::google::protobuf::Option& options(int index);
+  ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+      options();
   const ::google::protobuf::Option& options(int index) const;
   ::google::protobuf::Option* add_options();
   const ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
@@ -1190,7 +1190,7 @@ class LIBPROTOBUF_EXPORT Option : public ::google::protobuf::Message /* @@protoc
   static const int kValueFieldNumber = 2;
   const ::google::protobuf::Any& value() const;
   ::google::protobuf::Any* release_value();
-  ::google::protobuf::Any* mutable_value();
+  ::google::protobuf::Any& mutable_value();
   void set_allocated_value(::google::protobuf::Any* value);
   void unsafe_arena_set_allocated_value(
       ::google::protobuf::Any* value);
@@ -1302,14 +1302,14 @@ inline int Type::fields_size() const {
 inline void Type::clear_fields() {
   fields_.Clear();
 }
-inline ::google::protobuf::Field* Type::mutable_fields(int index) {
+inline ::google::protobuf::Field& Type::fields(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Type.fields)
-  return fields_.Mutable(index);
+  return *fields_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Field >*
-Type::mutable_fields() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Field >&
+Type::fields() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Type.fields)
-  return &fields_;
+  return fields_;
 }
 inline const ::google::protobuf::Field& Type::fields(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Type.fields)
@@ -1388,10 +1388,10 @@ Type::oneofs() const {
   // @@protoc_insertion_point(field_list:google.protobuf.Type.oneofs)
   return oneofs_;
 }
-inline ::google::protobuf::RepeatedPtrField< ::std::string>*
-Type::mutable_oneofs() {
+inline ::google::protobuf::RepeatedPtrField< ::std::string>&
+Type::oneofs() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Type.oneofs)
-  return &oneofs_;
+  return oneofs_;
 }
 
 // repeated .google.protobuf.Option options = 4;
@@ -1401,14 +1401,14 @@ inline int Type::options_size() const {
 inline void Type::clear_options() {
   options_.Clear();
 }
-inline ::google::protobuf::Option* Type::mutable_options(int index) {
+inline ::google::protobuf::Option& Type::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Type.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-Type::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+Type::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Type.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& Type::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Type.options)
@@ -1451,14 +1451,14 @@ inline ::google::protobuf::SourceContext* Type::unsafe_arena_release_source_cont
   source_context_ = NULL;
   return temp;
 }
-inline ::google::protobuf::SourceContext* Type::mutable_source_context() {
+inline ::google::protobuf::SourceContext& Type::mutable_source_context() {
   
   if (source_context_ == NULL) {
     source_context_ = ::google::protobuf::Arena::Create< ::google::protobuf::SourceContext >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Type.source_context)
-  return source_context_;
+  return *source_context_;
 }
 inline void Type::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -1724,14 +1724,14 @@ inline int Field::options_size() const {
 inline void Field::clear_options() {
   options_.Clear();
 }
-inline ::google::protobuf::Option* Field::mutable_options(int index) {
+inline ::google::protobuf::Option& Field::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Field.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-Field::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+Field::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Field.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& Field::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Field.options)
@@ -1983,14 +1983,14 @@ inline int Enum::enumvalue_size() const {
 inline void Enum::clear_enumvalue() {
   enumvalue_.Clear();
 }
-inline ::google::protobuf::EnumValue* Enum::mutable_enumvalue(int index) {
+inline ::google::protobuf::EnumValue& Enum::enumvalue(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Enum.enumvalue)
-  return enumvalue_.Mutable(index);
+  return *enumvalue_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValue >*
-Enum::mutable_enumvalue() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::EnumValue >&
+Enum::enumvalue() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Enum.enumvalue)
-  return &enumvalue_;
+  return enumvalue_;
 }
 inline const ::google::protobuf::EnumValue& Enum::enumvalue(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Enum.enumvalue)
@@ -2013,14 +2013,14 @@ inline int Enum::options_size() const {
 inline void Enum::clear_options() {
   options_.Clear();
 }
-inline ::google::protobuf::Option* Enum::mutable_options(int index) {
+inline ::google::protobuf::Option& Enum::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.Enum.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-Enum::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+Enum::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.Enum.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& Enum::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.Enum.options)
@@ -2063,14 +2063,14 @@ inline ::google::protobuf::SourceContext* Enum::unsafe_arena_release_source_cont
   source_context_ = NULL;
   return temp;
 }
-inline ::google::protobuf::SourceContext* Enum::mutable_source_context() {
+inline ::google::protobuf::SourceContext& Enum::mutable_source_context() {
   
   if (source_context_ == NULL) {
     source_context_ = ::google::protobuf::Arena::Create< ::google::protobuf::SourceContext >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Enum.source_context)
-  return source_context_;
+  return *source_context_;
 }
 inline void Enum::set_allocated_source_context(::google::protobuf::SourceContext* source_context) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
@@ -2205,14 +2205,14 @@ inline int EnumValue::options_size() const {
 inline void EnumValue::clear_options() {
   options_.Clear();
 }
-inline ::google::protobuf::Option* EnumValue::mutable_options(int index) {
+inline ::google::protobuf::Option& EnumValue::options(int index) {
   // @@protoc_insertion_point(field_mutable:google.protobuf.EnumValue.options)
-  return options_.Mutable(index);
+  return *options_.Mutable(index);
 }
-inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >*
-EnumValue::mutable_options() {
+inline ::google::protobuf::RepeatedPtrField< ::google::protobuf::Option >&
+EnumValue::options() {
   // @@protoc_insertion_point(field_mutable_list:google.protobuf.EnumValue.options)
-  return &options_;
+  return options_;
 }
 inline const ::google::protobuf::Option& EnumValue::options(int index) const {
   // @@protoc_insertion_point(field_get:google.protobuf.EnumValue.options)
@@ -2334,14 +2334,14 @@ inline ::google::protobuf::Any* Option::unsafe_arena_release_value() {
   value_ = NULL;
   return temp;
 }
-inline ::google::protobuf::Any* Option::mutable_value() {
+inline ::google::protobuf::Any& Option::mutable_value() {
   
   if (value_ == NULL) {
     value_ = ::google::protobuf::Arena::Create< ::google::protobuf::Any >(
         GetArenaNoVirtual());
   }
   // @@protoc_insertion_point(field_mutable:google.protobuf.Option.value)
-  return value_;
+  return *value_;
 }
 inline void Option::set_allocated_value(::google::protobuf::Any* value) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();

--- a/src/google/protobuf/util/field_mask_util_test.cc
+++ b/src/google/protobuf/util/field_mask_util_test.cc
@@ -440,47 +440,61 @@ TEST(FieldMaskUtilTest, MergeMessage) {
 #define TEST_MERGE_ONE_FIELD(field_name)                     \
   {                                                          \
     TestAllTypes tmp;                                        \
-    *tmp.mutable_##field_name() = src.field_name();          \
+    tmp.mutable_##field_name() = src.field_name();           \
     FieldMask mask;                                          \
     mask.add_paths(#field_name);                             \
     dst.Clear();                                             \
     FieldMaskUtil::MergeMessageTo(src, mask, options, &dst); \
     EXPECT_EQ(tmp.DebugString(), dst.DebugString());         \
   }
+
+#define TEST_MERGE_ONE_REPEATED_FIELD(field_name)            \
+  {                                                          \
+    TestAllTypes tmp;                                        \
+    tmp.field_name() = src.field_name();                     \
+    FieldMask mask;                                          \
+    mask.add_paths(#field_name);                             \
+    dst.Clear();                                             \
+    FieldMaskUtil::MergeMessageTo(src, mask, options, &dst); \
+    EXPECT_EQ(tmp.DebugString(), dst.DebugString());         \
+  }
+
   TEST_MERGE_ONE_FIELD(optional_nested_message)
   TEST_MERGE_ONE_FIELD(optional_foreign_message)
   TEST_MERGE_ONE_FIELD(optional_import_message)
 
-  TEST_MERGE_ONE_FIELD(repeated_int32)
-  TEST_MERGE_ONE_FIELD(repeated_int64)
-  TEST_MERGE_ONE_FIELD(repeated_uint32)
-  TEST_MERGE_ONE_FIELD(repeated_uint64)
-  TEST_MERGE_ONE_FIELD(repeated_sint32)
-  TEST_MERGE_ONE_FIELD(repeated_sint64)
-  TEST_MERGE_ONE_FIELD(repeated_fixed32)
-  TEST_MERGE_ONE_FIELD(repeated_fixed64)
-  TEST_MERGE_ONE_FIELD(repeated_sfixed32)
-  TEST_MERGE_ONE_FIELD(repeated_sfixed64)
-  TEST_MERGE_ONE_FIELD(repeated_float)
-  TEST_MERGE_ONE_FIELD(repeated_double)
-  TEST_MERGE_ONE_FIELD(repeated_bool)
-  TEST_MERGE_ONE_FIELD(repeated_string)
-  TEST_MERGE_ONE_FIELD(repeated_bytes)
-  TEST_MERGE_ONE_FIELD(repeated_nested_message)
-  TEST_MERGE_ONE_FIELD(repeated_foreign_message)
-  TEST_MERGE_ONE_FIELD(repeated_import_message)
-  TEST_MERGE_ONE_FIELD(repeated_nested_enum)
-  TEST_MERGE_ONE_FIELD(repeated_foreign_enum)
-  TEST_MERGE_ONE_FIELD(repeated_import_enum)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_int32)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_int64)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_uint32)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_uint64)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_sint32)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_sint64)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_fixed32)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_fixed64)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_sfixed32)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_sfixed64)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_float)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_double)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_bool)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_string)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_bytes)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_nested_message)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_foreign_message)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_import_message)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_nested_enum)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_foreign_enum)
+  TEST_MERGE_ONE_REPEATED_FIELD(repeated_import_enum)
+
 #undef TEST_MERGE_ONE_FIELD
+#undef TEST_MERGE_ONE_REPEATED_FIELD
 
   // Test merge nested fields.
   NestedTestAllTypes nested_src, nested_dst;
-  nested_src.mutable_child()->mutable_payload()->set_optional_int32(1234);
+  nested_src.mutable_child().mutable_payload().set_optional_int32(1234);
   nested_src.mutable_child()
-      ->mutable_child()
-      ->mutable_payload()
-      ->set_optional_int32(5678);
+      .mutable_child()
+      .mutable_payload()
+      .set_optional_int32(5678);
   FieldMask mask;
   FieldMaskUtil::FromString("child.payload", &mask);
   FieldMaskUtil::MergeMessageTo(nested_src, mask, options, &nested_dst);
@@ -507,7 +521,7 @@ TEST(FieldMaskUtilTest, MergeMessage) {
   // Test MergeOptions.
 
   nested_dst.Clear();
-  nested_dst.mutable_child()->mutable_payload()->set_optional_int64(4321);
+  nested_dst.mutable_child().mutable_payload().set_optional_int64(4321);
   // Message fields will be merged by default.
   FieldMaskUtil::FromString("child.payload", &mask);
   FieldMaskUtil::MergeMessageTo(nested_src, mask, options, &nested_dst);
@@ -535,8 +549,8 @@ TEST(FieldMaskUtilTest, MergeMessage) {
   FieldMaskUtil::MergeMessageTo(nested_src, mask, options, &nested_dst);
   EXPECT_FALSE(nested_dst.has_payload());
 
-  nested_src.mutable_payload()->add_repeated_int32(1234);
-  nested_dst.mutable_payload()->add_repeated_int32(5678);
+  nested_src.mutable_payload().add_repeated_int32(1234);
+  nested_dst.mutable_payload().add_repeated_int32(5678);
   // Repeated fields will be appended by default.
   FieldMaskUtil::FromString("payload.repeated_int32", &mask);
   FieldMaskUtil::MergeMessageTo(nested_src, mask, options, &nested_dst);
@@ -588,46 +602,61 @@ TEST(FieldMaskUtilTest, TrimMessage) {
     TestAllTypes msg;                                \
     TestUtil::SetAllFields(&msg);                    \
     TestAllTypes tmp;                                \
-    *tmp.mutable_##field_name() = msg.field_name();  \
+    tmp.mutable_##field_name() = msg.field_name();   \
     FieldMask mask;                                  \
     mask.add_paths(#field_name);                     \
     FieldMaskUtil::TrimMessage(mask, &msg);          \
     EXPECT_EQ(tmp.DebugString(), msg.DebugString()); \
   }
+
+#define TEST_TRIM_ONE_REPEATED_FIELD(field_name)     \
+  {                                                  \
+    TestAllTypes msg;                                \
+    TestUtil::SetAllFields(&msg);                    \
+    TestAllTypes tmp;                                \
+    tmp.field_name() = msg.field_name();             \
+    FieldMask mask;                                  \
+    mask.add_paths(#field_name);                     \
+    FieldMaskUtil::TrimMessage(mask, &msg);          \
+    EXPECT_EQ(tmp.DebugString(), msg.DebugString()); \
+  }
+
   TEST_TRIM_ONE_FIELD(optional_nested_message)
   TEST_TRIM_ONE_FIELD(optional_foreign_message)
   TEST_TRIM_ONE_FIELD(optional_import_message)
 
-  TEST_TRIM_ONE_FIELD(repeated_int32)
-  TEST_TRIM_ONE_FIELD(repeated_int64)
-  TEST_TRIM_ONE_FIELD(repeated_uint32)
-  TEST_TRIM_ONE_FIELD(repeated_uint64)
-  TEST_TRIM_ONE_FIELD(repeated_sint32)
-  TEST_TRIM_ONE_FIELD(repeated_sint64)
-  TEST_TRIM_ONE_FIELD(repeated_fixed32)
-  TEST_TRIM_ONE_FIELD(repeated_fixed64)
-  TEST_TRIM_ONE_FIELD(repeated_sfixed32)
-  TEST_TRIM_ONE_FIELD(repeated_sfixed64)
-  TEST_TRIM_ONE_FIELD(repeated_float)
-  TEST_TRIM_ONE_FIELD(repeated_double)
-  TEST_TRIM_ONE_FIELD(repeated_bool)
-  TEST_TRIM_ONE_FIELD(repeated_string)
-  TEST_TRIM_ONE_FIELD(repeated_bytes)
-  TEST_TRIM_ONE_FIELD(repeated_nested_message)
-  TEST_TRIM_ONE_FIELD(repeated_foreign_message)
-  TEST_TRIM_ONE_FIELD(repeated_import_message)
-  TEST_TRIM_ONE_FIELD(repeated_nested_enum)
-  TEST_TRIM_ONE_FIELD(repeated_foreign_enum)
-  TEST_TRIM_ONE_FIELD(repeated_import_enum)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_int32)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_int64)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_uint32)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_uint64)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_sint32)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_sint64)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_fixed32)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_fixed64)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_sfixed32)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_sfixed64)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_float)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_double)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_bool)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_string)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_bytes)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_nested_message)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_foreign_message)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_import_message)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_nested_enum)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_foreign_enum)
+  TEST_TRIM_ONE_REPEATED_FIELD(repeated_import_enum)
+
 #undef TEST_TRIM_ONE_FIELD
+#undef TEST_TRIM_ONE_REPEATED_FIELD
 
   // Test trim nested fields.
   NestedTestAllTypes nested_msg;
-  nested_msg.mutable_child()->mutable_payload()->set_optional_int32(1234);
+  nested_msg.mutable_child().mutable_payload().set_optional_int32(1234);
   nested_msg.mutable_child()
-      ->mutable_child()
-      ->mutable_payload()
-      ->set_optional_int32(5678);
+      .mutable_child()
+      .mutable_payload()
+      .set_optional_int32(5678);
   NestedTestAllTypes trimmed_msg(nested_msg);
   FieldMask mask;
   FieldMaskUtil::FromString("child.payload", &mask);
@@ -683,13 +712,13 @@ TEST(FieldMaskUtilTest, TrimMessage) {
 
   // Test trim required message with keep_required_fields is set true.
   TestRequiredMessage required_msg_2;
-  required_msg_2.mutable_optional_message()->set_a(1234);
-  required_msg_2.mutable_optional_message()->set_b(3456);
-  required_msg_2.mutable_optional_message()->set_c(5678);
-  required_msg_2.mutable_required_message()->set_a(1234);
-  required_msg_2.mutable_required_message()->set_b(3456);
-  required_msg_2.mutable_required_message()->set_c(5678);
-  required_msg_2.mutable_required_message()->set_dummy2(7890);
+  required_msg_2.mutable_optional_message().set_a(1234);
+  required_msg_2.mutable_optional_message().set_b(3456);
+  required_msg_2.mutable_optional_message().set_c(5678);
+  required_msg_2.mutable_required_message().set_a(1234);
+  required_msg_2.mutable_required_message().set_b(3456);
+  required_msg_2.mutable_required_message().set_c(5678);
+  required_msg_2.mutable_required_message().set_dummy2(7890);
   TestRequired* repeated_msg = required_msg_2.add_repeated_message();
   repeated_msg->set_a(1234);
   repeated_msg->set_b(3456);
@@ -698,14 +727,14 @@ TEST(FieldMaskUtilTest, TrimMessage) {
   FieldMaskUtil::FromString("optional_message.dummy2", &mask);
   options.set_keep_required_fields(true);
   required_msg_2.clear_repeated_message();
-  required_msg_2.mutable_required_message()->clear_dummy2();
+  required_msg_2.mutable_required_message().clear_dummy2();
   FieldMaskUtil::TrimMessage(mask, &trimmed_required_msg_2, options);
   EXPECT_EQ(trimmed_required_msg_2.DebugString(),
             required_msg_2.DebugString());
 
   FieldMaskUtil::FromString("required_message", &mask);
-  required_msg_2.mutable_required_message()->set_dummy2(7890);
-  trimmed_required_msg_2.mutable_required_message()->set_dummy2(7890);
+  required_msg_2.mutable_required_message().set_dummy2(7890);
+  trimmed_required_msg_2.mutable_required_message().set_dummy2(7890);
   required_msg_2.clear_optional_message();
   FieldMaskUtil::TrimMessage(mask, &trimmed_required_msg_2, options);
   EXPECT_EQ(trimmed_required_msg_2.DebugString(),
@@ -713,9 +742,9 @@ TEST(FieldMaskUtilTest, TrimMessage) {
 
   // Test trim required message with keep_required_fields is set false.
   FieldMaskUtil::FromString("required_message.dummy2", &mask);
-  required_msg_2.mutable_required_message()->clear_a();
-  required_msg_2.mutable_required_message()->clear_b();
-  required_msg_2.mutable_required_message()->clear_c();
+  required_msg_2.mutable_required_message().clear_a();
+  required_msg_2.mutable_required_message().clear_b();
+  required_msg_2.mutable_required_message().clear_c();
   options.set_keep_required_fields(false);
   FieldMaskUtil::TrimMessage(mask, &trimmed_required_msg_2, options);
   EXPECT_EQ(trimmed_required_msg_2.DebugString(),

--- a/src/google/protobuf/util/internal/protostream_objectsource_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource_test.cc
@@ -906,8 +906,8 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 TEST_P(ProtostreamObjectSourceStructTest, StructRenderSuccess) {
   StructType out;
   google::protobuf::Struct* s = &out.mutable_object();
-  s->mutable_fields()->operator[]("k1").set_number_value(123);
-  s->mutable_fields()->operator[]("k2").set_bool_value(true);
+  s->fields().operator[]("k1").set_number_value(123);
+  s->fields().operator[]("k2").set_bool_value(true);
 
   ow_.StartObject("")
       ->StartObject("object")
@@ -922,7 +922,7 @@ TEST_P(ProtostreamObjectSourceStructTest, StructRenderSuccess) {
 TEST_P(ProtostreamObjectSourceStructTest, MissingValueSkipsField) {
   StructType out;
   google::protobuf::Struct* s = &out.mutable_object();
-  s->mutable_fields()->operator[]("k1");
+  s->fields().operator[]("k1");
 
   ow_.StartObject("")->StartObject("object")->EndObject()->EndObject();
 

--- a/src/google/protobuf/util/internal/protostream_objectsource_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource_test.cc
@@ -547,9 +547,9 @@ TEST_P(ProtostreamObjectSourceTest, CyclicMessageDepthTest) {
   Cyclic cyclic;
   cyclic.set_m_int(123);
 
-  Book* book = cyclic.mutable_m_book();
+  Book* book = &cyclic.mutable_m_book();
   book->set_title("book title");
-  Cyclic* current = cyclic.mutable_m_cyclic();
+  Cyclic* current = &cyclic.mutable_m_cyclic();
   Author* current_author = cyclic.add_m_author();
   for (int i = 0; i < 63; ++i) {
     Author* next = current_author->add_friend_();
@@ -561,7 +561,7 @@ TEST_P(ProtostreamObjectSourceTest, CyclicMessageDepthTest) {
 
   // Recursive message with depth (65) > max (max is 64).
   for (int i = 0; i < 64; ++i) {
-    Cyclic* next = current->mutable_m_cyclic();
+    Cyclic* next = &current->mutable_m_cyclic();
     next->set_m_str(StrCat("count_", i));
     current = next;
   }
@@ -611,14 +611,14 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 // }
 TEST_P(ProtostreamObjectSourceMapsTest, MapsTest) {
   MapOut out;
-  (*out.mutable_map1())["key1"].set_foo("foovalue");
-  (*out.mutable_map1())["key2"].set_foo("barvalue");
+  out.map1()["key1"].set_foo("foovalue");
+  out.map1()["key2"].set_foo("barvalue");
 
-  MapOut* nested_value = &(*out.mutable_map2())["nestedself"];
-  (*nested_value->mutable_map1())["nested_key1"].set_foo("nested_foo");
+  MapOut* nested_value = &out.map2()["nestedself"];
+  nested_value->map1()["nested_key1"].set_foo("nested_foo");
   nested_value->set_bar("nested_bar_string");
 
-  (*out.mutable_map3())[111] = "one one one";
+  out.map3()[111] = "one one one";
 
   out.set_bar("top bar");
 
@@ -679,9 +679,9 @@ TEST_P(ProtostreamObjectSourceMapsTest, MissingKeysTest) {
   //     "false": "bool"
   //   }
   // }
-  out.add_map1()->mutable_value()->set_foo("foovalue");
-  MapOut* nested = out.add_map2()->mutable_value();
-  (*nested->mutable_map1())["nested_key1"].set_foo("nested_foo");
+  out.add_map1()->mutable_value().set_foo("foovalue");
+  MapOut* nested = &out.add_map2()->mutable_value();
+  nested->map1()["nested_key1"].set_foo("nested_foo");
   out.add_map3()->set_value("one one one");
   out.add_map4()->set_value("bool");
 
@@ -735,7 +735,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 // }
 TEST_P(ProtostreamObjectSourceAnysTest, BasicAny) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
 
   AnyM m;
   m.set_foo("foovalue");
@@ -754,7 +754,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, BasicAny) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, RecursiveAny) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("type.googleapis.com/google.protobuf.Any");
 
   ::google::protobuf::Any nested_any;
@@ -782,7 +782,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, RecursiveAny) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, DoubleRecursiveAny) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("type.googleapis.com/google.protobuf.Any");
 
   ::google::protobuf::Any nested_any;
@@ -826,7 +826,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, EmptyAnyOutputsEmptyObject) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, EmptyWithTypeAndNoValueOutputsType) {
   AnyOut out;
-  out.mutable_any()->set_type_url("foo.googleapis.com/my.Type");
+  out.mutable_any().set_type_url("foo.googleapis.com/my.Type");
 
   ow_.StartObject("")
       ->StartObject("any")
@@ -839,7 +839,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, EmptyWithTypeAndNoValueOutputsType) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, MissingTypeUrlError) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
 
   AnyM m;
   m.set_foo("foovalue");
@@ -854,7 +854,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, MissingTypeUrlError) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, UnknownTypeServiceError) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("foo.googleapis.com/my.own.Type");
 
   AnyM m;
@@ -870,7 +870,7 @@ TEST_P(ProtostreamObjectSourceAnysTest, UnknownTypeServiceError) {
 
 TEST_P(ProtostreamObjectSourceAnysTest, UnknownTypeError) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("type.googleapis.com/unknown.Type");
 
   AnyM m;
@@ -905,7 +905,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 //  }
 TEST_P(ProtostreamObjectSourceStructTest, StructRenderSuccess) {
   StructType out;
-  google::protobuf::Struct* s = out.mutable_object();
+  google::protobuf::Struct* s = &out.mutable_object();
   s->mutable_fields()->operator[]("k1").set_number_value(123);
   s->mutable_fields()->operator[]("k2").set_bool_value(true);
 
@@ -921,7 +921,7 @@ TEST_P(ProtostreamObjectSourceStructTest, StructRenderSuccess) {
 
 TEST_P(ProtostreamObjectSourceStructTest, MissingValueSkipsField) {
   StructType out;
-  google::protobuf::Struct* s = out.mutable_object();
+  google::protobuf::Struct* s = &out.mutable_object();
   s->mutable_fields()->operator[]("k1");
 
   ow_.StartObject("")->StartObject("object")->EndObject()->EndObject();
@@ -946,8 +946,8 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 TEST_P(ProtostreamObjectSourceFieldMaskTest, FieldMaskRenderSuccess) {
   FieldMaskTest out;
   out.set_id("1");
-  out.mutable_single_mask()->add_paths("path1");
-  out.mutable_single_mask()->add_paths("snake_case_path2");
+  out.mutable_single_mask().add_paths("path1");
+  out.mutable_single_mask().add_paths("snake_case_path2");
   ::google::protobuf::FieldMask* mask = out.add_repeated_mask();
   mask->add_paths("path3");
   mask = out.add_repeated_mask();
@@ -955,8 +955,8 @@ TEST_P(ProtostreamObjectSourceFieldMaskTest, FieldMaskRenderSuccess) {
   mask->add_paths("path5");
   NestedFieldMask* nested = out.add_nested_mask();
   nested->set_data("data");
-  nested->mutable_single_mask()->add_paths("nested.path1");
-  nested->mutable_single_mask()->add_paths("nested_field.snake_case_path2");
+  nested->mutable_single_mask().add_paths("nested.path1");
+  nested->mutable_single_mask().add_paths("nested_field.snake_case_path2");
   mask = nested->add_repeated_mask();
   mask->add_paths("nested_field.path3");
   mask->add_paths("nested.snake_case_path4");
@@ -1008,7 +1008,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 
 TEST_P(ProtostreamObjectSourceTimestampTest, InvalidTimestampBelowMinTest) {
   TimestampDuration out;
-  google::protobuf::Timestamp* ts = out.mutable_ts();
+  google::protobuf::Timestamp* ts = &out.mutable_ts();
   // Min allowed seconds - 1
   ts->set_seconds(kTimestampMinSeconds - 1);
   ow_.StartObject("");
@@ -1019,7 +1019,7 @@ TEST_P(ProtostreamObjectSourceTimestampTest, InvalidTimestampBelowMinTest) {
 
 TEST_P(ProtostreamObjectSourceTimestampTest, InvalidTimestampAboveMaxTest) {
   TimestampDuration out;
-  google::protobuf::Timestamp* ts = out.mutable_ts();
+  google::protobuf::Timestamp* ts = &out.mutable_ts();
   // Max allowed seconds + 1
   ts->set_seconds(kTimestampMaxSeconds + 1);
   ow_.StartObject("");
@@ -1030,7 +1030,7 @@ TEST_P(ProtostreamObjectSourceTimestampTest, InvalidTimestampAboveMaxTest) {
 
 TEST_P(ProtostreamObjectSourceTimestampTest, InvalidDurationBelowMinTest) {
   TimestampDuration out;
-  google::protobuf::Duration* dur = out.mutable_dur();
+  google::protobuf::Duration* dur = &out.mutable_dur();
   // Min allowed seconds - 1
   dur->set_seconds(kDurationMinSeconds - 1);
   ow_.StartObject("");
@@ -1041,7 +1041,7 @@ TEST_P(ProtostreamObjectSourceTimestampTest, InvalidDurationBelowMinTest) {
 
 TEST_P(ProtostreamObjectSourceTimestampTest, InvalidDurationAboveMaxTest) {
   TimestampDuration out;
-  google::protobuf::Duration* dur = out.mutable_dur();
+  google::protobuf::Duration* dur = &out.mutable_dur();
   // Min allowed seconds + 1
   dur->set_seconds(kDurationMaxSeconds + 1);
   ow_.StartObject("");
@@ -1052,8 +1052,8 @@ TEST_P(ProtostreamObjectSourceTimestampTest, InvalidDurationAboveMaxTest) {
 
 TEST_P(ProtostreamObjectSourceTimestampTest, TimestampDurationDefaultValue) {
   TimestampDuration out;
-  out.mutable_ts()->set_seconds(0);
-  out.mutable_dur()->set_seconds(0);
+  out.mutable_ts().set_seconds(0);
+  out.mutable_dur().set_seconds(0);
 
   ow_.StartObject("")
       ->RenderString("ts", "1970-01-01T00:00:00Z")

--- a/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
@@ -1507,8 +1507,8 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 TEST_P(ProtoStreamObjectWriterStructTest, StructRenderSuccess) {
   StructType struct_type;
   google::protobuf::Struct* s = &struct_type.mutable_object();
-  s->mutable_fields()->operator[]("k1").set_number_value(123);
-  s->mutable_fields()->operator[]("k2").set_bool_value(true);
+  s->fields().operator[]("k1").set_number_value(123);
+  s->fields().operator[]("k2").set_bool_value(true);
 
   ow_->StartObject("")
       ->StartObject("object")
@@ -1551,7 +1551,7 @@ TEST_P(ProtoStreamObjectWriterStructTest, StructAcceptsNull) {
 
 TEST_P(ProtoStreamObjectWriterStructTest, StructValuePreservesNull) {
   StructType struct_type;
-  (*struct_type.mutable_object().mutable_fields())["key"].set_null_value(
+  struct_type.mutable_object().fields()["key"].set_null_value(
       google::protobuf::NULL_VALUE);
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
 
@@ -1611,10 +1611,10 @@ TEST_P(ProtoStreamObjectWriterStructTest, RepeatedStructMapObjectKeyTest) {
 TEST_P(ProtoStreamObjectWriterStructTest, OptionStructIntAsStringsTest) {
   StructType struct_type;
   google::protobuf::Struct* s = &struct_type.mutable_object();
-  s->mutable_fields()->operator[]("k1").set_string_value("123");
-  s->mutable_fields()->operator[]("k2").set_bool_value(true);
-  s->mutable_fields()->operator[]("k3").set_string_value("-222222222");
-  s->mutable_fields()->operator[]("k4").set_string_value("33333333");
+  s->fields().operator[]("k1").set_string_value("123");
+  s->fields().operator[]("k2").set_bool_value(true);
+  s->fields().operator[]("k3").set_string_value("-222222222");
+  s->fields().operator[]("k4").set_string_value("33333333");
 
   options_.struct_integers_as_strings = true;
   ResetProtoWriter();
@@ -2041,7 +2041,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedObjectValue) {
   ::google::protobuf::Any* any = &out.mutable_any();
 
   ::google::protobuf::Value value;
-  (*value.mutable_struct_value()->mutable_fields())["foo"].set_string_value(
+  value.mutable_struct_value().fields()["foo"].set_string_value(
       "abc");
   any->PackFrom(value);
 
@@ -2069,7 +2069,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedArrayValue) {
   ::google::protobuf::Any* any = &out.mutable_any();
 
   ::google::protobuf::Value value;
-  value.mutable_list_value()->add_values()->set_string_value("hello");
+  value.mutable_list_value().add_values()->set_string_value("hello");
   any->PackFrom(value);
 
   ow_->StartObject("")

--- a/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/protostream_objectwriter_test.cc
@@ -226,9 +226,9 @@ TEST_P(ProtoStreamObjectWriterTest, SimpleMessage) {
   Book book;
   book.set_title("Some Book");
   book.set_length(102);
-  Publisher* publisher = book.mutable_publisher();
+  Publisher* publisher = &book.mutable_publisher();
   publisher->set_name("My Publisher");
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_alive(true);
   robert->set_name("robert");
   robert->add_pseudonym("bob");
@@ -260,7 +260,7 @@ TEST_P(ProtoStreamObjectWriterTest, SimpleMessage) {
 
 TEST_P(ProtoStreamObjectWriterTest, CustomJsonName) {
   Book book;
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_id(12345);
   robert->set_name("robert");
 
@@ -293,7 +293,7 @@ TEST_P(ProtoStreamObjectWriterTest, IntEnumValuesAreAccepted) {
   Book book;
   book.set_title("Some Book");
   book.set_type(google::protobuf::testing::Book_Type_KIDS);
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_name("robert");
 
   ow_->StartObject("")
@@ -310,7 +310,7 @@ TEST_P(ProtoStreamObjectWriterTest, EnumValuesWithoutUnderscoreAreAccepted) {
   Book book;
   book.set_title("Some Book");
   book.set_type(google::protobuf::testing::Book_Type_ACTION_AND_ADVENTURE);
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_name("robert");
 
   options_.use_lower_camel_for_enums = true;
@@ -330,7 +330,7 @@ TEST_P(ProtoStreamObjectWriterTest, EnumValuesInCamelCaseAreAccepted) {
   Book book;
   book.set_title("Some Book");
   book.set_type(google::protobuf::testing::Book_Type_ACTION_AND_ADVENTURE);
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_name("robert");
 
   options_.use_lower_camel_for_enums = true;
@@ -351,7 +351,7 @@ TEST_P(ProtoStreamObjectWriterTest,
   Book book;
   book.set_title("Some Book");
   book.set_type(google::protobuf::testing::Book_Type_arts_and_photography);
-  Author* robert = book.mutable_author();
+  Author* robert = &book.mutable_author();
   robert->set_name("robert");
 
   options_.use_lower_camel_for_enums = true;
@@ -536,7 +536,7 @@ TEST_P(ProtoStreamObjectWriterTest, NaNInputTest) {
 
 TEST_P(ProtoStreamObjectWriterTest, ImplicitPrimitiveList) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("The Author");
   author->add_pseudonym("first");
   author->add_pseudonym("second");
@@ -554,7 +554,7 @@ TEST_P(ProtoStreamObjectWriterTest, ImplicitPrimitiveList) {
 TEST_P(ProtoStreamObjectWriterTest,
        LastWriteWinsOnNonRepeatedPrimitiveFieldWithDuplicates) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("second");
 
   ow_->StartObject("")
@@ -568,7 +568,7 @@ TEST_P(ProtoStreamObjectWriterTest,
 
 TEST_P(ProtoStreamObjectWriterTest, ExplicitPrimitiveList) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("The Author");
   author->add_pseudonym("first");
   author->add_pseudonym("second");
@@ -608,7 +608,7 @@ TEST_P(ProtoStreamObjectWriterTest, NonRepeatedExplicitPrimitiveList) {
 
 TEST_P(ProtoStreamObjectWriterTest, ImplicitMessageList) {
   Book expected;
-  Author* outer = expected.mutable_author();
+  Author* outer = &expected.mutable_author();
   outer->set_name("outer");
   outer->set_alive(true);
   Author* first = outer->add_friend_();
@@ -634,9 +634,9 @@ TEST_P(ProtoStreamObjectWriterTest, ImplicitMessageList) {
 TEST_P(ProtoStreamObjectWriterTest,
        LastWriteWinsOnNonRepeatedMessageFieldWithDuplicates) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("The Author");
-  Publisher* publisher = expected.mutable_publisher();
+  Publisher* publisher = &expected.mutable_publisher();
   publisher->set_name("second");
 
   ow_->StartObject("")
@@ -655,7 +655,7 @@ TEST_P(ProtoStreamObjectWriterTest,
 
 TEST_P(ProtoStreamObjectWriterTest, ExplicitMessageList) {
   Book expected;
-  Author* outer = expected.mutable_author();
+  Author* outer = &expected.mutable_author();
   outer->set_name("outer");
   outer->set_alive(true);
   Author* first = outer->add_friend_();
@@ -682,7 +682,7 @@ TEST_P(ProtoStreamObjectWriterTest, ExplicitMessageList) {
 
 TEST_P(ProtoStreamObjectWriterTest, NonRepeatedExplicitMessageList) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("The Author");
 
   EXPECT_CALL(
@@ -719,7 +719,7 @@ TEST_P(ProtoStreamObjectWriterTest, UnknownFieldAtRoot) {
 
 TEST_P(ProtoStreamObjectWriterTest, UnknownFieldAtAuthorFriend) {
   Book expected;
-  Author* paul = expected.mutable_author();
+  Author* paul = &expected.mutable_author();
   paul->set_name("Paul");
   Author* mark = paul->add_friend_();
   mark->set_name("Mark");
@@ -763,7 +763,7 @@ TEST_P(ProtoStreamObjectWriterTest, UnknownObjectAtRoot) {
 
 TEST_P(ProtoStreamObjectWriterTest, UnknownObjectAtAuthor) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("William");
   author->add_pseudonym("Bill");
 
@@ -795,7 +795,7 @@ TEST_P(ProtoStreamObjectWriterTest, UnknownListAtRoot) {
 TEST_P(ProtoStreamObjectWriterTest, UnknownListAtPublisher) {
   Book expected;
   expected.set_title("Brainwashing");
-  Publisher* publisher = expected.mutable_publisher();
+  Publisher* publisher = &expected.mutable_publisher();
   publisher->set_name("propaganda");
 
   EXPECT_CALL(listener_, InvalidName(_, StringPiece("alliance"),
@@ -825,7 +825,7 @@ TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownFieldAtRoot) {
 
 TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownFieldAtAuthorFriend) {
   Book expected;
-  Author* paul = expected.mutable_author();
+  Author* paul = &expected.mutable_author();
   paul->set_name("Paul");
   Author* mark = paul->add_friend_();
   mark->set_name("Mark");
@@ -873,7 +873,7 @@ TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownObjectAtRoot) {
 
 TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownObjectAtAuthor) {
   Book expected;
-  Author* author = expected.mutable_author();
+  Author* author = &expected.mutable_author();
   author->set_name("William");
   author->add_pseudonym("Bill");
 
@@ -907,7 +907,7 @@ TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownListAtRoot) {
 TEST_P(ProtoStreamObjectWriterTest, IgnoreUnknownListAtPublisher) {
   Book expected;
   expected.set_title("Brainwashing");
-  Publisher* publisher = expected.mutable_publisher();
+  Publisher* publisher = &expected.mutable_publisher();
   publisher->set_name("propaganda");
 
   options_.ignore_unknown_fields = true;
@@ -1111,7 +1111,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest, ParseTimestamp) {
   TimestampDuration timestamp;
-  google::protobuf::Timestamp* ts = timestamp.mutable_ts();
+  google::protobuf::Timestamp* ts = &timestamp.mutable_ts();
   ts->set_seconds(1448249855);
   ts->set_nanos(33155000);
 
@@ -1124,7 +1124,7 @@ TEST_P(ProtoStreamObjectWriterTimestampDurationTest, ParseTimestamp) {
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
        ParseTimestampYearNotZeroPadded) {
   TimestampDuration timestamp;
-  google::protobuf::Timestamp* ts = timestamp.mutable_ts();
+  google::protobuf::Timestamp* ts = &timestamp.mutable_ts();
   ts->set_seconds(-61665654145);
   ts->set_nanos(33155000);
 
@@ -1137,7 +1137,7 @@ TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
        ParseTimestampYearZeroPadded) {
   TimestampDuration timestamp;
-  google::protobuf::Timestamp* ts = timestamp.mutable_ts();
+  google::protobuf::Timestamp* ts = &timestamp.mutable_ts();
   ts->set_seconds(-61665654145);
   ts->set_nanos(33155000);
 
@@ -1150,7 +1150,7 @@ TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
        ParseTimestampWithPositiveOffset) {
   TimestampDuration timestamp;
-  google::protobuf::Timestamp* ts = timestamp.mutable_ts();
+  google::protobuf::Timestamp* ts = &timestamp.mutable_ts();
   ts->set_seconds(1448249855);
   ts->set_nanos(33155000);
 
@@ -1163,7 +1163,7 @@ TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest,
        ParseTimestampWithNegativeOffset) {
   TimestampDuration timestamp;
-  google::protobuf::Timestamp* ts = timestamp.mutable_ts();
+  google::protobuf::Timestamp* ts = &timestamp.mutable_ts();
   ts->set_seconds(1448249855);
   ts->set_nanos(33155000);
 
@@ -1366,7 +1366,7 @@ TEST_P(ProtoStreamObjectWriterTimestampDurationTest, InvalidTimestampError8) {
 
 TEST_P(ProtoStreamObjectWriterTimestampDurationTest, ParseDuration) {
   TimestampDuration duration;
-  google::protobuf::Duration* dur = duration.mutable_dur();
+  google::protobuf::Duration* dur = &duration.mutable_dur();
   dur->set_seconds(1448216930);
   dur->set_nanos(132262000);
 
@@ -1506,7 +1506,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 // TODO(skarvaje): Write tests for failure cases.
 TEST_P(ProtoStreamObjectWriterStructTest, StructRenderSuccess) {
   StructType struct_type;
-  google::protobuf::Struct* s = struct_type.mutable_object();
+  google::protobuf::Struct* s = &struct_type.mutable_object();
   s->mutable_fields()->operator[]("k1").set_number_value(123);
   s->mutable_fields()->operator[]("k2").set_bool_value(true);
 
@@ -1551,7 +1551,7 @@ TEST_P(ProtoStreamObjectWriterStructTest, StructAcceptsNull) {
 
 TEST_P(ProtoStreamObjectWriterStructTest, StructValuePreservesNull) {
   StructType struct_type;
-  (*struct_type.mutable_object()->mutable_fields())["key"].set_null_value(
+  (*struct_type.mutable_object().mutable_fields())["key"].set_null_value(
       google::protobuf::NULL_VALUE);
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
 
@@ -1610,7 +1610,7 @@ TEST_P(ProtoStreamObjectWriterStructTest, RepeatedStructMapObjectKeyTest) {
 
 TEST_P(ProtoStreamObjectWriterStructTest, OptionStructIntAsStringsTest) {
   StructType struct_type;
-  google::protobuf::Struct* s = struct_type.mutable_object();
+  google::protobuf::Struct* s = &struct_type.mutable_object();
   s->mutable_fields()->operator[]("k1").set_string_value("123");
   s->mutable_fields()->operator[]("k2").set_bool_value(true);
   s->mutable_fields()->operator[]("k3").set_string_value("-222222222");
@@ -1632,7 +1632,7 @@ TEST_P(ProtoStreamObjectWriterStructTest, OptionStructIntAsStringsTest) {
 
 TEST_P(ProtoStreamObjectWriterStructTest, ValuePreservesNull) {
   ValueWrapper value;
-  value.mutable_value()->set_null_value(google::protobuf::NULL_VALUE);
+  value.mutable_value().set_null_value(google::protobuf::NULL_VALUE);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")->RenderNull("value")->EndObject();
@@ -1703,7 +1703,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 
 TEST_P(ProtoStreamObjectWriterAnyTest, AnyRenderSuccess) {
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.DoubleValue");
   google::protobuf::DoubleValue d;
   d.set_value(40.2);
@@ -1720,7 +1720,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyRenderSuccess) {
 
 TEST_P(ProtoStreamObjectWriterAnyTest, RecursiveAny) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("type.googleapis.com/google.protobuf.Any");
 
   ::google::protobuf::Any nested_any;
@@ -1747,7 +1747,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, RecursiveAny) {
 
 TEST_P(ProtoStreamObjectWriterAnyTest, DoubleRecursiveAny) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
   any->set_type_url("type.googleapis.com/google.protobuf.Any");
 
   ::google::protobuf::Any nested_any;
@@ -1793,7 +1793,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, TypeUrlAtEnd) {
   outer_any.PackFrom(any);
 
   AnyOut out;
-  out.mutable_any()->PackFrom(outer_any);
+  out.mutable_any().PackFrom(outer_any);
 
   // Put the @type field at the end of each Any message. Parsers should
   // be able to accept that.
@@ -1830,7 +1830,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, TypeUrlAtEndWithTemporaryStrings) {
   outer_any.PackFrom(any);
 
   AnyOut out;
-  out.mutable_any()->PackFrom(outer_any);
+  out.mutable_any().PackFrom(outer_any);
 
   string name, value;
   // Put the @type field at the end of each Any message. Parsers should
@@ -1989,7 +1989,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypeErrorTest) {
                                       StringPiece("Invalid time format: ")));
 
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Timestamp");
 
   ow_->StartObject("")
@@ -2011,7 +2011,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypeErrorTest) {
 // }
 TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedPrimitiveValue) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
 
   ::google::protobuf::Value value;
   value.set_string_value("abc");
@@ -2038,7 +2038,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedPrimitiveValue) {
 // }
 TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedObjectValue) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
 
   ::google::protobuf::Value value;
   (*value.mutable_struct_value()->mutable_fields())["foo"].set_string_value(
@@ -2066,7 +2066,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedObjectValue) {
 // }
 TEST_P(ProtoStreamObjectWriterAnyTest, AnyWithNestedArrayValue) {
   AnyOut out;
-  ::google::protobuf::Any* any = out.mutable_any();
+  ::google::protobuf::Any* any = &out.mutable_any();
 
   ::google::protobuf::Value value;
   value.mutable_list_value()->add_values()->set_string_value("hello");
@@ -2100,7 +2100,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest,
           _, StringPiece("Any"),
           StringPiece("Expect a \"value\" field for well-known types.")));
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Value");
 
   ow_->StartObject("")
@@ -2127,7 +2127,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypesNoValueFieldForObject) {
           _, StringPiece("Any"),
           StringPiece("Expect a \"value\" field for well-known types.")));
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Value");
 
   ow_->StartObject("")
@@ -2155,7 +2155,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypesNoValueFieldForArray) {
           _, StringPiece("Any"),
           StringPiece("Expect a \"value\" field for well-known types.")));
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Value");
 
   ow_->StartObject("")
@@ -2181,7 +2181,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypesExpectObjectForStruct) {
   EXPECT_CALL(listener_, InvalidValue(_, StringPiece("Any"),
                                       StringPiece("Expect a JSON object.")));
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Struct");
 
   ow_->StartObject("")
@@ -2205,7 +2205,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypesExpectObjectForAny) {
   EXPECT_CALL(listener_, InvalidValue(_, StringPiece("Any"),
                                       StringPiece("Expect a JSON object.")));
   AnyOut any;
-  google::protobuf::Any* any_type = any.mutable_any();
+  google::protobuf::Any* any_type = &any.mutable_any();
   any_type->set_type_url("type.googleapis.com/google.protobuf.Any");
 
   ow_->StartObject("")
@@ -2226,7 +2226,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyWellKnownTypesExpectObjectForAny) {
 TEST_P(ProtoStreamObjectWriterAnyTest, AnyInAnyAcceptsNull) {
   AnyOut out;
   google::protobuf::Any empty;
-  out.mutable_any()->PackFrom(empty);
+  out.mutable_any().PackFrom(empty);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")
@@ -2247,7 +2247,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, AnyInAnyAcceptsNull) {
 TEST_P(ProtoStreamObjectWriterAnyTest, TimestampInAnyAcceptsNull) {
   AnyOut out;
   google::protobuf::Timestamp empty;
-  out.mutable_any()->PackFrom(empty);
+  out.mutable_any().PackFrom(empty);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")
@@ -2268,7 +2268,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, TimestampInAnyAcceptsNull) {
 TEST_P(ProtoStreamObjectWriterAnyTest, DurationInAnyAcceptsNull) {
   AnyOut out;
   google::protobuf::Duration empty;
-  out.mutable_any()->PackFrom(empty);
+  out.mutable_any().PackFrom(empty);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")
@@ -2289,7 +2289,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, DurationInAnyAcceptsNull) {
 TEST_P(ProtoStreamObjectWriterAnyTest, FieldMaskInAnyAcceptsNull) {
   AnyOut out;
   google::protobuf::FieldMask empty;
-  out.mutable_any()->PackFrom(empty);
+  out.mutable_any().PackFrom(empty);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")
@@ -2310,7 +2310,7 @@ TEST_P(ProtoStreamObjectWriterAnyTest, FieldMaskInAnyAcceptsNull) {
 TEST_P(ProtoStreamObjectWriterAnyTest, WrapperInAnyAcceptsNull) {
   AnyOut out;
   google::protobuf::Int32Value empty;
-  out.mutable_any()->PackFrom(empty);
+  out.mutable_any().PackFrom(empty);
 
   EXPECT_CALL(listener_, InvalidValue(_, _, _)).Times(0);
   ow_->StartObject("")
@@ -2341,7 +2341,7 @@ INSTANTIATE_TEST_CASE_P(DifferentTypeInfoSourceTest,
 TEST_P(ProtoStreamObjectWriterFieldMaskTest, SimpleFieldMaskTest) {
   FieldMaskTest expected;
   expected.set_id("1");
-  expected.mutable_single_mask()->add_paths("path1");
+  expected.mutable_single_mask().add_paths("path1");
 
   ow_->StartObject("");
   ow_->RenderString("id", "1");
@@ -2354,9 +2354,9 @@ TEST_P(ProtoStreamObjectWriterFieldMaskTest, SimpleFieldMaskTest) {
 TEST_P(ProtoStreamObjectWriterFieldMaskTest, MutipleMasksInCompactForm) {
   FieldMaskTest expected;
   expected.set_id("1");
-  expected.mutable_single_mask()->add_paths("camel_case1");
-  expected.mutable_single_mask()->add_paths("camel_case2");
-  expected.mutable_single_mask()->add_paths("camel_case3");
+  expected.mutable_single_mask().add_paths("camel_case1");
+  expected.mutable_single_mask().add_paths("camel_case2");
+  expected.mutable_single_mask().add_paths("camel_case3");
 
   ow_->StartObject("");
   ow_->RenderString("id", "1");
@@ -2406,9 +2406,9 @@ TEST_P(ProtoStreamObjectWriterFieldMaskTest, MaskUsingApiaryStyleShouldWork) {
   // Case1
   ow_->RenderString("single_mask",
                     "outerField(camelCase1,camelCase2,camelCase3)");
-  expected.mutable_single_mask()->add_paths("outer_field.camel_case1");
-  expected.mutable_single_mask()->add_paths("outer_field.camel_case2");
-  expected.mutable_single_mask()->add_paths("outer_field.camel_case3");
+  expected.mutable_single_mask().add_paths("outer_field.camel_case1");
+  expected.mutable_single_mask().add_paths("outer_field.camel_case2");
+  expected.mutable_single_mask().add_paths("outer_field.camel_case3");
 
   ow_->StartList("repeated_mask");
 
@@ -2489,10 +2489,10 @@ TEST_P(ProtoStreamObjectWriterFieldMaskTest, MoreOpenThanCloseParentheses) {
 
 TEST_P(ProtoStreamObjectWriterFieldMaskTest, PathWithMapKeyShouldWork) {
   FieldMaskTest expected;
-  expected.mutable_single_mask()->add_paths("path.to.map[\"key1\"]");
-  expected.mutable_single_mask()->add_paths(
+  expected.mutable_single_mask().add_paths("path.to.map[\"key1\"]");
+  expected.mutable_single_mask().add_paths(
       "path.to.map[\"e\\\"[]][scape\\\"\"]");
-  expected.mutable_single_mask()->add_paths("path.to.map[\"key2\"]");
+  expected.mutable_single_mask().add_paths("path.to.map[\"key2\"]");
 
   ow_->StartObject("");
   ow_->RenderString("single_mask",
@@ -2549,13 +2549,13 @@ TEST_P(ProtoStreamObjectWriterFieldMaskTest, MapKeyMustBeEscapedCorrectly) {
 
 TEST_P(ProtoStreamObjectWriterFieldMaskTest, MapKeyCanContainAnyChars) {
   FieldMaskTest expected;
-  expected.mutable_single_mask()->add_paths(
+  expected.mutable_single_mask().add_paths(
       // \xE5\xAD\x99 is the UTF-8 byte sequence for chinese character 孙.
       // We cannot embed non-ASCII characters in the code directly because
       // some windows compilers will try to interpret them using the system's
       // current encoding and end up with invalid UTF-8 byte sequence.
       "path.to.map[\"(),[],\\\"'!@#$%^&*123_|War\xE5\xAD\x99,./?><\\\\\"]");
-  expected.mutable_single_mask()->add_paths("path.to.map[\"key2\"]");
+  expected.mutable_single_mask().add_paths("path.to.map[\"key2\"]");
 
   ow_->StartObject("");
   ow_->RenderString(

--- a/src/google/protobuf/util/json_util_test.cc
+++ b/src/google/protobuf/util/json_util_test.cc
@@ -245,7 +245,7 @@ TEST_F(JsonUtilTest, ParseMessage) {
 
 TEST_F(JsonUtilTest, ParseMap) {
   TestMap message;
-  (*message.mutable_string_map())["hello"] = 1234;
+  message.string_map()["hello"] = 1234;
   JsonPrintOptions print_options;
   JsonParseOptions parse_options;
   EXPECT_EQ("{\"stringMap\":{\"hello\":1234}}", ToJson(message, print_options));

--- a/src/google/protobuf/util/message_differencer_unittest.cc
+++ b/src/google/protobuf/util/message_differencer_unittest.cc
@@ -1323,40 +1323,40 @@ TEST(MessageDifferencerTest, RepeatedFieldMapTest_MultipleFieldPathsAsKey) {
   // Treat "item.m.rc" as Set
   protobuf_unittest::TestDiffMessage::Item* item = msg1.add_item();
   // key => value: (1, {2, 3}) => "a"
-  item->mutable_m()->set_a(1);
-  item->mutable_m()->add_rc(2);
-  item->mutable_m()->add_rc(3);
+  item->mutable_m().set_a(1);
+  item->mutable_m().add_rc(2);
+  item->mutable_m().add_rc(3);
   item->set_b("a");
   item = msg1.add_item();
   // key => value: (2, {1, 3}) => "b"
-  item->mutable_m()->set_a(2);
-  item->mutable_m()->add_rc(1);
-  item->mutable_m()->add_rc(3);
+  item->mutable_m().set_a(2);
+  item->mutable_m().add_rc(1);
+  item->mutable_m().add_rc(3);
   item->set_b("b");
   item = msg1.add_item();
   // key => value: (1, {1, 3}) => "c"
-  item->mutable_m()->set_a(1);
-  item->mutable_m()->add_rc(1);
-  item->mutable_m()->add_rc(3);
+  item->mutable_m().set_a(1);
+  item->mutable_m().add_rc(1);
+  item->mutable_m().add_rc(3);
   item->set_b("c");
 
   item = msg2.add_item();
   // key => value: (1, {1, 3}) => "c"
-  item->mutable_m()->set_a(1);
-  item->mutable_m()->add_rc(3);
-  item->mutable_m()->add_rc(1);
+  item->mutable_m().set_a(1);
+  item->mutable_m().add_rc(3);
+  item->mutable_m().add_rc(1);
   item->set_b("c");
   item = msg2.add_item();
   // key => value: (1, {2, 3}) => "a"
-  item->mutable_m()->set_a(1);
-  item->mutable_m()->add_rc(3);
-  item->mutable_m()->add_rc(2);
+  item->mutable_m().set_a(1);
+  item->mutable_m().add_rc(3);
+  item->mutable_m().add_rc(2);
   item->set_b("a");
   item = msg2.add_item();
   // key => value: (2, {1, 3}) => "b"
-  item->mutable_m()->set_a(2);
-  item->mutable_m()->add_rc(3);
-  item->mutable_m()->add_rc(1);
+  item->mutable_m().set_a(2);
+  item->mutable_m().add_rc(3);
+  item->mutable_m().add_rc(1);
   item->set_b("b");
 
   // Compare
@@ -1380,14 +1380,14 @@ TEST(MessageDifferencerTest, RepeatedFieldMapTest_MultipleFieldPathsAsKey) {
   msg1.clear_item();
   msg2.clear_item();
   item = msg1.add_item();
-  item->mutable_m()->set_a(4);
-  item->mutable_m()->add_rc(5);
-  item->mutable_m()->add_rc(6);
+  item->mutable_m().set_a(4);
+  item->mutable_m().add_rc(5);
+  item->mutable_m().add_rc(6);
   item->set_b("hello");
   item = msg2.add_item();
-  item->mutable_m()->set_a(4);
-  item->mutable_m()->add_rc(6);
-  item->mutable_m()->add_rc(5);
+  item->mutable_m().set_a(4);
+  item->mutable_m().add_rc(6);
+  item->mutable_m().add_rc(5);
   item->set_b("world");
   string output;
   differencer.ReportDifferencesToString(&output);
@@ -2159,21 +2159,21 @@ TEST_F(ComparisonTest, EquivalencyDeletionTest) {
 
 // Group tests.
 TEST_F(ComparisonTest, GroupAdditionTest) {
-  proto1_.mutable_optionalgroup()->clear_a();
+  proto1_.mutable_optionalgroup().clear_a();
 
   EXPECT_EQ("added: optionalgroup.a: 117\n",
             Run());
 }
 
 TEST_F(ComparisonTest, GroupDeletionTest) {
-  proto2_.mutable_optionalgroup()->clear_a();
+  proto2_.mutable_optionalgroup().clear_a();
 
   EXPECT_EQ("deleted: optionalgroup.a: 117\n",
             Run());
 }
 
 TEST_F(ComparisonTest, GroupModificationTest) {
-  proto1_.mutable_optionalgroup()->set_a(2);
+  proto1_.mutable_optionalgroup().set_a(2);
 
   EXPECT_EQ("modified: optionalgroup.a: 2 -> 117\n",
             Run());
@@ -2268,26 +2268,26 @@ TEST_F(ComparisonTest, RepeatedMapFieldTest_MessageKey) {
 
   // The following code creates one deletion, one addition and two moved fields
   // on the messages.
-  item->mutable_m()->set_c(0);
+  item->mutable_m().set_c(0);
   item->set_b("first");
   item = msg1.add_item();
-  item->mutable_m()->set_c(2);
+  item->mutable_m().set_c(2);
   item->set_b("second");
   item = msg1.add_item(); item->set_b("null");  // empty key moved
   item = msg1.add_item();
-  item->mutable_m()->set_c(3);
+  item->mutable_m().set_c(3);
   item->set_b("third");   // deletion
   item = msg1.add_item();
-  item->mutable_m()->set_c(2);
+  item->mutable_m().set_c(2);
   item->set_b("second");  // duplicated key ( deletion )
   item = msg2.add_item();
-  item->mutable_m()->set_c(2);
+  item->mutable_m().set_c(2);
   item->set_b("second");  // modification
   item = msg2.add_item();
-  item->mutable_m()->set_c(4);
+  item->mutable_m().set_c(4);
   item->set_b("fourth");  // addition
   item = msg2.add_item();
-  item->mutable_m()->set_c(0);
+  item->mutable_m().set_c(0);
   item->set_b("fist");    // move with change
   item = msg2.add_item(); item->set_b("null");
 
@@ -2438,21 +2438,21 @@ TEST_F(ComparisonTest, RepeatedSetFieldTest) {
 
 // Embedded message tests.
 TEST_F(ComparisonTest, EmbeddedAdditionTest) {
-  proto1_.mutable_optional_nested_message()->clear_bb();
+  proto1_.mutable_optional_nested_message().clear_bb();
 
   EXPECT_EQ("added: optional_nested_message.bb: 118\n",
             Run());
 }
 
 TEST_F(ComparisonTest, EmbeddedDeletionTest) {
-  proto2_.mutable_optional_nested_message()->clear_bb();
+  proto2_.mutable_optional_nested_message().clear_bb();
 
   EXPECT_EQ("deleted: optional_nested_message.bb: 118\n",
             Run());
 }
 
 TEST_F(ComparisonTest, EmbeddedModificationTest) {
-  proto1_.mutable_optional_nested_message()->set_bb(2);
+  proto1_.mutable_optional_nested_message().set_bb(2);
 
   EXPECT_EQ("modified: optional_nested_message.bb: 2 -> 118\n",
             Run());
@@ -2467,7 +2467,7 @@ TEST_F(ComparisonTest, EmbeddedFullAdditionTest) {
 
 TEST_F(ComparisonTest, EmbeddedPartialAdditionTest) {
   proto1_.clear_optional_nested_message();
-  proto2_.mutable_optional_nested_message()->clear_bb();
+  proto2_.mutable_optional_nested_message().clear_bb();
 
   EXPECT_EQ("added: optional_nested_message: { }\n",
             Run());
@@ -2693,8 +2693,8 @@ TEST_F(ComparisonTest, IgnoredRepeatedModifyTest) {
 }
 
 TEST_F(ComparisonTest, IgnoredWholeNestedMessage) {
-  proto1diff_.mutable_m()->set_c(3);
-  proto2diff_.mutable_m()->set_c(4);
+  proto1diff_.mutable_m().set_c(3);
+  proto2diff_.mutable_m().set_c(4);
 
   proto2diff_.set_w("foo");
 
@@ -2706,8 +2706,8 @@ TEST_F(ComparisonTest, IgnoredWholeNestedMessage) {
 }
 
 TEST_F(ComparisonTest, IgnoredNestedField) {
-  proto1diff_.mutable_m()->set_c(3);
-  proto2diff_.mutable_m()->set_c(4);
+  proto1diff_.mutable_m().set_c(3);
+  proto2diff_.mutable_m().set_c(4);
 
   proto2diff_.set_w("foo");
 
@@ -2735,9 +2735,9 @@ TEST_F(ComparisonTest, IgnoredRepeatedNested) {
 }
 
 TEST_F(ComparisonTest, IgnoredNestedRepeated) {
-  proto1diff_.mutable_m()->add_rc(23);
-  proto1diff_.mutable_m()->add_rc(24);
-  proto2diff_.mutable_m()->add_rc(25);
+  proto1diff_.mutable_m().add_rc(23);
+  proto1diff_.mutable_m().add_rc(24);
+  proto2diff_.mutable_m().add_rc(25);
 
   proto2diff_.set_w("foo");
 
@@ -2843,11 +2843,11 @@ TEST_F(ComparisonTest, EquivalentIgnoresUnknown) {
 }
 
 TEST_F(ComparisonTest, MapTest) {
-  Map<string, string>& map1 = *map_proto1_.mutable_map_string_string();
+  Map<string, string>& map1 = map_proto1_.map_string_string();
   map1["key1"] = "1";
   map1["key2"] = "2";
   map1["key3"] = "3";
-  Map<string, string>& map2 = *map_proto2_.mutable_map_string_string();
+  Map<string, string>& map2 = map_proto2_.map_string_string();
   map2["key3"] = "0";
   map2["key2"] = "2";
   map2["key1"] = "1";
@@ -2857,11 +2857,11 @@ TEST_F(ComparisonTest, MapTest) {
 }
 
 TEST_F(ComparisonTest, MapIgnoreKeyTest) {
-  Map<string, string>& map1 = *map_proto1_.mutable_map_string_string();
+  Map<string, string>& map1 = map_proto1_.map_string_string();
   map1["key1"] = "1";
   map1["key2"] = "2";
   map1["key3"] = "3";
-  Map<string, string>& map2 = *map_proto2_.mutable_map_string_string();
+  Map<string, string>& map2 = map_proto2_.map_string_string();
   map2["key4"] = "2";
   map2["key5"] = "3";
   map2["key6"] = "1";
@@ -3286,8 +3286,8 @@ TEST(AnyTest, Simple) {
   value2.set_a(21);
 
   protobuf_unittest::TestAny m1, m2;
-  m1.mutable_any_value()->PackFrom(value1);
-  m2.mutable_any_value()->PackFrom(value2);
+  m1.mutable_any_value().PackFrom(value1);
+  m2.mutable_any_value().PackFrom(value2);
   util::MessageDifferencer message_differencer;
   string difference_string;
   message_differencer.ReportDifferencesToString(&difference_string);

--- a/src/google/protobuf/util/type_resolver_util.cc
+++ b/src/google/protobuf/util/type_resolver_util.cc
@@ -105,8 +105,8 @@ class DescriptorPoolTypeResolver : public TypeResolver {
     for (int i = 0; i < descriptor->oneof_decl_count(); ++i) {
       type->add_oneofs(descriptor->oneof_decl(i)->name());
     }
-    type->mutable_source_context()->set_file_name(descriptor->file()->name());
-    ConvertMessageOptions(descriptor->options(), type->mutable_options());
+    type->mutable_source_context().set_file_name(descriptor->file()->name());
+    ConvertMessageOptions(descriptor->options(), &type->options());
   }
 
   void ConvertMessageOptions(const MessageOptions& options,
@@ -116,7 +116,7 @@ class DescriptorPoolTypeResolver : public TypeResolver {
       option->set_name("map_entry");
       BoolValue value;
       value.set_value(true);
-      option->mutable_value()->PackFrom(value);
+      option->mutable_value().PackFrom(value);
     }
 
     // TODO(xiaofeng): Set other "options"?
@@ -160,11 +160,11 @@ class DescriptorPoolTypeResolver : public TypeResolver {
                              Enum* enum_type) {
     enum_type->Clear();
     enum_type->set_name(descriptor->full_name());
-    enum_type->mutable_source_context()->set_file_name(
+    enum_type->mutable_source_context().set_file_name(
         descriptor->file()->name());
     for (int i = 0; i < descriptor->value_count(); ++i) {
       const EnumValueDescriptor* value_descriptor = descriptor->value(i);
-      EnumValue* value = enum_type->mutable_enumvalue()->Add();
+      EnumValue* value = enum_type->enumvalue().Add();
       value->set_name(value_descriptor->name());
       value->set_number(value_descriptor->number());
 

--- a/src/google/protobuf/wire_format_unittest.cc
+++ b/src/google/protobuf/wire_format_unittest.cc
@@ -613,7 +613,7 @@ TEST(WireFormatTest, ParseBrokenMessageSet) {
 
 TEST(WireFormatTest, RecursionLimit) {
   unittest::TestRecursiveMessage message;
-  message.mutable_a()->mutable_a()->mutable_a()->mutable_a()->set_i(1);
+  message.mutable_a().mutable_a().mutable_a().mutable_a().set_i(1);
   string data;
   message.SerializeToString(&data);
 


### PR DESCRIPTION
This is a POC for #4091:
  - mutable accessors return a mutable C++ reference
  - repeated fields generate a mutable accessor with a natural name

The point here is unify reader and writer scenarios:

**A reader:**
```
message.repeated_field(1).map_field()[0].value();
```

**A proposed writer:**
```
message.repeated_field(1).map_field()[0].set_value(...);
```

All tests compile and pass on Linux x86-64 using GCC 4.8 (Ubuntu 14). I have not compiled in other environments...