### PR TITLE
Fix TryCreateParentDirectory on Windows

### DIFF
--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -168,7 +168,12 @@ bool VerifyDirectoryExists(const string& path) {
 // directories listed in |filename|.
 bool TryCreateParentDirectory(const string& prefix, const string& filename) {
   // Recursively create parent directories to the output file.
+#if defined(_WIN32)
+  // on Windows, both '/' and '\' are valid path separators
+  std::vector<string> parts = Split(filename, "/\\", true);
+#else
   std::vector<string> parts = Split(filename, "/", true);
+#endif
   string path_so_far = prefix;
   for (int i = 0; i < parts.size() - 1; i++) {
     path_so_far += parts[i];

--- a/src/google/protobuf/compiler/command_line_interface.cc
+++ b/src/google/protobuf/compiler/command_line_interface.cc
@@ -168,12 +168,8 @@ bool VerifyDirectoryExists(const string& path) {
 // directories listed in |filename|.
 bool TryCreateParentDirectory(const string& prefix, const string& filename) {
   // Recursively create parent directories to the output file.
-#if defined(_WIN32)
-  // on Windows, both '/' and '\' are valid path separators
+  // On Windows, both '/' and '\' are valid path separators.
   std::vector<string> parts = Split(filename, "/\\", true);
-#else
-  std::vector<string> parts = Split(filename, "/", true);
-#endif
   string path_so_far = prefix;
   for (int i = 0; i < parts.size() - 1; i++) {
     path_so_far += parts[i];


### PR DESCRIPTION
On Windows, both '/' and '\' are valid path separators. So when creating
the parent directories, split the filename on both

Signed-off-by: Akshat Gokhale <agokhale@pivotal.io>