### PR TITLE
protoc-artifacts: Update centos base from 6.6 to 6.9

### DIFF
--- a/protoc-artifacts/Dockerfile
+++ b/protoc-artifacts/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.6
+FROM centos:6.9
 
 RUN yum install -y git \
                    tar \


### PR DESCRIPTION
This avoids the need to use "yum update && yum upgrade" in the container
to be able to contact GitHub, which requires TLS 1.2[1].

I have verified that binaries built with this container still run in the
previous container; no errors like "/lib64/libc.so.6: version
`GLIBC_2.14' not found", which occur if using too new of a glibc when
compiling. CentOS 6.6 has glibc version 2.12 release 1.209.el6. CentOS
6.9 has glibc version 2.12 release 1.149.el6. Both would upgrade to
release 1.212.el6 via "yum update && yum upgrade".

1. https://githubengineering.com/crypto-deprecation-notice/