### PR TITLE
add missed header files for dependency issue

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,8 @@ nobase_include_HEADERS =                                         \
   google/protobuf/stubs/status.h                                 \
   google/protobuf/stubs/stl_util.h                               \
   google/protobuf/stubs/stringpiece.h                            \
+  google/protobuf/stubs/stringprintf.h                           \
+  google/protobuf/stubs/strutil.h                                \
   google/protobuf/stubs/template_util.h                          \
   google/protobuf/any.pb.h                                       \
   google/protobuf/api.pb.h                                       \


### PR DESCRIPTION
`make install` will add missed header files to appropriate path