### PR TITLE
Fix typo in the doc

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,4 +1,4 @@
-# Protobuf Perforamcne
+# Protobuf Performance
 This benchmark result is tested on workstation with processor of Intel® Xeon® Processor E5-2630 and 32GB RAM
 
 This table contains 3 languages' results:


### PR DESCRIPTION
minor: Fixed typo in `performace.md`