### PR TITLE
Using binary one's complement to negate an unsigned int

### DIFF
--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -860,7 +860,7 @@ inline uint32 WireFormatLite::ZigZagEncode32(int32 n) {
 
 inline int32 WireFormatLite::ZigZagDecode32(uint32 n) {
   // Note:  Using unsigned types prevent undefined behavior
-  return static_cast<int32>((n >> 1) ^ -(n & 1));
+  return static_cast<int32>((n >> 1) ^ (~(n & 1) + 1));
 }
 
 inline uint64 WireFormatLite::ZigZagEncode64(int64 n) {
@@ -871,7 +871,7 @@ inline uint64 WireFormatLite::ZigZagEncode64(int64 n) {
 
 inline int64 WireFormatLite::ZigZagDecode64(uint64 n) {
   // Note:  Using unsigned types prevent undefined behavior
-  return static_cast<int64>((n >> 1) ^ -(n & 1));
+  return static_cast<int64>((n >> 1) ^ (~(n & 1) + 1));
 }
 
 // String is for UTF-8 text only, but, even so, ReadString() can simply


### PR DESCRIPTION
This removes a Visual Studio warning C4146: unary minus operator applied to unsigned type, result still unsigned.

Original code: https://github.com/google/protobuf/commit/24493eef9395e5b832360e12efabf9c363c9cb15

Fixes #4494