### PR TITLE
objectivec: Quash -Wself-assign and -Wvla

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -934,6 +934,9 @@ OBJC_SRCS = [
 objc_library(
     name = "objectivec",
     hdrs = OBJC_HDRS + OBJC_PRIVATE_HDRS,
+    copts = [
+        "-Wno-vla",
+    ],
     includes = [
         "objectivec",
     ],

--- a/objectivec/Tests/GPBTestUtilities.m
+++ b/objectivec/Tests/GPBTestUtilities.m
@@ -85,7 +85,7 @@ const uint32_t kGPBDefaultRepeatCount = 2;
   NSLog(@"Wrote data file to %@", path);
 #else
   // Kill off the unused variable warning.
-  dataToWrite = dataToWrite;
+  (void)dataToWrite;
 #endif
   return data;
 }


### PR DESCRIPTION
Eliminate trigger for `-Wself-assign` in Objective-C protobuf, and set `-Wno-vla` when building.