### PR TITLE
Use versions module from Skylib for version checking 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,13 @@ new_http_archive(
     url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
 )
 
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
+
 bind(
     name = "python_headers",
     actual = "//util/python:python_headers",

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:lib.bzl", "versions")
+
 def _GetPath(ctx, path):
   if ctx.label.workspace_root:
     return ctx.label.workspace_root + '/' + path
@@ -408,7 +410,4 @@ def check_protobuf_required_bazel_version():
   This ensures bazel supports our approach to proto_library() depending on a
   copied filegroup. (Fixed in bazel 0.5.4)
   """
-  expected = apple_common.dotted_version("0.5.4")
-  current = apple_common.dotted_version(native.bazel_version)
-  if current.compare_to(expected) < 0:
-    fail("Bazel must be newer than 0.5.4")
+  versions.check(minimum_bazel_version = "0.5.4")


### PR DESCRIPTION
Many Bazel repositories implement their own version comparison functions - one implementation is now in [bazelbuild/bazel-skylib](https://github.com/bazelbuild/bazel-skylib/blob/master/lib/versions.bzl).

Further details: https://github.com/bazelbuild/bazel/issues/4433.