### PR TITLE
Fix nested Message objects in to_h

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -681,9 +681,6 @@ VALUE Map_to_h(VALUE _self) {
                                   self->value_type_class,
                                   mem);
 
-    if (self->value_type == UPB_TYPE_MESSAGE) {
-      value = Message_to_h(value);
-    }
     rb_hash_aset(hash, key, value);
   }
   return hash;

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -1023,7 +1023,8 @@ module BasicTest
                             "b" => TestMessage2.new(:foo => 2)})
       expected_result = {
         :map_string_int32 => {"a" => 1, "b" => 2},
-        :map_string_msg => {"a" => {:foo => 1}, "b" => {:foo => 2}}
+        :map_string_msg => {"a" => TestMessage2.new(:foo => 1),
+                            "b" => TestMessage2.new(:foo => 2)}
       }
       assert_equal expected_result, m.to_h
     end


### PR DESCRIPTION
For example, for this proto file:

```
syntax = "proto3";
import "google/protobuf/struct.proto";

message Parent {
  map<string, Child> children = 1;
}

message Child {
  string name = 1;
}
```

We used to have:

```
irb(main):001:0> Parent.new(children: {'a' => Child.new(name: 'a')}).to_h
=> {:children=>{"a"=>{:name=>"a"}}}
```

Now:

```
irb(main):001:0> Parent.new(children: {'a' => Child.new(name: 'a')}).to_h
=> {:children=>{"a"=><Child: name: "a">}}
```

It appears this changed in #2847 / #396, but it's unclear what the intent
was with these lines, so I'm assuming this was an unintended side-effect
(it's not needed to solve #1761).