### PR TITLE
Bazel: Support building with Java 9

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,17 @@ licenses(["notice"])
 exports_files(["LICENSE"])
 
 ################################################################################
+# Java 9 configuration
+################################################################################
+
+config_setting(
+    name = "jdk9",
+    values = {
+        "java_toolchain": "@bazel_tools//tools/jdk:toolchain_jdk9",
+    },
+)
+
+################################################################################
 # Protobuf Runtime Library
 ################################################################################
 
@@ -608,7 +619,10 @@ java_library(
     ]) + [
         ":gen_well_known_protos_java",
     ],
-    javacopts = ["-source 7", "-target 7"],
+    javacopts = select({
+       "//:jdk9": ["--add-modules=jdk.unsupported"],
+       "//conditions:default": ["-source 7", "-target 7"],
+    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Fixes: #4256.

Bazel@HEAD supports Java 9.

The current code has one single issue with Java 9 compliance: the usage
of sun.misc package. We add sun.misc module with --add-modules compiler
option for now. Long term, the usage of non poblic API should be
avoided.

To build (or test) with Java 9, build custom bazel version and issue:

  $ bazel --host_javabase=/usr/lib64/jvm/java-9-openjdk build \
    --javacopt='--release 9' \
    --java_toolchain=@bazel_tools//tools/jdk:toolchain_jdk9 \
   :protobuf_java