### PR TITLE
Work around MSVC issue with std::atomic initialization

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,3 @@
-# Only test one combination: "Visual Studio 12 + Win64 + Debug + DLL". We can
-# test more combinations but AppVeyor just takes too long to finish (each
-# combination takes ~15mins).
 platform:
   - Win64
 
@@ -12,6 +9,11 @@ environment:
     - language: cpp
       image: Visual Studio 2015
       BUILD_DLL: ON
+      UNICODE: ON
+
+    - language: cpp
+      image: Visual Studio 2017
+      BUILD_DLL: OFF
       UNICODE: ON
 
     - language: csharp

--- a/src/google/protobuf/generated_message_util.h
+++ b/src/google/protobuf/generated_message_util.h
@@ -335,7 +335,16 @@ struct LIBPROTOBUF_EXPORT SCCInfoBase {
     kRunning = 1,
     kUninitialized = -1,  // initial state
   };
+#ifndef _MSC_VER
   std::atomic<int> visit_status;
+#else
+  // MSVC doesnt make std::atomic constant initialized. This union trick
+  // makes it so.
+  union {
+    int visit_status_to_make_linker_init;
+    std::atomic<int> visit_status;
+  };
+#endif
   int num_deps;
   void (*init_func)();
   // This is followed by an array  of num_deps


### PR DESCRIPTION
MSVC seems to have a bug where it does not use constant initialization
for std::atomic, which ends up causing crashes during initialization.
This change introduces a workaround by putting the std::atomic inside a
union, which causes the compiler to use constant initialization for it.