### PR TITLE
+ added an option: enum_value_name_style, it expected one of: full, s…

### DIFF
--- a/src/google/protobuf/compiler/js/js_generator.h
+++ b/src/google/protobuf/compiler/js/js_generator.h
@@ -80,7 +80,8 @@ struct GeneratorOptions {
         error_on_name_conflict(false),
         extension(".js"),
         one_output_file_per_input_file(false),
-        annotate_code(false) {}
+        annotate_code(false),
+        enum_value_name_style(kFullUpperCase) {}
 
   bool ParseFromOptions(
       const std::vector< std::pair< string, string > >& options,
@@ -122,6 +123,11 @@ struct GeneratorOptions {
   // If true, we should build .meta files that contain annotations for
   // generated code. See GeneratedCodeInfo in descriptor.proto.
   bool annotate_code;
+
+  enum EnumValueNameStyle {
+      kFullUpperCase,
+      kShortUpperCase,
+  } enum_value_name_style;
 };
 
 // CodeGenerator implementation which generates a JavaScript source file and


### PR DESCRIPTION
…hort.

  where it equal ~short~, the name of enum's value liked C# or Java style.
  such as:
enum kGenderType
{
  kGenderType_None = 0;
  kGenderType_Male = 1;
  kGenderType_Female = 2;
};

will generated JS code like:
proto.kGenderType = {
  NONE : 0,
  MALE: 1,
  FEMALE: 2
}