### PR TITLE
Adds an option in C++ JSON parser to ignore unrecognized enum values

### DIFF
--- a/src/google/protobuf/util/internal/datapiece.cc
+++ b/src/google/protobuf/util/internal/datapiece.cc
@@ -272,7 +272,8 @@ StatusOr<string> DataPiece::ToBytes() const {
 }
 
 StatusOr<int> DataPiece::ToEnum(const google::protobuf::Enum* enum_type,
-                                bool use_lower_camel_for_enums) const {
+                                bool use_lower_camel_for_enums,
+                                bool ignore_unknown_enum_values) const {
   if (type_ == TYPE_NULL) return google::protobuf::NULL_VALUE;
 
   if (type_ == TYPE_STRING) {
@@ -305,6 +306,10 @@ StatusOr<int> DataPiece::ToEnum(const google::protobuf::Enum* enum_type,
       value = FindEnumValueByNameWithoutUnderscoreOrNull(enum_type, enum_name);
       if (value != NULL) return value->number();
     }
+
+    // If ignore_unknown_enum_values is true an unknown enum value is treated
+    // as the default
+    if (ignore_unknown_enum_values) return enum_type->enumvalue(0).number();
   } else {
     // We don't need to check whether the value is actually declared in the
     // enum because we preserve unknown enum values as well.

--- a/src/google/protobuf/util/internal/datapiece.h
+++ b/src/google/protobuf/util/internal/datapiece.h
@@ -164,7 +164,8 @@ class LIBPROTOBUF_EXPORT DataPiece {
   // If the value is not a string, attempts to convert to a 32-bit integer.
   // If none of these succeeds, returns a conversion error status.
   util::StatusOr<int> ToEnum(const google::protobuf::Enum* enum_type,
-                               bool use_lower_camel_for_enums) const;
+                               bool use_lower_camel_for_enums,
+                               bool ignore_unknown_enum_values) const;
 
  private:
   // Disallow implicit constructor.

--- a/src/google/protobuf/util/internal/proto_writer.cc
+++ b/src/google/protobuf/util/internal/proto_writer.cc
@@ -267,8 +267,9 @@ inline Status WriteString(int field_number, const DataPiece& data,
 inline Status WriteEnum(int field_number, const DataPiece& data,
                         const google::protobuf::Enum* enum_type,
                         CodedOutputStream* stream,
-                        bool use_lower_camel_for_enums) {
-  StatusOr<int> e = data.ToEnum(enum_type, use_lower_camel_for_enums);
+                        bool use_lower_camel_for_enums,
+                        bool ignore_unknown_values) {
+  StatusOr<int> e = data.ToEnum(enum_type, use_lower_camel_for_enums, ignore_unknown_values);
   if (e.ok()) {
     WireFormatLite::WriteEnum(field_number, e.ValueOrDie(), stream);
   }
@@ -665,7 +666,8 @@ ProtoWriter* ProtoWriter::RenderPrimitiveField(
     case google::protobuf::Field_Kind_TYPE_ENUM: {
       status = WriteEnum(field.number(), data,
                          typeinfo_->GetEnumByTypeUrl(field.type_url()),
-                         stream_.get(), use_lower_camel_for_enums_);
+                         stream_.get(), use_lower_camel_for_enums_,
+                         ignore_unknown_fields_);
       break;
     }
     default:  // TYPE_GROUP or TYPE_MESSAGE

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -309,7 +309,7 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
   // Indicates whether we finished writing root message completely.
   bool done_;
 
-  // If true, don't report unknown field names to the listener.
+  // If true, don't report unknown field names and enum values to the listener.
   bool ignore_unknown_fields_;
 
   // If true, check if enum name in camel case or without underscore matches the


### PR DESCRIPTION
This PR adds `JsonParseOptions::ignore_unknown_enum_values` option to treat unknown enum values as 0.

For example, if we have an application compiled with the following protobuf scheme:
```
syntax = "proto3";
enum ShapeType
{
    DEFAULT = 0;
    RECTANGLE = 1;
    ELLIPSE = 2;
}
message Shape
{
    ShapeType type = 1;
}
```

It will fail to parse the following JSON created with the newer version of an application:
```json
{
  "type":"ROUNDED_RECTANGLE"
}
```
If you set the `ignore_unknown_enum_values` option to `true`, the application will be able to parse this JSON. The `Shape.type` field will be set to `DEFAULT` value (0). The application can handle this situation, for instance, by replacing a shape with one of the supported shape types.
If the `ignore_unknown_enum_values` option is `false`, the JSON parser will have existing behavior.