### PR TITLE
Add .proto files to extract_includes.bat

### DIFF
--- a/cmake/extract_includes.bat.in
+++ b/cmake/extract_includes.bat.in
@@ -111,9 +111,6 @@ copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format.h" includ
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format_lite.h" include\google\protobuf\wire_format_lite.h
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format_lite_inl.h" include\google\protobuf\wire_format_lite_inl.h
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wrappers.pb.h" include\google\protobuf\wrappers.pb.h
-mkdir include\google
-mkdir include\google\protobuf
-mkdir include\google\protobuf\compiler
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\any.proto" include\google\protobuf\any.proto
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\api.proto" include\google\protobuf\api.proto
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\compiler\plugin.proto" include\google\protobuf\compiler\plugin.proto

--- a/cmake/extract_includes.bat.in
+++ b/cmake/extract_includes.bat.in
@@ -111,3 +111,18 @@ copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format.h" includ
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format_lite.h" include\google\protobuf\wire_format_lite.h
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wire_format_lite_inl.h" include\google\protobuf\wire_format_lite_inl.h
 copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wrappers.pb.h" include\google\protobuf\wrappers.pb.h
+mkdir include\google
+mkdir include\google\protobuf
+mkdir include\google\protobuf\compiler
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\any.proto" include\google\protobuf\any.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\api.proto" include\google\protobuf\api.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\compiler\plugin.proto" include\google\protobuf\compiler\plugin.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\descriptor.proto" include\google\protobuf\descriptor.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\duration.proto" include\google\protobuf\duration.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\empty.proto" include\google\protobuf\empty.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\field_mask.proto" include\google\protobuf\field_mask.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\source_context.proto" include\google\protobuf\source_context.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\struct.proto" include\google\protobuf\struct.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\timestamp.proto" include\google\protobuf\timestamp.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\type.proto" include\google\protobuf\type.proto
+copy "${PROTOBUF_SOURCE_WIN32_PATH}\..\src\google\protobuf\wrappers.proto" include\google\protobuf\wrappers.proto

--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -139,6 +139,17 @@ for HEADER in $PUBLIC_HEADERS; do
   WINPATH=$(echo $HEADER | sed 's;/;\\;g')
   echo "copy \"\${PROTOBUF_SOURCE_WIN32_PATH}\\..\\src\\$WINPATH\" include\\$WINPATH" >> $EXTRACT_INCLUDES_BAT
 done
+for PROTO in ${WKT_PROTOS}; do
+  PROTO_DIR=$(dirname "$PROTO")
+  while [ ! "$PROTO_DIR" = "." ]; do
+    echo "mkdir include\\${PROTO_DIR//\//\\}"
+    PROTO_DIR=$(dirname "$PROTO_DIR")
+  done
+done | sort | uniq >> $EXTRACT_INCLUDES_BAT
+for PROTO in $WKT_PROTOS; do
+  WINPATH=${PROTO//\//\\}
+  echo "copy \"\${PROTOBUF_SOURCE_WIN32_PATH}\\..\\src\\$WINPATH\" include\\$WINPATH" >> $EXTRACT_INCLUDES_BAT
+done
 
 ################################################################################
 # Update bazel BUILD files.

--- a/update_file_lists.sh
+++ b/update_file_lists.sh
@@ -128,26 +128,15 @@ set_cmake_value $CMAKE_DIR/tests.cmake lite_arena_test_files $CMAKE_PREFIX $LITE
 
 # Generate extract_includes.bat
 echo "mkdir include" > $EXTRACT_INCLUDES_BAT
-for HEADER in $PUBLIC_HEADERS; do
-  HEADER_DIR=$(dirname $HEADER)
-  while [ ! "$HEADER_DIR" = "." ]; do
-    echo $HEADER_DIR | sed "s/\\//\\\\/g"
-    HEADER_DIR=$(dirname $HEADER_DIR)
-  done
-done | sort | uniq | sed "s/^/mkdir include\\\\/" >> $EXTRACT_INCLUDES_BAT
-for HEADER in $PUBLIC_HEADERS; do
-  WINPATH=$(echo $HEADER | sed 's;/;\\;g')
-  echo "copy \"\${PROTOBUF_SOURCE_WIN32_PATH}\\..\\src\\$WINPATH\" include\\$WINPATH" >> $EXTRACT_INCLUDES_BAT
-done
-for PROTO in ${WKT_PROTOS}; do
-  PROTO_DIR=$(dirname "$PROTO")
-  while [ ! "$PROTO_DIR" = "." ]; do
-    echo "mkdir include\\${PROTO_DIR//\//\\}"
-    PROTO_DIR=$(dirname "$PROTO_DIR")
+for INCLUDE in $PUBLIC_HEADERS $WKT_PROTOS; do
+  INCLUDE_DIR=$(dirname "$INCLUDE")
+  while [ ! "$INCLUDE_DIR" = "." ]; do
+    echo "mkdir include\\${INCLUDE_DIR//\//\\}"
+    INCLUDE_DIR=$(dirname "$INCLUDE_DIR")
   done
 done | sort | uniq >> $EXTRACT_INCLUDES_BAT
-for PROTO in $WKT_PROTOS; do
-  WINPATH=${PROTO//\//\\}
+for INCLUDE in $PUBLIC_HEADERS $WKT_PROTOS; do
+  WINPATH=${INCLUDE//\//\\}
   echo "copy \"\${PROTOBUF_SOURCE_WIN32_PATH}\\..\\src\\$WINPATH\" include\\$WINPATH" >> $EXTRACT_INCLUDES_BAT
 done
 


### PR DESCRIPTION
For google/or-tools, on windows, we need to use `import "google/protobuf/wrappers.proto";` since we want "optional" int64 and in version3 POD get default value...
-> so we use "google.protobuf.Int64Value" since 0 is a valid value and different from "not set" for our use case.