### PR TITLE
Fixed a Visual Studio 2017 build error. (#4488)

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_field.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_field.cc
@@ -117,8 +117,7 @@ FieldGeneratorMap::FieldGeneratorMap(const Descriptor* descriptor,
                                      SCCAnalyzer* scc_analyzer)
     : descriptor_(descriptor),
       options_(options),
-      field_generators_(
-          new std::unique_ptr<FieldGenerator>[descriptor->field_count()]) {
+      field_generators_(descriptor->field_count()) {
   // Construct all the FieldGenerators.
   for (int i = 0; i < descriptor->field_count(); i++) {
     field_generators_[i].reset(

--- a/src/google/protobuf/compiler/cpp/cpp_field.h
+++ b/src/google/protobuf/compiler/cpp/cpp_field.h
@@ -203,7 +203,7 @@ class FieldGeneratorMap {
  private:
   const Descriptor* descriptor_;
   const Options& options_;
-  std::unique_ptr<std::unique_ptr<FieldGenerator> []> field_generators_;
+  std::vector<std::unique_ptr<FieldGenerator>> field_generators_;
 
   static FieldGenerator* MakeGenerator(const FieldDescriptor* field,
                                        const Options& options,

--- a/src/google/protobuf/compiler/java/java_field.cc
+++ b/src/google/protobuf/compiler/java/java_field.cc
@@ -211,8 +211,7 @@ template <>
 FieldGeneratorMap<ImmutableFieldGenerator>::FieldGeneratorMap(
     const Descriptor* descriptor, Context* context)
     : descriptor_(descriptor),
-      field_generators_(new std::unique_ptr<
-          ImmutableFieldGenerator>[descriptor->field_count()]) {
+      field_generators_(descriptor->field_count()) {
 
   // Construct all the FieldGenerators and assign them bit indices for their
   // bit fields.
@@ -234,8 +233,7 @@ template <>
 FieldGeneratorMap<ImmutableFieldLiteGenerator>::FieldGeneratorMap(
     const Descriptor* descriptor, Context* context)
     : descriptor_(descriptor),
-      field_generators_(new std::unique_ptr<
-          ImmutableFieldLiteGenerator>[descriptor->field_count()]) {
+      field_generators_(descriptor->field_count()) {
   // Construct all the FieldGenerators and assign them bit indices for their
   // bit fields.
   int messageBitIndex = 0;

--- a/src/google/protobuf/compiler/java/java_field.h
+++ b/src/google/protobuf/compiler/java/java_field.h
@@ -138,7 +138,7 @@ class FieldGeneratorMap {
   const Descriptor* descriptor_;
   Context* context_;
   ClassNameResolver* name_resolver_;
-  std::unique_ptr<std::unique_ptr<FieldGeneratorType> []> field_generators_;
+  std::vector<std::unique_ptr<FieldGeneratorType>> field_generators_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGeneratorMap);
 };

--- a/src/google/protobuf/compiler/java/java_file.cc
+++ b/src/google/protobuf/compiler/java/java_file.cc
@@ -186,10 +186,8 @@ FileGenerator::FileGenerator(const FileDescriptor* file, const Options& options,
                              bool immutable_api)
     : file_(file),
       java_package_(FileJavaPackage(file, immutable_api)),
-      message_generators_(
-          new std::unique_ptr<MessageGenerator>[file->message_type_count()]),
-      extension_generators_(
-          new std::unique_ptr<ExtensionGenerator>[file->extension_count()]),
+      message_generators_(file->message_type_count()),
+      extension_generators_(file->extension_count()),
       context_(new Context(file, options)),
       name_resolver_(context_->GetNameResolver()),
       options_(options),

--- a/src/google/protobuf/compiler/java/java_file.h
+++ b/src/google/protobuf/compiler/java/java_file.h
@@ -98,8 +98,8 @@ class FileGenerator {
   string java_package_;
   string classname_;
 
-  std::unique_ptr<std::unique_ptr<MessageGenerator> []> message_generators_;
-  std::unique_ptr<std::unique_ptr<ExtensionGenerator> []> extension_generators_;
+  std::vector<std::unique_ptr<MessageGenerator>> message_generators_;
+  std::vector<std::unique_ptr<ExtensionGenerator>> extension_generators_;
   std::unique_ptr<GeneratorFactory> generator_factory_;
   std::unique_ptr<Context> context_;
   ClassNameResolver* name_resolver_;

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.cc
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.cc
@@ -410,10 +410,8 @@ bool RepeatedFieldGenerator::RuntimeUsesHasBit(void) const {
 FieldGeneratorMap::FieldGeneratorMap(const Descriptor* descriptor,
                                      const Options& options)
     : descriptor_(descriptor),
-      field_generators_(
-          new std::unique_ptr<FieldGenerator>[descriptor->field_count()]),
-      extension_generators_(
-          new std::unique_ptr<FieldGenerator>[descriptor->extension_count()]) {
+      field_generators_(descriptor->field_count()),
+      extension_generators_(descriptor->extension_count()) {
   // Construct all the FieldGenerators.
   for (int i = 0; i < descriptor->field_count(); i++) {
     field_generators_[i].reset(

--- a/src/google/protobuf/compiler/objectivec/objectivec_field.h
+++ b/src/google/protobuf/compiler/objectivec/objectivec_field.h
@@ -182,8 +182,8 @@ class FieldGeneratorMap {
 
  private:
   const Descriptor* descriptor_;
-  std::unique_ptr<std::unique_ptr<FieldGenerator>[]> field_generators_;
-  std::unique_ptr<std::unique_ptr<FieldGenerator>[]> extension_generators_;
+  std::vector<std::unique_ptr<FieldGenerator>> field_generators_;
+  std::vector<std::unique_ptr<FieldGenerator>> extension_generators_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(FieldGeneratorMap);
 };


### PR DESCRIPTION
The current 15.6.x versions of Visual Studio 2017 contain a bug that
prevent them from compiling the following construct under certain
conditions:

std::unique_ptr<std::unique_ptr<Foo> []> foos;

This will fail to compile if Foo is an abstract class. To work-around
the problem the whole construct was change into:

std::vector<std::unique_ptr<Foo>> foos;

This not only fixes the compiler error but is also more readable than
previous version.