### PR TITLE
CMake OSX rpath  management

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -7,7 +7,10 @@ endif()
 
 # CMake policies
 cmake_policy(SET CMP0022 NEW)
-
+# On MacOS use @rpath/ for target's install name prefix path
+if (POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif ()
 # Clear VERSION variables when no VERSION is given to project()
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # CMake policies
 cmake_policy(SET CMP0022 NEW)
 
+# Clear VERSION variables when no VERSION is given to project()
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -15,6 +15,13 @@ foreach(_library ${_protobuf_libraries})
     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
     $<BUILD_INTERFACE:${protobuf_source_dir}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  if (UNIX AND NOT APPLE)
+    set_property(TARGET ${_library}
+      PROPERTY INSTALL_RPATH "$ORIGIN")
+  elseif (APPLE)
+    set_property(TARGET ${_library}
+      PROPERTY INSTALL_RPATH "@loader_path")
+  endif()
   install(TARGETS ${_library} EXPORT protobuf-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
@@ -24,6 +31,13 @@ endforeach()
 if (protobuf_BUILD_PROTOC_BINARIES)
   install(TARGETS protoc EXPORT protobuf-targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+  if (UNIX AND NOT APPLE)
+    set_property(TARGET protoc
+      PROPERTY INSTALL_RPATH "$ORIGIN/../lib")
+  elseif (APPLE)
+    set_property(TARGET protoc
+      PROPERTY INSTALL_RPATH "@loader_path/../lib")
+  endif()
 endif (protobuf_BUILD_PROTOC_BINARIES)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")


### PR DESCRIPTION
CMake has introduced [CMP0042](https://cmake.org/cmake/help/latest/policy/CMP0042.html) in CMake 3.0

Context:
I'm currently moving google/or-tools from static dependencies to dynamic one, unfortunately protobuf don't use `@rpath/` as prefix path contrary to gflags and glog so it is difficult for me to recreate our sdk since libprotobuf.dylib contains absolute (build) path...

On MacOS library need to find itself and by default they use an absolute path pointing to the build dir (i.e. everyhing blow up at install and it is no relocatable ;)). Like on Unix world, you can use rpath and $ORIGIN like.
- First use `@rpath/` as --install-name prefix (done by enabling CMP0042)
- then you could add some `@loader_path;@loader_path/../lib;etc` to LC_RPATH list (cf [working example](https://github.com/Mizux/cmake-cpp/blob/master/FooBarApp/CMakeLists.txt#L11) if you are curious..)
note: `@loader_path` is the equivalent to `$ORIGIN`
note2: contrary to UNIX it seems you need several calls to  -Wl,-rpath, i.e. one path at a time while on unix you can add several path using colon ':' (on CMake with RPATH_INSTALL you can use item separator semicolon ';' so cmake will add several calls (otools -l will show you all LC_RPATH entries))

**WARNING**: On MacOS `protoc` depends on `libprotoc.dylib` and `libprotobuf.dylib`,  so while it's work in build dir since cmake add an `LC_RPATH`, **BUT** it's not working if using `make install DESTDIR=foo` with:
foo/usr/local:
 + /bin
      - protoc
 + /lib
     - libprotoc.dylib
     - libprotobuf.dylib

i.e. cmake remove build dir rpath (good) but doesn't add a `@loader_path/..` entry (bad but expected), working on it...
EDIT: my last commit add the correct rpath -> everything seems to work and are relocatable
ToDo: check if this fix the python setup.py use of protoc cf https://github.com/google/protobuf/blame/master/python/README.md#L60