### PR TITLE
Cleaner protoc artifacts

### DIFF
--- a/protoc-artifacts/Dockerfile
+++ b/protoc-artifacts/Dockerfile
@@ -11,7 +11,9 @@ RUN yum install -y git \
                    libtool \
                    glibc-static.i686 \
                    glibc-devel \
-                   glibc-devel.i686
+                   glibc-devel.i686 \
+                   && \
+    yum clean all
 
 # Install Java 8
 RUN wget -q --no-cookies --no-check-certificate \
@@ -27,13 +29,15 @@ RUN wget -q http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-
 ENV PATH /var/local/apache-maven-3.3.9/bin:$PATH
 
 # Install GCC 4.7 to support -static-libstdc++
-RUN wget http://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -P /etc/yum.repos.d
-RUN bash -c 'echo "enabled=1" >> /etc/yum.repos.d/devtools-1.1.repo'
-RUN bash -c "sed -e 's/\$basearch/i386/g' /etc/yum.repos.d/devtools-1.1.repo > /etc/yum.repos.d/devtools-i386-1.1.repo"
-RUN sed -e 's/testing-/testing-i386-/g' -i /etc/yum.repos.d/devtools-i386-1.1.repo
-RUN rpm --rebuilddb && yum install -y devtoolset-1.1 \
+RUN wget http://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -P /etc/yum.repos.d && \
+    bash -c 'echo "enabled=1" >> /etc/yum.repos.d/devtools-1.1.repo' && \
+    bash -c "sed -e 's/\$basearch/i386/g' /etc/yum.repos.d/devtools-1.1.repo > /etc/yum.repos.d/devtools-i386-1.1.repo" && \
+    sed -e 's/testing-/testing-i386-/g' -i /etc/yum.repos.d/devtools-i386-1.1.repo && \
+    rpm --rebuilddb && \
+    yum install -y devtoolset-1.1 \
                    devtoolset-1.1-libstdc++-devel \
-                   devtoolset-1.1-libstdc++-devel.i686
+                   devtoolset-1.1-libstdc++-devel.i686 && \
+    yum clean all
 
 # Start in devtoolset environment that uses GCC 4.7
 CMD ["scl", "enable", "devtoolset-1.1", "bash"]

--- a/protoc-artifacts/Dockerfile
+++ b/protoc-artifacts/Dockerfile
@@ -35,7 +35,5 @@ RUN rpm --rebuilddb && yum install -y devtoolset-1.1 \
                    devtoolset-1.1-libstdc++-devel \
                    devtoolset-1.1-libstdc++-devel.i686
 
-RUN git clone --depth 1 https://github.com/google/protobuf.git
-
 # Start in devtoolset environment that uses GCC 4.7
 CMD ["scl", "enable", "devtoolset-1.1", "bash"]

--- a/protoc-artifacts/Dockerfile
+++ b/protoc-artifacts/Dockerfile
@@ -39,5 +39,7 @@ RUN wget http://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -P /etc/yum
                    devtoolset-1.1-libstdc++-devel.i686 && \
     yum clean all
 
+COPY scl-enable-devtoolset.sh /var/local/
+
 # Start in devtoolset environment that uses GCC 4.7
-CMD ["scl", "enable", "devtoolset-1.1", "bash"]
+ENTRYPOINT ["/var/local/scl-enable-devtoolset.sh"]

--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -143,7 +143,11 @@ To run the image:
 $ docker run -it --rm=true protoc-artifacts
 ```
 
-The Protobuf repository has been cloned into ``/protobuf``.
+To checkout protobuf (run within the container):
+```
+$ # Replace v3.5.1 with the version you want
+$ wget -O - https://github.com/google/protobuf/archive/v3.5.1.tar.gz | tar xvzp
+```
 
 ### Tips for deploying on Windows
 Under Windows the following error may occur: ``gpg: cannot open tty `no tty':

--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -140,7 +140,7 @@ $ docker build -t protoc-artifacts .
 
 To run the image:
 ```
-$ docker run -it --rm=true protoc-artifacts
+$ docker run -it --rm=true protoc-artifacts bash
 ```
 
 To checkout protobuf (run within the container):

--- a/protoc-artifacts/scl-enable-devtoolset.sh
+++ b/protoc-artifacts/scl-enable-devtoolset.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu -o pipefail
+
+quote() {
+  local arg
+  for arg in "$@"; do
+    printf "'"
+    printf "%s" "$arg" | sed -e "s/'/'\\\\''/g"
+    printf "' "
+  done
+}
+
+exec scl enable devtoolset-1.1 "$(quote "$@")"


### PR DESCRIPTION
You'll want to look at each commit independently, including its description.
I'll want to submit the commits separately as well.

This does not fix the git clone TLS problem. But it allows you to workaround it
manually using wget instead.

The scl-enable-devtoolset.sh is a more powerful change than it may look
at first glance. It is taken from grpc-java (https://github.com/grpc/grpc-java/commit/9c5e96e376754cf922b1417af184fd8552f9feef) as part of
our work to improve our release process. Coupled with run_in_docker.sh
it allows an improved release and development process as the files are
stored on the host in a normal checkout and the computation is performed
in the docker environment.

run_in_docker.sh (in that referenced commit) is overly complex to
workaround Java issues when running as a uid that does not exist in
/etc/passwd. If not for Java, it would be a single "docker run" line notably
using -v to mount a host directory into the container and -u/-g to set
the user to run as so that created files have the correct permissions.

If one of the commits is unsettling, then I can split it out.

Fixes #4419