### PR TITLE
Java TestUtil.readTextFromFile(): normalize CR-LF to LF

### DIFF
--- a/java/core/src/test/java/com/google/protobuf/TestUtil.java
+++ b/java/core/src/test/java/com/google/protobuf/TestUtil.java
@@ -3775,7 +3775,7 @@ public final class TestUtil {
    * {@link #getTestDataDir}.
    */
   public static String readTextFromFile(String filePath) {
-    return readBytesFromFile(filePath).toStringUtf8();
+    return readBytesFromFile(filePath).toStringUtf8().replace("\r\n", "\n");
   }
 
   private static File getTestDataDir() {


### PR DESCRIPTION
(allows TextFormatTest to pass on Windows too)