### PR TITLE
Allows the Ruby json marshaller to be passed json marshal options

### DIFF
--- a/ruby/lib/google/protobuf.rb
+++ b/ruby/lib/google/protobuf.rb
@@ -60,8 +60,8 @@ module Google
       msg.to_proto
     end
 
-    def self.encode_json(msg)
-      msg.to_json
+    def self.encode_json(msg, options = {})
+      msg.to_json(options)
     end
 
     def self.decode(klass, proto)

--- a/ruby/lib/google/protobuf/message_exts.rb
+++ b/ruby/lib/google/protobuf/message_exts.rb
@@ -40,8 +40,8 @@ module Google
       module ClassMethods
       end
 
-      def to_json
-        self.class.encode_json(self)
+      def to_json(options = {})
+        self.class.encode_json(self, options)
       end
 
       def to_proto

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -60,4 +60,28 @@ class EncodeDecodeTest < Test::Unit::TestCase
     to = A::B::C::TestMessage.encode(m.oneof_msg)
     assert_equal '', to
   end
+
+  def test_encode_json
+    msg = A::B::C::TestMessage.new({ optional_int32: 22 })
+    json = msg.to_json
+
+    to = A::B::C::TestMessage.decode_json(json)
+    assert_equal to.optional_int32, 22
+
+    msg = A::B::C::TestMessage.new({ optional_int32: 22 })
+    json = msg.to_json({ preserve_proto_fieldnames: true })
+
+    assert_match 'optional_int32', json
+
+    to = A::B::C::TestMessage.decode_json(json)
+    assert_equal 22, to.optional_int32
+
+    msg = A::B::C::TestMessage.new({ optional_int32: 22 })
+    json = A::B::C::TestMessage.encode_json(
+      msg,
+      { preserve_proto_fieldnames: true, emit_defaults: true }
+    )
+
+    assert_match 'optional_int32', json
+  end
 end


### PR DESCRIPTION
The JSON marshaller accepts both the preseve_field_names and emit_defaults options in the C bindings, but these options are not easily exposed to the Ruby encode/decode methods. This PR adds an options hash, empty by default, that can be used to pass options at runtime.