### PR TITLE
Remove write-strings warning from COPTs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -47,7 +47,6 @@ COPTS = select({
         "-Wno-sign-compare",
         "-Wno-unused-function",
         # Prevents ISO C++ const string assignment warnings for pyext sources.
-	# no-write-strings is the standard GCC flag as of at least v5.
         "-Wno-writable-strings",
         "-Wno-write-strings",
     ],

--- a/BUILD
+++ b/BUILD
@@ -43,12 +43,13 @@ COPTS = select({
     "//conditions:default": [
         "-DHAVE_PTHREAD",
         "-Wall",
-        "-Wwrite-strings",
         "-Woverloaded-virtual",
         "-Wno-sign-compare",
         "-Wno-unused-function",
         # Prevents ISO C++ const string assignment warnings for pyext sources.
+	# no-write-strings is the standard GCC flag as of at least v5.
         "-Wno-writable-strings",
+        "-Wno-write-strings",
     ],
 })
 


### PR DESCRIPTION
This change reduces the excessive warnings when compiling C++ protobufs like "external/protobuf_archive/python/google/protobuf/pyext/message.cc:2629:1: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]"