### PR TITLE
When running unit tests, read reference files in text mode

### DIFF
--- a/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
+++ b/src/google/protobuf/compiler/cpp/cpp_bootstrap_unittest.cc
@@ -95,7 +95,7 @@ class MockGeneratorContext : public GeneratorContext {
 
     string actual_contents;
     GOOGLE_CHECK_OK(
-        File::GetContents(TestSourceDir() + "/" + physical_filename,
+        File::GetContentsAsText(TestSourceDir() + "/" + physical_filename,
                           &actual_contents, true));
     EXPECT_TRUE(actual_contents == *expected_contents)
         << physical_filename

--- a/src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_bootstrap_unittest.cc
@@ -90,7 +90,7 @@ class MockGeneratorContext : public GeneratorContext {
 
     string actual_contents;
     GOOGLE_CHECK_OK(
-        File::GetContents(TestSourceDir() + "/" + physical_filename,
+        File::GetContentsAsText(TestSourceDir() + "/" + physical_filename,
                           &actual_contents, true))
         << "Unable to get " << physical_filename;
     EXPECT_TRUE(actual_contents == *expected_contents)

--- a/src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc
+++ b/src/google/protobuf/compiler/ruby/ruby_generator_unittest.cc
@@ -90,12 +90,12 @@ TEST(RubyGeneratorTest, GeneratorTest) {
 
   // Load the generated output and compare to the expected result.
   string output;
-  GOOGLE_CHECK_OK(File::GetContents(
+  GOOGLE_CHECK_OK(File::GetContentsAsText(
       TestTempDir() + "/ruby_generated_code_pb.rb",
       &output,
       true));
   string expected_output;
-  GOOGLE_CHECK_OK(File::GetContents(
+  GOOGLE_CHECK_OK(File::GetContentsAsText(
       ruby_tests + "/ruby_generated_code_pb.rb",
       &expected_output,
       true));

--- a/src/google/protobuf/map_test.cc
+++ b/src/google/protobuf/map_test.cc
@@ -3183,7 +3183,7 @@ TEST(TextFormatMapTest, Sorted) {
   tester.SetMapFieldsViaReflection(&message);
 
   string expected_text;
-  GOOGLE_CHECK_OK(File::GetContents(
+  GOOGLE_CHECK_OK(File::GetContentsAsText(
       TestSourceDir() +
           "/google/protobuf/"
           "testdata/map_test_data.txt",

--- a/src/google/protobuf/testing/file.cc
+++ b/src/google/protobuf/testing/file.cc
@@ -69,9 +69,9 @@ bool File::Exists(const string& name) {
   return access(name.c_str(), F_OK) == 0;
 }
 
-bool File::ReadFileToString(const string& name, string* output) {
+bool File::ReadFileToString(const string& name, string* output, bool text_mode) {
   char buffer[1024];
-  FILE* file = fopen(name.c_str(), "rb");
+  FILE* file = fopen(name.c_str(), text_mode ? "rt" : "rb");
   if (file == NULL) return false;
 
   while (true) {

--- a/src/google/protobuf/testing/file.h
+++ b/src/google/protobuf/testing/file.h
@@ -50,7 +50,7 @@ class File {
 
   // Read an entire file to a string.  Return true if successful, false
   // otherwise.
-  static bool ReadFileToString(const string& name, string* output);
+  static bool ReadFileToString(const string& name, string* output, bool text_mode = false);
 
   // Same as above, but crash on failure.
   static void ReadFileToStringOrDie(const string& name, string* output);
@@ -83,6 +83,11 @@ class File {
   static bool GetContents(
       const string& name, string* output, bool /*is_default*/) {
     return ReadFileToString(name, output);
+  }
+
+  static bool GetContentsAsText(
+      const string& name, string* output, bool /*is_default*/) {
+    return ReadFileToString(name, output, true);
   }
 
   static bool SetContents(

--- a/src/google/protobuf/text_format_unittest.cc
+++ b/src/google/protobuf/text_format_unittest.cc
@@ -77,7 +77,7 @@ const string kEscapeTestStringEscaped =
 class TextFormatTest : public testing::Test {
  public:
   static void SetUpTestCase() {
-    GOOGLE_CHECK_OK(File::GetContents(
+    GOOGLE_CHECK_OK(File::GetContentsAsText(
         TestSourceDir() +
             "/google/protobuf/"
             "testdata/text_format_unittest_data_oneof_implemented.txt",
@@ -99,7 +99,7 @@ string TextFormatTest::static_proto_debug_string_;
 class TextFormatExtensionsTest : public testing::Test {
  public:
   static void SetUpTestCase() {
-    GOOGLE_CHECK_OK(File::GetContents(TestSourceDir() +
+    GOOGLE_CHECK_OK(File::GetContentsAsText(TestSourceDir() +
                                    "/google/protobuf/testdata/"
                                    "text_format_unittest_extensions_data.txt",
                                &static_proto_debug_string_, true));


### PR DESCRIPTION
This should put an end to all of the reports of unit test failures on Windows machines: #547, #3319, #2548