### PR TITLE
Install gcc 4.8 package on Travis build machine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,12 @@ matrix:
       addons:
         apt:
           sources:
-          - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main'
-            key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
+            - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main'
+              key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
+            - ubuntu-toolchain-r-test
           packages:
-          - dotnet-sharedframework-microsoft.netcore.app-1.0.5
+            - dotnet-sharedframework-microsoft.netcore.app-1.0.5
+            - g++-4.8
     # This test is kept on travis because it doesn't play nicely with other
     # tests on jenkins running in parallel.
     - os: linux

--- a/tests.sh
+++ b/tests.sh
@@ -18,7 +18,7 @@ internal_build_cpp() {
     return
   fi
 
-  if [[ $(uname -s) == "Linux" && "$TRAVIS" == "true" ]]; then
+  if [[ $(uname -s) == "Linux" && "$TRAVIS" == "true" && $(gcc -dumpversion) != "4.8" ]]; then
     # Install GCC 4.8 to replace the default GCC 4.6. We need 4.8 for more
     # decent C++ 11 support in order to compile conformance tests.
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
Newly created travis machines uses docker without **sudo**, so `tests.sh` will fail when installing gcc manualy. This ensures gcc 4.8 is installed on travis machine for testing **csharp** language.

