### PR TITLE
Fix GHS Integrity OS compiler error

### DIFF
--- a/src/google/protobuf/reflection_internal.h
+++ b/src/google/protobuf/reflection_internal.h
@@ -141,6 +141,8 @@ class RepeatedFieldWrapper : public RandomAccessRepeatedFieldAccessor {
 // RepeatedPtrField<T>.
 template<typename T>
 class RepeatedPtrFieldWrapper : public RandomAccessRepeatedFieldAccessor {
+  using RepeatedFieldAccessor::Add;
+
  public:
   RepeatedPtrFieldWrapper() {}
   virtual ~RepeatedPtrFieldWrapper() {}
@@ -303,7 +305,6 @@ class RepeatedFieldPrimitiveAccessor : public RepeatedFieldWrapper<T> {
 class RepeatedPtrFieldStringAccessor : public RepeatedPtrFieldWrapper<string> {
   typedef void Field;
   typedef void Value;
-  using RepeatedFieldAccessor::Add;
 
  public:
   RepeatedPtrFieldStringAccessor() {}


### PR DESCRIPTION
Compiling with Green Hills Integrity compiler will generate the following compiler error:

"..\vendor\protobuf\src\google/protobuf/reflection_internal.h", line 306: error #1001:
          class member designated by a using-declaration must be visible in a
          direct base class
    using RepeatedFieldAccessor::Add;

It appears that Green Hills compiler is more strict than MS Visual Studio or GNU compiler in order to comply with clause 13.3.3/17 of the C++ standard (see http://cpp14.centaur.ath.cx/namespace.udecl.html).