### PR TITLE
Re-enable GOOGLE_FALLTHROUGH_INTENDED attribute for macOS

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -237,8 +237,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 #define GOOGLE_SAFE_CONCURRENT_WRITES_END()
 #endif
 
-#if defined(__clang__) && defined(__has_cpp_attribute) \
-    && !defined(GOOGLE_PROTOBUF_OS_APPLE)
+#if defined(__clang__) && defined(__has_cpp_attribute)
 # if defined(GOOGLE_PROTOBUF_OS_NACL) || defined(EMSCRIPTEN) || \
      __has_cpp_attribute(clang::fallthrough)
 #  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]


### PR DESCRIPTION
I was able to replicate the error in #3038 and confirmed that this patch fixes the issue. I guess [[clang::fallthrough]] does work for macOS now.