### PR TITLE
fix build in cmake cross-compiling

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 project(protobuf C CXX)
 
 # Add c++11 flags for clang
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 # Options
 option(protobuf_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
append compiler flags but not overwrite
CMAKE_CXX_FLAGS may contains special flags used in cmake cross-compiling
this change fix build with android-ndk-r16b unified header, which needs the "-D__ANDROID_API__=21" flag
