### PR TITLE
Objective-C: Check return value on write of raw pointer

### DIFF
--- a/objectivec/GPBCodedOutputStream.m
+++ b/objectivec/GPBCodedOutputStream.m
@@ -942,7 +942,10 @@ static void GPBWriteRawLittleEndian64(GPBOutputBufferState *state,
       state_.position = length;
     } else {
       // Write is very big.  Let's do it all at once.
-      [state_.output write:((uint8_t *)value) + offset maxLength:length];
+      NSInteger written = [state_.output write:((uint8_t *)value) + offset maxLength:length];
+      if (written != (NSInteger)length) {
+        [NSException raise:GPBCodedOutputStreamException_WriteFailed format:@""];
+      }
     }
   }
 }

--- a/objectivec/Tests/GPBCodedOuputStreamTests.m
+++ b/objectivec/Tests/GPBCodedOuputStreamTests.m
@@ -423,4 +423,14 @@
   }
 }
 
+- (void)testThatItThrowsWhenWriteRawPtrFails {
+  NSOutputStream *output = [NSOutputStream outputStreamToMemory];
+  GPBCodedOutputStream *codedOutput =
+      [GPBCodedOutputStream streamWithOutputStream:output bufferSize:0];  // Skip buffering.
+  [output close];  // Close the output stream to force failure on write.
+  const char *cString = "raw";
+  XCTAssertThrowsSpecificNamed([codedOutput writeRawPtr:cString offset:0 length:strlen(cString)],
+                               NSException, GPBCodedOutputStreamException_WriteFailed);
+}
+
 @end


### PR DESCRIPTION
I was recently debugging an unrelated bug that made me look into a few details of the protobuf code and came across [this]( https://github.com/google/protobuf/blob/master/objectivec/GPBCodedOutputStream.m#L945), a call to `-[NSOutputStream write:maxLength:]` that doesn't check the return value (bytes written). A few lines up, in `GPBRefreshBuffer`, the bytes written [are checked](https://github.com/google/protobuf/blob/a48d58df9643781947da57bdc13a23ac8d868346/objectivec/GPBCodedOutputStream.m#L70-L74). This pull requests adds a test case and implements the check.