### PR TITLE
Add a third-party RPC implementation: raster

### DIFF
--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -124,6 +124,7 @@ GRPC (http://www.grpc.io/) is Google's RPC implementation for Protocol Buffers. 
 * https://github.com/tony612/grpc-elixir (Elixir)
 * https://github.com/johanbrandhorst/protobuf (GopherJS)
 * https://github.com/awakesecurity/gRPC-haskell (Haskell)
+* https://github.com/Yeolar/raster (C++)
 
 ## Other Utilities
 


### PR DESCRIPTION
Add a third-party RPC implementation: raster - a network framework supports pbrpc by 'service' keyword.