### PR TITLE
Update instructions about getting protobuf source.

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -41,9 +41,16 @@ Good. Now you are ready to continue.
 Getting Sources
 ===============
 
-You can get the latest stable source packages from the
-[releases](https://github.com/google/protobuf/releases) page.
-Or you can type:
+You can get the latest stable source packages from the release page:
+
+    https://github.com/google/protobuf/releases/latest
+
+For example: if you only need C++, download `protobuf-cpp-[VERSION].tar.gz`; if
+you need C++ and Java, download `protobuf-java-[VERSION].tar.gz` (every package
+contains C++ source already); if you need C++ and multiple other languages,
+download `protobuf-all-[VERSION].tar.gz`.
+
+Or you can use git to clone from protobuf git repository.
 
      C:\Path\to> git clone -b [release_tag] https://github.com/google/protobuf.git
 
@@ -55,7 +62,8 @@ Go to the project folder:
      C:\Path\to>cd protobuf
      C:\Path\to\protobuf>
 
-Remember to update any submodules:
+Remember to update any submodules if you are using git clone (you can skip this
+step if you are using a release .tar.gz or .zip package):
 
 ```console
 C:\Path\to> git submodule update --init --recursive
@@ -63,7 +71,7 @@ C:\Path\to> git submodule update --init --recursive
 
 Now go to *cmake* folder in protobuf sources:
 
-     C:\Path\to\protobuf\gmock>cd ..\cmake
+     C:\Path\to\protobuf>cd cmake
      C:\Path\to\protobuf\cmake>
 
 Good. Now you are ready to *CMake* configuration.
@@ -113,7 +121,7 @@ It will generate *nmake* *Makefile* in current directory.
 To create *Visual Studio* solution file:
 
      C:\Path\to\protobuf\cmake\build>mkdir solution & cd solution
-     C:\Path\to\protobuf\cmake\build\solution>cmake -G "Visual Studio 12 2013 Win64" ^
+     C:\Path\to\protobuf\cmake\build\solution>cmake -G "Visual Studio 14 2015 Win64" ^
      -DCMAKE_INSTALL_PREFIX=../../../../install ^
      ../..
 

--- a/src/README.md
+++ b/src/README.md
@@ -19,25 +19,31 @@ To build protobuf from source, the following tools are needed:
   * g++
   * unzip
 
-On Ubuntu, you can install them with:
+On Ubuntu/Debian, you can install them with:
 
     $ sudo apt-get install autoconf automake libtool curl make g++ unzip
 
 On other platforms, please use the corresponding package managing tool to
 install them before proceeding.
 
-If you get the source from github, you need to generate the configure script
-first:
+To get the source, download one of the release .tar.gz or .zip packages in the
+release page:
 
+    https://github.com/google/protobuf/releases/latest
+
+For example: if you only need C++, download `protobuf-cpp-[VERSION].tar.gz`; if
+you need C++ and Java, download `protobuf-java-[VERSION].tar.gz` (every package
+contains C++ source already); if you need C++ and multiple other languages,
+download `protobuf-all-[VERSION].tar.gz`.
+
+You can also get the source by "git clone" our git repository. Make sure you
+have also cloned the submodules and generated the configure script (skip this
+if you are using a release .tar.gz or .zip package):
+
+    $ git clone https://github.com/google/protobuf.git
+    $ cd protobuf
     $ git submodule update --init --recursive
     $ ./autogen.sh
-
-This will download gmock source (which is used for C++ Protocol Buffer
-unit-tests) to the current directory and run automake, autoconf, etc.
-to generate the configure script and various template makefiles.
-
-You can skip this step if you are using a release package (which already
-contains gmock and the configure script).
 
 To build and install the C++ Protocol Buffer runtime and the Protocol
 Buffer compiler (protoc) execute the following:
@@ -55,122 +61,122 @@ Proceed at your own risk.
 For advanced usage information on configure and make, please refer to the
 autoconf documentation:
 
-  http://www.gnu.org/software/autoconf/manual/autoconf.html#Running-configure-Scripts
+    http://www.gnu.org/software/autoconf/manual/autoconf.html#Running-configure-Scripts
 
 **Hint on install location**
 
-  By default, the package will be installed to /usr/local.  However,
-  on many platforms, /usr/local/lib is not part of LD_LIBRARY_PATH.
-  You can add it, but it may be easier to just install to /usr
-  instead.  To do this, invoke configure as follows:
+By default, the package will be installed to /usr/local.  However,
+on many platforms, /usr/local/lib is not part of LD_LIBRARY_PATH.
+You can add it, but it may be easier to just install to /usr
+instead.  To do this, invoke configure as follows:
 
     ./configure --prefix=/usr
 
-  If you already built the package with a different prefix, make sure
-  to run "make clean" before building again.
+If you already built the package with a different prefix, make sure
+to run "make clean" before building again.
 
 **Compiling dependent packages**
 
-  To compile a package that uses Protocol Buffers, you need to pass
-  various flags to your compiler and linker.  As of version 2.2.0,
-  Protocol Buffers integrates with pkg-config to manage this.  If you
-  have pkg-config installed, then you can invoke it to get a list of
-  flags like so:
+To compile a package that uses Protocol Buffers, you need to pass
+various flags to your compiler and linker.  As of version 2.2.0,
+Protocol Buffers integrates with pkg-config to manage this.  If you
+have pkg-config installed, then you can invoke it to get a list of
+flags like so:
 
     pkg-config --cflags protobuf         # print compiler flags
     pkg-config --libs protobuf           # print linker flags
     pkg-config --cflags --libs protobuf  # print both
 
-  For example:
+For example:
 
     c++ my_program.cc my_proto.pb.cc `pkg-config --cflags --libs protobuf`
 
-  Note that packages written prior to the 2.2.0 release of Protocol
-  Buffers may not yet integrate with pkg-config to get flags, and may
-  not pass the correct set of flags to correctly link against
-  libprotobuf.  If the package in question uses autoconf, you can
-  often fix the problem by invoking its configure script like:
+Note that packages written prior to the 2.2.0 release of Protocol
+Buffers may not yet integrate with pkg-config to get flags, and may
+not pass the correct set of flags to correctly link against
+libprotobuf.  If the package in question uses autoconf, you can
+often fix the problem by invoking its configure script like:
 
     configure CXXFLAGS="$(pkg-config --cflags protobuf)" \
               LIBS="$(pkg-config --libs protobuf)"
 
-  This will force it to use the correct flags.
+This will force it to use the correct flags.
 
-  If you are writing an autoconf-based package that uses Protocol
-  Buffers, you should probably use the PKG_CHECK_MODULES macro in your
-  configure script like:
+If you are writing an autoconf-based package that uses Protocol
+Buffers, you should probably use the PKG_CHECK_MODULES macro in your
+configure script like:
 
     PKG_CHECK_MODULES([protobuf], [protobuf])
 
-  See the pkg-config man page for more info.
+See the pkg-config man page for more info.
 
-  If you only want protobuf-lite, substitute "protobuf-lite" in place
-  of "protobuf" in these examples.
+If you only want protobuf-lite, substitute "protobuf-lite" in place
+of "protobuf" in these examples.
 
 **Note for Mac users**
 
-  For a Mac system, Unix tools are not available by default. You will first need
-  to install Xcode from the Mac AppStore and then run the following command from
-  a terminal:
+For a Mac system, Unix tools are not available by default. You will first need
+to install Xcode from the Mac AppStore and then run the following command from
+a terminal:
 
     $ sudo xcode-select --install
 
-  To install Unix tools, you can install "port" following the instructions at
-  https://www.macports.org . This will reside in /opt/local/bin/port for most
-  Mac installations.
+To install Unix tools, you can install "port" following the instructions at
+https://www.macports.org . This will reside in /opt/local/bin/port for most
+Mac installations.
 
     $ sudo /opt/local/bin/port install autoconf automake libtool
 
-  Then follow the Unix instructions above.
+Then follow the Unix instructions above.
 
 **Note for cross-compiling**
 
-  The makefiles normally invoke the protoc executable that they just
-  built in order to build tests.  When cross-compiling, the protoc
-  executable may not be executable on the host machine.  In this case,
-  you must build a copy of protoc for the host machine first, then use
-  the --with-protoc option to tell configure to use it instead.  For
-  example:
+The makefiles normally invoke the protoc executable that they just
+built in order to build tests.  When cross-compiling, the protoc
+executable may not be executable on the host machine.  In this case,
+you must build a copy of protoc for the host machine first, then use
+the --with-protoc option to tell configure to use it instead.  For
+example:
 
     ./configure --with-protoc=protoc
 
-  This will use the installed protoc (found in your $PATH) instead of
-  trying to execute the one built during the build process.  You can
-  also use an executable that hasn't been installed.  For example, if
-  you built the protobuf package for your host machine in ../host,
-  you might do:
+This will use the installed protoc (found in your $PATH) instead of
+trying to execute the one built during the build process.  You can
+also use an executable that hasn't been installed.  For example, if
+you built the protobuf package for your host machine in ../host,
+you might do:
 
     ./configure --with-protoc=../host/src/protoc
 
-  Either way, you must make sure that the protoc executable you use
-  has the same version as the protobuf source code you are trying to
-  use it with.
+Either way, you must make sure that the protoc executable you use
+has the same version as the protobuf source code you are trying to
+use it with.
 
 **Note for Solaris users**
 
-  Solaris 10 x86 has a bug that will make linking fail, complaining
-  about libstdc++.la being invalid.  We have included a work-around
-  in this package.  To use the work-around, run configure as follows:
+Solaris 10 x86 has a bug that will make linking fail, complaining
+about libstdc++.la being invalid.  We have included a work-around
+in this package.  To use the work-around, run configure as follows:
 
     ./configure LDFLAGS=-L$PWD/src/solaris
 
-  See src/solaris/libstdc++.la for more info on this bug.
+See src/solaris/libstdc++.la for more info on this bug.
 
 **Note for HP C++ Tru64 users**
 
-  To compile invoke configure as follows:
+To compile invoke configure as follows:
 
     ./configure CXXFLAGS="-O -std ansi -ieee -D__USE_STD_IOSTREAM"
 
-  Also, you will need to use gmake instead of make.
+Also, you will need to use gmake instead of make.
 
 **Note for AIX users**
 
-  Compile using the IBM xlC C++ compiler as follows:
+Compile using the IBM xlC C++ compiler as follows:
 
     ./configure CXX=xlC
 
-  Also, you will need to use GNU `make` (`gmake`) instead of AIX `make`.
+Also, you will need to use GNU `make` (`gmake`) instead of AIX `make`.
 
 C++ Installation - Windows
 --------------------------
@@ -178,7 +184,7 @@ C++ Installation - Windows
 If you only need the protoc binary, you can download it from the release
 page:
 
-  https://github.com/google/protobuf/releases
+    https://github.com/google/protobuf/releases/latest
 
 In the downloads section, download the zip file protoc-$VERSION-win32.zip.
 It contains the protoc binary as well as public proto files of protobuf


### PR DESCRIPTION
1. Make it clear that there are two ways to get protobuf source and explain what .tar.gz/.zip package users should be downloading.
2. Some format fixes and minor cleanups.