### PR TITLE
Add -std=c++11 for python setup on kokoro

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -206,6 +206,8 @@ if __name__ == '__main__':
       v = float('.'.join(v.split('.')[:2]))
       if v >= 10.12:
         extra_compile_args.append('-std=c++11')
+    elif os.getenv('KOKORO_BUILD_NUMBER') or os.getenv('KOKORO_BUILD_ID'):
+        extra_compile_args.append('-std=c++11')
 
     if warnings_as_errors in sys.argv:
       extra_compile_args.append('-Werror')


### PR DESCRIPTION
Kokoro is using c++ 4.8, which needs explicitly declare "-std=c++11" arg