### PR TITLE
Fix initialization with Visual Studio

### DIFF
--- a/src/google/protobuf/descriptor.cc
+++ b/src/google/protobuf/descriptor.cc
@@ -479,15 +479,8 @@ typedef std::map<DescriptorIntPair, const FieldDescriptor*>
   ExtensionsGroupedByDescriptorMap;
 typedef HASH_MAP<string, const SourceCodeInfo_Location*> LocationsByPathMap;
 
-std::set<string>* allowed_proto3_extendees_ = NULL;
-GOOGLE_PROTOBUF_DECLARE_ONCE(allowed_proto3_extendees_init_);
-
-void DeleteAllowedProto3Extendee() {
-  delete allowed_proto3_extendees_;
-}
-
-void InitAllowedProto3Extendee() {
-  allowed_proto3_extendees_ = new std::set<string>;
+std::set<string>* NewAllowedProto3Extendee() {
+  auto allowed_proto3_extendees = new std::set<string>;
   const char* kOptionNames[] = {
       "FileOptions",      "MessageOptions", "FieldOptions", "EnumOptions",
       "EnumValueOptions", "ServiceOptions", "MethodOptions", "OneofOptions"};
@@ -495,14 +488,13 @@ void InitAllowedProto3Extendee() {
     // descriptor.proto has a different package name in opensource. We allow
     // both so the opensource protocol compiler can also compile internal
     // proto3 files with custom options. See: b/27567912
-    allowed_proto3_extendees_->insert(string("google.protobuf.") +
+    allowed_proto3_extendees->insert(string("google.protobuf.") +
                                       kOptionNames[i]);
     // Split the word to trick the opensource processing scripts so they
     // will keep the origial package name.
-    allowed_proto3_extendees_->insert(string("proto") + "2." + kOptionNames[i]);
+    allowed_proto3_extendees->insert(string("proto") + "2." + kOptionNames[i]);
   }
-
-  google::protobuf::internal::OnShutdown(&DeleteAllowedProto3Extendee);
+  return allowed_proto3_extendees;
 }
 
 // Checks whether the extendee type is allowed in proto3.
@@ -510,9 +502,10 @@ void InitAllowedProto3Extendee() {
 // instead of comparing the descriptor directly because the extensions may be
 // defined in a different pool.
 bool AllowedExtendeeInProto3(const string& name) {
-  ::google::protobuf::GoogleOnceInit(&allowed_proto3_extendees_init_, &InitAllowedProto3Extendee);
-  return allowed_proto3_extendees_->find(name) !=
-         allowed_proto3_extendees_->end();
+  static auto allowed_proto3_extendees =
+      internal::OnShutdownDelete(NewAllowedProto3Extendee());
+  return allowed_proto3_extendees->find(name) !=
+         allowed_proto3_extendees->end();
 }
 
 }  // anonymous namespace
@@ -829,31 +822,10 @@ FileDescriptorTables::FileDescriptorTables()
 
 FileDescriptorTables::~FileDescriptorTables() {}
 
-namespace {
-
-FileDescriptorTables* file_descriptor_tables_ = NULL;
-GOOGLE_PROTOBUF_DECLARE_ONCE(file_descriptor_tables_once_init_);
-
-void DeleteFileDescriptorTables() {
-  delete file_descriptor_tables_;
-  file_descriptor_tables_ = NULL;
-}
-
-void InitFileDescriptorTables() {
-  file_descriptor_tables_ = new FileDescriptorTables();
-  internal::OnShutdown(&DeleteFileDescriptorTables);
-}
-
-inline void InitFileDescriptorTablesOnce() {
-  ::google::protobuf::GoogleOnceInit(
-      &file_descriptor_tables_once_init_, &InitFileDescriptorTables);
-}
-
-}  // anonymous namespace
-
 inline const FileDescriptorTables& FileDescriptorTables::GetEmptyInstance() {
-  InitFileDescriptorTablesOnce();
-  return *file_descriptor_tables_;
+  static auto file_descriptor_tables =
+      internal::OnShutdownDelete(new FileDescriptorTables());
+  return *file_descriptor_tables;
 }
 
 void DescriptorPool::Tables::AddCheckpoint() {
@@ -1335,42 +1307,28 @@ bool DescriptorPool::InternalIsFileLoaded(const string& filename) const {
 
 namespace {
 
-
-EncodedDescriptorDatabase* generated_database_ = NULL;
-DescriptorPool* generated_pool_ = NULL;
-GOOGLE_PROTOBUF_DECLARE_ONCE(generated_pool_init_);
-
-void DeleteGeneratedPool() {
-  delete generated_database_;
-  generated_database_ = NULL;
-  delete generated_pool_;
-  generated_pool_ = NULL;
+EncodedDescriptorDatabase* GeneratedDatabase() {
+  static auto generated_database =
+      internal::OnShutdownDelete(new EncodedDescriptorDatabase());
+  return generated_database;
 }
 
-static void InitGeneratedPool() {
-  generated_database_ = new EncodedDescriptorDatabase;
-  generated_pool_ = new DescriptorPool(generated_database_);
-  generated_pool_->InternalSetLazilyBuildDependencies();
-
-  internal::OnShutdown(&DeleteGeneratedPool);
-}
-
-inline void InitGeneratedPoolOnce() {
-  ::google::protobuf::GoogleOnceInit(&generated_pool_init_, &InitGeneratedPool);
+DescriptorPool* NewGeneratedPool() {
+  auto generated_pool = new DescriptorPool(GeneratedDatabase());
+  generated_pool->InternalSetLazilyBuildDependencies();
+  return generated_pool;
 }
 
 }  // anonymous namespace
 
-const DescriptorPool* DescriptorPool::generated_pool() {
-  InitGeneratedPoolOnce();
-  return generated_pool_;
+DescriptorPool* DescriptorPool::internal_generated_pool() {
+  static DescriptorPool* generated_pool =
+      internal::OnShutdownDelete(NewGeneratedPool());
+  return generated_pool;
 }
 
-
-
-DescriptorPool* DescriptorPool::internal_generated_pool() {
-  InitGeneratedPoolOnce();
-  return generated_pool_;
+const DescriptorPool* DescriptorPool::generated_pool() {
+  return internal_generated_pool();
 }
 
 void DescriptorPool::InternalAddGeneratedFile(
@@ -1397,8 +1355,7 @@ void DescriptorPool::InternalAddGeneratedFile(
   // Therefore, when we parse one, we have to be very careful to avoid using
   // any descriptor-based operations, since this might cause infinite recursion
   // or deadlock.
-  InitGeneratedPoolOnce();
-  GOOGLE_CHECK(generated_database_->Add(encoded_file_descriptor, size));
+  GOOGLE_CHECK(GeneratedDatabase()->Add(encoded_file_descriptor, size));
 }
 
 

--- a/src/google/protobuf/extension_set.h
+++ b/src/google/protobuf/extension_set.h
@@ -880,18 +880,17 @@ class RepeatedPrimitiveTypeTraits {
 
 LIBPROTOBUF_EXPORT extern ProtobufOnceType repeated_primitive_generic_type_traits_once_init_;
 
-class LIBPROTOBUF_EXPORT RepeatedPrimitiveGenericTypeTraits {
+class LIBPROTOBUF_EXPORT RepeatedPrimitiveDefaults {
  private:
   template<typename Type> friend class RepeatedPrimitiveTypeTraits;
-  static void InitializeDefaultRepeatedFields();
-  static void DestroyDefaultRepeatedFields();
-  static const RepeatedField<int32>* default_repeated_field_int32_;
-  static const RepeatedField<int64>* default_repeated_field_int64_;
-  static const RepeatedField<uint32>* default_repeated_field_uint32_;
-  static const RepeatedField<uint64>* default_repeated_field_uint64_;
-  static const RepeatedField<double>* default_repeated_field_double_;
-  static const RepeatedField<float>* default_repeated_field_float_;
-  static const RepeatedField<bool>* default_repeated_field_bool_;
+  static const RepeatedPrimitiveDefaults* default_instance();
+  RepeatedField<int32> default_repeated_field_int32_;
+  RepeatedField<int64> default_repeated_field_int64_;
+  RepeatedField<uint32> default_repeated_field_uint32_;
+  RepeatedField<uint64> default_repeated_field_uint64_;
+  RepeatedField<double> default_repeated_field_double_;
+  RepeatedField<float> default_repeated_field_float_;
+  RepeatedField<bool> default_repeated_field_bool_;
 };
 
 #define PROTOBUF_DEFINE_PRIMITIVE_TYPE(TYPE, METHOD)                       \
@@ -919,11 +918,8 @@ template<> inline void RepeatedPrimitiveTypeTraits<TYPE>::Add(             \
 }                                                                          \
 template<> inline const RepeatedField<TYPE>*                               \
     RepeatedPrimitiveTypeTraits<TYPE>::GetDefaultRepeatedField() {         \
-  ::google::protobuf::GoogleOnceInit(                                                          \
-      &repeated_primitive_generic_type_traits_once_init_,                  \
-      &RepeatedPrimitiveGenericTypeTraits::InitializeDefaultRepeatedFields); \
-  return RepeatedPrimitiveGenericTypeTraits::                              \
-      default_repeated_field_##TYPE##_;                                    \
+  return &RepeatedPrimitiveDefaults::default_instance()                    \
+              ->default_repeated_field_##TYPE##_;                          \
 }                                                                          \
 template<> inline const RepeatedField<TYPE>&                               \
     RepeatedPrimitiveTypeTraits<TYPE>::GetRepeated(int number,             \
@@ -980,8 +976,6 @@ class LIBPROTOBUF_EXPORT StringTypeTraits {
   }
 };
 
-LIBPROTOBUF_EXPORT extern ProtobufOnceType repeated_string_type_traits_once_init_;
-
 class LIBPROTOBUF_EXPORT RepeatedStringTypeTraits {
  public:
   typedef const string& ConstType;
@@ -1024,11 +1018,7 @@ class LIBPROTOBUF_EXPORT RepeatedStringTypeTraits {
                                      is_packed, NULL));
   }
 
-  static const RepeatedFieldType* GetDefaultRepeatedField() {
-    ::google::protobuf::GoogleOnceInit(&repeated_string_type_traits_once_init_,
-                   &InitializeDefaultRepeatedFields);
-    return default_repeated_field_;
-  }
+  static const RepeatedFieldType* GetDefaultRepeatedField();
 
   template <typename ExtendeeT>
   static void Register(int number, FieldType type, bool is_packed) {
@@ -1039,7 +1029,6 @@ class LIBPROTOBUF_EXPORT RepeatedStringTypeTraits {
  private:
   static void InitializeDefaultRepeatedFields();
   static void DestroyDefaultRepeatedFields();
-  static const RepeatedFieldType *default_repeated_field_;
 };
 
 // -------------------------------------------------------------------
@@ -1230,28 +1219,11 @@ class RepeatedMessageTypeTraits {
   }
 };
 
-LIBPROTOBUF_EXPORT extern ProtobufOnceType repeated_message_generic_type_traits_once_init_;
-
-// This class exists only to hold a generic default empty repeated field for all
-// message-type repeated field extensions.
-class LIBPROTOBUF_EXPORT RepeatedMessageGenericTypeTraits {
- public:
-  typedef RepeatedPtrField<::google::protobuf::MessageLite*> RepeatedFieldType;
- private:
-  template<typename Type> friend class RepeatedMessageTypeTraits;
-  static void InitializeDefaultRepeatedFields();
-  static void DestroyDefaultRepeatedFields();
-  static const RepeatedFieldType* default_repeated_field_;
-};
-
 template<typename Type> inline
     const typename RepeatedMessageTypeTraits<Type>::RepeatedFieldType*
     RepeatedMessageTypeTraits<Type>::GetDefaultRepeatedField() {
-  ::google::protobuf::GoogleOnceInit(
-      &repeated_message_generic_type_traits_once_init_,
-      &RepeatedMessageGenericTypeTraits::InitializeDefaultRepeatedFields);
-  return reinterpret_cast<const RepeatedFieldType*>(
-      RepeatedMessageGenericTypeTraits::default_repeated_field_);
+  static auto instance = OnShutdownDelete(new RepeatedFieldType);
+  return instance;
 }
 
 // -------------------------------------------------------------------

--- a/src/google/protobuf/message.cc
+++ b/src/google/protobuf/message.cc
@@ -262,9 +262,6 @@ namespace {
 
 class GeneratedMessageFactory : public MessageFactory {
  public:
-  GeneratedMessageFactory();
-  ~GeneratedMessageFactory();
-
   static GeneratedMessageFactory* singleton();
 
   typedef void RegistrationFunc(const string&);
@@ -284,25 +281,9 @@ class GeneratedMessageFactory : public MessageFactory {
   hash_map<const Descriptor*, const Message*> type_map_;
 };
 
-GeneratedMessageFactory* generated_message_factory_ = NULL;
-GOOGLE_PROTOBUF_DECLARE_ONCE(generated_message_factory_once_init_);
-
-void ShutdownGeneratedMessageFactory() {
-  delete generated_message_factory_;
-}
-
-void InitGeneratedMessageFactory() {
-  generated_message_factory_ = new GeneratedMessageFactory;
-  internal::OnShutdown(&ShutdownGeneratedMessageFactory);
-}
-
-GeneratedMessageFactory::GeneratedMessageFactory() {}
-GeneratedMessageFactory::~GeneratedMessageFactory() {}
-
 GeneratedMessageFactory* GeneratedMessageFactory::singleton() {
-  ::google::protobuf::GoogleOnceInit(&generated_message_factory_once_init_,
-                 &InitGeneratedMessageFactory);
-  return generated_message_factory_;
+  static auto instance = internal::OnShutdownDelete(new GeneratedMessageFactory);
+  return instance;
 }
 
 void GeneratedMessageFactory::RegisterFile(

--- a/src/google/protobuf/message_lite.h
+++ b/src/google/protobuf/message_lite.h
@@ -129,17 +129,9 @@ class ExplicitlyConstructed {
 // Default empty string object. Don't use this directly. Instead, call
 // GetEmptyString() to get the reference.
 LIBPROTOBUF_EXPORT extern ExplicitlyConstructed<::std::string> fixed_address_empty_string;
-LIBPROTOBUF_EXPORT extern ProtobufOnceType empty_string_once_init_;
-LIBPROTOBUF_EXPORT void InitEmptyString();
-
 
 LIBPROTOBUF_EXPORT inline const ::std::string& GetEmptyStringAlreadyInited() {
   return fixed_address_empty_string.get();
-}
-
-LIBPROTOBUF_EXPORT inline const ::std::string& GetEmptyString() {
-  ::google::protobuf::GoogleOnceInit(&empty_string_once_init_, &InitEmptyString);
-  return GetEmptyStringAlreadyInited();
 }
 
 LIBPROTOBUF_EXPORT size_t StringSpaceUsedExcludingSelfLong(const string& str);

--- a/src/google/protobuf/stubs/common.h
+++ b/src/google/protobuf/stubs/common.h
@@ -193,17 +193,22 @@ LIBPROTOBUF_EXPORT char* UTF8CoerceToStructurallyValid(
 //
 // It is safe to call this multiple times.  However, it is not safe to use
 // any other part of the protocol buffers library after
-// ShutdownProtobufLibrary() has been called.
+// ShutdownProtobufLibrary() has been called. Furthermore this call is not
+// thread safe, user needs to synchronize multiple calls.
 LIBPROTOBUF_EXPORT void ShutdownProtobufLibrary();
 
 namespace internal {
 
 // Register a function to be called when ShutdownProtocolBuffers() is called.
 LIBPROTOBUF_EXPORT void OnShutdown(void (*func)());
-// Destroy the string (call string destructor)
-LIBPROTOBUF_EXPORT void OnShutdownDestroyString(const std::string* ptr);
-// Destroy (not delete) the message
-LIBPROTOBUF_EXPORT void OnShutdownDestroyMessage(const void* ptr);
+// Run an arbitrary function on an arg
+LIBPROTOBUF_EXPORT void OnShutdownRun(void (*f)(const void*), const void* arg);
+
+template <typename T>
+T* OnShutdownDelete(T* p) {
+  OnShutdownRun([](const void* p) { delete static_cast<const T*>(p); }, p);
+  return p;
+}
 
 }  // namespace internal
 

--- a/src/google/protobuf/unknown_field_set.cc
+++ b/src/google/protobuf/unknown_field_set.cc
@@ -46,28 +46,9 @@
 namespace google {
 namespace protobuf {
 
-namespace {
-// This global instance is returned by unknown_fields() on any message class
-// when the object has no unknown fields. This is necessary because we now
-// instantiate the UnknownFieldSet dynamically only when required.
-UnknownFieldSet* default_unknown_field_set_instance_ = NULL;
-
-void DeleteDefaultUnknownFieldSet() {
-  delete default_unknown_field_set_instance_;
-}
-
-void InitDefaultUnknownFieldSet() {
-  default_unknown_field_set_instance_ = new UnknownFieldSet();
-  internal::OnShutdown(&DeleteDefaultUnknownFieldSet);
-}
-
-GOOGLE_PROTOBUF_DECLARE_ONCE(default_unknown_field_set_once_init_);
-}
-
 const UnknownFieldSet* UnknownFieldSet::default_instance() {
-  ::google::protobuf::GoogleOnceInit(&default_unknown_field_set_once_init_,
-                 &InitDefaultUnknownFieldSet);
-  return default_unknown_field_set_instance_;
+  static auto instance = internal::OnShutdownDelete(new UnknownFieldSet());
+  return instance;
 }
 
 void UnknownFieldSet::ClearFallback() {


### PR DESCRIPTION
It appears that Visual Studio does not work well with std::once_flag
because it has a bug causing it to initialize that during dynamic
initialization instead of constant initialization. This change works
around the problem by using function static initializers instead.

@gerben-s originally wrote this change for the Google-internal codebase
but I am just cherry-picking it here.

This fixes #4773.