### PR TITLE
Include the _pb2_grpc.py files in the output files when use_grpc_plugin is used.

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -45,8 +45,12 @@ def _CcSrcs(srcs, use_grpc_plugin=False):
 def _CcOuts(srcs, use_grpc_plugin=False):
   return _CcHdrs(srcs, use_grpc_plugin) + _CcSrcs(srcs, use_grpc_plugin)
 
-def _PyOuts(srcs):
-  return [s[:-len(".proto")] + "_pb2.py" for s in srcs]
+def _PyOuts(srcs, use_grpc_plugin=False):
+  ret = [s[:-len(".proto")] + "_pb2.py" for s in srcs]
+  if use_grpc_plugin:
+    ret += [s[:-len(".proto")] + "_pb2_grpc.py" for s in srcs]
+  return ret
+
 
 def _RelativeOutputPath(path, include, dest=""):
   if include == None:
@@ -344,7 +348,7 @@ def py_proto_library(
     **kargs: other keyword arguments that are passed to cc_library.
 
   """
-  outs = _PyOuts(srcs)
+  outs = _PyOuts(srcs, use_grpc_plugin)
 
   includes = []
   if include != None:


### PR DESCRIPTION
The _pb2_grpc.py files were added on Oct 20, 2016 in
grpc/grpc@d953959#diff-d5adca4a2d1e65549a73db695e0db419R768