### PR TITLE
Add header needed for module maps.

### DIFF
--- a/objectivec/GPBUnknownField.m
+++ b/objectivec/GPBUnknownField.m
@@ -32,6 +32,7 @@
 
 #import "GPBArray.h"
 #import "GPBCodedOutputStream_PackagePrivate.h"
+#import "GPBUnknownFieldSet.h"
 
 @implementation GPBUnknownField {
  @protected


### PR DESCRIPTION
If you make up a module map for Objective C protocol buffers, the compiler will complain about missing a declaration for GPBUnknownFieldSet which is used in this file.