### PR TITLE
Appveyor MinGW build

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -1,10 +1,22 @@
 setlocal
 
+IF %platform%==MinGW GOTO build_mingw
 IF %language%==cpp GOTO build_cpp
 IF %language%==csharp GOTO build_csharp
 
-echo Unsupported language %language%. Exiting.
+echo Unsupported language %language% and platform %platform%. Exiting.
 goto :error
+
+:build_mingw
+echo Building MinGW
+set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+mkdir build_mingw
+cd build_mingw
+cmake -G "%generator%" -Dprotobuf_BUILD_SHARED_LIBS=%BUILD_DLL% -Dprotobuf_UNICODE=%UNICODE% -Dprotobuf_BUILD_TESTS=0 ../cmake
+mingw32-make -j8 all || goto error
+rem cd %configuration%
+rem tests.exe || goto error
+goto :EOF
 
 :build_cpp
 echo Building C++

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,23 @@
 # Only test one combination: "Visual Studio 12 + Win64 + Debug + DLL". We can
 # test more combinations but AppVeyor just takes too long to finish (each
 # combination takes ~15mins).
-platform:
-  - Win64
-
 configuration:
   - Debug
 
 environment:
   matrix:
-    - language: cpp
+    - platform: MinGW
+      language: cpp
+      image: Visual Studio 2015
+
+    - platform: Win64
+      language: cpp
       image: Visual Studio 2015
       BUILD_DLL: ON
       UNICODE: ON
 
-    - language: csharp
+    - platform: Win64
+      language: csharp
       image: Visual Studio 2017
 
 # Our build scripts run tests automatically; we don't want AppVeyor
@@ -25,6 +28,7 @@ install:
   - git submodule update --init --recursive
 
 before_build:
+  - if %platform%==MinGW set generator=MinGW Makefiles
   - if %platform%==Win32 set generator=Visual Studio 14
   - if %platform%==Win64 set generator=Visual Studio 14 Win64
   - if %platform%==Win32 set vcplatform=Win32

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -204,6 +204,10 @@ if(protobuf_ABSOLUTE_TEST_PLUGIN_PATH)
   add_compile_options(-DGOOGLE_PROTOBUF_TEST_PLUGIN_PATH="$<TARGET_FILE:test_plugin>")
 endif()
 
+if(MINGW)
+  set_source_files_properties(${tests_files} PROPERTIES COMPILE_FLAGS "-Wno-narrowing")
+endif()
+
 add_executable(tests ${tests_files} ${common_test_files} ${tests_proto_files} ${lite_test_proto_files})
 target_link_libraries(tests libprotoc libprotobuf gmock_main)
 


### PR DESCRIPTION
MinGW Appveyor build protobuf lib and compiler.

Test currently disabled with -Dprotobuf_BUILD_TESTS=0 because some tests are failed to link with following errors: Fatal error: can't close map_lite_unittest.pb.cc.obj: File too big