### PR TITLE
PHP: disable unicode escape for json

### DIFF
--- a/php/src/Google/Protobuf/Internal/GPBJsonWire.php
+++ b/php/src/Google/Protobuf/Internal/GPBJsonWire.php
@@ -226,7 +226,7 @@ class GPBJsonWire
                 $output->writeRaw("\"", 1);
                 break;
             case GPBType::STRING:
-                $value = json_encode($value);
+                $value = json_encode($value, JSON_UNESCAPED_UNICODE);
                 $output->writeRaw($value, strlen($value));
                 break;
             //    case GPBType::GROUP:

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1483,7 +1483,7 @@ class Message
                 }
                 break;
             case GPBType::STRING:
-                $value = json_encode($value);
+                $value = json_encode($value, JSON_UNESCAPED_UNICODE);
                 $size += strlen($value);
                 break;
             case GPBType::BYTES:


### PR DESCRIPTION
Add the `JSON_UNESCAPED_UNICODE` options so that characters like **中国** will not be escaped into **\u4e2d\u56fd** to improve serialize and transfer performance.