### PR TITLE
Ruby: Build packages for Ruby 2.5

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -64,13 +64,13 @@ else
 
   task 'gem:windows' do
     require 'rake_compiler_dock'
-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
   end
 
   if RUBY_PLATFORM =~ /darwin/
     task 'gem:native' do
       system "rake genproto"
-      system "rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+      system "rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
     end
   else
     task 'gem:native' => [:genproto, 'gem:windows']


### PR DESCRIPTION
Installing the gem on MacOS with Ruby 2.5 fails due to not having been
cross compiled for 2.5.0.

Based on [a commit to support 2.4.0](014a5507fb4b1ccc12f35ff313b8a04c05d69b7f)

Fixes #4098