### PR TITLE
fix json_decode call parameters

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1104,7 +1104,7 @@ class Message
      */
     public function parseFromJsonStream($input)
     {
-        $array = json_decode($input->getData(), JSON_BIGINT_AS_STRING);
+        $array = json_decode($input->getData(), true, 512, JSON_BIGINT_AS_STRING);
         if (is_null($array)) {
             throw new GPBDecodeException(
                 "Cannot decode json string.");


### PR DESCRIPTION
This fixes the placement of the JSON_BIGINT_AS_STRING option passed to json_decode, this is being passed as the $assoc parameter which decodes the JSON as an associative array.