### PR TITLE
Added Kokoro protoc release build for OS X

### DIFF
--- a/kokoro/release/protoc/macos/build.sh
+++ b/kokoro/release/protoc/macos/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+CXXFLAGS_COMMON="-DNDEBUG -mmacosx-version-min=10.9"
+
+cd github/protobuf
+./autogen.sh
+
+mkdir build32 && cd build32
+export CXXFLAGS="$CXXFLAGS_COMMON -m32"
+../configure --disable-shared
+make -j4
+file src/protoc
+otool -L src/protoc | grep dylib
+cd ..
+
+mkdir build64 && cd build64
+export CXXFLAGS="$CXXFLAGS_COMMON -m64"
+../configure --disable-shared
+make -j4
+file src/protoc
+otool -L src/protoc | grep dylib
+cd ..

--- a/kokoro/release/protoc/macos/release.cfg
+++ b/kokoro/release/protoc/macos/release.cfg
@@ -1,0 +1,8 @@
+# Configuration for Mac OSX protoc release builds
+build_file: "protobuf/kokoro/release/protoc/macos/build.sh"
+
+action {
+  define_artifacts {
+    regex: "**/protoc"
+  }
+}


### PR DESCRIPTION
This configuration builds both 32-bit and 64-bit binaries for Mac OS X.
One thing I had to change was to increase our minimum supported version
for 10.7 to 10.9, because 10.9 (Mavericks) appears to be the earliest
version supporting C++11.