### PR TITLE
Include version information in Windows binaries #3380

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1033,6 +1033,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   cmake/protobuf.pc.cmake                \
   cmake/protoc.cmake                     \
   cmake/tests.cmake                      \
+  cmake/version.rc.in                    \
   editors/README.txt                     \
   editors/proto.vim                      \
   editors/protobuf-mode.el               \

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -162,11 +162,22 @@ if (MSVC)
   add_definitions(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})
   string(REPLACE "/" "\\" PROTOBUF_BINARY_WIN32_PATH ${protobuf_BINARY_DIR})
+  string(REPLACE "." ","  protobuf_RC_FILEVERSION "${protobuf_VERSION}")
   configure_file(extract_includes.bat.in extract_includes.bat)
-  
+
   # Suppress linker warnings about files with no symbols defined.
   set(CMAKE_STATIC_LINKER_FLAGS /ignore:4221)
+
+  # Configure Resource Compiler
+  enable_language(RC)
+  # use English language (0x409) in resource compiler
+  set(rc_flags "/l0x409")
+  # fix rc.exe invocations because of usage of add_definitions()
+  set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_flags} <DEFINES> /fo<OBJECT> <SOURCE>")
+
+  configure_file(version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc @ONLY)
 endif (MSVC)
+
 
 get_filename_component(protobuf_source_dir ${protobuf_SOURCE_DIR} PATH)
 

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -49,7 +49,8 @@ set(libprotobuf_lite_includes
 )
 
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_lite_includes})
+  ${libprotobuf_lite_files} ${libprotobuf_lite_includes}
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -48,9 +48,12 @@ set(libprotobuf_lite_includes
   ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.h
 )
 
+set(libprotobuf_lite_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_lite_includes}
-  ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+  ${libprotobuf_lite_files} ${libprotobuf_lite_includes} ${libprotobuf_lite_rc_files})
 target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -112,8 +112,12 @@ set(libprotobuf_includes
   ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.h
 )
 
+set(libprotobuf_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes})
+  ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes} ${libprotobuf_rc_files})
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
 if(protobuf_WITH_ZLIB)
     target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -161,6 +161,10 @@ set(libprotoc_headers
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.h
 )
 
+set(libprotoc_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+
 set(js_well_known_types_sources
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/any.js
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types/struct.js
@@ -174,7 +178,7 @@ add_custom_command(
 )
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
-  ${libprotoc_files} ${libprotoc_headers})
+  ${libprotoc_files} ${libprotoc_headers} ${libprotoc_rc_files})
 target_link_libraries(libprotoc libprotobuf)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -2,6 +2,9 @@ set(protoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc
 )
 
-add_executable(protoc ${protoc_files})
+add_executable(protoc ${protoc_files} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 target_link_libraries(protoc libprotobuf libprotoc)
 add_executable(protobuf::protoc ALIAS protoc)
+
+set_target_properties(protoc PROPERTIES
+    VERSION ${protobuf_VERSION})

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -2,7 +2,11 @@ set(protoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc
 )
 
-add_executable(protoc ${protoc_files} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+set(protoc_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+
+add_executable(protoc ${protoc_files} ${protoc_rc_files})
 target_link_libraries(protoc libprotobuf libprotoc)
 add_executable(protobuf::protoc ALIAS protoc)
 

--- a/cmake/version.rc.in
+++ b/cmake/version.rc.in
@@ -1,0 +1,45 @@
+#define VS_FF_DEBUG 0x1L
+#define VS_VERSION_INFO 0x1L
+#define VS_FFI_FILEFLAGSMASK 0x17L
+#define VER_PRIVATEBUILD 0x0L
+#define VER_PRERELEASE 0x0L
+#define VOS__WINDOWS32 0x4L
+#define VFT_DLL 0x2L
+#define VFT2_UNKNOWN 0x0L
+
+#ifndef DEBUG
+#define VER_DEBUG 0
+#else
+#define VER_DEBUG VS_FF_DEBUG
+#endif
+
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    @protobuf_RC_FILEVERSION@,0
+  PRODUCTVERSION @protobuf_RC_FILEVERSION@,0
+  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+  FILEFLAGS      VER_DEBUG
+  FILEOS         VOS__WINDOWS32
+  FILETYPE       VFT_DLL
+BEGIN
+    BLOCK "VarFileInfo"
+    BEGIN 
+        // English language (0x409) and the Windows Unicode codepage (1200)
+        VALUE "Translation", 0x409, 1200
+    END
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "Compiled with @CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@\0"
+            VALUE "ProductVersion", "@protobuf_VERSION@\0"
+            VALUE "FileVersion", "@protobuf_VERSION@\0"
+            VALUE "InternalName", "protobuf\0"
+            VALUE "ProductName", "Protocol Buffers - Google's Data Interchange Format\0"
+            VALUE "CompanyName", "Google Inc.\0"
+            VALUE "LegalCopyright", "Copyright 2008 Google Inc.  All rights reserved.\0"
+            VALUE "Licence", "BSD\0"
+            VALUE "Info", "https://developers.google.com/protocol-buffers/\0"
+        END
+    END
+END


### PR DESCRIPTION
Windows binaries of protobuf (DLLs built in shared mode and the protoc.exe) will contain version information in file details.

This fixes #3380

![image](https://user-images.githubusercontent.com/287778/39418850-016ab726-4c5d-11e8-99f5-e72fd15a64b4.png)
