### PR TITLE
Add C++ library target for including python_protobuf.h

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -793,6 +793,16 @@ py_library(
     ],
 )
 
+cc_library(
+    name = "python_protobuf",
+    hdrs = [
+        "python/google/protobuf/python_protobuf.h",
+    ],
+    deps = [
+        "//external:python_headers",
+    ],
+)
+
 internal_protobuf_py_tests(
     name = "python_tests_batch",
     data = glob([


### PR DESCRIPTION
Hi!  I'm Thomas Colthurst, and I work on the Nucleus project (github.com/google/nucleus).

For that project, I've written a custom Clif_PyObjAs converter that bypasses the expensive copies that Clif normally imposes when passing protocol buffers between C++ and Python.  But that function needs to call MutableCProtoInsidePyProto, and to do that, I need that function to be exported by some cc_library target.  Thus this pull request.