### PR TITLE
Revert "Removed mention of Buffer in byteSourceToUint8Array"

### DIFF
--- a/js/binary/utils.js
+++ b/js/binary/utils.js
@@ -971,6 +971,10 @@ jspb.utils.byteSourceToUint8Array = function(data) {
     return /** @type {!Uint8Array} */(new Uint8Array(data));
   }
 
+  if (data.constructor === Buffer) {
+    return /** @type {!Uint8Array} */(new Uint8Array(data));
+  }
+
   if (data.constructor === Array) {
     data = /** @type {!Array<number>} */(data);
     return /** @type {!Uint8Array} */(new Uint8Array(data));


### PR DESCRIPTION
This reverts commit f00e06c95bc117fb2ed0ca56c96041c93039f1fe.

Although Node Buffers are not covered by the tests, it seems that there
are users relying on them, so we need to add back in support for them.

This fixes issue #4359.