### PR TITLE
PHP string-to-int and int-to-string methods for enums

### DIFF
--- a/php/src/Google/Protobuf/EnumTrait.php
+++ b/php/src/Google/Protobuf/EnumTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2017 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+namespace Google\Protobuf;
+
+use LogicException;
+use UnexpectedValueException;
+
+trait EnumTrait
+{
+    public static function name($value)
+    {
+        if (!property_exists(__CLASS__, 'valueToName')) {
+            throw new LogicException(sprintf('Classes implementing %s must '
+                . 'define the static property $valueToName', __TRAIT__));
+        }
+        if (!isset(self::$valueToName[$value])) {
+            throw new UnexpectedValueException(sprintf(
+                'Enum %s has no name defined for value %s', __CLASS__, $value));
+        }
+        return self::$valueToName[$value];
+    }
+
+    public static function value($name)
+    {
+        $const = __CLASS__ . '::' . strtoupper($name);
+        if (!defined($const)) {
+            throw new UnexpectedValueException(sprintf(
+                'Enum %s has no value defined for name %s', __CLASS__, $name));
+        }
+        return constant($const);
+    }
+}

--- a/php/src/Google/Protobuf/Internal/FieldDescriptorProto_Label.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptorProto_Label.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Protobuf enum <code>Google\Protobuf\Internal</code>
  */
 class FieldDescriptorProto_Label
 {
+    use EnumTrait;
+
     /**
      * 0 is reserved for errors
      *
@@ -23,5 +27,11 @@ class FieldDescriptorProto_Label
      * Generated from protobuf enum <code>LABEL_REPEATED = 3;</code>
      */
     const LABEL_REPEATED = 3;
+
+    private static $valueToName = [
+        self::LABEL_OPTIONAL => 'LABEL_OPTIONAL',
+        self::LABEL_REQUIRED => 'LABEL_REQUIRED',
+        self::LABEL_REPEATED => 'LABEL_REPEATED',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Internal/FieldDescriptorProto_Type.php
+++ b/php/src/Google/Protobuf/Internal/FieldDescriptorProto_Type.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Protobuf enum <code>Google\Protobuf\Internal</code>
  */
 class FieldDescriptorProto_Type
 {
+    use EnumTrait;
+
     /**
      * 0 is reserved for errors.
      * Order is weird for historical reasons.
@@ -103,5 +107,26 @@ class FieldDescriptorProto_Type
      * Generated from protobuf enum <code>TYPE_SINT64 = 18;</code>
      */
     const TYPE_SINT64 = 18;
+
+    private static $valueToName = [
+        self::TYPE_DOUBLE => 'TYPE_DOUBLE',
+        self::TYPE_FLOAT => 'TYPE_FLOAT',
+        self::TYPE_INT64 => 'TYPE_INT64',
+        self::TYPE_UINT64 => 'TYPE_UINT64',
+        self::TYPE_INT32 => 'TYPE_INT32',
+        self::TYPE_FIXED64 => 'TYPE_FIXED64',
+        self::TYPE_FIXED32 => 'TYPE_FIXED32',
+        self::TYPE_BOOL => 'TYPE_BOOL',
+        self::TYPE_STRING => 'TYPE_STRING',
+        self::TYPE_GROUP => 'TYPE_GROUP',
+        self::TYPE_MESSAGE => 'TYPE_MESSAGE',
+        self::TYPE_BYTES => 'TYPE_BYTES',
+        self::TYPE_UINT32 => 'TYPE_UINT32',
+        self::TYPE_ENUM => 'TYPE_ENUM',
+        self::TYPE_SFIXED32 => 'TYPE_SFIXED32',
+        self::TYPE_SFIXED64 => 'TYPE_SFIXED64',
+        self::TYPE_SINT32 => 'TYPE_SINT32',
+        self::TYPE_SINT64 => 'TYPE_SINT64',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Internal/FieldOptions_CType.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions_CType.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Protobuf enum <code>Google\Protobuf\Internal</code>
  */
 class FieldOptions_CType
 {
+    use EnumTrait;
+
     /**
      * Default mode.
      *
@@ -23,5 +27,11 @@ class FieldOptions_CType
      * Generated from protobuf enum <code>STRING_PIECE = 2;</code>
      */
     const STRING_PIECE = 2;
+
+    private static $valueToName = [
+        self::STRING => 'STRING',
+        self::CORD => 'CORD',
+        self::STRING_PIECE => 'STRING_PIECE',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Internal/FieldOptions_JSType.php
+++ b/php/src/Google/Protobuf/Internal/FieldOptions_JSType.php
@@ -4,11 +4,15 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Protobuf enum <code>Google\Protobuf\Internal</code>
  */
 class FieldOptions_JSType
 {
+    use EnumTrait;
+
     /**
      * Use the default type.
      *
@@ -27,5 +31,11 @@ class FieldOptions_JSType
      * Generated from protobuf enum <code>JS_NUMBER = 2;</code>
      */
     const JS_NUMBER = 2;
+
+    private static $valueToName = [
+        self::JS_NORMAL => 'JS_NORMAL',
+        self::JS_STRING => 'JS_STRING',
+        self::JS_NUMBER => 'JS_NUMBER',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Internal/FileOptions_OptimizeMode.php
+++ b/php/src/Google/Protobuf/Internal/FileOptions_OptimizeMode.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Generated classes can be optimized for speed or code size.
  *
@@ -11,6 +13,8 @@ namespace Google\Protobuf\Internal;
  */
 class FileOptions_OptimizeMode
 {
+    use EnumTrait;
+
     /**
      * Generate complete code for parsing, serialization,
      *
@@ -29,5 +33,11 @@ class FileOptions_OptimizeMode
      * Generated from protobuf enum <code>LITE_RUNTIME = 3;</code>
      */
     const LITE_RUNTIME = 3;
+
+    private static $valueToName = [
+        self::SPEED => 'SPEED',
+        self::CODE_SIZE => 'CODE_SIZE',
+        self::LITE_RUNTIME => 'LITE_RUNTIME',
+    ];
 }
 

--- a/php/src/Google/Protobuf/Internal/MethodOptions_IdempotencyLevel.php
+++ b/php/src/Google/Protobuf/Internal/MethodOptions_IdempotencyLevel.php
@@ -4,6 +4,8 @@
 
 namespace Google\Protobuf\Internal;
 
+use Google\Protobuf\EnumTrait;
+
 /**
  * Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
  * or neither? HTTP based RPC implementation may choose GET verb for safe
@@ -13,6 +15,8 @@ namespace Google\Protobuf\Internal;
  */
 class MethodOptions_IdempotencyLevel
 {
+    use EnumTrait;
+
     /**
      * Generated from protobuf enum <code>IDEMPOTENCY_UNKNOWN = 0;</code>
      */
@@ -29,5 +33,11 @@ class MethodOptions_IdempotencyLevel
      * Generated from protobuf enum <code>IDEMPOTENT = 2;</code>
      */
     const IDEMPOTENT = 2;
+
+    private static $valueToName = [
+        self::IDEMPOTENCY_UNKNOWN => 'IDEMPOTENCY_UNKNOWN',
+        self::NO_SIDE_EFFECTS => 'NO_SIDE_EFFECTS',
+        self::IDEMPOTENT => 'IDEMPOTENT',
+    ];
 }
 

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -8,6 +8,7 @@ require_once('test_util.php');
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Protobuf\Internal\MapField;
 use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\EnumTrait;
 use Foo\TestEnum;
 use Foo\TestIncludeNamespaceMessage;
 use Foo\TestIncludePrefixMessage;
@@ -226,6 +227,37 @@ class GeneratedClassTest extends TestBase
         // Set string.
         $m->setOptionalEnum("1");
         $this->assertEquals(TestEnum::ONE, $m->getOptionalEnum());
+
+        // Test Enum methods
+        $this->assertEquals('ONE', TestEnum::name(1));
+        $this->assertEquals(1, TestEnum::value('ONE'));
+    }
+
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage Classes implementing Google\Protobuf\EnumTrait must define the static property $valueToName
+     */
+    public function testBadEnumThrowsException()
+    {
+        BadEnum::name(1);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Enum GoodEnum has no name defined for value 2
+     */
+    public function testInvalidEnumValueThrowsException()
+    {
+        GoodEnum::name(2);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage Enum GoodEnum has no value defined for name DOES_NOT_EXIST
+     */
+    public function testInvalidEnumNameThrowsException()
+    {
+        GoodEnum::value('DOES_NOT_EXIST');
     }
 
     public function testNestedEnum()
@@ -1171,4 +1203,20 @@ class GeneratedClassTest extends TestBase
         $m = new testLowerCaseMessage();
         $n = testLowerCaseEnum::VALUE;
     }
+}
+
+class BadEnum
+{
+    use EnumTrait;
+}
+
+class GoodEnum
+{
+    use EnumTrait;
+
+    const EXAMPLE_VALUE = 1;
+
+    private static $valueToName = [
+        self::EXAMPLE_VALUE => 'EXAMPLE_VALUE',
+    ];
 }

--- a/src/google/protobuf/compiler/php/php_generator.cc
+++ b/src/google/protobuf/compiler/php/php_generator.cc
@@ -1003,6 +1003,8 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
         "name", fullname.substr(0, lastindex));
   }
 
+  printer.Print("use Google\\Protobuf\\EnumTrait;\n\n");
+
   GenerateEnumDocComment(&printer, en, is_descriptor);
 
   if (lastindex != string::npos) {
@@ -1018,6 +1020,8 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
   }
   Indent(&printer);
 
+  printer.Print("use EnumTrait;\n\n");
+
   for (int i = 0; i < en->value_count(); i++) {
     const EnumValueDescriptor* value = en->value(i);
     GenerateEnumValueDocComment(&printer, value);
@@ -1025,6 +1029,16 @@ void GenerateEnumFile(const FileDescriptor* file, const EnumDescriptor* en,
                   "name", ConstantNamePrefix(value->name()) + value->name(),
                   "number", IntToString(value->number()));
   }
+
+  printer.Print("\nprivate static $valueToName = [\n");
+  Indent(&printer);
+  for (int i = 0; i < en->value_count(); i++) {
+    const EnumValueDescriptor* value = en->value(i);
+    printer.Print("self::^name^ => '^name^',\n",
+                  "name", ConstantNamePrefix(value->name()) + value->name());
+  }
+  Outdent(&printer);
+  printer.Print("];\n");
 
   Outdent(&printer);
   printer.Print("}\n\n");


### PR DESCRIPTION
In accordance with [Python](https://developers.google.com/protocol-buffers/docs/reference/python-generated#enum), this PR adds `name` and `value` methods to PHP Protobuf Enums, so that conversion is programmatically possible between the two.

```php
$this->assertEquals('VALUE_A', SomeEnum::name(SomeEnum::VALUE_A));
$this->assertEquals(5, SomeEnum::value('VALUE_B'))
```

cc @michaelbausor @dwsupplee @tmatsuo