### PR TITLE
protobuf_generate(): add relative path to output dir

### DIFF
--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -105,7 +105,7 @@ function(protobuf_generate)
     add_custom_command(
       OUTPUT ${_generated_srcs}
       COMMAND  protobuf::protoc
-      ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR} ${_protobuf_include_path} ${_abs_file}
+      ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR}/${_rel_dir} ${_protobuf_include_path} ${_abs_file}
       DEPENDS ${_abs_file} protobuf::protoc
       COMMENT "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}"
       VERBATIM )


### PR DESCRIPTION
Without this fix, protobuf_generate() sets the variable _generated_srcs to
`${protobuf_generate_PROTOC_OUT_DIR}/${_rel_dir}/${_basename}${_ext}`
but generates the files in
`${protobuf_generate_PROTOC_OUT_DIR}/${_basename}${_ext}`