### PR TITLE
js message support for jstype string on integers

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -939,6 +939,17 @@ jspb.Message.setProto3IntField = function(msg, fieldNumber, value) {
 
 
 /**
+ * Sets the value of a non-extension integer, handled as string, field of a proto3
+ * @param {!jspb.Message} msg A jspb proto.
+ * @param {number} fieldNumber The field number.
+ * @param {number} value New value
+ * @protected
+ */
+jspb.Message.setProto3StringIntField = function(msg, fieldNumber, value) {
+  jspb.Message.setFieldIgnoringDefault_(msg, fieldNumber, value, '0');
+};
+
+/**
  * Sets the value of a non-extension floating point field of a proto3
  * @param {!jspb.Message} msg A jspb proto.
  * @param {number} fieldNumber The field number.


### PR DESCRIPTION
Naive attempt to fix #4025. I'm not familiar with how to test a fork of an npm package, so any guidance on that would be great.