### PR TITLE
Make protobuf work with mbstring.func_overload >= 2

### DIFF
--- a/php/src/Google/Protobuf/Internal/CodedInputStream.php
+++ b/php/src/Google/Protobuf/Internal/CodedInputStream.php
@@ -36,7 +36,6 @@ use Google\Protobuf\Internal\Uint64;
 
 class CodedInputStream
 {
-
     private $buffer;
     private $buffer_size_after_limit;
     private $buffer_end;
@@ -55,7 +54,7 @@ class CodedInputStream
     public function __construct($buffer)
     {
         $start = 0;
-        $end = strlen($buffer);
+        $end = mb_strlen($buffer, '8bit');
         $this->buffer = $buffer;
         $this->buffer_size_after_limit = 0;
         $this->buffer_end = $end;
@@ -87,7 +86,7 @@ class CodedInputStream
 
     public function substr($start, $end)
     {
-        return substr($this->buffer, $start, $end - $start);
+        return mb_substr($this->buffer, $start, $end - $start, '8bit');
     }
 
     private function recomputeBufferLimits()
@@ -294,12 +293,11 @@ class CodedInputStream
 
     public function readRaw($size, &$buffer)
     {
-        $current_buffer_size = 0;
         if ($this->bufferSize() < $size) {
             return false;
         }
 
-        $buffer = substr($this->buffer, $this->current, $size);
+        $buffer = $this->substr($this->current, $this->current + $size);
         $this->advance($size);
 
         return true;

--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -283,7 +283,7 @@ class Message
 
         $bytes = str_repeat(chr(0), CodedOutputStream::MAX_VARINT64_BYTES);
         $size = CodedOutputStream::writeVarintToArray($tag, $bytes, true);
-        $this->unknown .= substr($bytes, 0, $size) . $input->substr($start, $end);
+        $this->unknown .= mb_substr($bytes, 0, $size, '8bit') . $input->substr($start, $end);
     }
 
     /**
@@ -1415,7 +1415,7 @@ class Message
                 break;
             case GPBType::STRING:
             case GPBType::BYTES:
-                $size += strlen($value);
+                $size += mb_strlen($value, '8bit');
                 $size += GPBWire::varint32Size($size);
                 break;
             case GPBType::MESSAGE:
@@ -1682,7 +1682,7 @@ class Message
         foreach ($fields as $field) {
             $size += $this->fieldByteSize($field);
         }
-        $size += strlen($this->unknown);
+        $size += mb_strlen($this->unknown, '8bit');
         return $size;
     }
 


### PR DESCRIPTION
This is the same fix, as in #3248, but for modern version of protobuf (#3248 had conflicts with master and thus was frozen)

It makes protobuf work with overloaded str* functions (when mbstring.func_overload PHP param is greater than 2).