### PR TITLE
map类型vaule默认值为0的时候长度过滤bug

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -1562,12 +1562,12 @@ class Message
                             $key);
                         $data_size += GPBWire::tagSize($key_field);
                     }
-                    if ($value != $this->defaultValue($value_field)) {
+                   // if ($value != $this->defaultValue($value_field)) {
                         $data_size += $this->fieldDataOnlyByteSize(
                             $value_field,
                             $value);
                         $data_size += GPBWire::tagSize($value_field);
-                    }
+                    //}
                     $size += GPBWire::varint32Size($data_size) + $data_size;
                 }
             }


### PR DESCRIPTION
长度过滤之后导致js解析报错