### PR TITLE
[objectivec] Fix memory leak of exceptions raised by RaiseException()

### DIFF
--- a/objectivec/GPBCodedInputStream.m
+++ b/objectivec/GPBCodedInputStream.m
@@ -63,8 +63,9 @@ static void RaiseException(NSInteger code, NSString *reason) {
 
   NSDictionary *exceptionInfo =
       @{ GPBCodedInputStreamUnderlyingErrorKey: error };
-  [[NSException exceptionWithName:GPBCodedInputStreamException reason:reason userInfo:exceptionInfo]
-      raise];
+  [[NSException exceptionWithName:GPBCodedInputStreamException
+                           reason:reason
+                         userInfo:exceptionInfo] raise];
 }
 
 static void CheckRecursionLimit(GPBCodedInputStreamState *state) {

--- a/objectivec/GPBCodedInputStream.m
+++ b/objectivec/GPBCodedInputStream.m
@@ -63,9 +63,8 @@ static void RaiseException(NSInteger code, NSString *reason) {
 
   NSDictionary *exceptionInfo =
       @{ GPBCodedInputStreamUnderlyingErrorKey: error };
-  [[[NSException alloc] initWithName:GPBCodedInputStreamException
-                              reason:reason
-                            userInfo:exceptionInfo] raise];
+  [[NSException exceptionWithName:GPBCodedInputStreamException reason:reason userInfo:exceptionInfo]
+      raise];
 }
 
 static void CheckRecursionLimit(GPBCodedInputStreamState *state) {


### PR DESCRIPTION
Currently exceptions raised by RaiseException() is never deallocated because:

* ARC is disabled for this library: https://github.com/google/protobuf/blob/master/BUILD#L913
* The NSException is constructed with `+alloc` but is never `-release`d.

This change fixes the issue by using `-[NSException exceptionWithName:...]` instead, which returns an autoreleased instance, so it is deallocated properly.

This also follows a common practice that you should pass an autoreleased exception to `-raise`. Otherwise every `@catch` clause for that exception must `-release` it.

I found this issue because Leaks Instruments reported this NSException instance as a Root Leak in our app, which uses this library. Verified that the leak has gone away in Leaks Instruments by applying this pull request.
