### PR TITLE
Removed forward declaration of MemBlock class

### DIFF
--- a/src/google/protobuf/stubs/bytestream.h
+++ b/src/google/protobuf/stubs/bytestream.h
@@ -57,7 +57,6 @@
 #include <google/protobuf/stubs/stringpiece.h>
 
 class CordByteSink;
-class MemBlock;
 
 namespace google {
 namespace protobuf {


### PR DESCRIPTION
Removed forward declaration of MemBlock class.

Declaration is in conflict with declaration `::strings::MemBlock`