### PR TITLE
Added support for building the aarch64 and ppcle64 protoc binaries with Kokoro

### DIFF
--- a/kokoro/release/protoc/linux/build.sh
+++ b/kokoro/release/protoc/linux/build.sh
@@ -11,6 +11,16 @@ git submodule update --init --recursive
 # Generate the configure script.
 ./autogen.sh
 
+# Cross-build for aarch64 and ppc64le. Note: we do these builds first to avoid
+# file permission issues. The Docker builds will create directories owned by
+# root, which causes problems if we try to add new artifacts to those
+# directories afterward.
+sudo apt install -y g++-aarch64-linux-gnu
+protoc-artifacts/build-protoc.sh linux aarch_64 protoc
+
+sudo apt install -y g++-powerpc64le-linux-gnu
+protoc-artifacts/build-protoc.sh linux ppcle_64 protoc
+
 # Use docker image to build linux artifacts.
 DOCKER_IMAGE_NAME=protobuf/protoc_$(sha1sum protoc-artifacts/Dockerfile | cut -f1 -d " ")
 docker pull $DOCKER_IMAGE_NAME
@@ -28,9 +38,3 @@ docker run -v $(pwd):/var/local/protobuf --rm $DOCKER_IMAGE_NAME \
   echo "Failed to build protoc for linux + x86_32."
   exit 1
 }
-
-# Cross-build for some architectures.
-# TODO(xiaofeng): It currently fails with "machine `aarch64' not recognized"
-# error.
-# sudo apt install -y g++-aarch64-linux-gnu
-# protoc-artifacts/build-protoc.sh linux aarch_64 protoc

--- a/protoc-artifacts/README.md
+++ b/protoc-artifacts/README.md
@@ -154,10 +154,10 @@ and upload these zip packages to the download section of the github
 release. For example:
 
 ```
-$ ./build-zip.sh 3.6.0
+$ ./build-zip.sh protoc 3.6.0
 ```
 
-The above command will create 5 zip files:
+The above command will create 7 zip files:
 
 ```
 dist/protoc-3.6.0-win32.zip
@@ -165,6 +165,7 @@ dist/protoc-3.6.0-osx-x86_32.zip
 dist/protoc-3.6.0-osx-x86_64.zip
 dist/protoc-3.6.0-linux-x86_32.zip
 dist/protoc-3.6.0-linux-x86_64.zip
+dist/protoc-3.6.0-linux-aarch_64.zip
 dist/protoc-3.6.0-linux-ppcle_64.zip
 ```
 


### PR DESCRIPTION
This was fairly straightforward using the existing build-protoc.sh
script. The only problem I ran into was that the x86 Docker builds
create output directories owned by root, which caused some permission
issues. Fortunately it was easy to get around that just by doing those
Docker builds last.