### PR TITLE
Amalgamate C++ sources in protobuf Bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,12 +21,12 @@ config_setting(
 
 MSVC_COPTS = [
     "/DHAVE_PTHREAD",
-    "/wd4018", # -Wno-sign-compare
-    "/wd4514", # -Wno-unused-function
+    "/wd4018",  # -Wno-sign-compare
+    "/wd4514",  # -Wno-unused-function
 ]
 
 COPTS = select({
-    ":msvc" : MSVC_COPTS,
+    ":msvc": MSVC_COPTS,
     "//conditions:default": [
         "-DHAVE_PTHREAD",
         "-Wall",
@@ -41,7 +41,7 @@ COPTS = select({
 
 config_setting(
     name = "msvc",
-    values = { "compiler": "msvc-cl" },
+    values = {"compiler": "msvc-cl"},
 )
 
 config_setting(
@@ -55,7 +55,10 @@ config_setting(
 LINK_OPTS = select({
     ":android": [],
     ":msvc": [],
-    "//conditions:default": ["-lpthread", "-lm"],
+    "//conditions:default": [
+        "-lpthread",
+        "-lm",
+    ],
 })
 
 load(
@@ -67,8 +70,8 @@ load(
     "internal_protobuf_py_tests",
 )
 
-cc_library(
-    name = "protobuf_lite",
+genrule(
+    name = "protobuf_lite_amalgamation",
     srcs = [
         # AUTOGEN(protobuf_lite_srcs)
         "src/google/protobuf/arena.cc",
@@ -95,6 +98,15 @@ cc_library(
         "src/google/protobuf/stubs/time.cc",
         "src/google/protobuf/wire_format_lite.cc",
     ],
+    outs = ["protobuf_lite_amalgamation.cc"],
+    cmd = "$(location //util:amalgamate) $(SRCS) >$@",
+    tools = ["//util:amalgamate"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "protobuf_lite",
+    srcs = ["protobuf_lite_amalgamation.cc"],
     hdrs = glob(["src/google/protobuf/**/*.h"]),
     copts = COPTS,
     includes = ["src/"],
@@ -102,8 +114,8 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
-    name = "protobuf",
+genrule(
+    name = "protobuf_amalgamation",
     srcs = [
         # AUTOGEN(protobuf_srcs)
         "src/google/protobuf/any.cc",
@@ -162,6 +174,15 @@ cc_library(
         "src/google/protobuf/wire_format.cc",
         "src/google/protobuf/wrappers.pb.cc",
     ],
+    outs = ["protobuf_amalgamation.cc"],
+    cmd = "$(location //util:amalgamate) $(SRCS) >$@",
+    tools = ["//util:amalgamate"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "protobuf",
+    srcs = ["protobuf_amalgamation.cc"],
     hdrs = glob(["src/**/*.h"]),
     copts = COPTS,
     includes = ["src/"],
@@ -192,18 +213,33 @@ objc_library(
 # Map of all well known protos.
 # name => (include path, imports)
 WELL_KNOWN_PROTO_MAP = {
-    "any" : ("google/protobuf/any.proto", []),
-    "api" : ("google/protobuf/api.proto", ["source_context", "type"]),
-    "compiler_plugin" : ("google/protobuf/compiler/plugin.proto", ["descriptor"]),
-    "descriptor" : ("google/protobuf/descriptor.proto", []),
-    "duration" : ("google/protobuf/duration.proto", []),
-    "empty" : ("google/protobuf/empty.proto", []),
-    "field_mask" : ("google/protobuf/field_mask.proto", []),
-    "source_context" : ("google/protobuf/source_context.proto", []),
-    "struct" : ("google/protobuf/struct.proto", []),
-    "timestamp" : ("google/protobuf/timestamp.proto", []),
-    "type" : ("google/protobuf/type.proto", ["any", "source_context"]),
-    "wrappers" : ("google/protobuf/wrappers.proto", []),
+    "any": ("google/protobuf/any.proto", []),
+    "api": (
+        "google/protobuf/api.proto",
+        [
+            "source_context",
+            "type",
+        ],
+    ),
+    "compiler_plugin": (
+        "google/protobuf/compiler/plugin.proto",
+        ["descriptor"],
+    ),
+    "descriptor": ("google/protobuf/descriptor.proto", []),
+    "duration": ("google/protobuf/duration.proto", []),
+    "empty": ("google/protobuf/empty.proto", []),
+    "field_mask": ("google/protobuf/field_mask.proto", []),
+    "source_context": ("google/protobuf/source_context.proto", []),
+    "struct": ("google/protobuf/struct.proto", []),
+    "timestamp": ("google/protobuf/timestamp.proto", []),
+    "type": (
+        "google/protobuf/type.proto",
+        [
+            "any",
+            "source_context",
+        ],
+    ),
+    "wrappers": ("google/protobuf/wrappers.proto", []),
 }
 
 RELATIVE_WELL_KNOWN_PROTOS = [proto[1][0] for proto in WELL_KNOWN_PROTO_MAP.items()]
@@ -249,9 +285,9 @@ internal_copied_filegroup(
 [proto_library(
     name = proto[0] + "_proto",
     srcs = [proto[1][0]],
-    deps = [dep + "_proto" for dep in proto[1][1]],
     visibility = ["//visibility:public"],
-    ) for proto in WELL_KNOWN_PROTO_MAP.items()]
+    deps = [dep + "_proto" for dep in proto[1][1]],
+) for proto in WELL_KNOWN_PROTO_MAP.items()]
 
 ################################################################################
 # Protocol Buffers Compiler
@@ -275,8 +311,8 @@ genrule(
     tools = [":js_embed"],
 )
 
-cc_library(
-    name = "protoc_lib",
+genrule(
+    name = "protoc_lib_amalgamation",
     srcs = [
         # AUTOGEN(protoc_lib_srcs)
         "src/google/protobuf/compiler/code_generator.cc",
@@ -363,6 +399,15 @@ cc_library(
         "src/google/protobuf/compiler/subprocess.cc",
         "src/google/protobuf/compiler/zip_writer.cc",
     ],
+    outs = ["protoc_lib_amalgamation.cc"],
+    cmd = "$(location //util:amalgamate) $(SRCS) >$@",
+    tools = ["//util:amalgamate"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "protoc_lib",
+    srcs = ["protoc_lib_amalgamation.cc"],
     copts = COPTS,
     includes = ["src/"],
     linkopts = LINK_OPTS,
@@ -480,11 +525,14 @@ cc_binary(
 cc_test(
     name = "win32_test",
     srcs = ["src/google/protobuf/stubs/io_win32_unittest.cc"],
+    tags = [
+        "manual",
+        "windows",
+    ],
     deps = [
         ":protobuf_lite",
         "//external:gtest_main",
     ],
-    tags = ["manual", "windows"],
 )
 
 cc_test(
@@ -600,8 +648,11 @@ java_library(
         ":gen_well_known_protos_java",
     ],
     javacopts = select({
-       "//:jdk9": ["--add-modules=jdk.unsupported"],
-       "//conditions:default": ["-source 7", "-target 7"],
+        "//:jdk9": ["--add-modules=jdk.unsupported"],
+        "//conditions:default": [
+            "-source 7",
+            "-target 7",
+        ],
     }),
     visibility = ["//visibility:public"],
 )
@@ -611,7 +662,10 @@ java_library(
     srcs = glob([
         "java/util/src/main/java/com/google/protobuf/util/*.java",
     ]),
-    javacopts = ["-source 7", "-target 7"],
+    javacopts = [
+        "-source 7",
+        "-target 7",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "protobuf_java",
@@ -725,11 +779,11 @@ py_proto_library(
     }),
     default_runtime = "",
     protoc = ":protoc",
+    py_extra_srcs = glob(["python/**/__init__.py"]),
     py_libs = [
         ":python_srcs",
         "//external:six",
     ],
-    py_extra_srcs = glob(["python/**/__init__.py"]),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
@@ -820,10 +874,10 @@ internal_protobuf_py_tests(
 
 proto_lang_toolchain(
     name = "cc_toolchain",
+    blacklisted_protos = [":_internal_wkt_protos_genrule"],
     command_line = "--cpp_out=$(OUT)",
     runtime = ":protobuf",
     visibility = ["//visibility:public"],
-    blacklisted_protos = [":_internal_wkt_protos_genrule"],
 )
 
 proto_lang_toolchain(

--- a/src/google/protobuf/compiler/java/java_enum_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_enum_field_lite.cc
@@ -53,12 +53,12 @@ namespace java {
 
 namespace {
 
-void SetEnumVariables(const FieldDescriptor* descriptor,
-                      int messageBitIndex,
-                      int builderBitIndex,
-                      const FieldGeneratorInfo* info,
-                      ClassNameResolver* name_resolver,
-                      std::map<string, string>* variables) {
+void SetEnumVariablesLite(const FieldDescriptor* descriptor,
+                          int messageBitIndex,
+                          int builderBitIndex,
+                          const FieldGeneratorInfo* info,
+                          ClassNameResolver* name_resolver,
+                          std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["type"] =
@@ -125,9 +125,9 @@ ImmutableEnumFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex),
     name_resolver_(context->GetNameResolver()) {
-  SetEnumVariables(descriptor, messageBitIndex, builderBitIndex,
-                   context->GetFieldGeneratorInfo(descriptor),
-                   name_resolver_, &variables_);
+  SetEnumVariablesLite(descriptor, messageBitIndex, builderBitIndex,
+                       context->GetFieldGeneratorInfo(descriptor),
+                       name_resolver_, &variables_);
 }
 
 ImmutableEnumFieldLiteGenerator::~ImmutableEnumFieldLiteGenerator() {}
@@ -577,9 +577,9 @@ RepeatedImmutableEnumFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetEnumVariables(descriptor, messageBitIndex, builderBitIndex,
-                   context->GetFieldGeneratorInfo(descriptor),
-                   name_resolver_, &variables_);
+  SetEnumVariablesLite(descriptor, messageBitIndex, builderBitIndex,
+                       context->GetFieldGeneratorInfo(descriptor),
+                       name_resolver_, &variables_);
 }
 
 RepeatedImmutableEnumFieldLiteGenerator::

--- a/src/google/protobuf/compiler/java/java_message.cc
+++ b/src/google/protobuf/compiler/java/java_message.cc
@@ -66,13 +66,13 @@ using internal::WireFormat;
 using internal::WireFormatLite;
 
 namespace {
-bool GenerateHasBits(const Descriptor* descriptor) {
+bool GenerateHasBits3(const Descriptor* descriptor) {
   return SupportFieldPresence(descriptor->file()) ||
       HasRepeatedFields(descriptor);
 }
 
-string MapValueImmutableClassdName(const Descriptor* descriptor,
-                                   ClassNameResolver* name_resolver) {
+string MapValueImmutableClassdName2(const Descriptor* descriptor,
+                                    ClassNameResolver* name_resolver) {
   const FieldDescriptor* value_field = descriptor->FindFieldByName("value");
   GOOGLE_CHECK_EQ(FieldDescriptor::TYPE_MESSAGE, value_field->type());
   return name_resolver->GetImmutableClassName(value_field->message_type());
@@ -400,7 +400,7 @@ void ImmutableMessageGenerator::Generate(io::Printer* printer) {
     messageGenerator.Generate(printer);
   }
 
-  if (GenerateHasBits(descriptor_)) {
+  if (GenerateHasBits3(descriptor_)) {
     // Integers for bit fields.
     int totalBits = 0;
     for (int i = 0; i < descriptor_->field_count(); i++) {
@@ -970,8 +970,8 @@ void ImmutableMessageGenerator::GenerateIsInitialized(
               "    return false;\n"
               "  }\n"
               "}\n",
-              "type", MapValueImmutableClassdName(field->message_type(),
-                                                  name_resolver_),
+              "type", MapValueImmutableClassdName2(field->message_type(),
+                                                   name_resolver_),
               "name", info->capitalized_name);
           } else {
             printer->Print(

--- a/src/google/protobuf/compiler/java/java_message_builder_lite.cc
+++ b/src/google/protobuf/compiler/java/java_message_builder_lite.cc
@@ -60,7 +60,7 @@ namespace compiler {
 namespace java {
 
 namespace {
-bool GenerateHasBits(const Descriptor* descriptor) {
+bool GenerateHasBits2(const Descriptor* descriptor) {
   return SupportFieldPresence(descriptor->file()) ||
       HasRepeatedFields(descriptor);
 }
@@ -120,7 +120,7 @@ Generate(io::Printer* printer) {
       "\n");
   }
 
-  if (GenerateHasBits(descriptor_)) {
+  if (GenerateHasBits2(descriptor_)) {
     // Integers for bit fields.
     int totalBits = 0;
     for (int i = 0; i < descriptor_->field_count(); i++) {

--- a/src/google/protobuf/compiler/java/java_message_field.cc
+++ b/src/google/protobuf/compiler/java/java_message_field.cc
@@ -51,12 +51,12 @@ namespace java {
 
 namespace {
 
-void SetMessageVariables(const FieldDescriptor* descriptor,
-                         int messageBitIndex,
-                         int builderBitIndex,
-                         const FieldGeneratorInfo* info,
-                         ClassNameResolver* name_resolver,
-                         std::map<string, string>* variables) {
+void SetMessageVariables3(const FieldDescriptor* descriptor,
+                          int messageBitIndex,
+                          int builderBitIndex,
+                          const FieldGeneratorInfo* info,
+                          ClassNameResolver* name_resolver,
+                          std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["type"] =
@@ -129,9 +129,9 @@ ImmutableMessageFieldGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-    SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+    SetMessageVariables3(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 ImmutableMessageFieldGenerator::~ImmutableMessageFieldGenerator() {}
@@ -799,9 +799,9 @@ RepeatedImmutableMessageFieldGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver())  {
-  SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
-                      context->GetFieldGeneratorInfo(descriptor),
-                      name_resolver_, &variables_);
+  SetMessageVariables3(descriptor, messageBitIndex, builderBitIndex,
+                       context->GetFieldGeneratorInfo(descriptor),
+                       name_resolver_, &variables_);
 }
 
 RepeatedImmutableMessageFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_message_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_message_field_lite.cc
@@ -51,12 +51,12 @@ namespace java {
 
 namespace {
 
-void SetMessageVariables(const FieldDescriptor* descriptor,
-                         int messageBitIndex,
-                         int builderBitIndex,
-                         const FieldGeneratorInfo* info,
-                         ClassNameResolver* name_resolver,
-                         std::map<string, string>* variables) {
+void SetMessageVariables4(const FieldDescriptor* descriptor,
+                          int messageBitIndex,
+                          int builderBitIndex,
+                          const FieldGeneratorInfo* info,
+                          ClassNameResolver* name_resolver,
+                          std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["type"] =
@@ -112,9 +112,9 @@ ImmutableMessageFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-    SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+    SetMessageVariables4(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 ImmutableMessageFieldLiteGenerator::~ImmutableMessageFieldLiteGenerator() {}
@@ -600,9 +600,9 @@ RepeatedImmutableMessageFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver())  {
-  SetMessageVariables(descriptor, messageBitIndex, builderBitIndex,
-                      context->GetFieldGeneratorInfo(descriptor),
-                      name_resolver_, &variables_);
+  SetMessageVariables4(descriptor, messageBitIndex, builderBitIndex,
+                       context->GetFieldGeneratorInfo(descriptor),
+                       name_resolver_, &variables_);
 }
 
 RepeatedImmutableMessageFieldLiteGenerator::

--- a/src/google/protobuf/compiler/java/java_message_lite.cc
+++ b/src/google/protobuf/compiler/java/java_message_lite.cc
@@ -74,13 +74,15 @@ bool EnableExperimentalRuntimeForLite() {
 #endif  // !PROTOBUF_EXPERIMENT
 }
 
-bool GenerateHasBits(const Descriptor* descriptor) {
+// TODO: I'm identical to what's in java_message.cc
+bool GenerateHasBits4(const Descriptor* descriptor) {
   return SupportFieldPresence(descriptor->file()) ||
       HasRepeatedFields(descriptor);
 }
 
-string MapValueImmutableClassdName(const Descriptor* descriptor,
-                                   ClassNameResolver* name_resolver) {
+// TODO: Consolidate me into a util file.
+string MapValueImmutableClassdName3(const Descriptor* descriptor,
+                                    ClassNameResolver* name_resolver) {
   const FieldDescriptor* value_field = descriptor->FindFieldByName("value");
   GOOGLE_CHECK_EQ(FieldDescriptor::TYPE_MESSAGE, value_field->type());
   return name_resolver->GetImmutableClassName(value_field->message_type());
@@ -233,7 +235,7 @@ void ImmutableMessageLiteGenerator::Generate(io::Printer* printer) {
     messageGenerator.Generate(printer);
   }
 
-  if (GenerateHasBits(descriptor_)) {
+  if (GenerateHasBits4(descriptor_)) {
     // Integers for bit fields.
     int totalBits = 0;
     for (int i = 0; i < descriptor_->field_count(); i++) {
@@ -842,8 +844,8 @@ void ImmutableMessageLiteGenerator::GenerateDynamicMethodIsInitialized(
               "    return null;\n"
               "  }\n"
               "}\n",
-              "type", MapValueImmutableClassdName(field->message_type(),
-                                                  name_resolver_),
+              "type", MapValueImmutableClassdName3(field->message_type(),
+                                                   name_resolver_),
               "name", info->capitalized_name);
           } else {
             printer->Print(
@@ -963,7 +965,7 @@ void ImmutableMessageLiteGenerator::GenerateDynamicMethodVisit(
       "oneof_name", context_->GetOneofGeneratorInfo(field)->name);
   }
 
-  if (GenerateHasBits(descriptor_)) {
+  if (GenerateHasBits4(descriptor_)) {
     // Integers for bit fields.
     int totalBits = 0;
     for (int i = 0; i < descriptor_->field_count(); i++) {

--- a/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_primitive_field_lite.cc
@@ -56,12 +56,13 @@ using internal::WireFormatLite;
 
 namespace {
 
-void SetPrimitiveVariables(const FieldDescriptor* descriptor,
-                           int messageBitIndex,
-                           int builderBitIndex,
-                           const FieldGeneratorInfo* info,
-                           ClassNameResolver* name_resolver,
-                           std::map<string, string>* variables) {
+// Note: Number suffix is so source files can be amalgamated.
+void SetPrimitiveVariables2(const FieldDescriptor* descriptor,
+                            int messageBitIndex,
+                            int builderBitIndex,
+                            const FieldGeneratorInfo* info,
+                            ClassNameResolver* name_resolver,
+                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
   JavaType javaType = GetJavaType(descriptor);
   (*variables)["type"] = PrimitiveTypeName(javaType);
@@ -180,9 +181,9 @@ ImmutablePrimitiveFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables2(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 ImmutablePrimitiveFieldLiteGenerator::~ImmutablePrimitiveFieldLiteGenerator() {}
@@ -616,9 +617,9 @@ RepeatedImmutablePrimitiveFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables2(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 RepeatedImmutablePrimitiveFieldLiteGenerator::

--- a/src/google/protobuf/compiler/java/java_string_field.cc
+++ b/src/google/protobuf/compiler/java/java_string_field.cc
@@ -57,12 +57,13 @@ using internal::WireFormatLite;
 
 namespace {
 
-void SetPrimitiveVariables(const FieldDescriptor* descriptor,
-                           int messageBitIndex,
-                           int builderBitIndex,
-                           const FieldGeneratorInfo* info,
-                           ClassNameResolver* name_resolver,
-                           std::map<string, string>* variables) {
+// Note: Number suffix is so source files can be amalgamated.
+void SetPrimitiveVariables3(const FieldDescriptor* descriptor,
+                            int messageBitIndex,
+                            int builderBitIndex,
+                            const FieldGeneratorInfo* info,
+                            ClassNameResolver* name_resolver,
+                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["empty_list"] = "com.google.protobuf.LazyStringArrayList.EMPTY";
@@ -145,9 +146,9 @@ ImmutableStringFieldGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables3(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 ImmutableStringFieldGenerator::~ImmutableStringFieldGenerator() {}
@@ -713,9 +714,9 @@ RepeatedImmutableStringFieldGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables3(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 RepeatedImmutableStringFieldGenerator::

--- a/src/google/protobuf/compiler/java/java_string_field_lite.cc
+++ b/src/google/protobuf/compiler/java/java_string_field_lite.cc
@@ -57,12 +57,13 @@ using internal::WireFormatLite;
 
 namespace {
 
-void SetPrimitiveVariables(const FieldDescriptor* descriptor,
-                           int messageBitIndex,
-                           int builderBitIndex,
-                           const FieldGeneratorInfo* info,
-                           ClassNameResolver* name_resolver,
-                           std::map<string, string>* variables) {
+// Note: Number suffix is so source files can be amalgamated.
+void SetPrimitiveVariables4(const FieldDescriptor* descriptor,
+                            int messageBitIndex,
+                            int builderBitIndex,
+                            const FieldGeneratorInfo* info,
+                            ClassNameResolver* name_resolver,
+                            std::map<string, string>* variables) {
   SetCommonFieldVariables(descriptor, info, variables);
 
   (*variables)["empty_list"] =
@@ -127,9 +128,9 @@ ImmutableStringFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables4(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 ImmutableStringFieldLiteGenerator::~ImmutableStringFieldLiteGenerator() {}
@@ -610,9 +611,9 @@ RepeatedImmutableStringFieldLiteGenerator(const FieldDescriptor* descriptor,
   : descriptor_(descriptor), messageBitIndex_(messageBitIndex),
     builderBitIndex_(builderBitIndex), context_(context),
     name_resolver_(context->GetNameResolver()) {
-  SetPrimitiveVariables(descriptor, messageBitIndex, builderBitIndex,
-                        context->GetFieldGeneratorInfo(descriptor),
-                        name_resolver_, &variables_);
+  SetPrimitiveVariables4(descriptor, messageBitIndex, builderBitIndex,
+                         context->GetFieldGeneratorInfo(descriptor),
+                         name_resolver_, &variables_);
 }
 
 RepeatedImmutableStringFieldLiteGenerator::

--- a/src/google/protobuf/extension_set.cc
+++ b/src/google/protobuf/extension_set.cc
@@ -257,7 +257,7 @@ void ExtensionSet::ClearExtension(int number) {
 
 namespace {
 
-enum Cardinality {
+enum AccessorCardinality {
   REPEATED,
   OPTIONAL
 };

--- a/src/google/protobuf/util/internal/json_stream_parser.cc
+++ b/src/google/protobuf/util/internal/json_stream_parser.cc
@@ -132,7 +132,7 @@ util::Status JsonStreamParser::Parse(StringPiece json) {
   }
 
   // Find the structurally valid UTF8 prefix and parse only that.
-  int n = internal::UTF8SpnStructurallyValid(chunk);
+  int n = ::google::protobuf::internal::UTF8SpnStructurallyValid(chunk);
   if (n > 0) {
     util::Status status = ParseChunk(chunk.substr(0, n));
 
@@ -157,11 +157,12 @@ util::Status JsonStreamParser::FinishParse() {
   std::unique_ptr<char[]> utf8;
   if (coerce_to_utf8_) {
     utf8.reset(new char[leftover_.size()]);
-    char* coerced = internal::UTF8CoerceToStructurallyValid(leftover_, utf8.get(), ' ');
+    char* coerced = ::google::protobuf::internal::UTF8CoerceToStructurallyValid(
+        leftover_, utf8.get(), ' ');
     p_ = json_ = StringPiece(coerced, leftover_.size());
   } else {
     p_ = json_ = leftover_;
-    if (!internal::IsStructurallyValidUTF8(leftover_)) {
+    if (!::google::protobuf::internal::IsStructurallyValidUTF8(leftover_)) {
       return ReportFailure("Encountered non UTF-8 code points.");
     }
   }

--- a/src/google/protobuf/util/message_differencer.cc
+++ b/src/google/protobuf/util/message_differencer.cc
@@ -486,7 +486,8 @@ bool MessageDifferencer::Compare(
     return false;
   }
   // Expand google.protobuf.Any payload if possible.
-  if (descriptor1->full_name() == internal::kAnyFullTypeName) {
+  if (descriptor1->full_name() ==
+      ::google::protobuf::internal::kAnyFullTypeName) {
     std::unique_ptr<Message> data1;
     std::unique_ptr<Message> data2;
     if (UnpackAny(message1, &data1) && UnpackAny(message2, &data2)) {
@@ -1069,12 +1070,14 @@ bool MessageDifferencer::UnpackAny(const Message& any,
   const Reflection* reflection = any.GetReflection();
   const FieldDescriptor* type_url_field;
   const FieldDescriptor* value_field;
-  if (!internal::GetAnyFieldDescriptors(any, &type_url_field, &value_field)) {
+  if (!::google::protobuf::internal::GetAnyFieldDescriptors(
+          any, &type_url_field, &value_field)) {
     return false;
   }
   const string& type_url = reflection->GetString(any, type_url_field);
   string full_type_name;
-  if (!internal::ParseAnyTypeUrl(type_url, &full_type_name)) {
+  if (!::google::protobuf::internal::ParseAnyTypeUrl(type_url,
+                                                     &full_type_name)) {
     return false;
   }
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,0 +1,5 @@
+cc_binary(
+    name = "amalgamate",
+    srcs = ["amalgamate.cc"],
+    visibility = ["//visibility:public"],
+)

--- a/util/amalgamate.cc
+++ b/util/amalgamate.cc
@@ -1,0 +1,59 @@
+// Copyright 2018 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_set>
+
+using std::cout;
+using std::string;
+
+int main(int argc, char* argv[]) {
+  string prefix("#include ");
+  std::unordered_set<string> includes;
+  for (int i = 1; i < argc; ++i) {
+    cout << '\n';
+    cout << "//////////////////////////////////////////////////////////////\n";
+    cout << "// " << argv[i] << '\n';
+    cout << "//////////////////////////////////////////////////////////////\n";
+    cout << '\n';
+    std::ifstream f(argv[i]);
+    string line;
+    while (std::getline(f, line)) {
+      if (line.compare(0, prefix.size(), prefix) == 0) {
+        if (includes.find(line) != includes.end()) {
+          continue;
+        }
+        includes.insert(line);
+      }
+      cout << line << '\n';
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
According to the SQLite author, this might make things go between 5% and 10%
faster: https://www.sqlite.org/amalgamation.html

It reduced `du -sh bazel-bin/external/protobuf_archive` from to 20MB to 14MB.
It also reduced the latency on one of my builds by about 10 seconds. If I also
use the --distinct_host_configuration=false it reduced by 20 seconds.

Please note mine editor runs buildifier automatically.