### PR TITLE
Don't generate well_known_types_embed in tree during out-of-tree CMake build

### DIFF
--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -1,3 +1,7 @@
+set(js_well_known_types_embed
+  ${CMAKE_CURRENT_BINARY_DIR}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+)
+
 set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/code_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/command_line_interface.cc
@@ -62,7 +66,6 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/java/java_string_field_lite.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/js/js_generator.cc
-  ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/objectivec/objectivec_extension.cc
@@ -82,6 +85,7 @@ set(libprotoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/ruby/ruby_generator.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/subprocess.cc
   ${protobuf_source_dir}/src/google/protobuf/compiler/zip_writer.cc
+  ${js_well_known_types_embed}
 )
 
 set(libprotoc_headers
@@ -168,9 +172,10 @@ set(js_well_known_types_sources
 )
 add_executable(js_embed ${protobuf_source_dir}/src/google/protobuf/compiler/js/embed.cc)
 add_custom_command(
-  OUTPUT ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+  OUTPUT ${js_well_known_types_embed}
   DEPENDS js_embed ${js_well_known_types_sources}
-  COMMAND js_embed ${js_well_known_types_sources} > ${protobuf_source_dir}/src/google/protobuf/compiler/js/well_known_types_embed.cc
+  COMMAND mkdir -p `dirname ${js_well_known_types_embed}`
+  COMMAND js_embed ${js_well_known_types_sources} > ${js_well_known_types_embed}
 )
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}


### PR DESCRIPTION
The well_known_types_embed.cc source file is generated during the build;
as a result, it should be generated in the build directory, not the
source directory, during an out-of-tree build. The autotools build does
this right, but the CMake build was doing it wrong.