### PR TITLE
Add support for libc++ on Windows.

### DIFF
--- a/src/google/protobuf/arena.h
+++ b/src/google/protobuf/arena.h
@@ -40,7 +40,7 @@
 #if LANG_CXX11
 #include <google/protobuf/stubs/type_traits.h>
 #endif
-#if defined(_MSC_VER) && !_HAS_EXCEPTIONS
+#if defined(_MSC_VER) && !defined(_LIBCPP_STD_VER) && !_HAS_EXCEPTIONS
 // Work around bugs in MSVC <typeinfo> header when _HAS_EXCEPTIONS=0.
 #include <exception>
 #include <typeinfo>

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -235,7 +235,8 @@ class hash_set : public std::set<Key, HashFcn> {
   HashFcn hash_function() const { return HashFcn(); }
 };
 
-#elif defined(_MSC_VER) && !defined(_STLPORT_VERSION)
+#elif defined(_MSC_VER) && !defined(_STLPORT_VERSION) && \
+    !(defined(_LIBCPP_STD_VER) && _LIBCPP_STD_VER >= 11)
 
 template <typename Key>
 struct hash : public GOOGLE_PROTOBUF_HASH_COMPARE<Key> {


### PR DESCRIPTION
This disables a couple of workarounds which are only necessary with
MSVC's standard library and cause problems with libc++.