### PR TITLE
Declare 'google' namespace when importing Python protobuf via Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -640,6 +640,7 @@ py_library(
     name = "python_srcs",
     srcs = glob(
         [
+            "python/google/__init__.py",
             "python/google/protobuf/*.py",
             "python/google/protobuf/**/*.py",
         ],


### PR DESCRIPTION
This fixes #4658.