### PR TITLE
Remove use of GOOGLE_FALLTHROUGH_INTENDED from protobuf.

### DIFF
--- a/src/google/protobuf/map_entry_lite.h
+++ b/src/google/protobuf/map_entry_lite.h
@@ -201,8 +201,7 @@ class MapEntryImpl : public Base {
             return false;
           }
           set_has_key();
-          if (!input->ExpectTag(kValueTag)) break;
-          GOOGLE_FALLTHROUGH_INTENDED;
+          break;
 
         case kValueTag:
           if (!ValueTypeHandler::Read(input, mutable_value())) {

--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -237,20 +237,6 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 #define GOOGLE_SAFE_CONCURRENT_WRITES_END()
 #endif
 
-#if defined(__clang__) && defined(__has_cpp_attribute) \
-    && !defined(GOOGLE_PROTOBUF_OS_APPLE)
-# if defined(GOOGLE_PROTOBUF_OS_NACL) || defined(EMSCRIPTEN) || \
-     __has_cpp_attribute(clang::fallthrough)
-#  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]
-# endif
-#elif defined(__GNUC__) && __GNUC__ > 6
-# define GOOGLE_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
-#endif
-
-#ifndef GOOGLE_FALLTHROUGH_INTENDED
-# define GOOGLE_FALLTHROUGH_INTENDED
-#endif
-
 #define GOOGLE_GUARDED_BY(x)
 #define GOOGLE_ATTRIBUTE_COLD
 


### PR DESCRIPTION
Chrome is running into two issues with the use of this macro
in open-source protobuf (https://crbug.com/809157):

1. GOOGLE_FALLTHROUGH_INTENDED is defined to nothing on `__APPLE__`
   platforms, which blocks us from enabling -Wimplicit-fallthrough
   on Mac and iOS. (We use a hermetic self-built modern clang,
   so whatever Xcode bug that exclusion might be for doesn't apply
   to us.)

2. It's in a public header file, and it's included in a public header file.
   When clang suggests adding [[clang::fallthrough]], it checks if it knows of
   a macro expanding to that and if so, suggests inserting that. Since lots of
   chrome code includes protobuf headers, it often suggests inserting
   GOOGLE_FALLTHROUGH_INTENDED (from protobuf) instead of the correct
   FALLTHROUGH (from chrome's base).

Since the fallthrough doens't do anyting useful, just remove it.
Long ago, this might have had perf impact, but d64a2d9941c36a7bc added a
parsing fast path that calls this switch as slow fallback, so it should
be off the hot path nowadays.

No intended behavior change.

This is the public version of internal change 184824132.