### PR TITLE
Remove broken link to code.google.com/p/protorpc

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -110,7 +110,6 @@ GRPC (http://www.grpc.io/) is Google's RPC implementation for Protocol Buffers. 
 * http://code.google.com/p/cxf-protobuf/ (Java)
 * http://code.google.com/p/protobuf-remote/ (C++/C#)
 * http://code.google.com/p/protobuf-rpc-pro/ (Java)
-* https://code.google.com/p/protorpc/ (Go/C++)
 * https://code.google.com/p/eneter-protobuf-serializer/ (Java/.NET)
 * http://www.deltavsoft.com/RCFProto.html (C++/Java/Python/C#)
 * https://github.com/robbinfan/claire-protorpc (C++)


### PR DESCRIPTION
Remove broken link to RPC implementation https://code.google.com/p/protorpc/. Going to this URL displays a 404 error message, with no indication that the project has a new location or still exists.