### PR TITLE
enable source link for csharp

### DIFF
--- a/csharp/build_packages.bat
+++ b/csharp/build_packages.bat
@@ -1,7 +1,7 @@
 @rem Builds Google.Protobuf NuGet packages
 
 dotnet restore src/Google.Protobuf.sln
-dotnet pack -c Release src/Google.Protobuf.sln || goto :error
+dotnet pack -c Release src/Google.Protobuf.sln /p:SourceLinkCreate=true || goto :error
 
 goto :EOF
 

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -17,8 +17,6 @@
     <PackageLicenseUrl>https://github.com/google/protobuf/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/google/protobuf.git</RepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
   </PropertyGroup>
 
   <!-- 
@@ -29,5 +27,9 @@
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.6" PrivateAssets="All" /> 
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@jskeet Thanks for adopting SourceLink.Create.CommandLine in the [Google Cloud .NET tools](https://github.com/GoogleCloudPlatform/google-cloud-dotnet/blob/master/tools/Google.Cloud.Tools.ProjectGenerator/Program.cs#L83). SourceLink 2.7 helps add the portable pdb files to the nupkg as well.