### PR TITLE
Use LIBPROTOBUF_EXPORT for DLL import/export macros in plugin.pb.h

### DIFF
--- a/generate_descriptor_proto.sh
+++ b/generate_descriptor_proto.sh
@@ -31,6 +31,7 @@ cd src
 declare -a RUNTIME_PROTO_FILES=(\
   google/protobuf/any.proto \
   google/protobuf/api.proto \
+  google/protobuf/compiler/plugin.proto \
   google/protobuf/descriptor.proto \
   google/protobuf/duration.proto \
   google/protobuf/empty.proto \
@@ -40,9 +41,6 @@ declare -a RUNTIME_PROTO_FILES=(\
   google/protobuf/timestamp.proto \
   google/protobuf/type.proto \
   google/protobuf/wrappers.proto)
-
-declare -a COMPILER_PROTO_FILES=(\
-  google/protobuf/compiler/plugin.proto)
 
 CORE_PROTO_IS_CORRECT=0
 PROCESS_ROUND=1
@@ -79,9 +77,8 @@ do
   fi
 
   $PROTOC --cpp_out=dllexport_decl=LIBPROTOBUF_EXPORT:$TMP ${RUNTIME_PROTO_FILES[@]} && \
-  $PROTOC --cpp_out=dllexport_decl=LIBPROTOC_EXPORT:$TMP ${COMPILER_PROTO_FILES[@]}
 
-  for PROTO_FILE in ${RUNTIME_PROTO_FILES[@]} ${COMPILER_PROTO_FILES[@]}; do
+  for PROTO_FILE in ${RUNTIME_PROTO_FILES[@]}; do
     BASE_NAME=${PROTO_FILE%.*}
     diff ${BASE_NAME}.pb.h $TMP/${BASE_NAME}.pb.h > /dev/null
     if test $? -ne 0; then
@@ -96,7 +93,7 @@ do
   # Only override the output if the files are different to avoid re-compilation
   # of the protoc.
   if [ $CORE_PROTO_IS_CORRECT -ne 1 ]; then
-    for PROTO_FILE in ${RUNTIME_PROTO_FILES[@]} ${COMPILER_PROTO_FILES[@]}; do
+    for PROTO_FILE in ${RUNTIME_PROTO_FILES[@]} do
       BASE_NAME=${PROTO_FILE%.*}
       mv $TMP/${BASE_NAME}.pb.h ${BASE_NAME}.pb.h
       mv $TMP/${BASE_NAME}.pb.cc ${BASE_NAME}.pb.cc

--- a/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
@@ -132,10 +132,9 @@ TEST(BootstrapTest, GeneratedDescriptorMatches) {
   CppGenerator generator;
   MockGeneratorContext context;
   string error;
-  string parameter = "dllexport_decl=LIBPROTOBUF_EXPORT";
+  const string parameter = "dllexport_decl=LIBPROTOBUF_EXPORT";
   ASSERT_TRUE(generator.Generate(proto_file, parameter,
                                  &context, &error));
-  parameter = "dllexport_decl=LIBPROTOC_EXPORT";
   ASSERT_TRUE(generator.Generate(plugin_proto_file, parameter,
                                  &context, &error));
 

--- a/src/google/protobuf/compiler/plugin.pb.h
+++ b/src/google/protobuf/compiler/plugin.pb.h
@@ -40,7 +40,7 @@
 
 namespace protobuf_google_2fprotobuf_2fcompiler_2fplugin_2eproto {
 // Internal implementation detail -- do not use these members.
-struct LIBPROTOC_EXPORT TableStruct {
+struct LIBPROTOBUF_EXPORT TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
   static const ::google::protobuf::internal::ParseTable schema[4];
@@ -48,16 +48,16 @@ struct LIBPROTOC_EXPORT TableStruct {
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
 };
-void LIBPROTOC_EXPORT AddDescriptors();
-void LIBPROTOC_EXPORT InitDefaultsVersionImpl();
-void LIBPROTOC_EXPORT InitDefaultsVersion();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorRequestImpl();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorRequest();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorResponse_FileImpl();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorResponse_File();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorResponseImpl();
-void LIBPROTOC_EXPORT InitDefaultsCodeGeneratorResponse();
-inline void LIBPROTOC_EXPORT InitDefaults() {
+void LIBPROTOBUF_EXPORT AddDescriptors();
+void LIBPROTOBUF_EXPORT InitDefaultsVersionImpl();
+void LIBPROTOBUF_EXPORT InitDefaultsVersion();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorRequestImpl();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorRequest();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorResponse_FileImpl();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorResponse_File();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorResponseImpl();
+void LIBPROTOBUF_EXPORT InitDefaultsCodeGeneratorResponse();
+inline void LIBPROTOBUF_EXPORT InitDefaults() {
   InitDefaultsVersion();
   InitDefaultsCodeGeneratorRequest();
   InitDefaultsCodeGeneratorResponse_File();
@@ -69,25 +69,25 @@ namespace protobuf {
 namespace compiler {
 class CodeGeneratorRequest;
 class CodeGeneratorRequestDefaultTypeInternal;
-LIBPROTOC_EXPORT extern CodeGeneratorRequestDefaultTypeInternal _CodeGeneratorRequest_default_instance_;
+LIBPROTOBUF_EXPORT extern CodeGeneratorRequestDefaultTypeInternal _CodeGeneratorRequest_default_instance_;
 class CodeGeneratorResponse;
 class CodeGeneratorResponseDefaultTypeInternal;
-LIBPROTOC_EXPORT extern CodeGeneratorResponseDefaultTypeInternal _CodeGeneratorResponse_default_instance_;
+LIBPROTOBUF_EXPORT extern CodeGeneratorResponseDefaultTypeInternal _CodeGeneratorResponse_default_instance_;
 class CodeGeneratorResponse_File;
 class CodeGeneratorResponse_FileDefaultTypeInternal;
-LIBPROTOC_EXPORT extern CodeGeneratorResponse_FileDefaultTypeInternal _CodeGeneratorResponse_File_default_instance_;
+LIBPROTOBUF_EXPORT extern CodeGeneratorResponse_FileDefaultTypeInternal _CodeGeneratorResponse_File_default_instance_;
 class Version;
 class VersionDefaultTypeInternal;
-LIBPROTOC_EXPORT extern VersionDefaultTypeInternal _Version_default_instance_;
+LIBPROTOBUF_EXPORT extern VersionDefaultTypeInternal _Version_default_instance_;
 }  // namespace compiler
 }  // namespace protobuf
 }  // namespace google
 namespace google {
 namespace protobuf {
-template<> LIBPROTOC_EXPORT ::google::protobuf::compiler::CodeGeneratorRequest* Arena::Create< ::google::protobuf::compiler::CodeGeneratorRequest>(Arena*);
-template<> LIBPROTOC_EXPORT ::google::protobuf::compiler::CodeGeneratorResponse* Arena::Create< ::google::protobuf::compiler::CodeGeneratorResponse>(Arena*);
-template<> LIBPROTOC_EXPORT ::google::protobuf::compiler::CodeGeneratorResponse_File* Arena::Create< ::google::protobuf::compiler::CodeGeneratorResponse_File>(Arena*);
-template<> LIBPROTOC_EXPORT ::google::protobuf::compiler::Version* Arena::Create< ::google::protobuf::compiler::Version>(Arena*);
+template<> LIBPROTOBUF_EXPORT ::google::protobuf::compiler::CodeGeneratorRequest* Arena::Create< ::google::protobuf::compiler::CodeGeneratorRequest>(Arena*);
+template<> LIBPROTOBUF_EXPORT ::google::protobuf::compiler::CodeGeneratorResponse* Arena::Create< ::google::protobuf::compiler::CodeGeneratorResponse>(Arena*);
+template<> LIBPROTOBUF_EXPORT ::google::protobuf::compiler::CodeGeneratorResponse_File* Arena::Create< ::google::protobuf::compiler::CodeGeneratorResponse_File>(Arena*);
+template<> LIBPROTOBUF_EXPORT ::google::protobuf::compiler::Version* Arena::Create< ::google::protobuf::compiler::Version>(Arena*);
 }  // namespace protobuf
 }  // namespace google
 namespace google {
@@ -96,7 +96,7 @@ namespace compiler {
 
 // ===================================================================
 
-class LIBPROTOC_EXPORT Version : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.Version) */ {
+class LIBPROTOBUF_EXPORT Version : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.Version) */ {
  public:
   Version();
   virtual ~Version();
@@ -248,7 +248,7 @@ class LIBPROTOC_EXPORT Version : public ::google::protobuf::Message /* @@protoc_
 };
 // -------------------------------------------------------------------
 
-class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorRequest) */ {
+class LIBPROTOBUF_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorRequest) */ {
  public:
   CodeGeneratorRequest();
   virtual ~CodeGeneratorRequest();
@@ -418,7 +418,7 @@ class LIBPROTOC_EXPORT CodeGeneratorRequest : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
-class LIBPROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse.File) */ {
+class LIBPROTOBUF_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse.File) */ {
  public:
   CodeGeneratorResponse_File();
   virtual ~CodeGeneratorResponse_File();
@@ -576,7 +576,7 @@ class LIBPROTOC_EXPORT CodeGeneratorResponse_File : public ::google::protobuf::M
 };
 // -------------------------------------------------------------------
 
-class LIBPROTOC_EXPORT CodeGeneratorResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse) */ {
+class LIBPROTOBUF_EXPORT CodeGeneratorResponse : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:google.protobuf.compiler.CodeGeneratorResponse) */ {
  public:
   CodeGeneratorResponse();
   virtual ~CodeGeneratorResponse();


### PR DESCRIPTION
This is an alternative to the partial revert proposed in <https://github.com/google/protobuf/pull/4347>. See <https://github.com/google/protobuf/pull/4334> for additional context.

Note: please make sure all CI builds (including AppVeyor) are green before merging.