### PR TITLE
Add DescriptorPool_clear function to reload protobuf definition 

### DIFF
--- a/ruby/ext/google/protobuf_c/defs.c
+++ b/ruby/ext/google/protobuf_c/defs.c
@@ -124,6 +124,7 @@ void DescriptorPool_register(VALUE module) {
   rb_define_method(klass, "add", DescriptorPool_add, 1);
   rb_define_method(klass, "build", DescriptorPool_build, 0);
   rb_define_method(klass, "lookup", DescriptorPool_lookup, 1);
+  rb_define_method(klass, "clear", DescriptorPool_clear, 0);
   rb_define_singleton_method(klass, "generated_pool",
                              DescriptorPool_generated_pool, 0);
   rb_gc_register_address(&cDescriptorPool);
@@ -204,6 +205,21 @@ VALUE DescriptorPool_lookup(VALUE _self, VALUE name) {
     return Qnil;
   }
   return get_def_obj(def);
+}
+
+/*
+ * call-seq:
+ *     DescriptorPool.clear()
+ *
+ * Clear all registered Descriptor.
+ */
+VALUE DescriptorPool_clear(VALUE _self) {
+  DEFINE_SELF(DescriptorPool, self, _self);
+
+  upb_symtab_free(self->symtab);
+  self->symtab = upb_symtab_new();
+
+  return Qnil;
 }
 
 /*

--- a/ruby/ext/google/protobuf_c/protobuf.h
+++ b/ruby/ext/google/protobuf_c/protobuf.h
@@ -177,6 +177,7 @@ DescriptorPool* ruby_to_DescriptorPool(VALUE value);
 VALUE DescriptorPool_add(VALUE _self, VALUE def);
 VALUE DescriptorPool_build(VALUE _self);
 VALUE DescriptorPool_lookup(VALUE _self, VALUE name);
+VALUE DescriptorPool_clear(VALUE _self);
 VALUE DescriptorPool_generated_pool(VALUE _self);
 
 void Descriptor_mark(void* _self);

--- a/ruby/tests/reload_test.rb
+++ b/ruby/tests/reload_test.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/ruby
+
+require 'google/protobuf'
+require 'test/unit'
+
+class ReloadTest < Test::Unit::TestCase
+  def test_reload_basic
+    pool = Google::Protobuf::DescriptorPool.new
+    pool.build do
+      add_message "redefine.TestMessage" do
+        optional :foo, :string, 1
+        optional :bar, :string, 2
+      end
+    end
+
+    m = pool.lookup("redefine.TestMessage").msgclass.new(foo: "foo", bar: "bar")
+    assert m.foo == "foo"
+    assert m.bar == "bar"
+
+    pool.clear
+
+    pool.build do
+      add_message "redefine.TestMessage" do
+        optional :foo, :int32, 1
+        optional :qux, :int32, 2
+      end
+    end
+
+    m2 = pool.lookup("redefine.TestMessage").msgclass.new(foo: 111, qux: 222)
+    assert_raise NoMethodError do
+      m2.bar
+    end
+    assert m2.foo == 111
+    assert m2.qux == 222
+  end
+end


### PR DESCRIPTION
When developing with Ruby on Rails, I would like to reload the protobuf definition. 
If I can clean generate_pool, I can accomplish this purpose.

```
Google::Protobuf::DescriptorPool.generated_pool.build do
  add_message "proto.example" do
    optional :test, :string, 1
  end
end

Google::Protobuf::DescriptorPool.generated_pool.clear  # added

Google::Protobuf::DescriptorPool.generated_pool.build do
    add_message "proto.example" do
      optional :test, :int32, 1
    end
end
```

This fixes #3814.