### PR TITLE
`update_file_lists.sh` depends on Bash features, thus needs Bash sebang.

### DIFF
--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script copies source file lists from src/Makefile.am to cmake files.
 


### PR DESCRIPTION
I noticed that running this script as `./update_file_lists.sh` on MacOS
was corrupting `cmake/extract_includes.bat.in`. Forcing the shell to
Bash fixes the generated file output.