### PR TITLE
Modified .proto files do not trigger a recompile via protoc

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -100,7 +100,7 @@ function(protobuf_generate)
       OUTPUT ${_generated_srcs}
       COMMAND  protobuf::protoc
       ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${_abs_file}
-      DEPENDS ${ABS_FIL} protobuf::protoc
+      DEPENDS ${_abs_file} protobuf::protoc
       COMMENT "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}"
       VERBATIM )
   endforeach()


### PR DESCRIPTION
Protobuf contains a `protobuf_generate` CMake function to simplify the compilation of proto files. The custom command behind this function uses an obsolete variable `ABS_FIL` to define the dependent input files. Hence, modification of the input file would not trigger a recompilation via protoc.

This pull request fixes this.