### PR TITLE
Fix all warnings that `./test.sh cpp` prints on my Linux box.

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -145,10 +145,6 @@ class CommandLineInterfaceTest : public testing::Test {
   // substring.
   void ExpectErrorSubstring(const string& expected_substring);
 
-  // Like ExpectErrorSubstring, but checks that Run() returned zero.
-  void ExpectErrorSubstringWithZeroReturnCode(
-      const string& expected_substring);
-
   // Checks that the captured stdout is the same as the expected_text.
   void ExpectCapturedStdout(const string& expected_text);
 
@@ -157,9 +153,11 @@ class CommandLineInterfaceTest : public testing::Test {
   void ExpectCapturedStdoutSubstringWithZeroReturnCode(
       const string& expected_substring);
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
   // Returns true if ExpectErrorSubstring(expected_substring) would pass, but
   // does not fail otherwise.
   bool HasAlternateErrorSubstring(const string& expected_substring);
+#endif
 
   // Checks that MockCodeGenerator::Generate() was called in the given
   // context (or the generator in test_plugin.cc, which produces the same
@@ -190,7 +188,9 @@ class CommandLineInterfaceTest : public testing::Test {
                                      const string& message_name);
   void CheckGeneratedAnnotations(const string& name, const string& file);
 
+#if defined(_WIN32)
   void ExpectNullCodeGeneratorCalled(const string& parameter);
+#endif
 
 
   void ReadDescriptorSet(const string& filename,
@@ -413,17 +413,13 @@ void CommandLineInterfaceTest::ExpectErrorSubstring(
   EXPECT_PRED_FORMAT2(testing::IsSubstring, expected_substring, error_text_);
 }
 
-void CommandLineInterfaceTest::ExpectErrorSubstringWithZeroReturnCode(
-    const string& expected_substring) {
-  EXPECT_EQ(0, return_code_);
-  EXPECT_PRED_FORMAT2(testing::IsSubstring, expected_substring, error_text_);
-}
-
+#if defined(_WIN32) && !defined(__CYGWIN__)
 bool CommandLineInterfaceTest::HasAlternateErrorSubstring(
     const string& expected_substring) {
   EXPECT_NE(0, return_code_);
   return error_text_.find(expected_substring) != string::npos;
 }
+#endif
 
 void CommandLineInterfaceTest::ExpectGenerated(
     const string& generator_name,
@@ -473,12 +469,13 @@ void CommandLineInterfaceTest::CheckGeneratedAnnotations(const string& name,
   MockCodeGenerator::CheckGeneratedAnnotations(name, file, temp_directory_);
 }
 
+#if defined(_WIN32)
 void CommandLineInterfaceTest::ExpectNullCodeGeneratorCalled(
     const string& parameter) {
   EXPECT_TRUE(null_generator_->called_);
   EXPECT_EQ(parameter, null_generator_->parameter_);
 }
-
+#endif
 
 void CommandLineInterfaceTest::ReadDescriptorSet(
     const string& filename, FileDescriptorSet* descriptor_set) {

--- a/src/google/protobuf/compiler/cpp/cpp_helpers.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_helpers.cc
@@ -59,10 +59,6 @@ static const char kAnyMessageName[] = "Any";
 static const char kAnyProtoFile[] = "google/protobuf/any.proto";
 static const char kGoogleProtobufPrefix[] = "google/protobuf/";
 
-string DotsToUnderscores(const string& name) {
-  return StringReplace(name, ".", "_", true);
-}
-
 string DotsToColons(const string& name) {
   return StringReplace(name, ".", "::", true);
 }

--- a/src/google/protobuf/compiler/cpp/cpp_message_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_message_field.cc
@@ -45,21 +45,6 @@ namespace cpp {
 
 namespace {
 
-// When we are generating code for implicit weak fields, we need to insert some
-// additional casts. These functions return the casted expression if
-// implicit_weak_field is true but otherwise return the original expression.
-// Ordinarily a static_cast is enough to cast google::protobuf::MessageLite* to a class
-// deriving from it, but we need a reinterpret_cast in cases where the generated
-// message is forward-declared but its full definition is not visible.
-string StaticCast(const string& type, const string& expression,
-                  bool implicit_weak_field) {
-  if (implicit_weak_field) {
-    return "static_cast< " + type + " >(" + expression + ")";
-  } else {
-    return expression;
-  }
-}
-
 string ReinterpretCast(const string& type, const string& expression,
                        bool implicit_weak_field) {
   if (implicit_weak_field) {

--- a/src/google/protobuf/compiler/python/python_generator.cc
+++ b/src/google/protobuf/compiler/python/python_generator.cc
@@ -78,9 +78,6 @@ namespace {
 
 // Reimplemented here because we can't bring in
 // absl/strings/string_view_utils.h because it needs C++11.
-bool StrStartsWith(StringPiece sp, StringPiece x) {
-  return sp.size() >= x.size() && sp.substr(0, x.size()) == x;
-}
 bool StrEndsWith(StringPiece sp, StringPiece x) {
   return sp.size() >= x.size() && sp.substr(sp.size() - x.size()) == x;
 }

--- a/src/google/protobuf/extension_set_unittest.cc
+++ b/src/google/protobuf/extension_set_unittest.cc
@@ -1034,7 +1034,7 @@ TEST(ExtensionSetTest, RepeatedFields) {
            unittest::repeated_nested_enum_extension).begin(),
        enum_const_end  = message.GetRepeatedExtension(
            unittest::repeated_nested_enum_extension).end();
-       enum_iter != enum_end; ++enum_iter) {
+       enum_const_iter != enum_const_end; ++enum_const_iter) {
     ASSERT_EQ(*enum_const_iter, unittest::TestAllTypes::NestedEnum_MAX);
   }
 


### PR DESCRIPTION
Mostly -Wunused-function warnings that are mostly true positives,
but also one -Wunused-but-set-variable that pointed out that one
test wasn't testing what it intended to test.