### PR TITLE
Revise package name parsing to reject whitespace

### DIFF
--- a/src/google/protobuf/compiler/parser.h
+++ b/src/google/protobuf/compiler/parser.h
@@ -193,6 +193,10 @@ class LIBPROTOBUF_EXPORT Parser {
   bool ConsumeEndOfDeclaration(
       const char* text, const LocationRecorder* location);
 
+  // Check the current token to see if whitespace preceded it. If so, report
+  // the given error message.
+  bool HasNoPrecedingWhitespace(const char *error);
+
   // -----------------------------------------------------------------
   // Error logging helpers
 

--- a/src/google/protobuf/compiler/parser_unittest.cc
+++ b/src/google/protobuf/compiler/parser_unittest.cc
@@ -1105,13 +1105,6 @@ TEST_F(ParseMiscTest, ParsePackage) {
     "package: \"foo.bar.baz\"");
 }
 
-TEST_F(ParseMiscTest, ParsePackageWithSpaces) {
-  ExpectParsesTo(
-    "package foo   .   bar.  \n"
-    "  baz;\n",
-    "package: \"foo.bar.baz\"");
-}
-
 // ===================================================================
 // options
 
@@ -1675,6 +1668,15 @@ TEST_F(ParseErrorTest, MultiplePackagesInFile) {
     "package foo;\n"
     "package bar;\n",
     "1:0: Multiple package definitions.\n");
+}
+
+TEST_F(ParseErrorTest, ParsePackageWithSpaces) {
+  ExpectHasErrors(
+    "package foo   .   bar.  \n"
+    "  baz;\n",
+    "0:12: Unexpected whitespace.\n"
+    "0:16: Unexpected whitespace.\n"
+    "0:23: Unexpected whitespace.\n");
 }
 
 // ===================================================================

--- a/src/google/protobuf/io/tokenizer.cc
+++ b/src/google/protobuf/io/tokenizer.cc
@@ -563,6 +563,8 @@ bool Tokenizer::Next() {
   previous_ = current_;
 
   while (!read_error_) {
+    // Keep track of whether or not there was whitespace before this token.
+    current_.follows_whitespace = LookingAt<Whitespace>();
     ConsumeZeroOrMore<Whitespace>();
 
     switch (TryConsumeCommentStart()) {

--- a/src/google/protobuf/io/tokenizer.h
+++ b/src/google/protobuf/io/tokenizer.h
@@ -85,9 +85,9 @@ class LIBPROTOBUF_EXPORT ErrorCollector {
 // This class converts a stream of raw text into a stream of tokens for
 // the protocol definition parser to parse.  The tokens recognized are
 // similar to those that make up the C language; see the TokenType enum for
-// precise descriptions.  Whitespace and comments are skipped.  By default,
-// C- and C++-style comments are recognized, but other styles can be used by
-// calling set_comment_style().
+// precise descriptions.  Comments are skipped. By default, C- and C++-style
+// comments are recognized, but other styles can be used by calling
+// set_comment_style().
 class LIBPROTOBUF_EXPORT Tokenizer {
  public:
   // Construct a Tokenizer that reads and tokenizes text from the given
@@ -133,6 +133,20 @@ class LIBPROTOBUF_EXPORT Tokenizer {
     int line;
     ColumnNumber column;
     ColumnNumber end_column;
+
+    // Record the presence of whitespace before this token. The parser can use
+    // this to reject tokens that contain whitespace between them. This is
+    // recorded on the token because the whitespace is parsed before the symbol
+    // itself, but we may need to know what the symbol is to know if whitespace
+    // was allowed!
+    //
+    // For example, consider the statement "package com.google.protobuf ;".
+    // Whitespace should be allowed between the "protobuf" and ";" tokens, but
+    // when Next() is called after "protobuf", we can't just report an error as
+    // soon as we see the following whitespace.  That's because we don't yet
+    // know if the next token is part of the identifier (a dot) or the end of
+    // the fullIdent (a semicolon).
+    bool follows_whitespace;
   };
 
   // Get the current token.  This is updated when Next() is called.  Before


### PR DESCRIPTION
Fixes issue #2128. Hope this hasn't been fixed internally already, I assumed it hadn't since the issue was last updated almost a year ago. Feel free to review @haberman.

There are a few ways to fix this, but I decided to leave this whitespace handling to the parser instead of the tokenizer. I tried adding support for fullIdent tokens to the tokenizer, but realized I'd need to add additional support for option names as well, and felt this was stepping too far into what the parser should be doing. The solution I ended on here allows the tokenizer to mark whether or not whitespace was present before it, and the parser can use that information as it wishes. Right now I've only added this support to package parsing, but this support can also be extended to option names (where this bug is also present.)

Also, I had to modify the ParsePackageWithSpaces unit test, which was actually testing to make sure this bug existed! I think we should instead be checking for failure on this case, so I modified the unit test to reflect that.