### PR TITLE
Updated generate_changelog.py

### DIFF
--- a/generate_changelog.py
+++ b/generate_changelog.py
@@ -20,11 +20,10 @@ languages = [
   ]),
   Language("Java", [
       "java",
-      "javanano",
-      "src/google/protobuf/compiler/cpp",
+      "src/google/protobuf/compiler/java",
   ]),
   Language("Python", [
-      "javanano",
+      "python",
       "src/google/protobuf/compiler/python",
   ]),
   Language("JavaScript", [


### PR DESCRIPTION
I removed references to javanano, since that implementation no longer
exists. While I was at it I found a couple places where it looked like
the wrong directory was used by mistake and I fixed them.