### PR TITLE
Adds better Ruby error messages for TypeErrors by including the field name

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -72,7 +72,7 @@ static VALUE table_key(Map* self, VALUE key,
     case UPB_TYPE_STRING:
       // Strings: use string content directly.
       Check_Type(key, T_STRING);
-      key = native_slot_encode_and_freeze_string(self->key_type, key);
+      key = native_slot_encode_and_freeze_string(self->field_name, self->key_type, key);
       *out_key = RSTRING_PTR(key);
       *out_length = RSTRING_LEN(key);
       break;
@@ -82,7 +82,7 @@ static VALUE table_key(Map* self, VALUE key,
     case UPB_TYPE_INT64:
     case UPB_TYPE_UINT32:
     case UPB_TYPE_UINT64:
-      native_slot_set(self->key_type, Qnil, buf, key);
+      native_slot_set(self->field_name, self->key_type, Qnil, buf, key);
       *out_key = buf;
       *out_length = native_slot_size(self->key_type);
       break;
@@ -396,7 +396,7 @@ VALUE Map_index_set(VALUE _self, VALUE key, VALUE value) {
   key = table_key(self, key, keybuf, &keyval, &length);
 
   mem = value_memory(&v);
-  native_slot_set(self->value_type, self->value_type_class, mem, value);
+  native_slot_set(self->field_name, self->value_type, self->value_type_class, mem, value);
 
   // Replace any existing value by issuing a 'remove' operation first.
   upb_strtable_remove2(&self->table, keyval, length, NULL);

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -288,14 +288,16 @@ VALUE Builder_finalize_to_pool(VALUE _self, VALUE pool_rb);
 #define NATIVE_SLOT_MAX_SIZE sizeof(uint64_t)
 
 size_t native_slot_size(upb_fieldtype_t type);
-void native_slot_set(upb_fieldtype_t type,
+void native_slot_set(const char* field_name,
+                     upb_fieldtype_t type,
                      VALUE type_class,
                      void* memory,
                      VALUE value);
 // Atomically (with respect to Ruby VM calls) either update the value and set a
 // oneof case, or do neither. If |case_memory| is null, then no case value is
 // set.
-void native_slot_set_value_and_case(upb_fieldtype_t type,
+void native_slot_set_value_and_case(const char* field_name,
+                                    upb_fieldtype_t type,
                                     VALUE type_class,
                                     void* memory,
                                     VALUE value,
@@ -310,8 +312,8 @@ void native_slot_dup(upb_fieldtype_t type, void* to, void* from);
 void native_slot_deep_copy(upb_fieldtype_t type, void* to, void* from);
 bool native_slot_eq(upb_fieldtype_t type, void* mem1, void* mem2);
 
-VALUE native_slot_encode_and_freeze_string(upb_fieldtype_t type, VALUE value);
-void native_slot_check_int_range_precision(upb_fieldtype_t type, VALUE value);
+VALUE native_slot_encode_and_freeze_string(const char* name, upb_fieldtype_t type, VALUE value);
+void native_slot_check_int_range_precision(const char* name, upb_fieldtype_t type, VALUE value);
 
 extern rb_encoding* kRubyStringUtf8Encoding;
 extern rb_encoding* kRubyStringASCIIEncoding;
@@ -342,6 +344,7 @@ const upb_fielddef* map_entry_value(const upb_msgdef* msgdef);
 // -----------------------------------------------------------------------------
 
 typedef struct {
+  const char* field_name;
   upb_fieldtype_t field_type;
   VALUE field_type_class;
   void* elements;
@@ -391,6 +394,7 @@ void validate_type_class(upb_fieldtype_t type, VALUE klass);
 typedef struct {
   upb_fieldtype_t key_type;
   upb_fieldtype_t value_type;
+  const char* field_name;
   VALUE value_type_class;
   VALUE parse_frame;
   upb_strtable table;

--- a/ruby/ext/google/protobuf_c/repeated_field.c
+++ b/ruby/ext/google/protobuf_c/repeated_field.c
@@ -44,6 +44,7 @@ VALUE cRepeatedField;
 RepeatedField* ruby_to_RepeatedField(VALUE _self) {
   RepeatedField* self;
   TypedData_Get_Struct(_self, RepeatedField, &RepeatedField_type, self);
+  self->field_name = "TODO";
   return self;
 }
 
@@ -178,7 +179,7 @@ VALUE RepeatedField_index_set(VALUE _self, VALUE _index, VALUE val) {
   }
 
   memory = RepeatedField_memoryat(self, index, element_size);
-  native_slot_set(field_type, field_type_class, memory, val);
+  native_slot_set(self->field_name, field_type, field_type_class, memory, val);
   return Qnil;
 }
 
@@ -217,7 +218,7 @@ VALUE RepeatedField_push(VALUE _self, VALUE val) {
 
   RepeatedField_reserve(self, self->size + 1);
   memory = (void *) (((uint8_t *)self->elements) + self->size * element_size);
-  native_slot_set(field_type, self->field_type_class, memory, val);
+  native_slot_set(self->field_name, field_type, self->field_type_class, memory, val);
   // native_slot_set may raise an error; bump size only after set.
   self->size++;
   return _self;

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -261,6 +261,7 @@ module BasicTest
       e = assert_raise NoMethodError do
         TestMessage.new.hello = "world"
       end
+
       assert_match(/hello/, e.message)
     end
 
@@ -283,33 +284,45 @@ module BasicTest
 
     def test_type_errors
       m = TestMessage.new
-      assert_raise TypeError do
+      e = assert_raise TypeError do
         m.optional_int32 = "hello"
       end
-      assert_raise TypeError do
+      assert_equal e.message, "Expected number type for integral field: optional_int32"
+
+      e = assert_raise TypeError do
         m.optional_string = 42
       end
-      assert_raise TypeError do
+      assert_equal e.message, "Invalid argument for string field: optional_string"
+
+      e = assert_raise TypeError do
         m.optional_string = nil
       end
-      assert_raise TypeError do
+      assert_equal e.message, "Invalid argument for string field: optional_string"
+
+      e = assert_raise TypeError do
         m.optional_bool = 42
       end
-      assert_raise TypeError do
+      assert_equal e.message, "Invalid argument for boolean field: optional_bool"
+
+      e = assert_raise TypeError do
         m.optional_msg = TestMessage.new  # expects TestMessage2
       end
+      assert_equal e.message, "Invalid type BasicTest::TestMessage to assign to submessage field: optional_msg"
 
-      assert_raise TypeError do
+      e = assert_raise TypeError do
         m.repeated_int32 = []  # needs RepeatedField
       end
+      assert_equal e.message, "Expected repeated field array"
 
-      assert_raise TypeError do
+      e = assert_raise TypeError do
         m.repeated_int32.push "hello"
       end
+      assert_equal e.message, "Expected number type for integral field: foo" # TODO
 
-      assert_raise TypeError do
+      e = assert_raise TypeError do
         m.repeated_msg.push TestMessage.new
       end
+      assert_equal e.message, "Invalid type BasicTest::TestMessage to assign to submessage field: foo" # TODO
     end
 
     def test_string_encoding


### PR DESCRIPTION
Currently the TypeErrors thrown by the generated classes do not include the field name in the error description, which can make debugging these issues a matter of bisecting messages until the error is repeatable. Including the name of the field in the TypeErrors thrown by these classes helps immensely with their debug-ability.

I've added extra tests to demonstrate this new behavior, but wanted to get some feedback before tackling the field names for the RepeatedField and Map type containers, neither of which currently hold their field name. If the above approach for primitives seems sane, I'd love some guidance on how to add the field names to those type containers so they can be passed to the type checkers for richer error messages.

* TODO: Add field name for repeated fields and maps (anything using the typed field containers)
* TODO: jRuby support. I am happy to add the jRuby support here as well once we everyone is onboard with this change.