### PR TITLE
pyext needs c++11 in linux and mac.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -185,6 +185,7 @@ if __name__ == '__main__':
         extra_compile_args.append('-Wno-write-strings')
         extra_compile_args.append('-Wno-invalid-offsetof')
         extra_compile_args.append('-Wno-sign-compare')
+        extra_compile_args.append('-std=c++11')
 
     # https://github.com/Theano/Theano/issues/4926
     if sys.platform == 'win32':
@@ -200,12 +201,6 @@ if __name__ == '__main__':
 
     if "clang" in os.popen('$CC --version 2> /dev/null').read():
       extra_compile_args.append('-Wno-shorten-64-to-32')
-
-    v, _, _ = platform.mac_ver()
-    if v:
-      extra_compile_args.append('-std=c++11')
-    elif os.getenv('KOKORO_BUILD_NUMBER') or os.getenv('KOKORO_BUILD_ID'):
-      extra_compile_args.append('-std=c++11')
 
     if warnings_as_errors in sys.argv:
       extra_compile_args.append('-Werror')


### PR DESCRIPTION
pyext build fails with protobuf-3.6.0 in linux:
`16:58:58 gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I. -I../src -I/usr/include/python2.7 -c google/protobuf/pyext/descriptor.cc -o build/temp.linux-x86_64-2.7/google/protobuf/pyext/descriptor.o -Wno-write-strings -Wno-invalid-offsetof -Wno-sign-compare
16:58:58 In file included from [01m[K/usr/include/c++/4.8.2/mutex:35:0[m[K,
16:58:58                  from [01m[K../src/google/protobuf/stubs/mutex.h:33[m[K,
16:58:58                  from [01m[K../src/google/protobuf/stubs/common.h:52[m[K,
16:58:58                  from [01m[K../src/google/protobuf/stubs/hash.h:39[m[K,
16:58:58                  from [01m[Kgoogle/protobuf/pyext/descriptor.cc:35[m[K:
16:58:58 [01m[K/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2:[m[K [01;31m[Kerror: [m[K#error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
16:58:58  #error This file requires compiler and library support for the \
16:58:58 [01;32m[K  ^[m[K
16:58:58 In file included from [01m[K../src/google/protobuf/arena.h:51:0[m[K,
16:58:58                  from [01m[K../src/google/protobuf/descriptor.pb.h:23[m[K,
16:58:58                  from [01m[Kgoogle/protobuf/pyext/descriptor.cc:39[m[K:
16:58:58 [01m[K../src/google/protobuf/arena_impl.h:311:3:[m[K [01;35m[Kwarning: [m[Kidentifier ‘[01m[Kstatic_assert[m[K’ is a keyword in C++11 [-Wc++0x-compat]
16:58:58    static_assert(kBlockHeaderSize % 8 == 0,
16:58:58 [01;32m[K   ^[m[K
16:58:59 In file included from [01m[K../src/google/protobuf/stubs/common.h:52:0[m[K,
16:58:59                  from [01m[K../src/google/protobuf/stubs/hash.h:39[m[K,
16:58:59                  from [01m[Kgoogle/protobuf/pyext/descriptor.cc:35[m[K:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:50:20:[m[K [01;35m[Kwarning: [m[Kdefaulted and deleted functions only available with -std=c++11 or -std=gnu++11 [enabled by default]
16:58:59    WrappedMutex() = default;
16:58:59 [01;32m[K                    ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:58:3:[m[K [01;31m[Kerror: [m[K‘[01m[Kmutex[m[K’ in namespace ‘[01m[Kstd[m[K’ does not name a type
16:58:59    std::mutex mu_;
16:58:59 [01;32m[K   ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:[m[K In member function ‘[01m[Kvoid google::protobuf::internal::WrappedMutex::Lock()[m[K’:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:51:17:[m[K [01;31m[Kerror: [m[K‘[01m[Kmu_[m[K’ was not declared in this scope
16:58:59    void Lock() { mu_.lock(); }
16:58:59 [01;32m[K                 ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:[m[K In member function ‘[01m[Kvoid google::protobuf::internal::WrappedMutex::Unlock()[m[K’:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:52:19:[m[K [01;31m[Kerror: [m[K‘[01m[Kmu_[m[K’ was not declared in this scope
16:58:59    void Unlock() { mu_.unlock(); }
16:58:59 [01;32m[K                   ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:[m[K At global scope:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:61:7:[m[K [01;31m[Kerror: [m[Kexpected nested-name-specifier before ‘[01m[KMutex[m[K’
16:58:59  using Mutex = WrappedMutex;
16:58:59 [01;32m[K       ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:61:7:[m[K [01;31m[Kerror: [m[K‘[01m[KMutex[m[K’ has not been declared
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:61:13:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K;[m[K’ before ‘[01m[K=[m[K’ token
16:58:59  using Mutex = WrappedMutex;
16:58:59 [01;32m[K             ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:61:13:[m[K [01;31m[Kerror: [m[Kexpected unqualified-id before ‘[01m[K=[m[K’ token
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:66:28:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K)[m[K’ before ‘[01m[K*[m[K’ token
16:58:59    explicit MutexLock(Mutex *mu) : mu_(mu) { this->mu_->Lock(); }
16:58:59 [01;32m[K                            ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:69:3:[m[K [01;31m[Kerror: [m[K‘[01m[KMutex[m[K’ does not name a type
16:58:59    Mutex *const mu_;
16:58:59 [01;32m[K   ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:[m[K In destructor ‘[01m[Kgoogle::protobuf::internal::MutexLock::~MutexLock()[m[K’:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:67:24:[m[K [01;31m[Kerror: [m[K‘[01m[Kclass google::protobuf::internal::MutexLock[m[K’ has no member named ‘[01m[Kmu_[m[K’
16:58:59    ~MutexLock() { this->mu_->Unlock(); }
16:58:59 [01;32m[K                        ^[m[K
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:[m[K At global scope:
16:58:59 [01m[K../src/google/protobuf/stubs/mutex.h:80:33:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K)[m[K’ before ‘[01m[K*[m[K’ token
16:58:59    explicit MutexLockMaybe(Mutex *mu) :
16:58:59 [01;32m[K                                 ^[m[K
16:58:59 In file included from [01m[K../src/google/protobuf/arena.h:48:0[m[K,
16:58:59                  from [01m[K../src/google/protobuf/descriptor.pb.h:23[m[K,
16:58:59                  from [01m[Kgoogle/protobuf/pyext/descriptor.cc:39[m[K:
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K}[m[K’ before end of line
16:58:59  #pragma GCC visibility push(default)
16:58:59 [01;32m[K                                     ^[m[K
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected unqualified-id before end of line
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K}[m[K’ before end of line
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K}[m[K’ before end of line
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected ‘[01m[K}[m[K’ before end of line
16:58:59 [01m[K/usr/include/c++/4.8.2/typeinfo:39:37:[m[K [01;31m[Kerror: [m[Kexpected declaration before end of line
16:58:59 distcc[69695] ERROR: compile google/protobuf/pyext/descriptor.cc on localhost failed
16:58:59 error: command 'gcc' failed with exit status 1`