### PR TITLE
Missing symbol exports for Windows DLL

### DIFF
--- a/src/google/protobuf/io/gzip_stream.h
+++ b/src/google/protobuf/io/gzip_stream.h
@@ -118,7 +118,7 @@ class LIBPROTOBUF_EXPORT GzipOutputStream : public ZeroCopyOutputStream {
     ZLIB = 2,
   };
 
-  struct Options {
+  struct LIBPROTOBUF_EXPORT Options {
     // Defaults to GZIP.
     Format format;
 

--- a/src/google/protobuf/repeated_field.h
+++ b/src/google/protobuf/repeated_field.h
@@ -705,13 +705,13 @@ void GenericTypeHandler<string>::Merge(const string& from,
 // Declarations of the specialization as we cannot define them here, as the
 // header that defines ProtocolMessage depends on types defined in this header.
 #define DECLARE_SPECIALIZATIONS_FOR_BASE_PROTO_TYPES(TypeName)                 \
-    template<>                                                                 \
+    template<> LIBPROTOBUF_EXPORT                                              \
     TypeName* GenericTypeHandler<TypeName>::NewFromPrototype(                  \
         const TypeName* prototype, google::protobuf::Arena* arena);                      \
-    template<>                                                                 \
+    template<> LIBPROTOBUF_EXPORT                                              \
     google::protobuf::Arena* GenericTypeHandler<TypeName>::GetArena(                     \
         TypeName* value);                                                      \
-    template<>                                                                 \
+    template<> LIBPROTOBUF_EXPORT                                              \
     void* GenericTypeHandler<TypeName>::GetMaybeArenaPointer(                  \
         TypeName* value);
 


### PR DESCRIPTION
Please don't drop these exports again in the near future when merging from the 'internal' sources ;-)
