### PR TITLE
Only check filenames when end with .py in _CalledFromGeneratedFile()

### DIFF
--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -115,7 +115,7 @@ bool _CalledFromGeneratedFile(int stacklevel) {
   }
   
   if ((filename_size < 3) || (strcmp(&filename[filename_size - 3], ".py") != 0)) {
-    // Cython is not using .py file and not at global module scope.
+    // Cython's stack does not have .py file name and is not at global module scope.
     return true;
   }
   
@@ -123,7 +123,6 @@ bool _CalledFromGeneratedFile(int stacklevel) {
     // filename is too short.
     return false;
   }
-
   if (strcmp(&filename[filename_size - 7], "_pb2.py") != 0) {
     // Filename is not ending with _pb2.
     return false;

--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -105,7 +105,6 @@ bool _CalledFromGeneratedFile(int stacklevel) {
   if (frame->f_code->co_filename == NULL) {
     return false;
   }
-  
   char* filename;
   Py_ssize_t filename_size;
   if (PyString_AsStringAndSize(frame->f_code->co_filename,
@@ -115,7 +114,7 @@ bool _CalledFromGeneratedFile(int stacklevel) {
     return false;
   }
   
-  if (filename_size < 3 or strcmp(&filename[filename_size - 3], ".py") != 0) {
+  if ((filename_size < 3) || (strcmp(&filename[filename_size - 3], ".py") != 0)) {
     // Cython is not using .py file and not at global module scope.
     return true;
   }

--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -127,9 +127,12 @@ bool _CalledFromGeneratedFile(int stacklevel) {
     // filename is too short.
     return false;
   }
-  if (strcmp(&filename[filename_size - 7], "_pb2.py") != 0) {
-    // Filename is not ending with _pb2.
-    return false;
+  // Cython is not using .py file. Only check filenames when end with .py
+  if (strcmp(&filename[filename_size - 3], ".py") == 0) {
+    if (strcmp(&filename[filename_size - 7], "_pb2.py") != 0) {
+      // Filename is not ending with _pb2.
+      return false;
+    }
   }
 #endif
   return true;

--- a/python/google/protobuf/pyext/descriptor.cc
+++ b/python/google/protobuf/pyext/descriptor.cc
@@ -101,7 +101,13 @@ bool _CalledFromGeneratedFile(int stacklevel) {
   if (frame == NULL) {
     return false;
   }
-  
+  while (stacklevel-- > 0) {
+    frame = frame->f_back;
+    if (frame == NULL) {
+      return false;
+    }
+  }
+
   if (frame->f_code->co_filename == NULL) {
     return false;
   }
@@ -113,12 +119,10 @@ bool _CalledFromGeneratedFile(int stacklevel) {
     PyErr_Clear();
     return false;
   }
-  
   if ((filename_size < 3) || (strcmp(&filename[filename_size - 3], ".py") != 0)) {
     // Cython's stack does not have .py file name and is not at global module scope.
     return true;
   }
-  
   if (filename_size < 7) {
     // filename is too short.
     return false;
@@ -128,12 +132,6 @@ bool _CalledFromGeneratedFile(int stacklevel) {
     return false;
   }
   
-  while (stacklevel-- > 0) {
-    frame = frame->f_back;
-    if (frame == NULL) {
-      return false;
-    }
-  }
   if (frame->f_globals != frame->f_locals) {
     // Not at global module scope
     return false;


### PR DESCRIPTION
Cython is not using .py file. Only check filenames when end with .py in _CalledFromGeneratedFile()

Fixes #2896