### PR TITLE
whitelisting aix platform as it has sched_yield

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ AM_CONDITIONAL([HAVE_PTHREAD], [test "x$acx_pthread_ok" = "xyes"])
 AC_CXX_STL_HASH
 
 case "$target_os" in
-  mingw* | cygwin* | win*)
+  mingw* | cygwin* | win* | aix*)
     ;;
   *)
     # Need to link against rt on Solaris


### PR DESCRIPTION
As per discussion here:https://github.com/google/protobuf/issues/4101