### PR TITLE
Added support for Visual Studio 2017 in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ cmake/cmake-build-debug/
 # Common build subdirectories.
 ./.build/
 ./_build/
+
+# Visual Studio 2017
+.vs


### PR DESCRIPTION
Visual studio keeps a lot of own state in .vs folder. This makes development much easier.