### PR TITLE
Added Kokoro Windows release build config for protoc

### DIFF
--- a/kokoro/release/protoc/windows/build.bat
+++ b/kokoro/release/protoc/windows/build.bat
@@ -1,0 +1,27 @@
+set PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
+set generator32=Visual Studio 14
+set generator64=Visual Studio 14 Win64
+set vcplatform32=win32
+set vcplatform64=x64
+set configuration=Release
+
+echo Building protoc
+cd github\protobuf
+
+mkdir build32
+cd build32
+cmake -G "%generator32%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ../cmake
+msbuild protobuf.sln /p:Platform=%vcplatform32% || goto error
+cd ..
+
+mkdir build64
+cd build64
+cmake -G "%generator64%" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_UNICODE=ON ../cmake
+msbuild protobuf.sln /p:Platform=%vcplatform64% || goto error
+cd ..
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %ERRORLEVEL%

--- a/kokoro/release/protoc/windows/release.cfg
+++ b/kokoro/release/protoc/windows/release.cfg
@@ -1,0 +1,8 @@
+# Configuration for Windows protoc release builds
+build_file: "protobuf/kokoro/release/protoc/windows/build.bat"
+
+action {
+  define_artifacts {
+    regex: "**/protoc.exe"
+  }
+}


### PR DESCRIPTION
This should make it easy to automatically build 32-bit and 64-bit
Windows protoc binaries.