### PR TITLE
Replace //:protoc and similar default macro arguments with

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -254,7 +254,7 @@ internal_copied_filegroup(
     srcs = WELL_KNOWN_PROTOS,
     dest = "",
     strip_prefix = "src",
-    visibility = ["//visibility:hidden"],
+    visibility = ["//visibility:private"],
 )
 
 [proto_library(

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -171,10 +171,10 @@ def cc_proto_library(
         deps=[],
         cc_libs=[],
         include=None,
-        protoc="//:protoc",
+        protoc="@com_google_protobuf//:protoc",
         internal_bootstrap_hack=False,
         use_grpc_plugin=False,
-        default_runtime="//:protobuf",
+        default_runtime="@com_google_protobuf//:protobuf",
         **kargs):
   """Bazel rule to create a C++ protobuf library from proto source files
 
@@ -317,8 +317,8 @@ def py_proto_library(
         py_libs=[],
         py_extra_srcs=[],
         include=None,
-        default_runtime="//:protobuf_python",
-        protoc="//:protoc",
+        default_runtime="@com_google_protobuf//:protobuf_python",
+        protoc="@com_google_protobuf//:protoc",
         use_grpc_plugin=False,
         **kargs):
   """Bazel rule to create a Python protobuf library from proto source files


### PR DESCRIPTION
Replace //:protoc and similar default macro arguments with @com_google_protobuf prefixed versions. This allows them to work in 3rd party repositories.
Fix a bad visibility rule. :hidden does not exist, but :private does.

Fixes: #4374 