### PR TITLE
protostream_objectsource: preserve print options across Any.

### DIFF
--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -648,6 +648,9 @@ Status ProtoStreamObjectSource::RenderAny(const ProtoStreamObjectSource* os,
   // using a nested ProtoStreamObjectSource using our nested type information.
   ProtoStreamObjectSource nested_os(&in_stream, os->typeinfo_, *nested_type);
 
+  // TODO(htuch): This is somewhat fragile, since new options may be omitted.
+  // We should probably do this via the constructor or some object grouping
+  // options.
   nested_os.set_use_lower_camel_for_enums(os->use_lower_camel_for_enums_);
   nested_os.set_use_ints_for_enums(os->use_ints_for_enums_);
   nested_os.set_preserve_proto_field_names(os->preserve_proto_field_names_);

--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -648,6 +648,10 @@ Status ProtoStreamObjectSource::RenderAny(const ProtoStreamObjectSource* os,
   // using a nested ProtoStreamObjectSource using our nested type information.
   ProtoStreamObjectSource nested_os(&in_stream, os->typeinfo_, *nested_type);
 
+  nested_os.set_use_lower_camel_for_enums(os->use_lower_camel_for_enums_);
+  nested_os.set_use_ints_for_enums(os->use_ints_for_enums_);
+  nested_os.set_preserve_proto_field_names(os->preserve_proto_field_names_);
+
   // We manually call start and end object here so we can inject the @type.
   ow->StartObject(field_name);
   ow->RenderString("@type", type_url);

--- a/src/google/protobuf/util/internal/testdata/books.proto
+++ b/src/google/protobuf/util/internal/testdata/books.proto
@@ -69,6 +69,9 @@ message Book {
   }
   optional Type type = 11;
 
+  // Useful for testing JSON snake/camel-case conversions.
+  optional string snake_field = 12;
+
   extensions 200 to 499;
 }
 


### PR DESCRIPTION
Fixes #4771. Based on the solution included in the issues from
@wangjinhua.

Validated this works with Envoy's /config_dump JSON rendering.

Signed-off-by: Harvey Tuch <htuch@google.com>