### PR TITLE
Fix to allow a compilation under mips big endian with gcc

### DIFF
--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -56,7 +56,7 @@
 #elif defined(__aarch64__)
 #define GOOGLE_PROTOBUF_ARCH_AARCH64 1
 #define GOOGLE_PROTOBUF_ARCH_64_BIT 1
-#elif defined(__MIPSEL__)
+#elif defined(__mips__)
 #if defined(__LP64__)
 #define GOOGLE_PROTOBUF_ARCH_MIPS64 1
 #define GOOGLE_PROTOBUF_ARCH_64_BIT 1


### PR DESCRIPTION
The __MIPSEL__ is mips little endian, specific and we needed
to compile for a big endian mips target that also happened
to be a mips64, so replaced the __MIPSEL__ with a __mip__
which should preserve the build on little endian and allow a
build for a big endian setup.

	$ echo | mips64-linux-gcc -E -dM -
	... snip snip ...
	#define __mips__ 1
	#define __MIPSEB__ 1

Signed-off-by: Charles Hardin <ckhardin@gmail.com>