### PR TITLE
message_meta: fix segfault in GetMessageDescriptor

### DIFF
--- a/python/google/protobuf/pyext/message.cc
+++ b/python/google/protobuf/pyext/message.cc
@@ -402,12 +402,6 @@ static PyObject* GetExtensionsByNumber(CMessageClass *self, void *closure) {
   return result.release();
 }
 
-static PyGetSetDef Getters[] = {
-  {"_extensions_by_name", (getter)GetExtensionsByName, NULL},
-  {"_extensions_by_number", (getter)GetExtensionsByNumber, NULL},
-  {NULL}
-};
-
 }  // namespace message_meta
 
 PyTypeObject CMessageClass_Type = {
@@ -440,7 +434,7 @@ PyTypeObject CMessageClass_Type = {
   0,                                   // tp_iternext
   0,                                   // tp_methods
   0,                                   // tp_members
-  message_meta::Getters,               // tp_getset
+  0,                                   // tp_getset
   0,                                   // tp_base
   0,                                   // tp_dict
   0,                                   // tp_descr_get


### PR DESCRIPTION
This fixes a segmentation fault triggered by the following command, see the gdb backtrace in issue #2911:
    
`python -c 'from google.protobuf import duration_pb2; help(duration_pb2.Duration)'`

Orivej Desh [writes](https://github.com/google/protobuf/issues/2974#issuecomment-354191487):

    The crash in accessing
    google.protobuf.pyext._message.Message._extensions_by_name happens
    because metaclass getters [1] shadow class getters [2] and the intended
    dispatch from the latter to the former [3] does not run. This can be
    fixed by replacing message_meta::Getters with 0 at [1].

[1] https://github.com/google/protobuf/blob/099d99759101c295244c24d8954ec85b8ac65ce3/python/google/protobuf/pyext/message.cc#L443
[2] https://github.com/google/protobuf/blob/099d99759101c295244c24d8954ec85b8ac65ce3/python/google/protobuf/pyext/message.cc#L2849
[3] https://github.com/google/protobuf/blob/099d99759101c295244c24d8954ec85b8ac65ce3/python/google/protobuf/pyext/message.cc#L2615-L2616

See: https://github.com/google/protobuf/issues/2974#issuecomment-354191487
Fixes: https://github.com/google/protobuf/issues/2974