### PR TITLE
Graceful failure in SerializeToArray().

### DIFF
--- a/src/google/protobuf/message_lite.cc
+++ b/src/google/protobuf/message_lite.cc
@@ -316,7 +316,11 @@ bool MessageLite::SerializeToArray(void* data, int size) const {
 }
 
 bool MessageLite::SerializePartialToArray(void* data, int size) const {
-  int byte_size = ByteSizeLong();
+  size_t byte_size = ByteSizeLong();
+  if (byte_size > INT_MAX) {
+    GOOGLE_LOG(ERROR) << "Exceeded maximum protobuf size of 2GB: " << size;
+    return false;
+  }
   if (size < byte_size) return false;
   uint8* start = reinterpret_cast<uint8*>(data);
   uint8* end = SerializeWithCachedSizesToArray(start);


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/19657 for
motivation. But long story short, without this change:

```c++
m.SerializeToArray(buffer, m.ByteSizeLong());
```

would result in a CHECK failure if `m.ByteSizeLong()` returned a value >2GB.