### PR TITLE
Add --fatal_warnings flag to treat warnings as errors

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -277,7 +277,7 @@ class CommandLineInterface::ErrorPrinter
       public DescriptorPool::ErrorCollector {
  public:
   ErrorPrinter(ErrorFormat format, DiskSourceTree *tree = NULL)
-    : format_(format), tree_(tree), found_errors_(false) {}
+    : format_(format), tree_(tree), found_errors_(false), found_warnings_(false) {}
   ~ErrorPrinter() {}
 
   // implements MultiFileErrorCollector ------------------------------
@@ -289,6 +289,7 @@ class CommandLineInterface::ErrorPrinter
 
   void AddWarning(const string& filename, int line, int column,
                   const string& message) {
+    found_warnings_ = true;
     AddErrorOrWarning(filename, line, column, message, "warning", std::clog);
   }
 
@@ -321,6 +322,8 @@ class CommandLineInterface::ErrorPrinter
   }
 
   bool FoundErrors() const { return found_errors_; }
+
+  bool FoundWarnings() const { return found_warnings_; }
 
  private:
   void AddErrorOrWarning(const string& filename, int line, int column,
@@ -361,6 +364,7 @@ class CommandLineInterface::ErrorPrinter
   const ErrorFormat format_;
   DiskSourceTree *tree_;
   bool found_errors_;
+  bool found_warnings_;
 };
 
 // -------------------------------------------------------------------
@@ -787,6 +791,7 @@ CommandLineInterface::CommandLineInterface()
     : mode_(MODE_COMPILE),
       print_mode_(PRINT_NONE),
       error_format_(ERROR_FORMAT_GCC),
+      fatal_warnings_(false),
       direct_dependencies_explicitly_set_(false),
       direct_dependencies_violation_msg_(
           kDefaultDirectDependenciesViolationMsg),
@@ -953,7 +958,8 @@ int CommandLineInterface::Run(int argc, const char* const argv[]) {
     }
   }
 
-  if (error_collector->FoundErrors()) {
+  if (error_collector->FoundErrors() ||
+      (fatal_warnings_ && error_collector->FoundWarnings())) {
     return 1;
   }
 
@@ -1355,7 +1361,8 @@ bool CommandLineInterface::ParseArgument(const char* arg,
       *name == "--include_source_info" ||
       *name == "--version" ||
       *name == "--decode_raw" ||
-      *name == "--print_free_field_numbers") {
+      *name == "--print_free_field_numbers" ||
+      *name == "--fatal_warnings") {
     // HACK:  These are the only flags that don't take a value.
     //   They probably should not be hard-coded like this but for now it's
     //   not worth doing better.
@@ -1588,6 +1595,12 @@ CommandLineInterface::InterpretArgument(const string& name,
       return PARSE_ARGUMENT_FAIL;
     }
 
+  } else if (name == "--fatal_warnings") {
+    if (fatal_warnings_) {
+      std::cerr << name << " may only be passed once." << std::endl;
+      return PARSE_ARGUMENT_FAIL;
+    }
+    fatal_warnings_ = true;
   } else if (name == "--plugin") {
     if (plugin_prefix_.empty()) {
       std::cerr << "This compiler does not support plugins." << std::endl;

--- a/src/google/protobuf/compiler/command_line_interface.h
+++ b/src/google/protobuf/compiler/command_line_interface.h
@@ -374,6 +374,9 @@ class LIBPROTOC_EXPORT CommandLineInterface {
 
   ErrorFormat error_format_;
 
+  // True if we should treat warnings as errors that fail the compilation.
+  bool fatal_warnings_;
+
   std::vector<std::pair<string, string> >
       proto_path_;                   // Search path for proto files.
   std::vector<string> input_files_;  // Names of the input proto files.

--- a/src/google/protobuf/compiler/command_line_interface_unittest.cc
+++ b/src/google/protobuf/compiler/command_line_interface_unittest.cc
@@ -132,6 +132,9 @@ class CommandLineInterfaceTest : public testing::Test {
   // -----------------------------------------------------------------
   // Methods to check the test results (called after Run()).
 
+  // Checks that Run() returned code r.
+  void ExpectReturnCode(int r);
+
   // Checks that no text was written to stderr during Run(), and Run()
   // returned 0.
   void ExpectNoErrors();
@@ -395,6 +398,10 @@ void CommandLineInterfaceTest::CreateTempDir(const string& name) {
 }
 
 // -------------------------------------------------------------------
+
+void CommandLineInterfaceTest::ExpectReturnCode(int r) {
+  EXPECT_EQ(r, return_code_);
+}
 
 void CommandLineInterfaceTest::ExpectNoErrors() {
   EXPECT_EQ(0, return_code_);
@@ -2087,11 +2094,31 @@ TEST_F(CommandLineInterfaceTest, InvalidErrorFormat) {
     "syntax = \"proto2\";\n"
     "badsyntax\n");
 
-  Run("protocol_compiler --test_out=$tmpdir "
-      "--proto_path=$tmpdir --error_format=invalid foo.proto");
+  Run("protocol_compiler --test_out=$tmpdir --proto_path=$tmpdir foo.proto");
 
   ExpectErrorText(
     "Unknown error format: invalid\n");
+}
+
+TEST_F(CommandLineInterfaceTest, Warnings) {
+  // Test --fatal_warnings.
+
+  CreateTempFile("foo.proto",
+    "syntax = \"proto2\";\n"
+    "import \"bar.proto\";\n");
+  CreateTempFile("bar.proto",
+    "syntax = \"proto2\";\n");
+
+  Run("protocol_compiler --test_out=$tmpdir "
+    "--proto_path=$tmpdir foo.proto");
+  ExpectReturnCode(0);
+  ExpectErrorSubstringWithZeroReturnCode(
+    "foo.proto: warning: Import bar.proto but not used.");
+
+  Run("protocol_compiler --test_out=$tmpdir --fatal_warnings "
+    "--proto_path=$tmpdir foo.proto");
+  ExpectErrorSubstring(
+    "foo.proto: warning: Import bar.proto but not used.");
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Add a --fatal_warnings flag that requests that protoc exit with a failing status code if any warnings are generated during compilation.

Partially address #3980.

/cc @pherl

