### PR TITLE
Align Bazel on Windows with CMake's MSVC flags

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,6 @@ config_setting(
 MSVC_COPTS = [
     "/DHAVE_PTHREAD",
     "/wd4018", # -Wno-sign-compare
-    "/wd4065", # switch statement contains
     "/wd4065", # switch statement contains 'default' but no 'case' labels
     "/wd4146", # unary minus operator applied to unsigned type, result still unsigned
     "/wd4244", # 'conversion' conversion from 'type1' to 'type2', possible loss of data

--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,21 @@ config_setting(
 MSVC_COPTS = [
     "/DHAVE_PTHREAD",
     "/wd4018", # -Wno-sign-compare
+    "/wd4065", # switch statement contains
+    "/wd4065", # switch statement contains 'default' but no 'case' labels
+    "/wd4146", # unary minus operator applied to unsigned type, result still unsigned
+    "/wd4244", # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+    "/wd4251", # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+    "/wd4267", # 'var' : conversion from 'size_t' to 'type', possible loss of data
+    "/wd4305", # 'identifier' : truncation from 'type1' to 'type2'
+    "/wd4307", # 'operator' : integral constant overflow
+    "/wd4309", # 'conversion' : truncation of constant value
+    "/wd4334", # 'operator' : result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+    "/wd4355", # 'this' : used in base member initializer list
+    "/wd4506", # no definition for inline function 'function'
     "/wd4514", # -Wno-unused-function
+    "/wd4800", # 'type' : forcing value to bool 'true' or 'false' (performance warning)
+    "/wd4996", # The compiler encountered a deprecated declaration.
 ]
 
 COPTS = select({
@@ -66,6 +80,8 @@ LINK_OPTS = select({
         #   package, which it is not.
         # See https://msdn.microsoft.com/en-us/library/8bch7bkk.aspx
         "-WHOLEARCHIVE:setargv.obj",
+        # Suppress linker warnings about files with no symbols defined.
+        "-ignore:4221",
     ],
     "//conditions:default": ["-lpthread", "-lm"],
 })


### PR DESCRIPTION
Make Bazel on Windows build log less noisy.