### PR TITLE
Require C++11 and pass -std=c++11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AS_IF([test "x${ac_cv_env_CXXFLAGS_set}" = "x"],[
   # Protocol Buffers contains several checks that are intended to be used only
   # for debugging and which might hurt performance.  Most users are probably
   # end users who don't want these checks, so add -DNDEBUG by default.
-  CXXFLAGS="$CXXFLAGS -DNDEBUG"
+  CXXFLAGS="$CXXFLAGS -std=c++11 -DNDEBUG"
 
   AC_MSG_RESULT([use default: $PROTOBUF_OPT_FLAG $CXXFLAGS])
 ],[
@@ -207,7 +207,7 @@ case "$target_os" in
 esac
 AM_CONDITIONAL([OBJC_CONFORMANCE_TEST], [test $OBJC_CONFORMANCE_TEST = 1])
 
-AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 # HACK:  Make gmock's configure script pick up our copy of CFLAGS and CXXFLAGS,
 #   since the flags added by ACX_CHECK_SUNCC must be used when compiling gmock


### PR DESCRIPTION
This commit updates the Autotools build to require a C++11 compiler and
explicitly pass -std=c++11. This seems to be necessary for enabling
C++11 support in older compilers.

This should fix issue #4705.