### PR TITLE
Do Not Define GOOGLE_FALLTHROUGH_INTENDED on GCC Without Attribute Support

### DIFF
--- a/src/google/protobuf/stubs/port.h
+++ b/src/google/protobuf/stubs/port.h
@@ -243,7 +243,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
      __has_cpp_attribute(clang::fallthrough)
 #  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]
 # endif
-#elif defined(__GNUC__) && __GNUC__ > 6
+#elif defined(__GNUC__) && __GNUC__ > 6 && __cpp_attributes >= 200809
 # define GOOGLE_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
 #endif
 


### PR DESCRIPTION
The definition of `GOOGLE_FALLTHROUGH_INTENDED` assumed that `[[gnu::fallthrough]]` was always available on GCC 7+. While `gnu::fallthrough` is supported on GCC 7+, C++ attributes themselves are not supported on GCC if the C++ standard is before C++11. As a fix, the guard on this definition has been expanded to include a check for C++ attribute support. The form of this check is the one recommended by GCC at https://gcc.gnu.org/projects/cxx-status.html.

This fixes #4935.