### PR TITLE
remove PACKAGE_NAME and REPOSITORY_NAME deprecated usage

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -266,8 +266,8 @@ def internal_gen_well_known_protos_java(srcs):
   Args:
     srcs: the well known protos
   """
-  root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
-  pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
+  root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
+  pkg = native.package_name() + "/" if native.package_name() else ""
   if root == "":
     include = " -I%ssrc " % pkg
   else:


### PR DESCRIPTION
Hi,
We (rules_scala) use this repository as a bazel source repository.
We want to run with bazel 0.13.0 with `--all_incompatible_changes` and fail because of https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#package-name-is-a-function
This PR fixes it.
@dslomov should there be a process to make sure very root projects (like protobuf) support the above flag?
cc @johnynek