### PR TITLE
Add proto_library() well_known_protos_proto.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -226,6 +226,13 @@ cc_proto_library(
     visibility = ["//visibility:public"],
 )
 
+proto_library(
+    name = "well_known_protos_proto",
+    srcs = [],
+    deps = [dep + "_proto" for dep in WELL_KNOWN_PROTO_MAP],
+    visibility = ["//visibility:public"],
+)
+
 ################################################################################
 # Well Known Types Proto Library Rules
 #


### PR DESCRIPTION
This wraps us all the well known protos into one proto_library that
consumers can add to deps.