### PR TITLE
Add "override" keyword for overridden virtual functions

### DIFF
--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -103,7 +103,7 @@ class SourceTreeDescriptorDatabase::SingleFileErrorCollector
   bool had_errors() { return had_errors_; }
 
   // implements ErrorCollector ---------------------------------------
-  void AddError(int line, int column, const string& message) {
+  void AddError(int line, int column, const string& message) override {
     if (multi_file_error_collector_ != NULL) {
       multi_file_error_collector_->AddError(filename_, line, column, message);
     }

--- a/src/google/protobuf/compiler/importer.h
+++ b/src/google/protobuf/compiler/importer.h
@@ -96,12 +96,13 @@ class LIBPROTOBUF_EXPORT SourceTreeDescriptorDatabase : public DescriptorDatabas
   }
 
   // implements DescriptorDatabase -----------------------------------
-  bool FindFileByName(const string& filename, FileDescriptorProto* output);
+  bool FindFileByName(const string& filename,
+                      FileDescriptorProto* output) override;
   bool FindFileContainingSymbol(const string& symbol_name,
-                                FileDescriptorProto* output);
+                                FileDescriptorProto*output) override;
   bool FindFileContainingExtension(const string& containing_type,
                                    int field_number,
-                                   FileDescriptorProto* output);
+                                   FileDescriptorProto* output) override;
 
  private:
   class SingleFileErrorCollector;
@@ -119,13 +120,13 @@ class LIBPROTOBUF_EXPORT SourceTreeDescriptorDatabase : public DescriptorDatabas
                   const string& element_name,
                   const Message* descriptor,
                   ErrorLocation location,
-                  const string& message);
+                  const string& message) override;
 
     virtual void AddWarning(const string& filename,
                             const string& element_name,
                             const Message* descriptor,
                             ErrorLocation location,
-                            const string& message);
+                            const string& message) override;
 
    private:
     SourceTreeDescriptorDatabase* owner_;
@@ -293,9 +294,9 @@ class LIBPROTOBUF_EXPORT DiskSourceTree : public SourceTree {
   bool VirtualFileToDiskFile(const string& virtual_file, string* disk_file);
 
   // implements SourceTree -------------------------------------------
-  virtual io::ZeroCopyInputStream* Open(const string& filename);
+  virtual io::ZeroCopyInputStream* Open(const string& filename) override;
 
-  virtual string GetLastErrorMessage();
+  virtual string GetLastErrorMessage() override;
 
  private:
   struct Mapping {

--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -6951,7 +6951,7 @@ class DescriptorBuilder::OptionInterpreter::AggregateOptionFinder
   DescriptorBuilder* builder_;
 
   virtual const FieldDescriptor* FindExtension(
-      Message* message, const string& name) const {
+      Message* message, const string& name) const override {
     assert_mutex_held(builder_->pool_);
     const Descriptor* descriptor = message->GetDescriptor();
     Symbol result = builder_->LookupSymbolNoPlaceholder(
@@ -6989,7 +6989,7 @@ class AggregateErrorCollector : public io::ErrorCollector {
   string error_;
 
   virtual void AddError(int /* line */, int /* column */,
-                        const string& message) {
+                const string& message) override {
     if (!error_.empty()) {
       error_ += "; ";
     }
@@ -6997,7 +6997,7 @@ class AggregateErrorCollector : public io::ErrorCollector {
   }
 
   virtual void AddWarning(int /* line */, int /* column */,
-                          const string& /* message */) {
+                  const string& /* message */) override {
     // Ignore warnings
   }
 };

--- a/src/google/protobuf/descriptor_database.h
+++ b/src/google/protobuf/descriptor_database.h
@@ -142,7 +142,7 @@ class LIBPROTOBUF_EXPORT DescriptorDatabase {
 class LIBPROTOBUF_EXPORT SimpleDescriptorDatabase : public DescriptorDatabase {
  public:
   SimpleDescriptorDatabase();
-  ~SimpleDescriptorDatabase();
+  ~SimpleDescriptorDatabase() override;
 
   // Adds the FileDescriptorProto to the database, making a copy.  The object
   // can be deleted after Add() returns.  Returns false if the file conflicted
@@ -155,14 +155,14 @@ class LIBPROTOBUF_EXPORT SimpleDescriptorDatabase : public DescriptorDatabase {
 
   // implements DescriptorDatabase -----------------------------------
   bool FindFileByName(const string& filename,
-                      FileDescriptorProto* output);
+                      FileDescriptorProto* output) override;
   bool FindFileContainingSymbol(const string& symbol_name,
-                                FileDescriptorProto* output);
+                                FileDescriptorProto* output) override;
   bool FindFileContainingExtension(const string& containing_type,
                                    int field_number,
-                                   FileDescriptorProto* output);
+                                   FileDescriptorProto* output) override;
   bool FindAllExtensionNumbers(const string& extendee_type,
-                               std::vector<int>* output);
+                               std::vector<int>* output) override;
 
  private:
   // So that it can use DescriptorIndex.
@@ -280,7 +280,7 @@ class LIBPROTOBUF_EXPORT SimpleDescriptorDatabase : public DescriptorDatabase {
 class LIBPROTOBUF_EXPORT EncodedDescriptorDatabase : public DescriptorDatabase {
  public:
   EncodedDescriptorDatabase();
-  ~EncodedDescriptorDatabase();
+  ~EncodedDescriptorDatabase() override;
 
   // Adds the FileDescriptorProto to the database.  The descriptor is provided
   // in encoded form.  The database does not make a copy of the bytes, nor
@@ -300,14 +300,14 @@ class LIBPROTOBUF_EXPORT EncodedDescriptorDatabase : public DescriptorDatabase {
 
   // implements DescriptorDatabase -----------------------------------
   bool FindFileByName(const string& filename,
-                      FileDescriptorProto* output);
+                      FileDescriptorProto* output) override;
   bool FindFileContainingSymbol(const string& symbol_name,
-                                FileDescriptorProto* output);
+                                FileDescriptorProto* output) override;
   bool FindFileContainingExtension(const string& containing_type,
                                    int field_number,
-                                   FileDescriptorProto* output);
+                                   FileDescriptorProto* output) override;
   bool FindAllExtensionNumbers(const string& extendee_type,
-                               std::vector<int>* output);
+                               std::vector<int>* output) override;
 
  private:
   SimpleDescriptorDatabase::DescriptorIndex<std::pair<const void*, int> >
@@ -326,18 +326,18 @@ class LIBPROTOBUF_EXPORT EncodedDescriptorDatabase : public DescriptorDatabase {
 class LIBPROTOBUF_EXPORT DescriptorPoolDatabase : public DescriptorDatabase {
  public:
   explicit DescriptorPoolDatabase(const DescriptorPool& pool);
-  ~DescriptorPoolDatabase();
+  ~DescriptorPoolDatabase() override;
 
   // implements DescriptorDatabase -----------------------------------
   bool FindFileByName(const string& filename,
-                      FileDescriptorProto* output);
+                      FileDescriptorProto* output) override;
   bool FindFileContainingSymbol(const string& symbol_name,
-                                FileDescriptorProto* output);
+                                FileDescriptorProto* output) override;
   bool FindFileContainingExtension(const string& containing_type,
                                    int field_number,
-                                   FileDescriptorProto* output);
+                                   FileDescriptorProto* output) override;
   bool FindAllExtensionNumbers(const string& extendee_type,
-                               std::vector<int>* output);
+                               std::vector<int>* output) override;
 
  private:
   const DescriptorPool& pool_;
@@ -356,20 +356,20 @@ class LIBPROTOBUF_EXPORT MergedDescriptorDatabase : public DescriptorDatabase {
   // DescriptorDatabases need to stick around.
   explicit MergedDescriptorDatabase(
       const std::vector<DescriptorDatabase*>& sources);
-  ~MergedDescriptorDatabase();
+  ~MergedDescriptorDatabase() override;
 
   // implements DescriptorDatabase -----------------------------------
   bool FindFileByName(const string& filename,
-                      FileDescriptorProto* output);
+                      FileDescriptorProto* output) override;
   bool FindFileContainingSymbol(const string& symbol_name,
-                                FileDescriptorProto* output);
+                                FileDescriptorProto* output) override;
   bool FindFileContainingExtension(const string& containing_type,
                                    int field_number,
-                                   FileDescriptorProto* output);
+                                   FileDescriptorProto* output) override;
   // Merges the results of calling all databases. Returns true iff any
   // of the databases returned true.
   bool FindAllExtensionNumbers(const string& extendee_type,
-                               std::vector<int>* output);
+                               std::vector<int>* output) override;
 
 
  private:

--- a/src/google/protobuf/dynamic_message.cc
+++ b/src/google/protobuf/dynamic_message.cc
@@ -258,14 +258,14 @@ class DynamicMessage : public Message {
 
   // implements Message ----------------------------------------------
 
-  Message* New() const;
-  Message* New(::google::protobuf::Arena* arena) const;
-  ::google::protobuf::Arena* GetArena() const { return arena_; }
+  Message* New() const override;
+  Message* New(::google::protobuf::Arena* arena) const override;
+  ::google::protobuf::Arena* GetArena() const override { return arena_; }
 
-  int GetCachedSize() const;
-  void SetCachedSize(int size) const;
+  int GetCachedSize() const override;
+  void SetCachedSize(int size) const override;
 
-  Metadata GetMetadata() const;
+  Metadata GetMetadata() const override;
 
   // We actually allocate more memory than sizeof(*this) when this
   // class's memory is allocated via the global operator new. Thus, we need to

--- a/src/google/protobuf/dynamic_message.h
+++ b/src/google/protobuf/dynamic_message.h
@@ -115,7 +115,7 @@ class LIBPROTOBUF_EXPORT DynamicMessageFactory : public MessageFactory {
   // outlive the DynamicMessageFactory.
   //
   // The method is thread-safe.
-  const Message* GetPrototype(const Descriptor* type);
+  const Message* GetPrototype(const Descriptor* type) override;
 
  private:
   const DescriptorPool* pool_;

--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -134,7 +134,7 @@ class LIBPROTOBUF_EXPORT GeneratedExtensionFinder : public ExtensionFinder {
   virtual ~GeneratedExtensionFinder() {}
 
   // Returns true and fills in *output if found, otherwise returns false.
-  virtual bool Find(int number, ExtensionInfo* output);
+  virtual bool Find(int number, ExtensionInfo* output) override;
 
  private:
   const MessageLite* containing_type_;

--- a/src/google/protobuf/extension_set_heavy.cc
+++ b/src/google/protobuf/extension_set_heavy.cc
@@ -85,9 +85,9 @@ class DescriptorPoolExtensionFinder : public ExtensionFinder {
                                 MessageFactory* factory,
                                 const Descriptor* containing_type)
       : pool_(pool), factory_(factory), containing_type_(containing_type) {}
-  virtual ~DescriptorPoolExtensionFinder() {}
+  virtual ~DescriptorPoolExtensionFinder() override {}
 
-  virtual bool Find(int number, ExtensionInfo* output);
+  virtual bool Find(int number, ExtensionInfo* output) override;
 
  private:
   const DescriptorPool* pool_;

--- a/src/google/protobuf/generated_message_reflection.h
+++ b/src/google/protobuf/generated_message_reflection.h
@@ -304,199 +304,208 @@ class GeneratedMessageReflection final : public Reflection {
                              const DescriptorPool* pool,
                              MessageFactory* factory);
 
-  ~GeneratedMessageReflection();
+
+  ~GeneratedMessageReflection() override;
 
   // implements Reflection -------------------------------------------
 
-  const UnknownFieldSet& GetUnknownFields(const Message& message) const;
-  UnknownFieldSet* MutableUnknownFields(Message* message) const;
+  const UnknownFieldSet& GetUnknownFields(
+      const Message& message) const override;
+  UnknownFieldSet* MutableUnknownFields(Message* message) const override;
 
-  size_t SpaceUsedLong(const Message& message) const;
+  size_t SpaceUsedLong(const Message& message) const override;
 
-  bool HasField(const Message& message, const FieldDescriptor* field) const;
-  int FieldSize(const Message& message, const FieldDescriptor* field) const;
-  void ClearField(Message* message, const FieldDescriptor* field) const;
+  bool HasField(const Message& message,
+                const FieldDescriptor* field) const override;
+  int FieldSize(const Message& message,
+                const FieldDescriptor* field) const override;
+  void ClearField(Message* message,
+                  const FieldDescriptor* field) const override;
   bool HasOneof(const Message& message,
-                const OneofDescriptor* oneof_descriptor) const;
-  void ClearOneof(Message* message, const OneofDescriptor* field) const;
-  void RemoveLast(Message* message, const FieldDescriptor* field) const;
-  Message* ReleaseLast(Message* message, const FieldDescriptor* field) const;
-  void Swap(Message* message1, Message* message2) const;
+                const OneofDescriptor* oneof_descriptor) const override;
+  void ClearOneof(Message* message,
+                  const OneofDescriptor* field) const override;
+  void RemoveLast(Message* message,
+                  const FieldDescriptor* field) const override;
+  Message* ReleaseLast(Message* message,
+                       const FieldDescriptor* field) const override;
+  void Swap(Message* message1, Message* message2) const override;
   void SwapFields(Message* message1, Message* message2,
-                  const std::vector<const FieldDescriptor*>& fields) const;
+                  const std::vector<const FieldDescriptor*>& fields) const override;
   void SwapElements(Message* message, const FieldDescriptor* field,
-                    int index1, int index2) const;
+                    int index1, int index2) const override;
   void ListFields(const Message& message,
-                  std::vector<const FieldDescriptor*>* output) const;
-
+                  std::vector<const FieldDescriptor*>* output) const override;
   int32  GetInt32 (const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   int64  GetInt64 (const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   uint32 GetUInt32(const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   uint64 GetUInt64(const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   float  GetFloat (const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   double GetDouble(const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   bool   GetBool  (const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   string GetString(const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   const string& GetStringReference(const Message& message,
                                    const FieldDescriptor* field,
-                                   string* scratch) const;
-  const EnumValueDescriptor* GetEnum(const Message& message,
-                                     const FieldDescriptor* field) const;
+                                   string* scratch) const override;
+  const EnumValueDescriptor* GetEnum(
+      const Message& message, const FieldDescriptor* field) const override;
   int GetEnumValue(const Message& message,
-                   const FieldDescriptor* field) const;
+                   const FieldDescriptor* field) const override;
   const Message& GetMessage(const Message& message,
                             const FieldDescriptor* field,
-                            MessageFactory* factory = NULL) const;
+                            MessageFactory* factory = NULL) const override;
 
   const FieldDescriptor* GetOneofFieldDescriptor(
       const Message& message,
-      const OneofDescriptor* oneof_descriptor) const;
+      const OneofDescriptor* oneof_descriptor) const override;
 
  private:
   bool ContainsMapKey(const Message& message,
                       const FieldDescriptor* field,
-                      const MapKey& key) const;
+                      const MapKey& key) const override;
   bool InsertOrLookupMapValue(Message* message,
                               const FieldDescriptor* field,
                               const MapKey& key,
-                              MapValueRef* val) const;
+                              MapValueRef* val) const override;
   bool DeleteMapValue(Message* message,
                       const FieldDescriptor* field,
-                      const MapKey& key) const;
+                      const MapKey& key) const override;
   MapIterator MapBegin(
       Message* message,
-      const FieldDescriptor* field) const;
+      const FieldDescriptor* field) const override;
   MapIterator MapEnd(
       Message* message,
-      const FieldDescriptor* field) const;
-  int MapSize(const Message& message, const FieldDescriptor* field) const;
+      const FieldDescriptor* field) const override;
+  int MapSize(const Message& message,
+              const FieldDescriptor* field) const override;
 
  public:
   void SetInt32 (Message* message,
-                 const FieldDescriptor* field, int32  value) const;
+                 const FieldDescriptor* field, int32  value) const override;
   void SetInt64 (Message* message,
-                 const FieldDescriptor* field, int64  value) const;
+                 const FieldDescriptor* field, int64  value) const override;
   void SetUInt32(Message* message,
-                 const FieldDescriptor* field, uint32 value) const;
+                 const FieldDescriptor* field, uint32 value) const override;
   void SetUInt64(Message* message,
-                 const FieldDescriptor* field, uint64 value) const;
+                 const FieldDescriptor* field, uint64 value) const override;
   void SetFloat (Message* message,
-                 const FieldDescriptor* field, float  value) const;
+                 const FieldDescriptor* field, float  value) const override;
   void SetDouble(Message* message,
-                 const FieldDescriptor* field, double value) const;
+                 const FieldDescriptor* field, double value) const override;
   void SetBool  (Message* message,
-                 const FieldDescriptor* field, bool   value) const;
+                 const FieldDescriptor* field, bool   value) const override;
   void SetString(Message* message,
                  const FieldDescriptor* field,
-                 const string& value) const;
+                 const string& value) const override;
   void SetEnum  (Message* message, const FieldDescriptor* field,
-                 const EnumValueDescriptor* value) const;
+                 const EnumValueDescriptor* value) const override;
   void SetEnumValue(Message* message, const FieldDescriptor* field,
-                    int value) const;
+                    int value) const override;
   Message* MutableMessage(Message* message, const FieldDescriptor* field,
-                          MessageFactory* factory = NULL) const;
+                          MessageFactory* factory = NULL) const override;
   void SetAllocatedMessage(Message* message,
                            Message* sub_message,
-                           const FieldDescriptor* field) const;
+                           const FieldDescriptor* field) const override;
   Message* ReleaseMessage(Message* message, const FieldDescriptor* field,
-                          MessageFactory* factory = NULL) const;
+                          MessageFactory* factory = NULL) const override;
 
-  int32  GetRepeatedInt32 (const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  int64  GetRepeatedInt64 (const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  uint32 GetRepeatedUInt32(const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  uint64 GetRepeatedUInt64(const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  float  GetRepeatedFloat (const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  double GetRepeatedDouble(const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  bool   GetRepeatedBool  (const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  string GetRepeatedString(const Message& message,
-                           const FieldDescriptor* field, int index) const;
-  const string& GetRepeatedStringReference(const Message& message,
+  int32 GetRepeatedInt32(const Message& message, const FieldDescriptor* field,
+                         int index) const override;
+  int64 GetRepeatedInt64(const Message& message, const FieldDescriptor* field,
+                         int index) const override;
+  uint32 GetRepeatedUInt32(const Message& message, const FieldDescriptor* field,
+                           int index) const override;
+  uint64 GetRepeatedUInt64(const Message& message, const FieldDescriptor* field,
+                           int index) const override;
+  float GetRepeatedFloat(const Message& message, const FieldDescriptor* field,
+                         int index) const override;
+  double GetRepeatedDouble(const Message& message, const FieldDescriptor* field,
+                           int index) const override;
+  bool GetRepeatedBool(const Message& message, const FieldDescriptor* field,
+                       int index) const override;
+  string GetRepeatedString(const Message& message, const FieldDescriptor* field,
+                           int index) const override;
+  const string &GetRepeatedStringReference(const Message& message,
                                            const FieldDescriptor* field,
-                                           int index, string* scratch) const;
+                                           int index,
+                                           string* scratch) const override;
   const EnumValueDescriptor* GetRepeatedEnum(const Message& message,
                                              const FieldDescriptor* field,
-                                             int index) const;
-  int GetRepeatedEnumValue(const Message& message,
-                           const FieldDescriptor* field,
-                           int index) const;
-  const Message& GetRepeatedMessage(const Message& message,
+                                             int index) const override;
+  int GetRepeatedEnumValue(const Message& message, const FieldDescriptor* field,
+                           int index) const override;
+  const Message &GetRepeatedMessage(const Message& message,
                                     const FieldDescriptor* field,
-                                    int index) const;
+                                    int index) const override;
 
   // Set the value of a field.
-  void SetRepeatedInt32 (Message* message,
-                         const FieldDescriptor* field, int index, int32  value) const;
-  void SetRepeatedInt64 (Message* message,
-                         const FieldDescriptor* field, int index, int64  value) const;
-  void SetRepeatedUInt32(Message* message,
-                         const FieldDescriptor* field, int index, uint32 value) const;
-  void SetRepeatedUInt64(Message* message,
-                         const FieldDescriptor* field, int index, uint64 value) const;
-  void SetRepeatedFloat (Message* message,
-                         const FieldDescriptor* field, int index, float  value) const;
-  void SetRepeatedDouble(Message* message,
-                         const FieldDescriptor* field, int index, double value) const;
-  void SetRepeatedBool  (Message* message,
-                         const FieldDescriptor* field, int index, bool   value) const;
-  void SetRepeatedString(Message* message,
-                         const FieldDescriptor* field, int index,
-                         const string& value) const;
+  void SetRepeatedInt32(Message* message, const FieldDescriptor* field,
+                        int index, int32 value) const override;
+  void SetRepeatedInt64(Message* message, const FieldDescriptor* field,
+                        int index, int64 value) const override;
+  void SetRepeatedUInt32(Message* message, const FieldDescriptor* field,
+                         int index, uint32 value) const override;
+  void SetRepeatedUInt64(Message* message, const FieldDescriptor* field,
+                         int index, uint64 value) const override;
+  void SetRepeatedFloat(Message* message, const FieldDescriptor* field,
+                        int index, float value) const override;
+  void SetRepeatedDouble(Message* message, const FieldDescriptor* field,
+                         int index, double value) const override;
+  void SetRepeatedBool(Message* message, const FieldDescriptor* field,
+                       int index, bool value) const override;
+  void SetRepeatedString(Message* message, const FieldDescriptor* field,
+                         int index, const string &value) const override;
   void SetRepeatedEnum(Message* message, const FieldDescriptor* field,
-                       int index, const EnumValueDescriptor* value) const;
+                       int index,
+                       const EnumValueDescriptor* value) const override;
   void SetRepeatedEnumValue(Message* message, const FieldDescriptor* field,
-                            int index, int value) const;
+                            int index, int value) const override;
   // Get a mutable pointer to a field with a message type.
   Message* MutableRepeatedMessage(Message* message,
                                   const FieldDescriptor* field,
-                                  int index) const;
+                                  int index) const override;
 
   void AddInt32 (Message* message,
-                 const FieldDescriptor* field, int32  value) const;
+                 const FieldDescriptor* field, int32  value) const override;
   void AddInt64 (Message* message,
-                 const FieldDescriptor* field, int64  value) const;
+                 const FieldDescriptor* field, int64  value) const override;
   void AddUInt32(Message* message,
-                 const FieldDescriptor* field, uint32 value) const;
+                 const FieldDescriptor* field, uint32 value) const override;
   void AddUInt64(Message* message,
-                 const FieldDescriptor* field, uint64 value) const;
+                 const FieldDescriptor* field, uint64 value) const override;
   void AddFloat (Message* message,
-                 const FieldDescriptor* field, float  value) const;
+                 const FieldDescriptor* field, float  value) const override;
   void AddDouble(Message* message,
-                 const FieldDescriptor* field, double value) const;
+                 const FieldDescriptor* field, double value) const override;
   void AddBool  (Message* message,
-                 const FieldDescriptor* field, bool   value) const;
-  void AddString(Message* message,
-                 const FieldDescriptor* field, const string& value) const;
+                 const FieldDescriptor* field, bool   value) const override;
+  void AddString(Message* message, const FieldDescriptor* field,
+                 const string& value) const override;
   void AddEnum(Message* message,
                const FieldDescriptor* field,
-               const EnumValueDescriptor* value) const;
+               const EnumValueDescriptor* value) const override;
   void AddEnumValue(Message* message,
                     const FieldDescriptor* field,
-                    int value) const;
+                    int value) const override;
   Message* AddMessage(Message* message, const FieldDescriptor* field,
-                      MessageFactory* factory = NULL) const;
+                      MessageFactory* factory = NULL) const override;
   void AddAllocatedMessage(
       Message* message, const FieldDescriptor* field,
-      Message* new_entry) const;
+      Message* new_entry) const override;
 
-  const FieldDescriptor* FindKnownExtensionByName(const string& name) const;
-  const FieldDescriptor* FindKnownExtensionByNumber(int number) const;
+  const FieldDescriptor* FindKnownExtensionByName(
+      const string& name) const override;
+  const FieldDescriptor* FindKnownExtensionByNumber(int number) const override;
 
-  bool SupportsUnknownEnumValues() const;
+  bool SupportsUnknownEnumValues() const override;
 
   // This value for arena_offset_ indicates that there is no arena pointer in
   // this message (e.g., old generated code).
@@ -514,19 +523,19 @@ class GeneratedMessageReflection final : public Reflection {
  protected:
   void* MutableRawRepeatedField(
       Message* message, const FieldDescriptor* field, FieldDescriptor::CppType,
-      int ctype, const Descriptor* desc) const;
+      int ctype, const Descriptor* desc) const override;
 
   const void* GetRawRepeatedField(
       const Message& message, const FieldDescriptor* field,
       FieldDescriptor::CppType, int ctype,
-      const Descriptor* desc) const;
+      const Descriptor* desc) const override;
 
-  virtual MessageFactory* GetMessageFactory() const;
+  virtual MessageFactory* GetMessageFactory() const override;
 
   virtual void* RepeatedFieldData(
       Message* message, const FieldDescriptor* field,
       FieldDescriptor::CppType cpp_type,
-      const Descriptor* message_type) const;
+      const Descriptor* message_type) const override;
 
  private:
   friend class google::protobuf::flat::MetadataBuilder;
@@ -661,7 +670,7 @@ class GeneratedMessageReflection final : public Reflection {
                                       const FieldDescriptor* field) const;
 
   internal::MapFieldBase* MapData(
-      Message* message, const FieldDescriptor* field) const;
+      Message* message, const FieldDescriptor* field) const override;
 
   friend inline  // inline so nobody can call this function.
       void

--- a/src/google/protobuf/io/zero_copy_stream_impl.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl.h
@@ -87,24 +87,24 @@ class LIBPROTOBUF_EXPORT FileInputStream : public ZeroCopyInputStream {
   int GetErrno() { return copying_input_.GetErrno(); }
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
  private:
   class LIBPROTOBUF_EXPORT CopyingFileInputStream : public CopyingInputStream {
    public:
     CopyingFileInputStream(int file_descriptor);
-    ~CopyingFileInputStream();
+    ~CopyingFileInputStream() override;
 
     bool Close();
     void SetCloseOnDelete(bool value) { close_on_delete_ = value; }
     int GetErrno() { return errno_; }
 
     // implements CopyingInputStream ---------------------------------
-    int Read(void* buffer, int size);
-    int Skip(int count);
+    int Read(void* buffer, int size) override;
+    int Skip(int count) override;
 
    private:
     // The file descriptor.
@@ -144,7 +144,7 @@ class LIBPROTOBUF_EXPORT FileOutputStream : public ZeroCopyOutputStream {
   // that should be returned by Next().  Otherwise, a reasonable default
   // is used.
   explicit FileOutputStream(int file_descriptor, int block_size = -1);
-  ~FileOutputStream();
+  ~FileOutputStream() override;
 
   // Flushes any buffers and closes the underlying file.  Returns false if
   // an error occurs during the process; use GetErrno() to examine the error.
@@ -170,22 +170,22 @@ class LIBPROTOBUF_EXPORT FileOutputStream : public ZeroCopyOutputStream {
   int GetErrno() { return copying_output_.GetErrno(); }
 
   // implements ZeroCopyOutputStream ---------------------------------
-  bool Next(void** data, int* size);
-  void BackUp(int count);
-  int64 ByteCount() const;
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override;
+  int64 ByteCount() const override;
 
  private:
   class LIBPROTOBUF_EXPORT CopyingFileOutputStream : public CopyingOutputStream {
    public:
     CopyingFileOutputStream(int file_descriptor);
-    ~CopyingFileOutputStream();
+    ~CopyingFileOutputStream() override;
 
     bool Close();
     void SetCloseOnDelete(bool value) { close_on_delete_ = value; }
     int GetErrno() { return errno_; }
 
     // implements CopyingOutputStream --------------------------------
-    bool Write(const void* buffer, int size);
+    bool Write(const void* buffer, int size) override;
 
    private:
     // The file descriptor.
@@ -220,19 +220,19 @@ class LIBPROTOBUF_EXPORT IstreamInputStream : public ZeroCopyInputStream {
   explicit IstreamInputStream(std::istream* stream, int block_size = -1);
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
  private:
   class LIBPROTOBUF_EXPORT CopyingIstreamInputStream : public CopyingInputStream {
    public:
     CopyingIstreamInputStream(std::istream* input);
-    ~CopyingIstreamInputStream();
+    ~CopyingIstreamInputStream() override;
 
     // implements CopyingInputStream ---------------------------------
-    int Read(void* buffer, int size);
+    int Read(void* buffer, int size) override;
     // (We use the default implementation of Skip().)
 
    private:
@@ -261,21 +261,21 @@ class LIBPROTOBUF_EXPORT OstreamOutputStream : public ZeroCopyOutputStream {
   // that should be returned by Next().  Otherwise, a reasonable default
   // is used.
   explicit OstreamOutputStream(std::ostream* stream, int block_size = -1);
-  ~OstreamOutputStream();
+  ~OstreamOutputStream() override;
 
   // implements ZeroCopyOutputStream ---------------------------------
-  bool Next(void** data, int* size);
-  void BackUp(int count);
-  int64 ByteCount() const;
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override;
+  int64 ByteCount() const override;
 
  private:
   class LIBPROTOBUF_EXPORT CopyingOstreamOutputStream : public CopyingOutputStream {
    public:
     CopyingOstreamOutputStream(std::ostream* output);
-    ~CopyingOstreamOutputStream();
+    ~CopyingOstreamOutputStream() override;
 
     // implements CopyingOutputStream --------------------------------
-    bool Write(const void* buffer, int size);
+    bool Write(const void* buffer, int size) override;
 
    private:
     // The stream.
@@ -304,12 +304,13 @@ class LIBPROTOBUF_EXPORT ConcatenatingInputStream : public ZeroCopyInputStream {
   // All streams passed in as well as the array itself must remain valid
   // until the ConcatenatingInputStream is destroyed.
   ConcatenatingInputStream(ZeroCopyInputStream* const streams[], int count);
+  ~ConcatenatingInputStream() override = default;
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
 
  private:
@@ -329,13 +330,13 @@ class LIBPROTOBUF_EXPORT ConcatenatingInputStream : public ZeroCopyInputStream {
 class LIBPROTOBUF_EXPORT LimitingInputStream : public ZeroCopyInputStream {
  public:
   LimitingInputStream(ZeroCopyInputStream* input, int64 limit);
-  ~LimitingInputStream();
+  ~LimitingInputStream() override;
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
 
  private:

--- a/src/google/protobuf/io/zero_copy_stream_impl_lite.h
+++ b/src/google/protobuf/io/zero_copy_stream_impl_lite.h
@@ -70,12 +70,13 @@ class LIBPROTOBUF_EXPORT ArrayInputStream : public ZeroCopyInputStream {
   // useful for testing; in production you would probably never want to set
   // it.
   ArrayInputStream(const void* data, int size, int block_size = -1);
+  ~ArrayInputStream() override = default;
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
 
  private:
@@ -103,11 +104,12 @@ class LIBPROTOBUF_EXPORT ArrayOutputStream : public ZeroCopyOutputStream {
   // useful for testing; in production you would probably never want to set
   // it.
   ArrayOutputStream(void* data, int size, int block_size = -1);
+  ~ArrayOutputStream() override = default;
 
   // implements ZeroCopyOutputStream ---------------------------------
-  bool Next(void** data, int* size);
-  void BackUp(int count);
-  int64 ByteCount() const;
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override;
+  int64 ByteCount() const override;
 
  private:
   uint8* const data_;        // The byte array.
@@ -136,11 +138,12 @@ class LIBPROTOBUF_EXPORT StringOutputStream : public ZeroCopyOutputStream {
   //   the first call to Next() will return at least n bytes of buffer
   //   space.
   explicit StringOutputStream(string* target);
+  ~StringOutputStream() override = default;
 
   // implements ZeroCopyOutputStream ---------------------------------
-  bool Next(void** data, int* size);
-  void BackUp(int count);
-  int64 ByteCount() const;
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override;
+  int64 ByteCount() const override;
 
  protected:
   void SetString(string* target);
@@ -205,17 +208,17 @@ class LIBPROTOBUF_EXPORT CopyingInputStreamAdaptor : public ZeroCopyInputStream 
   // copying_stream unless SetOwnsCopyingStream(true) is called.
   explicit CopyingInputStreamAdaptor(CopyingInputStream* copying_stream,
                                      int block_size = -1);
-  ~CopyingInputStreamAdaptor();
+  ~CopyingInputStreamAdaptor() override;
 
   // Call SetOwnsCopyingStream(true) to tell the CopyingInputStreamAdaptor to
   // delete the underlying CopyingInputStream when it is destroyed.
   void SetOwnsCopyingStream(bool value) { owns_copying_stream_ = value; }
 
   // implements ZeroCopyInputStream ----------------------------------
-  bool Next(const void** data, int* size);
-  void BackUp(int count);
-  bool Skip(int count);
-  int64 ByteCount() const;
+  bool Next(const void** data, int* size) override;
+  void BackUp(int count) override;
+  bool Skip(int count) override;
+  int64 ByteCount() const override;
 
  private:
   // Insures that buffer_ is not NULL.
@@ -288,7 +291,7 @@ class LIBPROTOBUF_EXPORT CopyingOutputStreamAdaptor : public ZeroCopyOutputStrea
   // is used.
   explicit CopyingOutputStreamAdaptor(CopyingOutputStream* copying_stream,
                                       int block_size = -1);
-  ~CopyingOutputStreamAdaptor();
+  ~CopyingOutputStreamAdaptor() override;
 
   // Writes all pending data to the underlying stream.  Returns false if a
   // write error occurred on the underlying stream.  (The underlying
@@ -300,9 +303,9 @@ class LIBPROTOBUF_EXPORT CopyingOutputStreamAdaptor : public ZeroCopyOutputStrea
   void SetOwnsCopyingStream(bool value) { owns_copying_stream_ = value; }
 
   // implements ZeroCopyOutputStream ---------------------------------
-  bool Next(void** data, int* size);
-  void BackUp(int count);
-  int64 ByteCount() const;
+  bool Next(void** data, int* size) override;
+  void BackUp(int count) override;
+  int64 ByteCount() const override;
 
  private:
   // Write the current buffer, if it is present.

--- a/src/google/protobuf/map_entry.h
+++ b/src/google/protobuf/map_entry.h
@@ -95,6 +95,19 @@ class MapEntry
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
 
+  using typename MapEntryImpl<Derived, Message, Key, Value, kKeyFieldType,
+                              kValueFieldType,
+                              default_enum_value>::KeyTypeHandler;
+  using typename MapEntryImpl<Derived, Message, Key, Value, kKeyFieldType,
+                              kValueFieldType,
+                              default_enum_value>::ValueTypeHandler;
+  size_t SpaceUsedLong() const override {
+    size_t size = sizeof(Derived);
+    size += KeyTypeHandler::SpaceUsedInMapEntryLong(this->key_);
+    size += ValueTypeHandler::SpaceUsedInMapEntryLong(this->value_);
+    return size;
+  }
+
   InternalMetadataWithArena _internal_metadata_;
 
  private:

--- a/src/google/protobuf/map_entry_lite.h
+++ b/src/google/protobuf/map_entry_lite.h
@@ -177,13 +177,13 @@ class MapEntryImpl : public Base {
 
   // MapEntryImpl is for implementation only and this function isn't called
   // anywhere. Just provide a fake implementation here for MessageLite.
-  string GetTypeName() const { return ""; }
+  string GetTypeName() const override { return ""; }
 
-  void CheckTypeAndMergeFrom(const MessageLite& other) {
+  void CheckTypeAndMergeFrom(const MessageLite& other) override {
     MergeFromInternal(*::google::protobuf::down_cast<const Derived*>(&other));
   }
 
-  bool MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream* input) {
+  bool MergePartialFromCodedStream(::google::protobuf::io::CodedInputStream* input) override {
     uint32 tag;
 
     for (;;) {
@@ -224,7 +224,7 @@ class MapEntryImpl : public Base {
     }
   }
 
-  size_t ByteSizeLong() const {
+  size_t ByteSizeLong() const override {
     size_t size = 0;
     size += has_key() ?
         kTagSize + static_cast<size_t>(KeyTypeHandler::ByteSize(key())) : 0;
@@ -233,13 +233,13 @@ class MapEntryImpl : public Base {
     return size;
   }
 
-  void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream* output) const {
+  void SerializeWithCachedSizes(::google::protobuf::io::CodedOutputStream* output) const override {
     KeyTypeHandler::Write(kKeyFieldNumber, key(), output);
     ValueTypeHandler::Write(kValueFieldNumber, value(), output);
   }
 
   ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(bool deterministic,
-                                                   ::google::protobuf::uint8* output) const {
+                                                   ::google::protobuf::uint8* output) const override {
     output = KeyTypeHandler::InternalWriteToArray(kKeyFieldNumber, key(),
                                                   deterministic, output);
     output = ValueTypeHandler::InternalWriteToArray(kValueFieldNumber, value(),
@@ -249,7 +249,7 @@ class MapEntryImpl : public Base {
 
   // Don't override SerializeWithCachedSizesToArray.  Use MessageLite's.
 
-  int GetCachedSize() const {
+  int GetCachedSize() const override {
     int size = 0;
     size += has_key()
         ? static_cast<int>(kTagSize) + KeyTypeHandler::GetCachedSize(key())
@@ -260,23 +260,16 @@ class MapEntryImpl : public Base {
     return size;
   }
 
-  bool IsInitialized() const { return ValueTypeHandler::IsInitialized(value_); }
+  bool IsInitialized() const override { return ValueTypeHandler::IsInitialized(value_); }
 
-  Base* New() const {
+  Base* New() const override {
     Derived* entry = new Derived;
     return entry;
   }
 
-  Base* New(Arena* arena) const {
+  Base* New(Arena* arena) const override {
     Derived* entry = Arena::CreateMessage<Derived>(arena);
     return entry;
-  }
-
-  size_t SpaceUsedLong() const {
-    size_t size = sizeof(Derived);
-    size += KeyTypeHandler::SpaceUsedInMapEntryLong(key_);
-    size += ValueTypeHandler::SpaceUsedInMapEntryLong(value_);
-    return size;
   }
 
  protected:
@@ -298,7 +291,7 @@ class MapEntryImpl : public Base {
   }
 
  public:
-  void Clear() {
+  void Clear() override {
     KeyTypeHandler::Clear(&key_, GetArenaNoVirtual());
     ValueTypeHandler::ClearMaybeByDefaultEnum(
         &value_, GetArenaNoVirtual(), default_enum_value);
@@ -312,7 +305,7 @@ class MapEntryImpl : public Base {
     ValueTypeHandler::AssignDefaultValue(&d->value_);
   }
 
-  Arena* GetArena() const {
+  Arena* GetArena() const override {
     return GetArenaNoVirtual();
   }
 
@@ -466,8 +459,8 @@ class MapEntryImpl : public Base {
       BaseClass::set_has_key();
       BaseClass::set_has_value();
     }
-    inline const KeyMapEntryAccessorType& key() const { return key_; }
-    inline const ValueMapEntryAccessorType& value() const { return value_; }
+    inline const KeyMapEntryAccessorType &key() const override { return key_; }
+    inline const ValueMapEntryAccessorType& value() const override { return value_; }
 
    private:
     const Key& key_;

--- a/src/google/protobuf/map_field.h
+++ b/src/google/protobuf/map_field.h
@@ -181,10 +181,10 @@ class TypeDefinedMapFieldBase : public MapFieldBase {
  public:
   TypeDefinedMapFieldBase() {}
   explicit TypeDefinedMapFieldBase(Arena* arena) : MapFieldBase(arena) {}
-  ~TypeDefinedMapFieldBase() {}
-  void MapBegin(MapIterator* map_iter) const;
-  void MapEnd(MapIterator* map_iter) const;
-  bool EqualIterator(const MapIterator& a, const MapIterator& b) const;
+  ~TypeDefinedMapFieldBase() override {}
+  void MapBegin(MapIterator* map_iter) const override;
+  void MapEnd(MapIterator* map_iter) const override;
+  bool EqualIterator(const MapIterator& a, const MapIterator& b) const override;
 
   virtual const Map<Key, T>& GetMap() const = 0;
   virtual Map<Key, T>* MutableMap() = 0;
@@ -194,11 +194,11 @@ class TypeDefinedMapFieldBase : public MapFieldBase {
       const MapIterator* map_iter) const;
 
  private:
-  void InitializeIterator(MapIterator* map_iter) const;
-  void DeleteIterator(MapIterator* map_iter) const;
+  void InitializeIterator(MapIterator* map_iter) const override;
+  void DeleteIterator(MapIterator* map_iter) const override;
   void CopyIterator(MapIterator* this_iteratorm,
-                    const MapIterator& that_iterator) const;
-  void IncreaseIterator(MapIterator* map_iter) const;
+                    const MapIterator& that_iterator) const override;
+  void IncreaseIterator(MapIterator* map_iter) const override;
 
   virtual void SetMapIteratorValue(MapIterator* map_iter) const = 0;
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(TypeDefinedMapFieldBase);
@@ -243,16 +243,16 @@ class MapField : public TypeDefinedMapFieldBase<Key, T> {
       : TypeDefinedMapFieldBase<Key, T>(arena), impl_(arena) {}
 
   // Implement MapFieldBase
-  bool ContainsMapKey(const MapKey& map_key) const;
-  bool InsertOrLookupMapValue(const MapKey& map_key, MapValueRef* val);
-  bool DeleteMapValue(const MapKey& map_key);
+  bool ContainsMapKey(const MapKey& map_key) const override;
+  bool InsertOrLookupMapValue(const MapKey& map_key, MapValueRef* val) override;
+  bool DeleteMapValue(const MapKey& map_key) override;
 
-  const Map<Key, T>& GetMap() const {
+  const Map<Key, T>& GetMap() const override {
     MapFieldBase::SyncMapWithRepeatedField();
     return impl_.GetMap();
   }
 
-  Map<Key, T>* MutableMap() {
+  Map<Key, T>* MutableMap() override {
     MapFieldBase::SyncMapWithRepeatedField();
     Map<Key, T>* result = impl_.MutableMap();
     MapFieldBase::SetMapDirty();
@@ -260,7 +260,7 @@ class MapField : public TypeDefinedMapFieldBase<Key, T> {
   }
 
   // Convenient methods for generated message implementation.
-  int size() const;
+  int size() const override;
   void Clear();
   void MergeFrom(const MapField& other);
   void Swap(MapField* other);
@@ -285,12 +285,13 @@ class MapField : public TypeDefinedMapFieldBase<Key, T> {
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
 
-  // Implements MapFieldBase
-  void SyncRepeatedFieldWithMapNoLock() const;
-  void SyncMapWithRepeatedFieldNoLock() const;
-  size_t SpaceUsedExcludingSelfNoLock() const;
 
-  void SetMapIteratorValue(MapIterator* map_iter) const;
+  // Implements MapFieldBase
+  void SyncRepeatedFieldWithMapNoLock() const override;
+  void SyncMapWithRepeatedFieldNoLock() const override;
+  size_t SpaceUsedExcludingSelfNoLock() const override;
+
+  void SetMapIteratorValue(MapIterator* map_iter) const override;
 
   friend class ::google::protobuf::Arena;
   friend class MapFieldStateTest;  // For testing, it needs raw access to impl_
@@ -311,27 +312,27 @@ class LIBPROTOBUF_EXPORT DynamicMapField: public TypeDefinedMapFieldBase<MapKey,
  public:
   explicit DynamicMapField(const Message* default_entry);
   DynamicMapField(const Message* default_entry, Arena* arena);
-  ~DynamicMapField();
+  ~DynamicMapField() override;
 
   // Implement MapFieldBase
-  bool ContainsMapKey(const MapKey& map_key) const;
-  bool InsertOrLookupMapValue(const MapKey& map_key, MapValueRef* val);
-  bool DeleteMapValue(const MapKey& map_key);
+  bool ContainsMapKey(const MapKey& map_key) const override;
+  bool InsertOrLookupMapValue(const MapKey& map_key, MapValueRef* val) override;
+  bool DeleteMapValue(const MapKey& map_key) override;
 
-  const Map<MapKey, MapValueRef>& GetMap() const;
-  Map<MapKey, MapValueRef>* MutableMap();
+  const Map<MapKey, MapValueRef>& GetMap() const override;
+  Map<MapKey, MapValueRef>* MutableMap() override;
 
-  int size() const;
+  int size() const override;
 
  private:
   Map<MapKey, MapValueRef> map_;
   const Message* default_entry_;
 
   // Implements MapFieldBase
-  void SyncRepeatedFieldWithMapNoLock() const;
-  void SyncMapWithRepeatedFieldNoLock() const;
-  size_t SpaceUsedExcludingSelfNoLock() const;
-  void SetMapIteratorValue(MapIterator* map_iter) const;
+  void SyncRepeatedFieldWithMapNoLock() const override;
+  void SyncMapWithRepeatedFieldNoLock() const override;
+  size_t SpaceUsedExcludingSelfNoLock() const override;
+  void SetMapIteratorValue(MapIterator* map_iter) const override;
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(DynamicMapField);
 };
 

--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -272,7 +272,7 @@ class GeneratedMessageFactory : public MessageFactory {
   void RegisterType(const Descriptor* descriptor, const Message* prototype);
 
   // implements MessageFactory ---------------------------------------
-  const Message* GetPrototype(const Descriptor* type);
+  const Message* GetPrototype(const Descriptor* type) override;
 
  private:
   // Only written at static init time, so does not require locking.

--- a/src/google/protobuf/message.h
+++ b/src/google/protobuf/message.h
@@ -196,12 +196,12 @@ class LIBPROTOBUF_EXPORT Message : public MessageLite {
   // Construct a new instance of the same type.  Ownership is passed to the
   // caller.  (This is also defined in MessageLite, but is defined again here
   // for return-type covariance.)
-  virtual Message* New() const = 0;
+  virtual Message* New() const override = 0;
 
   // Construct a new instance on the arena. Ownership is passed to the caller
   // if arena is a NULL. Default implementation allows for API compatibility
   // during the Arena transition.
-  virtual Message* New(::google::protobuf::Arena* arena) const {
+  virtual Message* New(::google::protobuf::Arena* arena) const override {
     Message* message = New();
     if (arena != NULL) {
       arena->Own(message);
@@ -233,7 +233,7 @@ class LIBPROTOBUF_EXPORT Message : public MessageLite {
 
   // Like FindInitializationErrors, but joins all the strings, delimited by
   // commas, and returns them.
-  string InitializationErrorString() const;
+  string InitializationErrorString() const override;
 
   // Clears all unknown fields from this message and all embedded messages.
   // Normally, if unknown tag numbers are encountered when parsing a message,
@@ -305,13 +305,13 @@ class LIBPROTOBUF_EXPORT Message : public MessageLite {
   // These methods are pure-virtual in MessageLite, but Message provides
   // reflection-based default implementations.
 
-  virtual string GetTypeName() const;
-  virtual void Clear();
-  virtual bool IsInitialized() const;
-  virtual void CheckTypeAndMergeFrom(const MessageLite& other);
-  virtual bool MergePartialFromCodedStream(io::CodedInputStream* input);
-  virtual size_t ByteSizeLong() const;
-  virtual void SerializeWithCachedSizes(io::CodedOutputStream* output) const;
+  virtual string GetTypeName() const override;
+  virtual void Clear() override;
+  virtual bool IsInitialized() const override;
+  virtual void CheckTypeAndMergeFrom(const MessageLite& other) override;
+  virtual bool MergePartialFromCodedStream(io::CodedInputStream* input) override;
+  virtual size_t ByteSizeLong() const override;
+  virtual void SerializeWithCachedSizes(io::CodedOutputStream* output) const override;
 
  private:
   // This is called only by the default implementation of ByteSize(), to

--- a/src/google/protobuf/reflection_internal.h
+++ b/src/google/protobuf/reflection_internal.h
@@ -43,32 +43,32 @@ namespace internal {
 // corresponding random-access methods.
 class RandomAccessRepeatedFieldAccessor : public RepeatedFieldAccessor {
  public:
-  virtual ~RandomAccessRepeatedFieldAccessor() {}
+  virtual ~RandomAccessRepeatedFieldAccessor() override {}
 
-  virtual Iterator* BeginIterator(const Field* data) const {
+  virtual Iterator* BeginIterator(const Field* data) const override {
     return PositionToIterator(0);
   }
-  virtual Iterator* EndIterator(const Field* data) const {
+  virtual Iterator* EndIterator(const Field* data) const override {
     return PositionToIterator(this->Size(data));
   }
   virtual Iterator* CopyIterator(const Field* data,
-                                 const Iterator* iterator) const {
+                         const Iterator* iterator) const override {
     return const_cast<Iterator*>(iterator);
   }
   virtual Iterator* AdvanceIterator(const Field* data,
-                                    Iterator* iterator) const {
+                            Iterator* iterator) const override {
     return PositionToIterator(IteratorToPosition(iterator) + 1);
   }
   virtual bool EqualsIterator(const Field* data,
-                              const Iterator* a,
-                              const Iterator* b) const {
+                      const Iterator* a,
+                      const Iterator* b) const override {
     return a == b;
   }
-  virtual void DeleteIterator(const Field* data, Iterator* iterator) const {
+  virtual void DeleteIterator(const Field* data, Iterator* iterator) const override {
   }
   virtual const Value* GetIteratorValue(const Field* data,
-                                        const Iterator* iterator,
-                                        Value* scratch_space) const {
+                                const Iterator* iterator,
+                                Value* scratch_space) const override {
     return Get(data, static_cast<int>(IteratorToPosition(iterator)),
                scratch_space);
   }
@@ -88,30 +88,30 @@ template<typename T>
 class RepeatedFieldWrapper : public RandomAccessRepeatedFieldAccessor {
  public:
   RepeatedFieldWrapper() {}
-  virtual ~RepeatedFieldWrapper() {}
-  virtual bool IsEmpty(const Field* data) const {
+  virtual ~RepeatedFieldWrapper() override {}
+  virtual bool IsEmpty(const Field* data) const override {
     return GetRepeatedField(data)->empty();
   }
-  virtual int Size(const Field* data) const {
+  virtual int Size(const Field* data) const override {
     return GetRepeatedField(data)->size();
   }
   virtual const Value* Get(const Field* data, int index,
-                          Value* scratch_space) const {
+                   Value* scratch_space) const override {
     return ConvertFromT(GetRepeatedField(data)->Get(index), scratch_space);
   }
-  virtual void Clear(Field* data) const {
+  virtual void Clear(Field* data) const override {
     MutableRepeatedField(data)->Clear();
   }
-  virtual void Set(Field* data, int index, const Value* value) const {
+  virtual void Set(Field* data, int index, const Value* value) const override {
     MutableRepeatedField(data)->Set(index, ConvertToT(value));
   }
-  virtual void Add(Field* data, const Value* value) const {
+  virtual void Add(Field* data, const Value* value) const override {
     MutableRepeatedField(data)->Add(ConvertToT(value));
   }
-  virtual void RemoveLast(Field* data) const {
+  virtual void RemoveLast(Field* data) const override {
     MutableRepeatedField(data)->RemoveLast();
   }
-  virtual void SwapElements(Field* data, int index1, int index2) const {
+  virtual void SwapElements(Field* data, int index1, int index2) const override {
     MutableRepeatedField(data)->SwapElements(index1, index2);
   }
 
@@ -144,31 +144,31 @@ class RepeatedPtrFieldWrapper : public RandomAccessRepeatedFieldAccessor {
  public:
   RepeatedPtrFieldWrapper() {}
   virtual ~RepeatedPtrFieldWrapper() {}
-  virtual bool IsEmpty(const Field* data) const {
+  virtual bool IsEmpty(const Field* data) const override {
     return GetRepeatedField(data)->empty();
   }
-  virtual int Size(const Field* data) const {
+  virtual int Size(const Field* data) const override {
     return GetRepeatedField(data)->size();
   }
   virtual const Value* Get(const Field* data, int index,
-                           Value* scratch_space) const {
+                   Value* scratch_space) const override {
     return ConvertFromT(GetRepeatedField(data)->Get(index), scratch_space);
   }
-  virtual void Clear(Field* data) const {
+  virtual void Clear(Field* data) const override {
     MutableRepeatedField(data)->Clear();
   }
-  virtual void Set(Field* data, int index, const Value* value) const {
+  virtual void Set(Field* data, int index, const Value* value) const override {
     ConvertToT(value, MutableRepeatedField(data)->Mutable(index));
   }
-  virtual void Add(Field* data, const Value* value) const {
+  virtual void Add(Field* data, const Value* value) const override {
     T* allocated = New(value);
     ConvertToT(value, allocated);
     MutableRepeatedField(data)->AddAllocated(allocated);
   }
-  virtual void RemoveLast(Field* data) const {
+  virtual void RemoveLast(Field* data) const override {
     MutableRepeatedField(data)->RemoveLast();
   }
-  virtual void SwapElements(Field* data, int index1, int index2) const {
+  virtual void SwapElements(Field* data, int index1, int index2) const override {
     MutableRepeatedField(data)->SwapElements(index1, index2);
   }
 
@@ -205,38 +205,38 @@ class RepeatedPtrFieldWrapper : public RandomAccessRepeatedFieldAccessor {
 class MapFieldAccessor : public RandomAccessRepeatedFieldAccessor {
  public:
   MapFieldAccessor() {}
-  virtual ~MapFieldAccessor() {}
-  virtual bool IsEmpty(const Field* data) const {
+  virtual ~MapFieldAccessor() override {}
+  virtual bool IsEmpty(const Field* data) const override {
     return GetRepeatedField(data)->empty();
   }
-  virtual int Size(const Field* data) const {
+  virtual int Size(const Field* data) const override {
     return GetRepeatedField(data)->size();
   }
   virtual const Value* Get(const Field* data, int index,
-                           Value* scratch_space) const {
+                   Value* scratch_space) const override {
     return ConvertFromEntry(GetRepeatedField(data)->Get(index), scratch_space);
   }
-  virtual void Clear(Field* data) const {
+  virtual void Clear(Field* data) const override {
     MutableRepeatedField(data)->Clear();
   }
-  virtual void Set(Field* data, int index, const Value* value) const {
+  virtual void Set(Field* data, int index, const Value* value) const override {
     ConvertToEntry(value, MutableRepeatedField(data)->Mutable(index));
   }
-  virtual void Add(Field* data, const Value* value) const {
+  virtual void Add(Field* data, const Value* value) const override {
     Message* allocated = New(value);
     ConvertToEntry(value, allocated);
     MutableRepeatedField(data)->AddAllocated(allocated);
   }
-  virtual void RemoveLast(Field* data) const {
+  virtual void RemoveLast(Field* data) const override {
     MutableRepeatedField(data)->RemoveLast();
   }
-  virtual void SwapElements(Field* data, int index1, int index2) const {
+  virtual void SwapElements(Field* data, int index1, int index2) const override {
     MutableRepeatedField(data)->SwapElements(index1, index2);
   }
   virtual void Swap(
       Field* data,
       const internal::RepeatedFieldAccessor* other_mutator,
-      Field* other_data) const {
+      Field* other_data) const override {
     GOOGLE_CHECK(this == other_mutator);
     MutableRepeatedField(data)->Swap(MutableRepeatedField(other_data));
   }
@@ -276,11 +276,11 @@ class RepeatedFieldPrimitiveAccessor : public RepeatedFieldWrapper<T> {
 
  public:
   RepeatedFieldPrimitiveAccessor() {}
-  virtual ~RepeatedFieldPrimitiveAccessor() {}
+  virtual ~RepeatedFieldPrimitiveAccessor() override {}
   virtual void Swap(
       Field* data,
       const internal::RepeatedFieldAccessor* other_mutator,
-      Field* other_data) const {
+      Field* other_data) const override {
     // Currently RepeatedFieldPrimitiveAccessor is the only implementation of
     // RepeatedFieldAccessor for primitive types. As we are using singletons
     // for these accessors, here "other_mutator" must be "this".
@@ -289,11 +289,11 @@ class RepeatedFieldPrimitiveAccessor : public RepeatedFieldWrapper<T> {
   }
 
  protected:
-  virtual T ConvertToT(const Value* value) const {
+  virtual T ConvertToT(const Value* value) const override {
     return *static_cast<const T*>(value);
   }
   virtual const Value* ConvertFromT(const T& value,
-                                    Value* scratch_space) const {
+                            Value* scratch_space) const override {
     return static_cast<const Value*>(&value);
   }
 };
@@ -307,11 +307,11 @@ class RepeatedPtrFieldStringAccessor : public RepeatedPtrFieldWrapper<string> {
 
  public:
   RepeatedPtrFieldStringAccessor() {}
-  virtual ~RepeatedPtrFieldStringAccessor() {}
+  virtual ~RepeatedPtrFieldStringAccessor() override {}
   virtual void Swap(
       Field* data,
       const internal::RepeatedFieldAccessor* other_mutator,
-      Field* other_data) const {
+      Field* other_data) const override {
     if (this == other_mutator) {
       MutableRepeatedField(data)->Swap(MutableRepeatedField(other_data));
     } else {
@@ -330,14 +330,14 @@ class RepeatedPtrFieldStringAccessor : public RepeatedPtrFieldWrapper<string> {
   }
 
  protected:
-  virtual string* New(const Value*) const {
+  virtual string* New(const Value*) const override {
     return new string();
   }
-  virtual void ConvertToT(const Value* value, string* result) const {
+  virtual void ConvertToT(const Value* value, string* result) const override {
     *result = *static_cast<const string*>(value);
   }
   virtual const Value* ConvertFromT(const string& value,
-                                    Value* scratch_space) const {
+                            Value* scratch_space) const override {
     return static_cast<const Value*>(&value);
   }
 };
@@ -350,24 +350,24 @@ class RepeatedPtrFieldMessageAccessor
 
  public:
   RepeatedPtrFieldMessageAccessor() {}
-  virtual ~RepeatedPtrFieldMessageAccessor() {}
+  virtual ~RepeatedPtrFieldMessageAccessor() override {}
   virtual void Swap(
       Field* data,
       const internal::RepeatedFieldAccessor* other_mutator,
-      Field* other_data) const {
+      Field* other_data) const override {
     GOOGLE_CHECK(this == other_mutator);
     MutableRepeatedField(data)->Swap(MutableRepeatedField(other_data));
   }
 
  protected:
-  virtual Message* New(const Value* value) const {
+  virtual Message* New(const Value* value) const override {
     return static_cast<const Message*>(value)->New();
   }
-  virtual void ConvertToT(const Value* value, Message* result) const {
+  virtual void ConvertToT(const Value* value, Message* result) const override {
     result->CopyFrom(*static_cast<const Message*>(value));
   }
   virtual const Value* ConvertFromT(const Message& value,
-                                    Value* scratch_space) const {
+                            Value* scratch_space) const override {
     return static_cast<const Value*>(&value);
   }
 };

--- a/src/google/protobuf/stubs/bytestream.h
+++ b/src/google/protobuf/stubs/bytestream.h
@@ -162,7 +162,7 @@ class LIBPROTOBUF_EXPORT ByteSource {
 class LIBPROTOBUF_EXPORT UncheckedArrayByteSink : public ByteSink {
  public:
   explicit UncheckedArrayByteSink(char* dest) : dest_(dest) {}
-  virtual void Append(const char* data, size_t n);
+  virtual void Append(const char* data, size_t n) override;
 
   // Returns the current output pointer so that a caller can see how many bytes
   // were produced.
@@ -190,7 +190,7 @@ class LIBPROTOBUF_EXPORT UncheckedArrayByteSink : public ByteSink {
 class LIBPROTOBUF_EXPORT CheckedArrayByteSink : public ByteSink {
  public:
   CheckedArrayByteSink(char* outbuf, size_t capacity);
-  virtual void Append(const char* bytes, size_t n);
+  virtual void Append(const char* bytes, size_t n) override;
 
   // Returns the number of bytes actually written to the sink.
   size_t NumberOfBytesWritten() const { return size_; }
@@ -227,7 +227,7 @@ class LIBPROTOBUF_EXPORT GrowingArrayByteSink : public strings::ByteSink {
  public:
   explicit GrowingArrayByteSink(size_t estimated_size);
   virtual ~GrowingArrayByteSink();
-  virtual void Append(const char* bytes, size_t n);
+  virtual void Append(const char* bytes, size_t n) override;
 
   // Returns the allocated buffer, and sets nbytes to its size. The caller takes
   // ownership of the buffer and must delete it with delete[].
@@ -256,7 +256,7 @@ class LIBPROTOBUF_EXPORT GrowingArrayByteSink : public strings::ByteSink {
 class LIBPROTOBUF_EXPORT StringByteSink : public ByteSink {
  public:
   explicit StringByteSink(string* dest) : dest_(dest) {}
-  virtual void Append(const char* data, size_t n);
+  virtual void Append(const char* data, size_t n) override;
 
  private:
   string* dest_;
@@ -273,7 +273,7 @@ class LIBPROTOBUF_EXPORT StringByteSink : public ByteSink {
 class LIBPROTOBUF_EXPORT NullByteSink : public ByteSink {
  public:
   NullByteSink() {}
-  virtual void Append(const char *data, size_t n) {}
+  virtual void Append(const char *data, size_t n) override {}
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(NullByteSink);
@@ -296,9 +296,9 @@ class LIBPROTOBUF_EXPORT ArrayByteSource : public ByteSource {
  public:
   explicit ArrayByteSource(StringPiece s) : input_(s) {}
 
-  virtual size_t Available() const;
-  virtual StringPiece Peek();
-  virtual void Skip(size_t n);
+  virtual size_t Available() const override;
+  virtual StringPiece Peek() override;
+  virtual void Skip(size_t n) override;
 
  private:
   StringPiece   input_;
@@ -328,13 +328,13 @@ class LIBPROTOBUF_EXPORT LimitByteSource : public ByteSource {
   // Returns at most "limit" bytes from "source".
   LimitByteSource(ByteSource* source, size_t limit);
 
-  virtual size_t Available() const;
-  virtual StringPiece Peek();
-  virtual void Skip(size_t n);
+  virtual size_t Available() const override;
+  virtual StringPiece Peek() override;
+  virtual void Skip(size_t n) override;
 
   // We override CopyTo so that we can forward to the underlying source, in
   // case it has an efficient implementation of CopyTo.
-  virtual void CopyTo(ByteSink* sink, size_t n);
+  virtual void CopyTo(ByteSink* sink, size_t n) override;
 
  private:
   ByteSource* source_;

--- a/src/google/protobuf/stubs/callback.h
+++ b/src/google/protobuf/stubs/callback.h
@@ -125,7 +125,7 @@ class LIBPROTOBUF_EXPORT FunctionClosure0 : public Closure {
     : function_(function), self_deleting_(self_deleting) {}
   ~FunctionClosure0();
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     function_();
     if (needs_delete) delete this;
@@ -145,7 +145,7 @@ class MethodClosure0 : public Closure {
     : object_(object), method_(method), self_deleting_(self_deleting) {}
   ~MethodClosure0() {}
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     (object_->*method_)();
     if (needs_delete) delete this;
@@ -168,7 +168,7 @@ class FunctionClosure1 : public Closure {
       arg1_(arg1) {}
   ~FunctionClosure1() {}
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     function_(arg1_);
     if (needs_delete) delete this;
@@ -191,7 +191,7 @@ class MethodClosure1 : public Closure {
       arg1_(arg1) {}
   ~MethodClosure1() {}
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     (object_->*method_)(arg1_);
     if (needs_delete) delete this;
@@ -215,7 +215,7 @@ class FunctionClosure2 : public Closure {
       arg1_(arg1), arg2_(arg2) {}
   ~FunctionClosure2() {}
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     function_(arg1_, arg2_);
     if (needs_delete) delete this;
@@ -239,7 +239,7 @@ class MethodClosure2 : public Closure {
       arg1_(arg1), arg2_(arg2) {}
   ~MethodClosure2() {}
 
-  void Run() {
+  void Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     (object_->*method_)(arg1_, arg2_);
     if (needs_delete) delete this;
@@ -262,7 +262,7 @@ class FunctionResultCallback_0_0 : public ResultCallback<R> {
       : function_(function), self_deleting_(self_deleting) {}
   ~FunctionResultCallback_0_0() {}
 
-  R Run() {
+  R Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     R result = function_();
     if (needs_delete) delete this;
@@ -284,7 +284,7 @@ class FunctionResultCallback_1_0 : public ResultCallback<R> {
       : function_(function), self_deleting_(self_deleting), p1_(p1) {}
   ~FunctionResultCallback_1_0() {}
 
-  R Run() {
+  R Run() override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     R result = function_(p1_);
     if (needs_delete) delete this;
@@ -306,7 +306,7 @@ class FunctionResultCallback_0_1 : public ResultCallback1<R, Arg1> {
       : function_(function), self_deleting_(self_deleting) {}
   ~FunctionResultCallback_0_1() {}
 
-  R Run(Arg1 a1) {
+  R Run(Arg1 a1) override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     R result = function_(a1);
     if (needs_delete) delete this;
@@ -328,7 +328,7 @@ class FunctionResultCallback_1_1 : public ResultCallback1<R, A1> {
       : function_(function), self_deleting_(self_deleting), p1_(p1) {}
   ~FunctionResultCallback_1_1() {}
 
-  R Run(A1 a1) {
+  R Run(A1 a1) override {
     bool needs_delete = self_deleting_;  // read in case callback deletes
     R result = function_(p1_, a1);
     if (needs_delete) delete this;
@@ -387,7 +387,7 @@ class MethodResultCallback_5_2 : public ResultCallback2<R, A1, A2> {
         p5_(p5) {}
   ~MethodResultCallback_5_2() {}
 
-  R Run(A1 a1, A2 a2) {
+  R Run(A1 a1, A2 a2) override {
     bool needs_delete = self_deleting_;
     R result = (object_->*method_)(p1_, p2_, p3_, p4_, p5_, a1, a2);
     if (needs_delete) delete this;

--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -1138,13 +1138,13 @@ label_skip_parsing:
     explicit ParserErrorCollector(TextFormat::Parser::ParserImpl* parser) :
         parser_(parser) { }
 
-    virtual ~ParserErrorCollector() { }
+    ~ParserErrorCollector() override { }
 
-    virtual void AddError(int line, int column, const string& message) {
+    void AddError(int line, int column, const string& message) override {
       parser_->ReportError(line, column, message);
     }
 
-    virtual void AddWarning(int line, int column, const string& message) {
+    void AddWarning(int line, int column, const string& message) override {
       parser_->ReportWarning(line, column, message);
     }
 
@@ -1444,7 +1444,7 @@ namespace {
 // A BaseTextGenerator that writes to a string.
 class StringBaseTextGenerator : public TextFormat::BaseTextGenerator {
  public:
-  void Print(const char* text, size_t size) { output_.append(text, size); }
+  void Print(const char* text, size_t size) override { output_.append(text, size); }
 
 // Some compilers do not support ref-qualifiers even in C++11 mode.
 // Disable the optimization for now and revisit it later.
@@ -1642,37 +1642,37 @@ class FieldValuePrinterWrapper : public TextFormat::FastFieldValuePrinter {
     delegate_.reset(delegate);
   }
 
-  void PrintBool(bool val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintBool(bool val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintBool(val));
   }
-  void PrintInt32(int32 val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintInt32(int32 val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintInt32(val));
   }
-  void PrintUInt32(uint32 val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintUInt32(uint32 val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintUInt32(val));
   }
-  void PrintInt64(int64 val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintInt64(int64 val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintInt64(val));
   }
-  void PrintUInt64(uint64 val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintUInt64(uint64 val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintUInt64(val));
   }
-  void PrintFloat(float val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintFloat(float val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintFloat(val));
   }
-  void PrintDouble(double val, TextFormat::BaseTextGenerator* generator) const {
+  void PrintDouble(double val, TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintDouble(val));
   }
   void PrintString(const string& val,
-                   TextFormat::BaseTextGenerator* generator) const {
+                   TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintString(val));
   }
   void PrintBytes(const string& val,
-                  TextFormat::BaseTextGenerator* generator) const {
+                  TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintBytes(val));
   }
   void PrintEnum(int32 val, const string& name,
-                 TextFormat::BaseTextGenerator* generator) const {
+                 TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintEnum(val, name));
   }
   void PrintFieldName(const Message& message, int field_index, int field_count,
@@ -1684,19 +1684,19 @@ class FieldValuePrinterWrapper : public TextFormat::FastFieldValuePrinter {
   }
   void PrintFieldName(const Message& message, const Reflection* reflection,
                       const FieldDescriptor* field,
-                      TextFormat::BaseTextGenerator* generator) const {
+                      TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(
         delegate_->PrintFieldName(message, reflection, field));
   }
   void PrintMessageStart(const Message& message, int field_index,
                          int field_count, bool single_line_mode,
-                         TextFormat::BaseTextGenerator* generator) const {
+                         TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintMessageStart(
         message, field_index, field_count, single_line_mode));
   }
   void PrintMessageEnd(const Message& message, int field_index, int field_count,
                        bool single_line_mode,
-                       TextFormat::BaseTextGenerator* generator) const {
+                       TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintString(delegate_->PrintMessageEnd(
         message, field_index, field_count, single_line_mode));
   }
@@ -1710,13 +1710,13 @@ class FastFieldValuePrinterUtf8Escaping
     : public TextFormat::FastFieldValuePrinter {
  public:
   void PrintString(const string& val,
-                   TextFormat::BaseTextGenerator* generator) const {
+                   TextFormat::BaseTextGenerator* generator) const override {
     generator->PrintLiteral("\"");
     generator->PrintString(strings::Utf8SafeCEscape(val));
     generator->PrintLiteral("\"");
   }
   void PrintBytes(const string& val,
-                  TextFormat::BaseTextGenerator* generator) const {
+                  TextFormat::BaseTextGenerator* generator) const override {
     return FastFieldValuePrinter::PrintString(val, generator);
   }
 };

--- a/src/google/protobuf/util/field_comparator.h
+++ b/src/google/protobuf/util/field_comparator.h
@@ -110,14 +110,14 @@ class LIBPROTOBUF_EXPORT DefaultFieldComparator : public FieldComparator {
   // Creates new comparator with float comparison set to EXACT.
   DefaultFieldComparator();
 
-  virtual ~DefaultFieldComparator();
+  ~DefaultFieldComparator() override;
 
-  virtual ComparisonResult Compare(
+  ComparisonResult Compare(
       const google::protobuf::Message& message_1,
       const google::protobuf::Message& message_2,
       const google::protobuf::FieldDescriptor* field,
       int index_1, int index_2,
-      const google::protobuf::util::FieldContext* field_context);
+      const google::protobuf::util::FieldContext* field_context) override;
 
   void set_float_comparison(FloatComparison float_comparison) {
     float_comparison_ = float_comparison;

--- a/src/google/protobuf/util/internal/default_value_objectwriter.h
+++ b/src/google/protobuf/util/internal/default_value_objectwriter.h
@@ -83,37 +83,37 @@ class LIBPROTOBUF_EXPORT DefaultValueObjectWriter : public ObjectWriter {
   virtual ~DefaultValueObjectWriter();
 
   // ObjectWriter methods.
-  virtual DefaultValueObjectWriter* StartObject(StringPiece name);
+  virtual DefaultValueObjectWriter* StartObject(StringPiece name) override;
 
-  virtual DefaultValueObjectWriter* EndObject();
+  virtual DefaultValueObjectWriter* EndObject() override;
 
-  virtual DefaultValueObjectWriter* StartList(StringPiece name);
+  virtual DefaultValueObjectWriter* StartList(StringPiece name) override;
 
-  virtual DefaultValueObjectWriter* EndList();
+  virtual DefaultValueObjectWriter* EndList() override;
 
-  virtual DefaultValueObjectWriter* RenderBool(StringPiece name, bool value);
+  virtual DefaultValueObjectWriter* RenderBool(StringPiece name, bool value) override;
 
-  virtual DefaultValueObjectWriter* RenderInt32(StringPiece name, int32 value);
+  virtual DefaultValueObjectWriter* RenderInt32(StringPiece name, int32 value) override;
 
   virtual DefaultValueObjectWriter* RenderUint32(StringPiece name,
-                                                 uint32 value);
+                                         uint32 value) override;
 
-  virtual DefaultValueObjectWriter* RenderInt64(StringPiece name, int64 value);
+  virtual DefaultValueObjectWriter* RenderInt64(StringPiece name, int64 value) override;
 
   virtual DefaultValueObjectWriter* RenderUint64(StringPiece name,
-                                                 uint64 value);
+                                         uint64 value) override;
 
   virtual DefaultValueObjectWriter* RenderDouble(StringPiece name,
-                                                 double value);
+                                         double value) override;
 
-  virtual DefaultValueObjectWriter* RenderFloat(StringPiece name, float value);
+  virtual DefaultValueObjectWriter* RenderFloat(StringPiece name, float value) override;
 
   virtual DefaultValueObjectWriter* RenderString(StringPiece name,
-                                                 StringPiece value);
+                                         StringPiece value) override;
   virtual DefaultValueObjectWriter* RenderBytes(StringPiece name,
-                                                StringPiece value);
+                                        StringPiece value) override;
 
-  virtual DefaultValueObjectWriter* RenderNull(StringPiece name);
+  virtual DefaultValueObjectWriter* RenderNull(StringPiece name) override;
 
   // Register the callback for scrubbing of fields. Owership of
   // field_scrub_callback pointer is also transferred to this class

--- a/src/google/protobuf/util/internal/error_listener.h
+++ b/src/google/protobuf/util/internal/error_listener.h
@@ -76,16 +76,16 @@ class LIBPROTOBUF_EXPORT ErrorListener {
 class LIBPROTOBUF_EXPORT NoopErrorListener : public ErrorListener {
  public:
   NoopErrorListener() {}
-  virtual ~NoopErrorListener() {}
+  virtual ~NoopErrorListener() override {}
 
   virtual void InvalidName(const LocationTrackerInterface& loc,
-                           StringPiece invalid_name, StringPiece message) {}
+                           StringPiece invalid_name, StringPiece message) override {}
 
-  virtual void InvalidValue(const LocationTrackerInterface& loc,
-                            StringPiece type_name, StringPiece value) {}
+  virtual void InvalidValue(const LocationTrackerInterface &loc, StringPiece type_name,
+                    StringPiece value) override {}
 
-  virtual void MissingField(const LocationTrackerInterface& loc,
-                            StringPiece missing_name) {}
+  virtual void MissingField(const LocationTrackerInterface &loc,
+                    StringPiece missing_name) override {}
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(NoopErrorListener);

--- a/src/google/protobuf/util/internal/json_objectwriter.h
+++ b/src/google/protobuf/util/internal/json_objectwriter.h
@@ -94,20 +94,20 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
   virtual ~JsonObjectWriter();
 
   // ObjectWriter methods.
-  virtual JsonObjectWriter* StartObject(StringPiece name);
-  virtual JsonObjectWriter* EndObject();
-  virtual JsonObjectWriter* StartList(StringPiece name);
-  virtual JsonObjectWriter* EndList();
-  virtual JsonObjectWriter* RenderBool(StringPiece name, bool value);
-  virtual JsonObjectWriter* RenderInt32(StringPiece name, int32 value);
-  virtual JsonObjectWriter* RenderUint32(StringPiece name, uint32 value);
-  virtual JsonObjectWriter* RenderInt64(StringPiece name, int64 value);
-  virtual JsonObjectWriter* RenderUint64(StringPiece name, uint64 value);
-  virtual JsonObjectWriter* RenderDouble(StringPiece name, double value);
-  virtual JsonObjectWriter* RenderFloat(StringPiece name, float value);
-  virtual JsonObjectWriter* RenderString(StringPiece name, StringPiece value);
-  virtual JsonObjectWriter* RenderBytes(StringPiece name, StringPiece value);
-  virtual JsonObjectWriter* RenderNull(StringPiece name);
+  virtual JsonObjectWriter* StartObject(StringPiece name) override;
+  virtual JsonObjectWriter* EndObject() override;
+  virtual JsonObjectWriter* StartList(StringPiece name) override;
+  virtual JsonObjectWriter* EndList() override;
+  virtual JsonObjectWriter* RenderBool(StringPiece name, bool value) override;
+  virtual JsonObjectWriter* RenderInt32(StringPiece name, int32 value) override;
+  virtual JsonObjectWriter* RenderUint32(StringPiece name, uint32 value) override;
+  virtual JsonObjectWriter* RenderInt64(StringPiece name, int64 value) override;
+  virtual JsonObjectWriter* RenderUint64(StringPiece name, uint64 value) override;
+  virtual JsonObjectWriter* RenderDouble(StringPiece name, double value) override;
+  virtual JsonObjectWriter* RenderFloat(StringPiece name, float value) override;
+  virtual JsonObjectWriter* RenderString(StringPiece name, StringPiece value) override;
+  virtual JsonObjectWriter* RenderBytes(StringPiece name, StringPiece value) override;
+  virtual JsonObjectWriter* RenderNull(StringPiece name) override;
   virtual JsonObjectWriter* RenderNullAsEmpty(StringPiece name);
 
   void set_use_websafe_base64_for_bytes(bool value) {
@@ -143,17 +143,17 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
     GOOGLE_DISALLOW_IMPLICIT_CONSTRUCTORS(Element);
   };
 
-  virtual Element* element() { return element_.get(); }
+  Element* element() override { return element_.get(); }
 
  private:
   class LIBPROTOBUF_EXPORT ByteSinkWrapper : public strings::ByteSink {
    public:
     explicit ByteSinkWrapper(google::protobuf::io::CodedOutputStream* stream)
         : stream_(stream) {}
-    virtual ~ByteSinkWrapper() {}
+    ~ByteSinkWrapper() override {}
 
     // ByteSink methods.
-    virtual void Append(const char* bytes, size_t n) {
+    void Append(const char* bytes, size_t n) override {
       stream_->WriteRaw(bytes, n);
     }
 

--- a/src/google/protobuf/util/internal/object_location_tracker.h
+++ b/src/google/protobuf/util/internal/object_location_tracker.h
@@ -47,10 +47,10 @@ class ObjectLocationTracker : public LocationTrackerInterface {
   // Creates an empty location tracker.
   ObjectLocationTracker() {}
 
-  virtual ~ObjectLocationTracker() {}
+  ~ObjectLocationTracker() override {}
 
   // Returns empty because nothing is tracked.
-  virtual string ToString() const { return ""; }
+  string ToString() const override { return ""; }
 
  private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ObjectLocationTracker);

--- a/src/google/protobuf/util/internal/proto_writer.h
+++ b/src/google/protobuf/util/internal/proto_writer.h
@@ -78,7 +78,7 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
 // Constructor. Does not take ownership of any parameter passed in.
   ProtoWriter(TypeResolver* type_resolver, const google::protobuf::Type& type,
               strings::ByteSink* output, ErrorListener* listener);
-  virtual ~ProtoWriter();
+  virtual ~ProtoWriter() override;
 
   // ObjectWriter methods.
   ProtoWriter* StartObject(StringPiece name) override;
@@ -110,7 +110,7 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
     return RenderDataPiece(name,
                            DataPiece(value, use_strict_base64_decoding()));
   }
-  virtual ProtoWriter* RenderBytes(StringPiece name, StringPiece value) {
+  ProtoWriter* RenderBytes(StringPiece name, StringPiece value) override {
     return RenderDataPiece(
         name, DataPiece(value, false, use_strict_base64_decoding()));
   }
@@ -163,7 +163,7 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
     ProtoElement(ProtoElement* parent, const google::protobuf::Field* field,
                  const google::protobuf::Type& type, bool is_list);
 
-    virtual ~ProtoElement() {}
+    virtual ~ProtoElement() override {}
 
     // Called just before the destructor for clean up:
     //   - reports any missing required fields
@@ -183,9 +183,9 @@ class LIBPROTOBUF_EXPORT ProtoWriter : public StructuredObjectWriter {
     void RegisterField(const google::protobuf::Field* field);
 
     // To report location on error messages.
-    virtual string ToString() const;
+    virtual string ToString() const override;
 
-    virtual ProtoElement* parent() const {
+    virtual ProtoElement* parent() const override {
       return static_cast<ProtoElement*>(BaseElement::parent());
     }
 

--- a/src/google/protobuf/util/internal/protostream_objectsource.h
+++ b/src/google/protobuf/util/internal/protostream_objectsource.h
@@ -78,9 +78,9 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectSource : public ObjectSource {
                           TypeResolver* type_resolver,
                           const google::protobuf::Type& type);
 
-  virtual ~ProtoStreamObjectSource();
+  virtual ~ProtoStreamObjectSource() override;
 
-  virtual util::Status NamedWriteTo(StringPiece name, ObjectWriter* ow) const;
+  virtual util::Status NamedWriteTo(StringPiece name, ObjectWriter* ow) const override;
 
   // Sets whether or not to use lowerCamelCase casing for enum values. If set to
   // false, enum values are output without any case conversions.

--- a/src/google/protobuf/util/internal/protostream_objectwriter.h
+++ b/src/google/protobuf/util/internal/protostream_objectwriter.h
@@ -112,18 +112,18 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
                           strings::ByteSink* output, ErrorListener* listener,
                           const ProtoStreamObjectWriter::Options& options =
                               ProtoStreamObjectWriter::Options::Defaults());
-  virtual ~ProtoStreamObjectWriter();
+  virtual ~ProtoStreamObjectWriter() override;
 
   // ObjectWriter methods.
-  virtual ProtoStreamObjectWriter* StartObject(StringPiece name);
-  virtual ProtoStreamObjectWriter* EndObject();
-  virtual ProtoStreamObjectWriter* StartList(StringPiece name);
-  virtual ProtoStreamObjectWriter* EndList();
+  virtual ProtoStreamObjectWriter* StartObject(StringPiece name) override;
+  virtual ProtoStreamObjectWriter* EndObject() override;
+  virtual ProtoStreamObjectWriter* StartList(StringPiece name) override;
+  virtual ProtoStreamObjectWriter* EndList() override;
 
   // Renders a DataPiece 'value' into a field whose wire type is determined
   // from the given field 'name'.
   virtual ProtoStreamObjectWriter* RenderDataPiece(StringPiece name,
-                                                   const DataPiece& value);
+                                           const DataPiece& value) override;
 
  protected:
   // Function that renders a well known type with modified behavior.
@@ -263,7 +263,7 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
     // Constructor for a field of a message.
     Item(Item* parent, ItemType item_type, bool is_placeholder, bool is_list);
 
-    virtual ~Item() {}
+    virtual ~Item() override {}
 
     // These functions return true if the element type is corresponding to the
     // type in function name.
@@ -272,7 +272,7 @@ class LIBPROTOBUF_EXPORT ProtoStreamObjectWriter : public ProtoWriter {
 
     AnyWriter* any() const { return any_.get(); }
 
-    virtual Item* parent() const {
+    virtual Item* parent() const override {
       return static_cast<Item*>(BaseElement::parent());
     }
 

--- a/src/google/protobuf/util/internal/type_info.cc
+++ b/src/google/protobuf/util/internal/type_info.cc
@@ -59,7 +59,7 @@ class TypeInfoForTypeResolver : public TypeInfo {
   }
 
   virtual util::StatusOr<const google::protobuf::Type*> ResolveTypeUrl(
-      StringPiece type_url) const {
+      StringPiece type_url) const override {
     std::map<StringPiece, StatusOrType>::iterator it =
         cached_types_.find(type_url);
     if (it != cached_types_.end()) {
@@ -79,13 +79,13 @@ class TypeInfoForTypeResolver : public TypeInfo {
   }
 
   virtual const google::protobuf::Type* GetTypeByTypeUrl(
-      StringPiece type_url) const {
+      StringPiece type_url) const override {
     StatusOrType result = ResolveTypeUrl(type_url);
     return result.ok() ? result.ValueOrDie() : NULL;
   }
 
   virtual const google::protobuf::Enum* GetEnumByTypeUrl(
-      StringPiece type_url) const {
+      StringPiece type_url) const override {
     std::map<StringPiece, StatusOrEnum>::iterator it =
         cached_enums_.find(type_url);
     if (it != cached_enums_.end()) {
@@ -105,8 +105,10 @@ class TypeInfoForTypeResolver : public TypeInfo {
     return result.ok() ? result.ValueOrDie() : NULL;
   }
 
+
   virtual const google::protobuf::Field* FindField(
-      const google::protobuf::Type* type, StringPiece camel_case_name) const {
+      const google::protobuf::Type* type,
+      StringPiece camel_case_name) const override {
     std::map<const google::protobuf::Type*, CamelCaseNameTable>::const_iterator
         it = indexed_types_.find(type);
     const CamelCaseNameTable& camel_case_name_table =

--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -119,19 +119,20 @@ util::Status BinaryToJsonString(TypeResolver* resolver,
 namespace {
 class StatusErrorListener : public converter::ErrorListener {
  public:
+
   StatusErrorListener() {}
-  virtual ~StatusErrorListener() {}
+  virtual ~StatusErrorListener() override {}
 
   util::Status GetStatus() { return status_; }
 
   virtual void InvalidName(const converter::LocationTrackerInterface& loc,
-                           StringPiece unknown_name, StringPiece message) {
+                   StringPiece unknown_name, StringPiece message) override {
     status_ = util::Status(util::error::INVALID_ARGUMENT,
                              loc.ToString() + ": " + string(message));
   }
 
   virtual void InvalidValue(const converter::LocationTrackerInterface& loc,
-                            StringPiece type_name, StringPiece value) {
+                    StringPiece type_name, StringPiece value) override {
     status_ =
         util::Status(util::error::INVALID_ARGUMENT,
                        loc.ToString() + ": invalid value " + string(value) +
@@ -139,7 +140,7 @@ class StatusErrorListener : public converter::ErrorListener {
   }
 
   virtual void MissingField(const converter::LocationTrackerInterface& loc,
-                            StringPiece missing_name) {
+                    StringPiece missing_name) override {
     status_ = util::Status(
         util::error::INVALID_ARGUMENT,
         loc.ToString() + ": missing field " + string(missing_name));

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -182,7 +182,7 @@ class LIBPROTOBUF_EXPORT ZeroCopyStreamByteSink : public strings::ByteSink {
       : stream_(stream), buffer_(NULL), buffer_size_(0) {}
   ~ZeroCopyStreamByteSink();
 
-  virtual void Append(const char* bytes, size_t len);
+  virtual void Append(const char* bytes, size_t len) override;
 
  private:
   io::ZeroCopyOutputStream* stream_;

--- a/src/google/protobuf/util/message_differencer.cc
+++ b/src/google/protobuf/util/message_differencer.cc
@@ -90,7 +90,7 @@ class MessageDifferencer::MultipleFieldsMapKeyComparator
   virtual bool IsMatch(
       const Message& message1,
       const Message& message2,
-      const std::vector<SpecificField>& parent_fields) const {
+      const std::vector<SpecificField>& parent_fields) const override {
     for (int i = 0; i < key_field_paths_.size(); ++i) {
       if (!IsMatchInternal(message1, message2, parent_fields,
                            key_field_paths_[i], 0)) {

--- a/src/google/protobuf/util/message_differencer.h
+++ b/src/google/protobuf/util/message_differencer.h
@@ -597,7 +597,7 @@ class LIBPROTOBUF_EXPORT MessageDifferencer {
    public:
     explicit StreamReporter(io::ZeroCopyOutputStream* output);
     explicit StreamReporter(io::Printer* printer);  // delimiter '$'
-    virtual ~StreamReporter();
+    virtual ~StreamReporter() override;
 
     // When set to true, the stream reporter will also output aggregates nodes
     // (i.e. messages and groups) whose subfields have been modified. When
@@ -607,32 +607,33 @@ class LIBPROTOBUF_EXPORT MessageDifferencer {
     }
 
     // The following are implementations of the methods described above.
+
     virtual void ReportAdded(const Message& message1, const Message& message2,
-                             const std::vector<SpecificField>& field_path);
+                             const std::vector<SpecificField>& field_path) override;
 
     virtual void ReportDeleted(const Message& message1,
                                const Message& message2,
-                               const std::vector<SpecificField>& field_path);
+                               const std::vector<SpecificField>& field_path) override;
 
     virtual void ReportModified(const Message& message1,
                                 const Message& message2,
-                                const std::vector<SpecificField>& field_path);
+                                const std::vector<SpecificField>& field_path) override;
 
     virtual void ReportMoved(const Message& message1,
                              const Message& message2,
-                             const std::vector<SpecificField>& field_path);
+                             const std::vector<SpecificField>& field_path) override;
 
     virtual void ReportMatched(const Message& message1,
                                const Message& message2,
-                               const std::vector<SpecificField>& field_path);
+                               const std::vector<SpecificField>& field_path) override;
 
     virtual void ReportIgnored(const Message& message1,
                                const Message& message2,
-                               const std::vector<SpecificField>& field_path);
+                               const std::vector<SpecificField>& field_path) override;
 
-    virtual void ReportUnknownFieldIgnored(
+    void ReportUnknownFieldIgnored(
         const Message& message1, const Message& message2,
-        const std::vector<SpecificField>& field_path);
+        const std::vector<SpecificField>& field_path) override;
 
    protected:
     // Prints the specified path of fields to the buffer.  message is used to
@@ -681,7 +682,7 @@ class LIBPROTOBUF_EXPORT MessageDifferencer {
    public:
     explicit MapEntryKeyComparator(MessageDifferencer* message_differencer);
     virtual bool IsMatch(const Message& message1, const Message& message2,
-                         const std::vector<SpecificField>& parent_fields) const;
+                         const std::vector<SpecificField>& parent_fields) const override;
 
    private:
     MessageDifferencer* message_differencer_;

--- a/src/google/protobuf/util/type_resolver_util.cc
+++ b/src/google/protobuf/util/type_resolver_util.cc
@@ -60,7 +60,7 @@ class DescriptorPoolTypeResolver : public TypeResolver {
                              const DescriptorPool* pool)
       : url_prefix_(url_prefix), pool_(pool) {}
 
-  Status ResolveMessageType(const string& type_url, Type* type) {
+  Status ResolveMessageType(const string& type_url, Type* type) override {
     string type_name;
     Status status = ParseTypeUrl(type_url, &type_name);
     if (!status.ok()) {
@@ -75,7 +75,7 @@ class DescriptorPoolTypeResolver : public TypeResolver {
     return Status();
   }
 
-  Status ResolveEnumType(const string& type_url, Enum* enum_type) {
+  Status ResolveEnumType(const string& type_url, Enum* enum_type) override {
     string type_name;
     Status status = ParseTypeUrl(type_url, &type_name);
     if (!status.ok()) {

--- a/src/google/protobuf/wire_format.h
+++ b/src/google/protobuf/wire_format.h
@@ -260,12 +260,12 @@ class LIBPROTOBUF_EXPORT UnknownFieldSetFieldSkipper : public FieldSkipper {
  public:
   UnknownFieldSetFieldSkipper(UnknownFieldSet* unknown_fields)
       : unknown_fields_(unknown_fields) {}
-  virtual ~UnknownFieldSetFieldSkipper() {}
+  virtual ~UnknownFieldSetFieldSkipper() override {}
 
   // implements FieldSkipper -----------------------------------------
-  virtual bool SkipField(io::CodedInputStream* input, uint32 tag);
-  virtual bool SkipMessage(io::CodedInputStream* input);
-  virtual void SkipUnknownEnum(int field_number, int value);
+  virtual bool SkipField(io::CodedInputStream* input, uint32 tag) override;
+  virtual bool SkipMessage(io::CodedInputStream* input) override;
+  virtual void SkipUnknownEnum(int field_number, int value) override;
 
  protected:
   UnknownFieldSet* unknown_fields_;

--- a/src/google/protobuf/wire_format_lite.h
+++ b/src/google/protobuf/wire_format_lite.h
@@ -763,9 +763,9 @@ class LIBPROTOBUF_EXPORT CodedOutputStreamFieldSkipper : public FieldSkipper {
   virtual ~CodedOutputStreamFieldSkipper() {}
 
   // implements FieldSkipper -----------------------------------------
-  virtual bool SkipField(io::CodedInputStream* input, uint32 tag);
-  virtual bool SkipMessage(io::CodedInputStream* input);
-  virtual void SkipUnknownEnum(int field_number, int value);
+  virtual bool SkipField(io::CodedInputStream* input, uint32 tag) override;
+  virtual bool SkipMessage(io::CodedInputStream* input) override;
+  virtual void SkipUnknownEnum(int field_number, int value) override;
 
  protected:
   io::CodedOutputStream* unknown_fields_;


### PR DESCRIPTION
Add PROTOBUF_OVERRIDE macro, which is defined to be
"override" for c++11 and nothing for older versions.
PROTOBUF_OVERRIDE is added for overridden virtual
functions.
Please refer following issue for discussion on this.
https://github.com/google/protobuf/issues/67