### PR TITLE
Don't assume c-strings are 4 byte aligned.

### DIFF
--- a/objectivec/GPBDescriptor.m
+++ b/objectivec/GPBDescriptor.m
@@ -548,7 +548,8 @@ uint32_t GPBFieldAlternateTag(GPBFieldDescriptor *self) {
         // descriptor structure.
         const uint8_t *bytes = (const uint8_t *)defaultValue_.valueData;
         if (bytes) {
-          uint32_t length = *((uint32_t *)bytes);
+          uint32_t length;
+          memcpy(&length, bytes, sizeof(length));
           length = ntohl(length);
           bytes += sizeof(length);
           defaultValue_.valueData =
@@ -963,7 +964,8 @@ uint32_t GPBFieldAlternateTag(GPBFieldDescriptor *self) {
       const uint8_t *bytes =
           (const uint8_t *)description->defaultValue.valueData;
       if (bytes) {
-        uint32_t length = *((uint32_t *)bytes);
+        uint32_t length;
+        memcpy(&length, bytes, sizeof(length));
         // The length is stored in network byte order.
         length = ntohl(length);
         bytes += sizeof(length);


### PR DESCRIPTION
The Undefined Behavior sanitizer flags one part of the unittests for this.
For default values for `bytes` we write a length on the front of a c-string
in the static data, apparently the compiler/linker doesn't always make this
4 byte aligned, so it get flagged for undefined/degraded performance. Avoid
this by using memcpy instead.