### PR TITLE
Added the ability to ignore unknown types in csharp's JsonParser

### DIFF
--- a/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
+++ b/csharp/src/Google.Protobuf.Test/JsonParserTest.cs
@@ -848,6 +848,24 @@ namespace Google.Protobuf
         }
 
         [Test]
+        public void Any_IgnoreUnknownType_WithValue()
+        {
+            string json = "{ \"@type\": \"type.googleapis.com/bogus\", \"foo\": \"bar\" }";
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownTypes(true));
+            var any = parser.Parse<Any>(json);
+            Assert.IsTrue(any.Value.IsEmpty);
+        }
+
+        [Test]
+        public void Any_IgnoreUnknownType_NoValue()
+        {
+            string json = "{ \"@type\": \"type.googleapis.com/bogus\" }";
+            var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownTypes(true));
+            var any = parser.Parse<Any>(json);
+            Assert.IsTrue(any.Value.IsEmpty);
+        }
+
+        [Test]
         public void Any_NoTypeUrl()
         {
             string json = "{ \"foo\": \"bar\" }";


### PR DESCRIPTION
This feature request is similar to https://github.com/google/protobuf/issues/2838

Except instead of ignoring fields, we should be able to ignore an unknown type when parsing an Any message.

I added IgnoreUnknownTypes to JsonParser.Settings just like IgnoreUnknownFields to opt into this.