### PR TITLE
Add TextFormat::Parser AllowUnknownField

### DIFF
--- a/src/google/protobuf/text_format.h
+++ b/src/google/protobuf/text_format.h
@@ -502,6 +502,14 @@ class LIBPROTOBUF_EXPORT TextFormat {
       allow_case_insensitive_field_ = allow;
     }
 
+    // Allow unknown fields to be ignored.
+    // This is not advisable if the input is manually created and human errors
+    // (like typos) need to be caught.
+    // This is 'false' by default.
+    void AllowUnknownField(bool allow) {
+      allow_unknown_field_ = allow;
+    }
+
     // Like TextFormat::ParseFieldValueFromString
     bool ParseFieldValueFromString(const string& input,
                                    const FieldDescriptor* field,

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -1329,6 +1329,18 @@ TEST_F(TextFormatParserTest, InvalidFieldName) {
       1, 14);
 }
 
+TEST_F(TextFormatParserTest, AllowInvalidFieldName) {
+  TextFormat::Parser parser;
+  protobuf_unittest::TestAllTypes proto;
+
+  // This field doesn't exist
+  EXPECT_FALSE(parser.ParseFromString("invalid_field: somevalue\n", &proto));
+
+  // ... but is ignored if we allow unknown fields.
+  parser.AllowUnknownField(true);
+  EXPECT_TRUE(parser.ParseFromString("invalid_field: somevalue\n", &proto));
+}
+
 TEST_F(TextFormatParserTest, InvalidCapitalization) {
   // We require that group names be exactly as they appear in the .proto.
   ExpectFailure(


### PR DESCRIPTION
As in [#2092](https://github.com/google/protobuf/pull/2092) which added `AllowUnknownField` support for Java, this does the same for C++.

The default behaviour of throwing an exception remains.

