### PR TITLE
Run flake8 to find Python syntax errors and undefined names

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -3,6 +3,7 @@ setlocal
 IF %platform%==MinGW GOTO build_mingw
 IF %language%==cpp GOTO build_cpp
 IF %language%==csharp GOTO build_csharp
+IF %language%==python GOTO build_python
 
 echo Unsupported language %language% and platform %platform%. Exiting.
 goto :error
@@ -41,6 +42,28 @@ echo Testing C#
 dotnet test -c %configuration% -f netcoreapp1.0 Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 dotnet test -c %configuration% -f net451 Google.Protobuf.Test\Google.Protobuf.Test.csproj || goto error
 
+goto :EOF
+
+:build_python
+echo Building Python 2.7
+c:\python27\python.exe --version
+c:\python27\python.exe -m pip --version
+c:\python27\python.exe -m pip install flake8
+echo stop the build if there are Python syntax errors or undefined names
+c:\python27\python.exe -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+REM c:\python27\python.exe -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics || goto error
+echo exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+c:\python27\python.exe -m flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
+
+echo Building Python 3.6
+c:\python36\python.exe --version
+c:\python36\python.exe -m pip --version
+c:\python36\python.exe -m pip install flake8
+echo stop the build if there are Python syntax errors or undefined names
+c:\python36\python.exe -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+REM c:\python36\python.exe -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics || goto error
+echo exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+c:\python36\python.exe -m flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
 goto :EOF
 
 :error

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       language: csharp
       image: Visual Studio 2017
 
+    - platform: Win64
+      language: python
+      image: Visual Studio 2017
+
 # Our build scripts run tests automatically; we don't want AppVeyor
 # to try to detect them itself.
 test: off


### PR DESCRIPTION
http://flake8.pycqa.org tests can find Python syntax errors and undefined names on each pull request before they are reviewed.

Results on Python 2.7:
* 3     F821 undefined name

Results on Python 3.6:
* 10    E999 SyntaxError: invalid syntax
* 5     F821 undefined name
