### PR TITLE
Make proto_api target visible

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -842,6 +842,7 @@ cc_library(
     deps = [
         "//external:python_headers",
     ],
+    visibility = ["//visibility:public"],
 )
 
 proto_lang_toolchain(


### PR DESCRIPTION
The creation of the new proto_api (https://github.com/google/protobuf/pull/4698, https://github.com/google/protobuf/pull/4725) is almost usable but just needs the proto_api target to be visible.