### PR TITLE
Make assertEquals pass for message

### DIFF
--- a/php/ext/google/protobuf/message.c
+++ b/php/ext/google/protobuf/message.c
@@ -222,13 +222,7 @@ static zval* message_get_property_ptr_ptr(zval* object, zval* member, int type,
 }
 
 static HashTable* message_get_properties(zval* object TSRMLS_DC) {
-  // User cannot get property directly (e.g., $a = $m->a)
-  zend_error(E_USER_ERROR, "Cannot access private properties.");
-#if PHP_MAJOR_VERSION < 7
-  return zend_std_get_properties(object TSRMLS_CC);
-#else
-  return zend_std_get_properties(object);
-#endif
+  return NULL;
 }
 
 static HashTable* message_get_gc(zval* object, CACHED_VALUE** table,

--- a/php/tests/generated_class_test.php
+++ b/php/tests/generated_class_test.php
@@ -1342,4 +1342,17 @@ class GeneratedClassTest extends TestBase
 
         TestUtil::assertTestMessage($m);
     }
+
+    #########################################################
+    # Test message equals.
+    #########################################################
+
+    public function testMessageEquals()
+    {
+        $m = new TestMessage();
+        TestUtil::setTestMessage($m);
+        $n = new TestMessage();
+        TestUtil::setTestMessage($n);
+        $this->assertEquals($m, $n);
+    }
 }


### PR DESCRIPTION
This change only makes assertEquals pass for message in c extension. However, it actually does nothing.
This is the same behavior before 3.6.0 release.