### PR TITLE
Add VS2017 optional component dependency details to the C# ReadMe for #4119

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -41,6 +41,12 @@ in its implementation, as well as the new Visual Studio 2017 csproj
 format. These features have no impact when using the compiled code - 
 they're only relevant when building the `Google.Protobuf` assembly.
 
+In order to run and debug the AddressBook example in the IDE, you must
+install the optional component, ".Net Core 1.0 - 1.1 development tools
+for Web" (as it's labelled in current versions of the VS2017
+installer), above and beyond the main .NET Core cross-platform
+development feature.
+
 Testing
 =======
 


### PR DESCRIPTION
Add mention to the "Build" section of the ReadMe of the requirement of installing an optional component to VS2017, as discussed with @jskeet in #4119.