### PR TITLE
Add space between class name and concat message

### DIFF
--- a/php/src/Google/Protobuf/Internal/Message.php
+++ b/php/src/Google/Protobuf/Internal/Message.php
@@ -82,7 +82,7 @@ class Message
         $pool = DescriptorPool::getGeneratedPool();
         $this->desc = $pool->getDescriptorByClassName(get_class($this));
         if (is_null($this->desc)) {
-            user_error(get_class($this) . "is not found in descriptor pool.");
+            user_error(get_class($this) . " is not found in descriptor pool.");
         }
         foreach ($this->desc->getField() as $field) {
             $setter = $field->getSetter();


### PR DESCRIPTION
The class name was linked to the next word in the sentence.
"User\UserRequestis not found in descriptor pool."