### PR TITLE
Make text_encoding.CUnescape return a result in UTF-8 format

### DIFF
--- a/python/google/protobuf/text_encoding.py
+++ b/python/google/protobuf/text_encoding.py
@@ -104,4 +104,4 @@ def CUnescape(text):
   return (result.encode('ascii')  # Make it bytes to allow decode.
           .decode('unicode_escape')
           # Make it bytes again to return the proper type.
-          .encode('raw_unicode_escape'))
+          .encode('utf-8'))


### PR DESCRIPTION
This function seemed to have a bug where it would encode its result in
the "raw_unicode_escape" format, which is an unusual Python-specific
format. The docstring indicates it should return UTF-8 bytes, so this
commit changes it to do that. This should fix a bug that was causing
text format protos with non-ASCII characters to be unparseable (#4721).