### PR TITLE
Create std::string in Arena memory

### DIFF
--- a/src/google/protobuf/arenastring.h
+++ b/src/google/protobuf/arenastring.h
@@ -322,10 +322,8 @@ struct LIBPROTOBUF_EXPORT ArenaStringPtr {
   void CreateInstance(::google::protobuf::Arena* arena,
                       const ::std::string* initial_value) {
     GOOGLE_DCHECK(initial_value != NULL);
-    ptr_ = new ::std::string(*initial_value);
-    if (arena != NULL) {
-      arena->Own(ptr_);
-    }
+    // uses "new ::std::string" when arena is nullptr
+    ptr_ = Arena::Create<::std::string>(arena, *initial_value);
   }
   GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE
   void CreateInstanceNoArena(const ::std::string* initial_value) {

--- a/src/google/protobuf/arenastring.h
+++ b/src/google/protobuf/arenastring.h
@@ -323,7 +323,7 @@ struct LIBPROTOBUF_EXPORT ArenaStringPtr {
                       const ::std::string* initial_value) {
     GOOGLE_DCHECK(initial_value != NULL);
     // uses "new ::std::string" when arena is nullptr
-    ptr_ = Arena::Create<::std::string>(arena, *initial_value);
+    ptr_ = Arena::Create< ::std::string >(arena, *initial_value);
   }
   GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE
   void CreateInstanceNoArena(const ::std::string* initial_value) {


### PR DESCRIPTION
Instead of just owned by the Arena, std::string objects are now created in the Arena memory.
String payload that exceeds the small string optimization is still allocated on the heap.

As the lifetime of strings was already bound to the lifetime of the Arena, this should not require any other changes.

I ran the benchmarks on a Ryzen 5 1600 with gcc-7.2 and clang-5.0 with default compiler flags and had an average improvement of ~8% on the *_parse_newarena tests.

On the top end, the speed of _google_message3_2_parse_newarena_ and _google_message2_parse_newarena_ improved by 15% while  _google_message3_4_parse_newarena_ had only 1% speed improvement.

Despite the fact that I disabled speed stepping, the variations were quite high.