### PR TITLE
Updated release documentation

### DIFF
--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -119,7 +119,9 @@ target directory layout:
           protoc.exe
         + x86_32
           protoc.exe
-      + macos
+        + aarch_64
+          protoc.exe
+      + osx
         + x86_64
           protoc.exe
         + x86_32
@@ -137,7 +139,7 @@ Use the following command to deploy artifacts for the host platform to a
 staging repository.
 
 ```
-$ mvn clean deploy -P release
+$ mvn deploy -P release
 ```
 
 It creates a new staging repository. Go to


### PR DESCRIPTION
I made a few small fixes to the documentation related to publishing
protoc artifacts:
- The target directory for Mac should be called osx instead of macos.
- There needs to be a directory for aarch_64.
- We need to avoid calling "mvn clean" inside the protoc-artifacts
  directory, since that will delete the contents of the target/
  subdirectory.