### PR TITLE
Fix broken test of const repeated field iterators

### DIFF
--- a/src/google/protobuf/extension_set_unittest.cc
+++ b/src/google/protobuf/extension_set_unittest.cc
@@ -1055,7 +1055,7 @@ TEST(ExtensionSetTest, RepeatedFields) {
            unittest::repeated_nested_enum_extension).begin(),
        enum_const_end  = message.GetRepeatedExtension(
            unittest::repeated_nested_enum_extension).end();
-       enum_iter != enum_end; ++enum_iter) {
+       enum_const_iter != enum_const_end; ++enum_const_iter) {
     ASSERT_EQ(*enum_const_iter, unittest::TestAllTypes::NestedEnum_MAX);
   }
 


### PR DESCRIPTION
The old version had a NOP for loop, which doesn't make sense. I'm pretty
sure this was the original intention. Newer GCC's
-Wunused-but-set-variable flags the old version.