### PR TITLE
Removed using statements from common.h

### DIFF
--- a/conformance/conformance_test.cc
+++ b/conformance/conformance_test.cc
@@ -754,7 +754,7 @@ void ConformanceTestSuite::TestValidDataForType(
 }
 
 void ConformanceTestSuite::SetFailureList(const string& filename,
-                                          const vector<string>& failure_list) {
+                                          const std::vector<string>& failure_list) {
   failure_list_filename_ = filename;
   expected_to_fail_.clear();
   std::copy(failure_list.begin(), failure_list.end(),

--- a/conformance/conformance_test_runner.cc
+++ b/conformance/conformance_test_runner.cc
@@ -264,7 +264,7 @@ void UsageError() {
   exit(1);
 }
 
-void ParseFailureList(const char *filename, vector<string>* failure_list) {
+void ParseFailureList(const char *filename, std::vector<string>* failure_list) {
   std::ifstream infile(filename);
 
   if (!infile.is_open()) {
@@ -291,7 +291,7 @@ int main(int argc, char *argv[]) {
   google::protobuf::ConformanceTestSuite suite;
 
   string failure_list_filename;
-  vector<string> failure_list;
+  std::vector<string> failure_list;
 
   for (int arg = 1; arg < argc; ++arg) {
     if (strcmp(argv[arg], "--failure_list") == 0) {

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -226,7 +226,7 @@ bool IsInstalledProtoPath(const string& path) {
 
 // Add the paths where google/protobuf/descriptor.proto and other well-known
 // type protos are installed.
-void AddDefaultProtoPaths(vector<pair<string, string> >* paths) {
+void AddDefaultProtoPaths(std::vector<std::pair<string, string> >* paths) {
   // TODO(xiaofeng): The code currently only checks relative paths of where
   // the protoc binary is installed. We probably should make it handle more
   // cases than that.
@@ -242,12 +242,12 @@ void AddDefaultProtoPaths(vector<pair<string, string> >* paths) {
   path = path.substr(0, pos);
   // Check the binary's directory.
   if (IsInstalledProtoPath(path)) {
-    paths->push_back(pair<string, string>("", path));
+    paths->push_back(std::pair<string, string>("", path));
     return;
   }
   // Check if there is an include subdirectory.
   if (IsInstalledProtoPath(path + "/include")) {
-    paths->push_back(pair<string, string>("", path + "/include"));
+    paths->push_back(std::pair<string, string>("", path + "/include"));
     return;
   }
   // Check if the upper level directory has an "include" subdirectory.
@@ -257,7 +257,7 @@ void AddDefaultProtoPaths(vector<pair<string, string> >* paths) {
   }
   path = path.substr(0, pos);
   if (IsInstalledProtoPath(path + "/include")) {
-    paths->push_back(pair<string, string>("", path + "/include"));
+    paths->push_back(std::pair<string, string>("", path + "/include"));
     return;
   }
 }

--- a/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
@@ -56,7 +56,7 @@ void WriteDocCommentBodyImpl(io::Printer* printer, SourceLocation location) {
     // node of a summary element, not part of an attribute.
     comments = StringReplace(comments, "&", "&amp;", true);
     comments = StringReplace(comments, "<", "&lt;", true);
-    vector<string> lines = Split(comments, "\n", false /* skip_empty */);
+    std::vector<string> lines = Split(comments, "\n", false /* skip_empty */);
     // TODO: We really should work out which part to put in the summary and which to put in the remarks...
     // but that needs to be part of a bigger effort to understand the markdown better anyway.
     printer->Print("/// <summary>\n");

--- a/src/google/protobuf/compiler/csharp/csharp_generator.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_generator.cc
@@ -64,7 +64,7 @@ bool Generator::Generate(
     GeneratorContext* generator_context,
     string* error) const {
 
-  vector<pair<string, string> > options;
+  std::vector<std::pair<string, string> > options;
   ParseGeneratorParameter(parameter, &options);
 
   // We only support proto3 - but we make an exception for descriptor.proto.

--- a/src/google/protobuf/compiler/javanano/javanano_enum.h
+++ b/src/google/protobuf/compiler/javanano/javanano_enum.h
@@ -68,13 +68,13 @@ class EnumGenerator {
   // considered equivalent.  We treat the first defined constant for any
   // given numeric value as "canonical" and the rest as aliases of that
   // canonical value.
-  vector<const EnumValueDescriptor*> canonical_values_;
+  std::vector<const EnumValueDescriptor*> canonical_values_;
 
   struct Alias {
     const EnumValueDescriptor* value;
     const EnumValueDescriptor* canonical_value;
   };
-  vector<Alias> aliases_;
+  std::vector<Alias> aliases_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumGenerator);
 };

--- a/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_enum_field.cc
@@ -83,7 +83,7 @@ void SetEnumVariables(const Params& params,
 }
 
 void LoadEnumValues(const Params& params,
-    const EnumDescriptor* enum_descriptor, vector<string>* canonical_values) {
+    const EnumDescriptor* enum_descriptor, std::vector<string>* canonical_values) {
   string enum_class_name = ClassName(params, enum_descriptor);
   for (int i = 0; i < enum_descriptor->value_count(); i++) {
     const EnumValueDescriptor* value = enum_descriptor->value(i);
@@ -97,7 +97,7 @@ void LoadEnumValues(const Params& params,
 }
 
 void PrintCaseLabels(
-    io::Printer* printer, const vector<string>& canonical_values) {
+    io::Printer* printer, const std::vector<string>& canonical_values) {
   for (int i = 0; i < canonical_values.size(); i++) {
     printer->Print(
       "  case $value$:\n",

--- a/src/google/protobuf/compiler/javanano/javanano_enum_field.h
+++ b/src/google/protobuf/compiler/javanano/javanano_enum_field.h
@@ -63,7 +63,7 @@ class EnumFieldGenerator : public FieldGenerator {
  private:
   const FieldDescriptor* descriptor_;
   std::map<string, string> variables_;
-  vector<string> canonical_values_;
+  std::vector<string> canonical_values_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumFieldGenerator);
 };
@@ -86,7 +86,7 @@ class AccessorEnumFieldGenerator : public FieldGenerator {
  private:
   const FieldDescriptor* descriptor_;
   std::map<string, string> variables_;
-  vector<string> canonical_values_;
+  std::vector<string> canonical_values_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(AccessorEnumFieldGenerator);
 };
@@ -113,7 +113,7 @@ class RepeatedEnumFieldGenerator : public FieldGenerator {
 
   const FieldDescriptor* descriptor_;
   std::map<string, string> variables_;
-  vector<string> canonical_values_;
+  std::vector<string> canonical_values_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(RepeatedEnumFieldGenerator);
 };

--- a/src/google/protobuf/compiler/javanano/javanano_file.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_file.cc
@@ -59,7 +59,7 @@ bool UsesExtensions(const Message& message) {
   // We conservatively assume that unknown fields are extensions.
   if (reflection->GetUnknownFields(message).field_count() > 0) return true;
 
-  vector<const FieldDescriptor*> fields;
+  std::vector<const FieldDescriptor*> fields;
   reflection->ListFields(message, &fields);
 
   for (int i = 0; i < fields.size(); i++) {
@@ -216,7 +216,7 @@ static void GenerateSibling(const string& package_dir,
                             const string& java_package,
                             const DescriptorClass* descriptor,
                             GeneratorContext* output_directory,
-                            vector<string>* file_list,
+                            std::vector<string>* file_list,
                             const Params& params) {
   string filename = package_dir + descriptor->name() + ".java";
   file_list->push_back(filename);
@@ -239,7 +239,7 @@ static void GenerateSibling(const string& package_dir,
 
 void FileGenerator::GenerateSiblings(const string& package_dir,
                                      GeneratorContext* output_directory,
-                                     vector<string>* file_list) {
+                                     std::vector<string>* file_list) {
   if (params_.java_multiple_files(file_->name())) {
     for (int i = 0; i < file_->message_type_count(); i++) {
       GenerateSibling<MessageGenerator>(package_dir, java_package_,

--- a/src/google/protobuf/compiler/javanano/javanano_file.h
+++ b/src/google/protobuf/compiler/javanano/javanano_file.h
@@ -72,7 +72,7 @@ class FileGenerator {
   // service type).
   void GenerateSiblings(const string& package_dir,
                         GeneratorContext* output_directory,
-                        vector<string>* file_list);
+                        std::vector<string>* file_list);
 
   const string& java_package() { return java_package_; }
   const string& classname()    { return classname_;    }

--- a/src/google/protobuf/compiler/javanano/javanano_generator.cc
+++ b/src/google/protobuf/compiler/javanano/javanano_generator.cc
@@ -94,7 +94,7 @@ bool JavaNanoGenerator::Generate(const FileDescriptor* file,
                              const string& parameter,
                              GeneratorContext* output_directory,
                              string* error) const {
-  vector<pair<string, string> > options;
+  std::vector<std::pair<string, string> > options;
 
   ParseGeneratorParameter(parameter, &options);
 
@@ -116,24 +116,24 @@ bool JavaNanoGenerator::Generate(const FileDescriptor* file,
     if (option_name == "output_list_file") {
       output_list_file = option_value;
     } else if (option_name == "java_package") {
-        vector<string> parts;
-        SplitStringUsing(option_value, "|", &parts);
-        if (parts.size() != 2) {
-          *error = "Bad java_package, expecting filename|PackageName found '"
-            + option_value + "'";
-          return false;
-        }
-        params.set_java_package(parts[0], parts[1]);
+      std::vector<string> parts;
+      SplitStringUsing(option_value, "|", &parts);
+      if (parts.size() != 2) {
+        *error = "Bad java_package, expecting filename|PackageName found '"
+          + option_value + "'";
+        return false;
+      }
+      params.set_java_package(parts[0], parts[1]);
     } else if (option_name == "java_outer_classname") {
-        vector<string> parts;
-        SplitStringUsing(option_value, "|", &parts);
-        if (parts.size() != 2) {
-          *error = "Bad java_outer_classname, "
-                   "expecting filename|ClassName found '"
-                   + option_value + "'";
-          return false;
-        }
-        params.set_java_outer_classname(parts[0], parts[1]);
+      std::vector<string> parts;
+      SplitStringUsing(option_value, "|", &parts);
+      if (parts.size() != 2) {
+        *error = "Bad java_outer_classname, "
+                 "expecting filename|ClassName found '"
+                 + option_value + "'";
+        return false;
+      }
+      params.set_java_outer_classname(parts[0], parts[1]);
     } else if (option_name == "store_unknown_fields") {
       params.set_store_unknown_fields(option_value == "true");
     } else if (option_name == "java_multiple_files") {
@@ -191,7 +191,7 @@ bool JavaNanoGenerator::Generate(const FileDescriptor* file,
     StringReplace(file_generator.java_package(), ".", "/", true);
   if (!package_dir.empty()) package_dir += "/";
 
-  vector<string> all_files;
+  std::vector<string> all_files;
 
   if (IsOuterClassNeeded(params, file)) {
     string java_filename = package_dir;

--- a/src/google/protobuf/compiler/objectivec/objectivec_enum.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_enum.h
@@ -59,8 +59,8 @@ class EnumGenerator {
 
  private:
   const EnumDescriptor* descriptor_;
-  vector<const EnumValueDescriptor*> base_values_;
-  vector<const EnumValueDescriptor*> all_values_;
+  std::vector<const EnumValueDescriptor*> base_values_;
+  std::vector<const EnumValueDescriptor*> all_values_;
   const string name_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(EnumGenerator);

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.cc
@@ -116,9 +116,9 @@ bool FileContainsExtensions(const FileDescriptor* file) {
 // deps as visited and prunes them from the needed files list.
 void PruneFileAndDepsMarkingAsVisited(
     const FileDescriptor* file,
-    vector<const FileDescriptor*>* files,
+    std::vector<const FileDescriptor*>* files,
     std::set<const FileDescriptor*>* files_visited) {
-  vector<const FileDescriptor*>::iterator iter =
+  std::vector<const FileDescriptor*>::iterator iter =
       std::find(files->begin(), files->end(), file);
   if (iter != files->end()) {
     files->erase(iter);
@@ -132,7 +132,7 @@ void PruneFileAndDepsMarkingAsVisited(
 // Helper for CollectMinimalFileDepsContainingExtensions.
 void CollectMinimalFileDepsContainingExtensionsWorker(
     const FileDescriptor* file,
-    vector<const FileDescriptor*>* files,
+    std::vector<const FileDescriptor*>* files,
     std::set<const FileDescriptor*>* files_visited) {
   if (files_visited->find(file) != files_visited->end()) {
     return;
@@ -165,7 +165,7 @@ void CollectMinimalFileDepsContainingExtensionsWorker(
 // specifically).
 void CollectMinimalFileDepsContainingExtensions(
     const FileDescriptor* file,
-    vector<const FileDescriptor*>* files) {
+    std::vector<const FileDescriptor*>* files) {
   std::set<const FileDescriptor*> files_visited;
   for (int i = 0; i < file->dependency_count(); i++) {
     const FileDescriptor* dep = file->dependency(i);
@@ -258,7 +258,7 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
       "\n");
 
   std::set<string> fwd_decls;
-  for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
+  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
        iter != message_generators_.end(); ++iter) {
     (*iter)->DetermineForwardDeclarations(&fwd_decls);
   }
@@ -275,12 +275,12 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
       "\n");
 
   // need to write out all enums first
-  for (vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
+  for (std::vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
        iter != enum_generators_.end(); ++iter) {
     (*iter)->GenerateHeader(printer);
   }
 
-  for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
+  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
        iter != message_generators_.end(); ++iter) {
     (*iter)->GenerateEnumHeader(printer);
   }
@@ -311,7 +311,7 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
         "@interface $root_class_name$ (DynamicMethods)\n",
         "root_class_name", root_class_name_);
 
-    for (vector<ExtensionGenerator *>::iterator iter =
+    for (std::vector<ExtensionGenerator *>::iterator iter =
              extension_generators_.begin();
          iter != extension_generators_.end(); ++iter) {
       (*iter)->GenerateMembersHeader(printer);
@@ -320,7 +320,7 @@ void FileGenerator::GenerateHeader(io::Printer *printer) {
     printer->Print("@end\n\n");
   }  // extension_generators_.size() > 0
 
-  for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
+  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
        iter != message_generators_.end(); ++iter) {
     (*iter)->GenerateMessageHeader(printer);
   }
@@ -346,7 +346,7 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
         "\n");
   }
 
-  vector<const FileDescriptor*> deps_with_extensions;
+  std::vector<const FileDescriptor*> deps_with_extensions;
   CollectMinimalFileDepsContainingExtensions(file_, &deps_with_extensions);
 
   {
@@ -376,7 +376,7 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
     // imported so it can get merged into the root's extensions registry.
     // See the Note by CollectMinimalFileDepsContainingExtensions before
     // changing this.
-    for (vector<const FileDescriptor *>::iterator iter =
+    for (std::vector<const FileDescriptor *>::iterator iter =
              deps_with_extensions.begin();
          iter != deps_with_extensions.end(); ++iter) {
       if (!IsDirectDependency(*iter, file_)) {
@@ -388,7 +388,7 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
   }
 
   bool includes_oneof = false;
-  for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
+  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
        iter != message_generators_.end(); ++iter) {
     if ((*iter)->IncludesOneOfDefinition()) {
       includes_oneof = true;
@@ -441,12 +441,12 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
       printer->Print(
           "static GPBExtensionDescription descriptions[] = {\n");
       printer->Indent();
-      for (vector<ExtensionGenerator *>::iterator iter =
+      for (std::vector<ExtensionGenerator *>::iterator iter =
                extension_generators_.begin();
            iter != extension_generators_.end(); ++iter) {
         (*iter)->GenerateStaticVariablesInitialization(printer);
       }
-      for (vector<MessageGenerator *>::iterator iter =
+      for (std::vector<MessageGenerator *>::iterator iter =
                message_generators_.begin();
            iter != message_generators_.end(); ++iter) {
         (*iter)->GenerateStaticVariablesInitialization(printer);
@@ -470,7 +470,7 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
     } else {
       printer->Print(
           "// Merge in the imports (direct or indirect) that defined extensions.\n");
-      for (vector<const FileDescriptor *>::iterator iter =
+      for (std::vector<const FileDescriptor *>::iterator iter =
                deps_with_extensions.begin();
            iter != deps_with_extensions.end(); ++iter) {
         const string root_class_name(FileClassName((*iter)));
@@ -546,11 +546,11 @@ void FileGenerator::GenerateSource(io::Printer *printer) {
         "\n");
   }
 
-  for (vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
+  for (std::vector<EnumGenerator *>::iterator iter = enum_generators_.begin();
        iter != enum_generators_.end(); ++iter) {
     (*iter)->GenerateSource(printer);
   }
-  for (vector<MessageGenerator *>::iterator iter = message_generators_.begin();
+  for (std::vector<MessageGenerator *>::iterator iter = message_generators_.begin();
        iter != message_generators_.end(); ++iter) {
     (*iter)->GenerateSource(printer);
   }

--- a/src/google/protobuf/compiler/objectivec/objectivec_file.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_file.h
@@ -67,9 +67,9 @@ class FileGenerator {
   const FileDescriptor* file_;
   string root_class_name_;
 
-  vector<EnumGenerator*> enum_generators_;
-  vector<MessageGenerator*> message_generators_;
-  vector<ExtensionGenerator*> extension_generators_;
+  std::vector<EnumGenerator*> enum_generators_;
+  std::vector<MessageGenerator*> message_generators_;
+  std::vector<ExtensionGenerator*> extension_generators_;
 
   const Options options_;
 

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.cc
@@ -57,7 +57,7 @@ bool ObjectiveCGenerator::Generate(const FileDescriptor* file,
   return false;
 }
 
-bool ObjectiveCGenerator::GenerateAll(const vector<const FileDescriptor*>& files,
+bool ObjectiveCGenerator::GenerateAll(const std::vector<const FileDescriptor*>& files,
                                       const string& parameter,
                                       GeneratorContext* context,
                                       string* error) const {
@@ -71,7 +71,7 @@ bool ObjectiveCGenerator::GenerateAll(const vector<const FileDescriptor*>& files
 
   Options generation_options;
 
-  vector<pair<string, string> > options;
+  std::vector<std::pair<string, string> > options;
   ParseGeneratorParameter(parameter, &options);
   for (int i = 0; i < options.size(); i++) {
     if (options[i].first == "expected_prefixes_path") {

--- a/src/google/protobuf/compiler/objectivec/objectivec_generator.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_generator.h
@@ -56,7 +56,7 @@ class LIBPROTOC_EXPORT ObjectiveCGenerator : public CodeGenerator {
                 const string& parameter,
                 GeneratorContext* context,
                 string* error) const;
-  bool GenerateAll(const vector<const FileDescriptor*>& files,
+  bool GenerateAll(const std::vector<const FileDescriptor*>& files,
                    const string& parameter,
                    GeneratorContext* context,
                    string* error) const;

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc
@@ -100,7 +100,7 @@ bool ascii_isnewline(char c) {
 // Do not expose this outside of helpers, stick to having functions for specific
 // cases (ClassName(), FieldName()), so there is always consistent suffix rules.
 string UnderscoresToCamelCase(const string& input, bool first_capitalized) {
-  vector<string> values;
+  std::vector<string> values;
   string current;
 
   bool last_char_was_number = false;
@@ -141,7 +141,7 @@ string UnderscoresToCamelCase(const string& input, bool first_capitalized) {
 
   string result;
   bool first_segment_forces_upper = false;
-  for (vector<string>::iterator i = values.begin(); i != values.end(); ++i) {
+  for (std::vector<string>::iterator i = values.begin(); i != values.end(); ++i) {
     string value = *i;
     bool all_upper = (kUpperSegments.count(value) > 0);
     if (all_upper && (result.length() == 0)) {
@@ -864,7 +864,7 @@ bool HasNonZeroDefaultValue(const FieldDescriptor* field) {
 }
 
 string BuildFlagsString(const FlagType flag_type,
-                        const vector<string>& strings) {
+                        const std::vector<string>& strings) {
   if (strings.size() == 0) {
     return GetZeroEnumNameForFlagType(flag_type);
   } else if (strings.size() == 1) {
@@ -886,7 +886,7 @@ string BuildCommentsString(const SourceLocation& location,
   const string& comments = location.leading_comments.empty()
                                ? location.trailing_comments
                                : location.leading_comments;
-  vector<string> lines;
+  std::vector<string> lines;
   SplitStringAllowEmpty(comments, "\n", &lines);
   while (!lines.empty() && lines.back().empty()) {
     lines.pop_back();
@@ -1156,7 +1156,7 @@ bool ValidateObjCClassPrefix(
 
 }  // namespace
 
-bool ValidateObjCClassPrefixes(const vector<const FileDescriptor*>& files,
+bool ValidateObjCClassPrefixes(const std::vector<const FileDescriptor*>& files,
                                const Options& generation_options,
                                string* out_error) {
   // Load the expected package prefixes, if available, to validate against.
@@ -1187,7 +1187,7 @@ TextFormatDecodeData::~TextFormatDecodeData() { }
 void TextFormatDecodeData::AddString(int32 key,
                                      const string& input_for_decode,
                                      const string& desired_output) {
-  for (vector<DataEntry>::const_iterator i = entries_.begin();
+  for (std::vector<DataEntry>::const_iterator i = entries_.begin();
        i != entries_.end(); ++i) {
     if (i->first == key) {
       std::cerr << "error: duplicate key (" << key
@@ -1211,7 +1211,7 @@ string TextFormatDecodeData::Data() const {
     io::CodedOutputStream output_stream(&data_outputstream);
 
     output_stream.WriteVarint32(num_entries());
-    for (vector<DataEntry>::const_iterator i = entries_.begin();
+    for (std::vector<DataEntry>::const_iterator i = entries_.begin();
          i != entries_.end(); ++i) {
       output_stream.WriteVarint32(i->first);
       output_stream.WriteString(i->second);
@@ -1561,7 +1561,7 @@ void ImportWriter::Print(io::Printer* printer) const {
     printer->Print(
         "#if $cpp_symbol$\n",
         "cpp_symbol", cpp_symbol);
-    for (vector<string>::const_iterator iter = protobuf_framework_imports_.begin();
+    for (std::vector<string>::const_iterator iter = protobuf_framework_imports_.begin();
          iter != protobuf_framework_imports_.end(); ++iter) {
       printer->Print(
           " #import <$framework_name$/$header$>\n",
@@ -1570,7 +1570,7 @@ void ImportWriter::Print(io::Printer* printer) const {
     }
     printer->Print(
         "#else\n");
-    for (vector<string>::const_iterator iter = protobuf_non_framework_imports_.begin();
+    for (std::vector<string>::const_iterator iter = protobuf_non_framework_imports_.begin();
          iter != protobuf_non_framework_imports_.end(); ++iter) {
       printer->Print(
           " #import \"$header$\"\n",
@@ -1587,7 +1587,7 @@ void ImportWriter::Print(io::Printer* printer) const {
       printer->Print("\n");
     }
 
-    for (vector<string>::const_iterator iter = other_framework_imports_.begin();
+    for (std::vector<string>::const_iterator iter = other_framework_imports_.begin();
          iter != other_framework_imports_.end(); ++iter) {
       printer->Print(
           " #import <$header$>\n",
@@ -1602,7 +1602,7 @@ void ImportWriter::Print(io::Printer* printer) const {
       printer->Print("\n");
     }
 
-    for (vector<string>::const_iterator iter = other_imports_.begin();
+    for (std::vector<string>::const_iterator iter = other_imports_.begin();
          iter != other_imports_.end(); ++iter) {
       printer->Print(
           " #import \"$header$\"\n",

--- a/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_helpers.h
@@ -190,7 +190,7 @@ string LIBPROTOC_EXPORT GPBGenericValueFieldName(const FieldDescriptor* field);
 string LIBPROTOC_EXPORT DefaultValue(const FieldDescriptor* field);
 bool LIBPROTOC_EXPORT HasNonZeroDefaultValue(const FieldDescriptor* field);
 
-string LIBPROTOC_EXPORT BuildFlagsString(const FlagType type, const vector<string>& strings);
+string LIBPROTOC_EXPORT BuildFlagsString(const FlagType type, const std::vector<string>& strings);
 
 // Builds HeaderDoc/appledoc style comments out of the comments in the .proto
 // file.
@@ -210,7 +210,7 @@ bool LIBPROTOC_EXPORT IsProtobufLibraryBundledProtoFile(const FileDescriptor* fi
 // Checks the prefix for the given files and outputs any warnings as needed. If
 // there are flat out errors, then out_error is filled in with the first error
 // and the result is false.
-bool LIBPROTOC_EXPORT ValidateObjCClassPrefixes(const vector<const FileDescriptor*>& files,
+bool LIBPROTOC_EXPORT ValidateObjCClassPrefixes(const std::vector<const FileDescriptor*>& files,
                                const Options& generation_options,
                                string* out_error);
 
@@ -233,7 +233,7 @@ class LIBPROTOC_EXPORT TextFormatDecodeData {
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(TextFormatDecodeData);
 
   typedef std::pair<int32, string> DataEntry;
-  vector<DataEntry> entries_;
+  std::vector<DataEntry> entries_;
 };
 
 // Helper for parsing simple files.
@@ -278,10 +278,10 @@ class LIBPROTOC_EXPORT ImportWriter {
   std::map<string, string> proto_file_to_framework_name_;
   bool need_to_parse_mapping_file_;
 
-  vector<string> protobuf_framework_imports_;
-  vector<string> protobuf_non_framework_imports_;
-  vector<string> other_framework_imports_;
-  vector<string> other_imports_;
+  std::vector<string> protobuf_framework_imports_;
+  std::vector<string> protobuf_non_framework_imports_;
+  std::vector<string> other_framework_imports_;
+  std::vector<string> other_imports_;
 };
 
 }  // namespace objectivec

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.cc
@@ -220,13 +220,13 @@ MessageGenerator::~MessageGenerator() {
 
 void MessageGenerator::GenerateStaticVariablesInitialization(
     io::Printer* printer) {
-  for (vector<ExtensionGenerator*>::iterator iter =
+  for (std::vector<ExtensionGenerator*>::iterator iter =
            extension_generators_.begin();
        iter != extension_generators_.end(); ++iter) {
     (*iter)->GenerateStaticVariablesInitialization(printer);
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->GenerateStaticVariablesInitialization(printer);
@@ -242,7 +242,7 @@ void MessageGenerator::DetermineForwardDeclarations(std::set<string>* fwd_decls)
     }
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->DetermineForwardDeclarations(fwd_decls);
@@ -254,7 +254,7 @@ bool MessageGenerator::IncludesOneOfDefinition() const {
     return true;
   }
 
-  for (vector<MessageGenerator*>::const_iterator iter =
+  for (std::vector<MessageGenerator*>::const_iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     if ((*iter)->IncludesOneOfDefinition()) {
@@ -266,12 +266,12 @@ bool MessageGenerator::IncludesOneOfDefinition() const {
 }
 
 void MessageGenerator::GenerateEnumHeader(io::Printer* printer) {
-  for (vector<EnumGenerator*>::iterator iter = enum_generators_.begin();
+  for (std::vector<EnumGenerator*>::iterator iter = enum_generators_.begin();
        iter != enum_generators_.end(); ++iter) {
     (*iter)->GenerateHeader(printer);
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->GenerateEnumHeader(printer);
@@ -280,13 +280,13 @@ void MessageGenerator::GenerateEnumHeader(io::Printer* printer) {
 
 void MessageGenerator::GenerateExtensionRegistrationSource(
     io::Printer* printer) {
-  for (vector<ExtensionGenerator*>::iterator iter =
+  for (std::vector<ExtensionGenerator*>::iterator iter =
            extension_generators_.begin();
        iter != extension_generators_.end(); ++iter) {
     (*iter)->GenerateRegistrationSource(printer);
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->GenerateExtensionRegistrationSource(printer);
@@ -296,7 +296,7 @@ void MessageGenerator::GenerateExtensionRegistrationSource(
 void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
   // This a a map entry message, just recurse and do nothing directly.
   if (IsMapEntryMessage(descriptor_)) {
-    for (vector<MessageGenerator*>::iterator iter =
+    for (std::vector<MessageGenerator*>::iterator iter =
              nested_message_generators_.begin();
          iter != nested_message_generators_.end(); ++iter) {
       (*iter)->GenerateMessageHeader(printer);
@@ -326,7 +326,7 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
     printer->Print("};\n\n");
   }
 
-  for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+  for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
        iter != oneof_generators_.end(); ++iter) {
     (*iter)->GenerateCaseEnum(printer);
   }
@@ -345,7 +345,7 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
       "deprecated_attribute", deprecated_attribute_,
       "comments", message_comments);
 
-  vector<char> seen_oneofs(descriptor_->oneof_decl_count(), 0);
+  std::vector<char> seen_oneofs(descriptor_->oneof_decl_count(), 0);
   for (int i = 0; i < descriptor_->field_count(); i++) {
     const FieldDescriptor* field = descriptor_->field(i);
     if (field->containing_oneof() != NULL) {
@@ -367,7 +367,7 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
   }
 
   if (!oneof_generators_.empty()) {
-    for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+    for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
          iter != oneof_generators_.end(); ++iter) {
       (*iter)->GenerateClearFunctionDeclaration(printer);
     }
@@ -377,7 +377,7 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
   if (descriptor_->extension_count() > 0) {
     printer->Print("@interface $classname$ (DynamicMethods)\n\n",
                    "classname", class_name_);
-    for (vector<ExtensionGenerator*>::iterator iter =
+    for (std::vector<ExtensionGenerator*>::iterator iter =
              extension_generators_.begin();
          iter != extension_generators_.end(); ++iter) {
       (*iter)->GenerateMembersHeader(printer);
@@ -385,7 +385,7 @@ void MessageGenerator::GenerateMessageHeader(io::Printer* printer) {
     printer->Print("@end\n\n");
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->GenerateMessageHeader(printer);
@@ -410,7 +410,7 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
     printer->Print("@implementation $classname$\n\n",
                    "classname", class_name_);
 
-    for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+    for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
          iter != oneof_generators_.end(); ++iter) {
       (*iter)->GeneratePropertyImplementation(printer);
     }
@@ -425,7 +425,7 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
     scoped_array<const FieldDescriptor*> size_order_fields(
         SortFieldsByStorageSize(descriptor_));
 
-    vector<const Descriptor::ExtensionRange*> sorted_extensions;
+    std::vector<const Descriptor::ExtensionRange*> sorted_extensions;
     for (int i = 0; i < descriptor_->extension_range_count(); ++i) {
       sorted_extensions.push_back(descriptor_->extension_range(i));
     }
@@ -448,7 +448,7 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
       sizeof_has_storage = 1;
     }
     // Tell all the fields the oneof base.
-    for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+    for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
          iter != oneof_generators_.end(); ++iter) {
       (*iter)->SetOneofIndexBase(sizeof_has_storage);
     }
@@ -548,7 +548,7 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
     if (oneof_generators_.size() != 0) {
       printer->Print(
           "    static const char *oneofs[] = {\n");
-      for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+      for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
            iter != oneof_generators_.end(); ++iter) {
         printer->Print(
             "      \"$name$\",\n",
@@ -623,18 +623,18 @@ void MessageGenerator::GenerateSource(io::Printer* printer) {
           .GenerateCFunctionImplementations(printer);
     }
 
-    for (vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
+    for (std::vector<OneofGenerator*>::iterator iter = oneof_generators_.begin();
          iter != oneof_generators_.end(); ++iter) {
       (*iter)->GenerateClearFunctionImplementation(printer);
     }
   }
 
-  for (vector<EnumGenerator*>::iterator iter = enum_generators_.begin();
+  for (std::vector<EnumGenerator*>::iterator iter = enum_generators_.begin();
        iter != enum_generators_.end(); ++iter) {
     (*iter)->GenerateSource(printer);
   }
 
-  for (vector<MessageGenerator*>::iterator iter =
+  for (std::vector<MessageGenerator*>::iterator iter =
            nested_message_generators_.begin();
        iter != nested_message_generators_.end(); ++iter) {
     (*iter)->GenerateSource(printer);

--- a/src/google/protobuf/compiler/objectivec/objectivec_message.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_message.h
@@ -86,10 +86,10 @@ class MessageGenerator {
   FieldGeneratorMap field_generators_;
   const string class_name_;
   const string deprecated_attribute_;
-  vector<ExtensionGenerator*> extension_generators_;
-  vector<EnumGenerator*> enum_generators_;
-  vector<MessageGenerator*> nested_message_generators_;
-  vector<OneofGenerator*> oneof_generators_;
+  std::vector<ExtensionGenerator*> extension_generators_;
+  std::vector<EnumGenerator*> enum_generators_;
+  std::vector<MessageGenerator*> nested_message_generators_;
+  std::vector<OneofGenerator*> oneof_generators_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(MessageGenerator);
 };

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1265,7 +1265,7 @@ static void GenerateDocCommentBodyForLocation(
     // HTML-escape them so that they don't accidentally close the doc comment.
     comments = EscapePhpdoc(comments);
 
-    vector<string> lines = Split(comments, "\n");
+    std::vector<string> lines = Split(comments, "\n");
     while (!lines.empty() && lines.back().empty()) {
       lines.pop_back();
     }

--- a/src/google/protobuf/stubs/common.cc
+++ b/src/google/protobuf/stubs/common.cc
@@ -430,9 +430,9 @@ struct ShutdownData {
     }
   }
 
-  vector<void (*)()> functions;
-  vector<const std::string*> strings;
-  vector<const MessageLite*> messages;
+  std::vector<void (*)()> functions;
+  std::vector<const std::string*> strings;
+  std::vector<const MessageLite*> messages;
   Mutex mutex;
 };
 

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -229,12 +229,7 @@ class FatalException : public std::exception {
 
 // This is at the end of the file instead of the beginning to work around a bug
 // in some versions of MSVC.
-// TODO(acozzette): remove these using statements
-using std::istream;
-using std::ostream;
-using std::pair;
 using std::string;
-using std::vector;
 
 }  // namespace protobuf
 }  // namespace google

--- a/src/google/protobuf/stubs/common_unittest.cc
+++ b/src/google/protobuf/stubs/common_unittest.cc
@@ -75,7 +75,7 @@ TEST(CommonTest, IntMinMaxConstants) {
   EXPECT_EQ(0, kuint64max + 1);
 }
 
-vector<string> captured_messages_;
+std::vector<string> captured_messages_;
 
 void CaptureLog(LogLevel level, const char* filename, int line,
                 const string& message) {

--- a/src/google/protobuf/stubs/hash.h
+++ b/src/google/protobuf/stubs/hash.h
@@ -408,8 +408,8 @@ struct hash<string> {
 };
 
 template <typename First, typename Second>
-struct hash<pair<First, Second> > {
-  inline size_t operator()(const pair<First, Second>& key) const {
+struct hash<std::pair<First, Second> > {
+  inline size_t operator()(const std::pair<First, Second>& key) const {
     size_t first_hash = hash<First>()(key.first);
     size_t second_hash = hash<Second>()(key.second);
 
@@ -420,8 +420,8 @@ struct hash<pair<First, Second> > {
 
   static const size_t bucket_size = 4;
   static const size_t min_buckets = 8;
-  inline bool operator()(const pair<First, Second>& a,
-                           const pair<First, Second>& b) const {
+  inline bool operator()(const std::pair<First, Second>& a,
+                           const std::pair<First, Second>& b) const {
     return a < b;
   }
 };

--- a/src/google/protobuf/stubs/map_util.h
+++ b/src/google/protobuf/stubs/map_util.h
@@ -708,7 +708,7 @@ void AppendKeysFromMap(const MapContainer& map_container,
 // without the complexity of a SFINAE-based solution.)
 template <class MapContainer, class KeyType>
 void AppendKeysFromMap(const MapContainer& map_container,
-                       vector<KeyType>* key_container) {
+                       std::vector<KeyType>* key_container) {
   GOOGLE_CHECK(key_container != NULL);
   // We now have the opportunity to call reserve(). Calling reserve() every
   // time is a bad idea for some use cases: libstdc++'s implementation of
@@ -752,7 +752,7 @@ void AppendValuesFromMap(const MapContainer& map_container,
 // without the complexity of a SFINAE-based solution.)
 template <class MapContainer, class ValueType>
 void AppendValuesFromMap(const MapContainer& map_container,
-                         vector<ValueType>* value_container) {
+                         std::vector<ValueType>* value_container) {
   GOOGLE_CHECK(value_container != NULL);
   // See AppendKeysFromMap for why this is done.
   if (value_container->empty()) {

--- a/src/google/protobuf/stubs/status.cc
+++ b/src/google/protobuf/stubs/status.cc
@@ -124,7 +124,7 @@ string Status::ToString() const {
   }
 }
 
-ostream& operator<<(ostream& os, const Status& x) {
+std::ostream& operator<<(std::ostream& os, const Status& x) {
   os << x.ToString();
   return os;
 }

--- a/src/google/protobuf/stubs/status.h
+++ b/src/google/protobuf/stubs/status.h
@@ -106,7 +106,7 @@ class LIBPROTOBUF_EXPORT Status {
 };
 
 // Prints a human-readable representation of 'x' to 'os'.
-LIBPROTOBUF_EXPORT ostream& operator<<(ostream& os, const Status& x);
+LIBPROTOBUF_EXPORT std::ostream& operator<<(std::ostream& os, const Status& x);
 
 #define EXPECT_OK(value) EXPECT_TRUE((value).ok())
 

--- a/src/google/protobuf/stubs/stringprintf.cc
+++ b/src/google/protobuf/stubs/stringprintf.cc
@@ -137,7 +137,7 @@ const int kStringPrintfVectorMaxArgs = 32;
 // and we can fix the problem or protect against an attack.
 static const char string_printf_empty_block[256] = { '\0' };
 
-string StringPrintfVector(const char* format, const vector<string>& v) {
+string StringPrintfVector(const char* format, const std::vector<string>& v) {
   GOOGLE_CHECK_LE(v.size(), kStringPrintfVectorMaxArgs)
       << "StringPrintfVector currently only supports up to "
       << kStringPrintfVectorMaxArgs << " arguments. "

--- a/src/google/protobuf/stubs/stringprintf.h
+++ b/src/google/protobuf/stubs/stringprintf.h
@@ -68,7 +68,7 @@ LIBPROTOBUF_EXPORT extern const int kStringPrintfVectorMaxArgs;
 // You can use this version when all your arguments are strings, but
 // you don't know how many arguments you'll have at compile time.
 // StringPrintfVector will LOG(FATAL) if v.size() > kStringPrintfVectorMaxArgs
-LIBPROTOBUF_EXPORT extern string StringPrintfVector(const char* format, const vector<string>& v);
+LIBPROTOBUF_EXPORT extern string StringPrintfVector(const char* format, const std::vector<string>& v);
 
 }  // namespace protobuf
 }  // namespace google

--- a/src/google/protobuf/stubs/strutil.cc
+++ b/src/google/protobuf/stubs/strutil.cc
@@ -226,8 +226,8 @@ void SplitStringToIteratorUsing(const string& full,
 
 void SplitStringUsing(const string& full,
                       const char* delim,
-                      vector<string>* result) {
-  std::back_insert_iterator< vector<string> > it(*result);
+                      std::vector<string>* result) {
+  std::back_insert_iterator< std::vector<string> > it(*result);
   SplitStringToIteratorUsing(full, delim, it);
 }
 
@@ -264,8 +264,8 @@ void SplitStringToIteratorAllowEmpty(const StringType& full,
 }
 
 void SplitStringAllowEmpty(const string& full, const char* delim,
-                           vector<string>* result) {
-  std::back_insert_iterator<vector<string> > it(*result);
+                           std::vector<string>* result) {
+  std::back_insert_iterator<std::vector<string> > it(*result);
   SplitStringToIteratorAllowEmpty(full, delim, 0, it);
 }
 
@@ -303,7 +303,7 @@ static void JoinStringsIterator(const ITERATOR& start,
   }
 }
 
-void JoinStrings(const vector<string>& components,
+void JoinStrings(const std::vector<string>& components,
                  const char* delim,
                  string * result) {
   JoinStringsIterator(components.begin(), components.end(), delim, result);
@@ -332,7 +332,7 @@ int UnescapeCEscapeSequences(const char* source, char* dest) {
 }
 
 int UnescapeCEscapeSequences(const char* source, char* dest,
-                             vector<string> *errors) {
+                             std::vector<string> *errors) {
   GOOGLE_DCHECK(errors == NULL) << "Error reporting not implemented.";
 
   char* d = dest;
@@ -468,7 +468,7 @@ int UnescapeCEscapeString(const string& src, string* dest) {
 }
 
 int UnescapeCEscapeString(const string& src, string* dest,
-                          vector<string> *errors) {
+                          std::vector<string> *errors) {
   scoped_array<char> unescaped(new char[src.size() + 1]);
   int len = UnescapeCEscapeSequences(src.c_str(), unescaped.get(), errors);
   GOOGLE_CHECK(dest);

--- a/src/google/protobuf/stubs/strutil.h
+++ b/src/google/protobuf/stubs/strutil.h
@@ -213,7 +213,7 @@ LIBPROTOBUF_EXPORT string StringReplace(const string& s, const string& oldsub,
 //    over all of them.
 // ----------------------------------------------------------------------
 LIBPROTOBUF_EXPORT void SplitStringUsing(const string& full, const char* delim,
-                                         vector<string>* res);
+                                         std::vector<string>* res);
 
 // Split a string using one or more byte delimiters, presented
 // as a nul-terminated c string. Append the components to 'result'.
@@ -225,15 +225,15 @@ LIBPROTOBUF_EXPORT void SplitStringUsing(const string& full, const char* delim,
 // ----------------------------------------------------------------------
 LIBPROTOBUF_EXPORT void SplitStringAllowEmpty(const string& full,
                                               const char* delim,
-                                              vector<string>* result);
+                                              std::vector<string>* result);
 
 // ----------------------------------------------------------------------
 // Split()
 //    Split a string using a character delimiter.
 // ----------------------------------------------------------------------
-inline vector<string> Split(
+inline std::vector<string> Split(
     const string& full, const char* delim, bool skip_empty = true) {
-  vector<string> result;
+  std::vector<string> result;
   if (skip_empty) {
     SplitStringUsing(full, delim, &result);
   } else {
@@ -250,10 +250,10 @@ inline vector<string> Split(
 //    another takes a pointer to the target string. In the latter case the
 //    target string is cleared and overwritten.
 // ----------------------------------------------------------------------
-LIBPROTOBUF_EXPORT void JoinStrings(const vector<string>& components,
+LIBPROTOBUF_EXPORT void JoinStrings(const std::vector<string>& components,
                                     const char* delim, string* result);
 
-inline string JoinStrings(const vector<string>& components,
+inline string JoinStrings(const std::vector<string>& components,
                           const char* delim) {
   string result;
   JoinStrings(components, delim, &result);
@@ -285,15 +285,15 @@ inline string JoinStrings(const vector<string>& components,
 //
 //    Errors: In the first form of the call, errors are reported with
 //    LOG(ERROR). The same is true for the second form of the call if
-//    the pointer to the string vector is NULL; otherwise, error
-//    messages are stored in the vector. In either case, the effect on
+//    the pointer to the string std::vector is NULL; otherwise, error
+//    messages are stored in the std::vector. In either case, the effect on
 //    the dest array is not defined, but rest of the source will be
 //    processed.
 //    ----------------------------------------------------------------------
 
 LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest);
 LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest,
-                                                vector<string> *errors);
+                                                std::vector<string> *errors);
 
 // ----------------------------------------------------------------------
 // UnescapeCEscapeString()
@@ -312,7 +312,7 @@ LIBPROTOBUF_EXPORT int UnescapeCEscapeSequences(const char* source, char* dest,
 
 LIBPROTOBUF_EXPORT int UnescapeCEscapeString(const string& src, string* dest);
 LIBPROTOBUF_EXPORT int UnescapeCEscapeString(const string& src, string* dest,
-                                             vector<string> *errors);
+                                             std::vector<string> *errors);
 LIBPROTOBUF_EXPORT string UnescapeCEscapeString(const string& src);
 
 // ----------------------------------------------------------------------

--- a/src/google/protobuf/stubs/strutil_unittest.cc
+++ b/src/google/protobuf/stubs/strutil_unittest.cc
@@ -782,7 +782,7 @@ TEST(Base64, EscapeAndUnescape) {
       reinterpret_cast<const unsigned char*>(base64_strings[i].plaintext);
     int plain_length = strlen(base64_strings[i].plaintext);
     int cypher_length = strlen(base64_strings[i].cyphertext);
-    vector<char> buffer(cypher_length+1);
+    std::vector<char> buffer(cypher_length+1);
     int encode_length = WebSafeBase64Escape(unsigned_plaintext,
                                                      plain_length,
                                                      &buffer[0],

--- a/src/google/protobuf/stubs/type_traits_unittest.cc
+++ b/src/google/protobuf/stubs/type_traits_unittest.cc
@@ -253,7 +253,7 @@ TEST(TypeTraitsTest, TestIsPointer) {
   EXPECT_TRUE(is_pointer<const void* volatile>::value);
   EXPECT_TRUE(is_pointer<char** const volatile>::value);
   EXPECT_FALSE(is_pointer<const int>::value);
-  EXPECT_FALSE(is_pointer<volatile vector<int*> >::value);
+  EXPECT_FALSE(is_pointer<volatile std::vector<int*> >::value);
   EXPECT_FALSE(is_pointer<const volatile double>::value);
 }
 

--- a/src/google/protobuf/testing/googletest.cc
+++ b/src/google/protobuf/testing/googletest.cc
@@ -263,7 +263,7 @@ ScopedMemoryLog::~ScopedMemoryLog() {
   active_log_ = NULL;
 }
 
-const vector<string>& ScopedMemoryLog::GetMessages(LogLevel level) {
+const std::vector<string>& ScopedMemoryLog::GetMessages(LogLevel level) {
   GOOGLE_CHECK(level == ERROR ||
                level == WARNING);
   return messages_[level];

--- a/src/google/protobuf/testing/googletest.h
+++ b/src/google/protobuf/testing/googletest.h
@@ -83,10 +83,10 @@ class ScopedMemoryLog {
   virtual ~ScopedMemoryLog();
 
   // Fetches all messages with the given severity level.
-  const vector<string>& GetMessages(LogLevel error);
+  const std::vector<string>& GetMessages(LogLevel error);
 
  private:
-  std::map<LogLevel, vector<string> > messages_;
+  std::map<LogLevel, std::vector<string> > messages_;
   LogHandler* old_handler_;
 
   static void HandleLog(LogLevel level, const char* filename, int line,

--- a/src/google/protobuf/util/delimited_message_util.cc
+++ b/src/google/protobuf/util/delimited_message_util.cc
@@ -12,7 +12,7 @@ bool SerializeDelimitedToFileDescriptor(const MessageLite& message, int file_des
   return SerializeDelimitedToZeroCopyStream(message, &output);
 }
 
-bool SerializeDelimitedToOstream(const MessageLite& message, ostream* output) {
+bool SerializeDelimitedToOstream(const MessageLite& message, std::ostream* output) {
   {
     io::OstreamOutputStream zero_copy_output(output);
     if (!SerializeDelimitedToZeroCopyStream(message, &zero_copy_output)) return false;

--- a/src/google/protobuf/util/delimited_message_util.h
+++ b/src/google/protobuf/util/delimited_message_util.h
@@ -32,7 +32,7 @@ namespace util {
 // underlying source, so instead you must keep using the same stream object.
 bool LIBPROTOBUF_EXPORT SerializeDelimitedToFileDescriptor(const MessageLite& message, int file_descriptor);
 
-bool LIBPROTOBUF_EXPORT SerializeDelimitedToOstream(const MessageLite& message, ostream* output);
+bool LIBPROTOBUF_EXPORT SerializeDelimitedToOstream(const MessageLite& message, std::ostream* output);
 
 // Read a single size-delimited message from the given stream. Delimited
 // format allows a single file or stream to contain multiple messages,


### PR DESCRIPTION
These statements pulled a bunch of symbols from the std namespace into
the global namespace. This commit removes all of them except for
std::string, which is a bit trickier to remove.