### PR TITLE
CMake: Update CXX Standard management

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1.3)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
@@ -15,8 +15,10 @@ endif()
 # Project
 project(protobuf C CXX)
 
-# Add c++11 flags for clang
-set(CMAKE_CXX_FLAGS "-std=c++11")
+# Add c++11 flags
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Options
 option(protobuf_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
Add -std=c++11 using CMake default target properties...
It follows #4475 and #4509

/!\ THIS WILL BUMP MINIMUM CMAKE VERSION TO 3.1.3 /!\

ref:
https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD_REQUIRED.html
https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html