### PR TITLE
Add msbuild targets to C# tools for protoc compilers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ pkgconfig_DATA = protobuf.pc protobuf-lite.pc
 csharp_EXTRA_DIST=                                                           \
   csharp/.gitignore                                                          \
   csharp/CHANGES.txt                                                         \
+  csharp/Google.Protobuf.Tools.targets                                       \
   csharp/Google.Protobuf.Tools.nuspec                                        \
   csharp/README.md                                                           \
   csharp/build_packages.bat                                                  \

--- a/csharp/Google.Protobuf.Tools.nuspec
+++ b/csharp/Google.Protobuf.Tools.nuspec
@@ -33,5 +33,7 @@
     <file src="..\src\google\protobuf\timestamp.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\type.proto" target="tools\google\protobuf" />
     <file src="..\src\google\protobuf\wrappers.proto" target="tools\google\protobuf" />
+    <file src="Google.Protobuf.Tools.targets" target="buildCrossTargeting" />
+    <file src="Google.Protobuf.Tools.targets" target="build" />
   </files>
 </package>

--- a/csharp/Google.Protobuf.Tools.targets
+++ b/csharp/Google.Protobuf.Tools.targets
@@ -1,0 +1,16 @@
+<Project>
+    <PropertyGroup>
+        <protoc_linux64>$(MSBuildThisFileDirectory)..\tools\linux_x64\protoc</protoc_linux64>
+        <protoc_linux86>$(MSBuildThisFileDirectory)..\tools\linux_x86\protoc</protoc_linux86>
+        <protoc_macosx64>$(MSBuildThisFileDirectory)..\tools\macosx_x64\protoc</protoc_macosx64>
+        <protoc_macosx86>$(MSBuildThisFileDirectory)..\tools\macosx_x86\protoc</protoc_macosx86>
+        <protoc_windows64>$(MSBuildThisFileDirectory)..\tools\windows_x64\protoc.exe</protoc_windows64>
+        <protoc_windows86>$(MSBuildThisFileDirectory)..\tools\windows_x86\protoc.exe</protoc_windows86>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(Linux))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'">$(protoc_linux64)</protoc>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(Linux))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X86'">$(protoc_linux86)</protoc>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(OSX))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'">$(protoc_macosx64)</protoc>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(OSX))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X86'">$(protoc_macosx86)</protoc>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(Windows))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'">$(protoc_windows64)</protoc>
+        <protoc Condition="'$([MSBuild]::IsOsPlatform(Windows))' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X86'">$(protoc_windows86)</protoc>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
Adds msbuild properties to Google.Protobuf.Tools that point to each protoc compiler executable. Also includes a "protoc" property that points to the protoc compiler for the current OS and OS architecture.
