### PR TITLE
Ruby: Allows decode_json to optionally ignore unknown fields

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -246,6 +246,10 @@ void Descriptor_free(void* _self) {
     upb_json_parsermethod_unref(self->json_fill_method,
                                 &self->json_fill_method);
   }
+  if (self->json_fill_method_ignore_unknown) {
+    upb_json_parsermethod_unref(self->json_fill_method_ignore_unknown,
+                                &self->json_fill_method_ignore_unknown);
+  }
   if (self->pb_serialize_handlers) {
     upb_handlers_unref(self->pb_serialize_handlers,
                        &self->pb_serialize_handlers);
@@ -279,6 +283,7 @@ VALUE Descriptor_alloc(VALUE klass) {
   self->fill_handlers = NULL;
   self->fill_method = NULL;
   self->json_fill_method = NULL;
+  self->json_fill_method_ignore_unknown = NULL;
   self->pb_serialize_handlers = NULL;
   self->json_serialize_handlers = NULL;
   self->json_serialize_handlers_preserve = NULL;

--- a/ruby/ext/google/protobuf_c/encode_decode.c
+++ b/ruby/ext/google/protobuf_c/encode_decode.c
@@ -763,12 +763,24 @@ static const upb_pbdecodermethod *msgdef_decodermethod(Descriptor* desc) {
   return desc->fill_method;
 }
 
-static const upb_json_parsermethod *msgdef_jsonparsermethod(Descriptor* desc) {
-  if (desc->json_fill_method == NULL) {
-    desc->json_fill_method =
-        upb_json_parsermethod_new(desc->msgdef, &desc->json_fill_method);
+static const upb_json_parsermethod *msgdef_jsonparsermethod(
+    Descriptor* desc, bool ignore_unknown_fields) {
+
+  if (ignore_unknown_fields) {
+    if (desc->json_fill_method_ignore_unknown == NULL) {
+      desc->json_fill_method_ignore_unknown =
+          upb_json_parsermethod_new(desc->msgdef, &desc->json_fill_method_ignore_unknown, ignore_unknown_fields);
+    }
+
+    return desc->json_fill_method_ignore_unknown;
+  } else {
+    if (desc->json_fill_method == NULL) {
+      desc->json_fill_method =
+          upb_json_parsermethod_new(desc->msgdef, &desc->json_fill_method, ignore_unknown_fields);
+    }
+
+    return desc->json_fill_method;
   }
-  return desc->json_fill_method;
 }
 
 
@@ -860,16 +872,33 @@ VALUE Message_decode(VALUE klass, VALUE data) {
  * format) under the interpretration given by this message class's definition
  * and returns a message object with the corresponding field values.
  */
-VALUE Message_decode_json(VALUE klass, VALUE data) {
+VALUE Message_decode_json(int argc, VALUE* argv, VALUE klass) {
   VALUE descriptor = rb_ivar_get(klass, descriptor_instancevar_interned);
   Descriptor* desc = ruby_to_Descriptor(descriptor);
   VALUE msgklass = Descriptor_msgclass(descriptor);
   VALUE msg_rb;
+  VALUE data;
   MessageHeader* msg;
+  VALUE ignore_unknown_fields = Qfalse;
 
+  if (argc < 1 || argc > 2) {
+    rb_raise(rb_eArgError, "Expected 1 or 2 arguments.");
+  }
+
+  data = argv[0];
   if (TYPE(data) != T_STRING) {
     rb_raise(rb_eArgError, "Expected string for JSON data.");
   }
+
+  if (argc == 2) {
+    VALUE hash_args = argv[1];
+    if (TYPE(hash_args) != T_HASH) {
+      rb_raise(rb_eArgError, "Expected hash arguments.");
+    }
+    ignore_unknown_fields = rb_hash_lookup2(
+        hash_args, ID2SYM(rb_intern("ignore_unknown_fields")), Qfalse);
+  }
+
   // TODO(cfallin): Check and respect string encoding. If not UTF-8, we need to
   // convert, because string handlers pass data directly to message string
   // fields.
@@ -878,7 +907,7 @@ VALUE Message_decode_json(VALUE klass, VALUE data) {
   TypedData_Get_Struct(msg_rb, MessageHeader, &Message_type, msg);
 
   {
-    const upb_json_parsermethod* method = msgdef_jsonparsermethod(desc);
+    const upb_json_parsermethod* method = msgdef_jsonparsermethod(desc, RTEST(ignore_unknown_fields));
     stackenv se;
     upb_sink sink;
     upb_json_parser* parser;

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -561,7 +561,7 @@ VALUE build_class_from_descriptor(Descriptor* desc) {
   rb_define_method(klass, "[]=", Message_index_set, 2);
   rb_define_singleton_method(klass, "decode", Message_decode, 1);
   rb_define_singleton_method(klass, "encode", Message_encode, 1);
-  rb_define_singleton_method(klass, "decode_json", Message_decode_json, 1);
+  rb_define_singleton_method(klass, "decode_json", Message_decode_json, -1);
   rb_define_singleton_method(klass, "encode_json", Message_encode_json, -1);
   rb_define_singleton_method(klass, "descriptor", Message_descriptor, 0);
 

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -113,6 +113,7 @@ struct Descriptor {
   const upb_handlers* fill_handlers;
   const upb_pbdecodermethod* fill_method;
   const upb_json_parsermethod* json_fill_method;
+  const upb_json_parsermethod* json_fill_method_ignore_unknown;
   const upb_handlers* pb_serialize_handlers;
   const upb_handlers* json_serialize_handlers;
   const upb_handlers* json_serialize_handlers_preserve;
@@ -512,7 +513,7 @@ VALUE Message_index_set(VALUE _self, VALUE field_name, VALUE value);
 VALUE Message_descriptor(VALUE klass);
 VALUE Message_decode(VALUE klass, VALUE data);
 VALUE Message_encode(VALUE klass, VALUE msg_rb);
-VALUE Message_decode_json(VALUE klass, VALUE data);
+VALUE Message_decode_json(int argc, VALUE* argv, VALUE klass);
 VALUE Message_encode_json(int argc, VALUE* argv, VALUE klass);
 
 VALUE Google_Protobuf_discard_unknown(VALUE self, VALUE msg_rb);

--- a/ruby/ext/google/protobuf_c/upb.h
+++ b/ruby/ext/google/protobuf_c/upb.h
@@ -4943,7 +4943,7 @@ struct Func5 : public UnboundFunc {
 
 /* BoundFunc2, BoundFunc3: Like Func2/Func3 except also contains a value that
  * shall be bound to the function's second parameter.
- * 
+ *
  * Note that the second parameter is a const pointer, but our stored bound value
  * is non-const so we can free it when the handlers are destroyed. */
 template <class T>
@@ -8840,7 +8840,7 @@ upb_json_parser* upb_json_parser_create(upb_env* e,
 upb_bytessink *upb_json_parser_input(upb_json_parser *p);
 
 upb_json_parsermethod* upb_json_parsermethod_new(const upb_msgdef* md,
-                                                 const void* owner);
+                                                 const void* owner, bool ignore_unknown_fields);
 const upb_handlers *upb_json_parsermethod_desthandlers(
     const upb_json_parsermethod *m);
 const upb_byteshandler *upb_json_parsermethod_inputhandler(
@@ -8872,7 +8872,7 @@ inline const BytesHandler* ParserMethod::input_handler() const {
 /* static */
 inline reffed_ptr<const ParserMethod> ParserMethod::New(
     const MessageDef* md) {
-  const upb_json_parsermethod *m = upb_json_parsermethod_new(md, &m);
+  const upb_json_parsermethod *m = upb_json_parsermethod_new(md, &m, false);
   return reffed_ptr<const ParserMethod>(m, &m);
 }
 

--- a/ruby/lib/google/protobuf.rb
+++ b/ruby/lib/google/protobuf.rb
@@ -68,8 +68,8 @@ module Google
       klass.decode(proto)
     end
 
-    def self.decode_json(klass, json)
-      klass.decode_json(json)
+    def self.decode_json(klass, json, options = {})
+      klass.decode_json(json, options)
     end
 
   end

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -973,6 +973,16 @@ module BasicTest
       assert_equal TestMessage.decode_json(m.to_json), decoded_msg
     end
 
+    def test_protobuf_decode_json_ignore_unknown_fields
+      m = TestMessage.decode_json({ optional_string: "foo", not_in_message: "some_value" }.to_json, { ignore_unknown_fields: true })
+      assert_equal m.optional_string, "foo"
+
+      e = assert_raise Google::Protobuf::ParseError do
+        TestMessage.decode_json({ not_in_message: "some_value" }.to_json)
+      end
+      assert_match(/No such field: not_in_message/, e.message)
+    end
+
     def test_to_h
       m = TestMessage.new(:optional_bool => true, :optional_double => -10.100001, :optional_string => 'foo', :repeated_string => ['bar1', 'bar2'], :repeated_msg => [TestMessage2.new(:foo => 100)])
       expected_result = {


### PR DESCRIPTION
Currently the json parser raises a ParseError in the case that an
unexpected field is present. To better preserve forwards and backwards
compatible changes, an option to ignore these unknown fields can be
passed to decode_json. This fixes a long standing TODO by @haberman 
and adopts functionality already present in the json parsers for Go, C++, 
and Java.

Fixes #4251

I've noticed that this same upb code is used for PHP and in a standalone library. Should I make changes to those projects in addition?