### PR TITLE
Option to print 64-bit integers as integers in JSON.

### DIFF
--- a/src/google/protobuf/util/internal/json_objectwriter.cc
+++ b/src/google/protobuf/util/internal/json_objectwriter.cc
@@ -100,18 +100,18 @@ JsonObjectWriter* JsonObjectWriter::RenderUint32(StringPiece name,
 JsonObjectWriter* JsonObjectWriter::RenderInt64(StringPiece name,
                                                 int64 value) {
   WritePrefix(name);
-  WriteChar('"');
+  WriteInt64Quote();
   stream_->WriteString(SimpleItoa(value));
-  WriteChar('"');
+  WriteInt64Quote();
   return this;
 }
 
 JsonObjectWriter* JsonObjectWriter::RenderUint64(StringPiece name,
                                                  uint64 value) {
   WritePrefix(name);
-  WriteChar('"');
+  WriteInt64Quote();
   stream_->WriteString(SimpleItoa(value));
-  WriteChar('"');
+  WriteInt64Quote();
   return this;
 }
 

--- a/src/google/protobuf/util/internal/json_objectwriter.h
+++ b/src/google/protobuf/util/internal/json_objectwriter.h
@@ -89,7 +89,8 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
         stream_(out),
         sink_(out),
         indent_string_(indent_string),
-        use_websafe_base64_for_bytes_(false) {}
+        use_websafe_base64_for_bytes_(false),
+        print_int64_as_integer_(false) {}
   virtual ~JsonObjectWriter();
 
   // ObjectWriter methods.
@@ -112,6 +113,10 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
 
   void set_use_websafe_base64_for_bytes(bool value) {
     use_websafe_base64_for_bytes_ = value;
+  }
+
+  void set_print_int64_as_integer(bool value) {
+    print_int64_as_integer_ = value;
   }
 
  protected:
@@ -207,6 +212,13 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
   // Writes an individual character to the output.
   void WriteChar(const char c) { stream_->WriteRaw(&c, sizeof(c)); }
 
+  // If integers are rendered as strings, this will write a quote to the output.
+  void WriteInt64Quote() {
+    if (!print_int64_as_integer_) {
+        WriteChar('"');
+    }
+  }
+
   std::unique_ptr<Element> element_;
   io::CodedOutputStream* stream_;
   ByteSinkWrapper sink_;
@@ -215,6 +227,10 @@ class LIBPROTOBUF_EXPORT JsonObjectWriter : public StructuredObjectWriter {
   // Whether to use regular or websafe base64 encoding for byte fields. Defaults
   // to regular base64 encoding.
   bool use_websafe_base64_for_bytes_;
+
+  // Whether to render int64 and uint64 integers. Default value is false, where
+  // they are rendered as strings.
+  bool print_int64_as_integer_;
 
   GOOGLE_DISALLOW_IMPLICIT_CONSTRUCTORS(JsonObjectWriter);
 };

--- a/src/google/protobuf/util/internal/json_objectwriter_test.cc
+++ b/src/google/protobuf/util/internal/json_objectwriter_test.cc
@@ -174,6 +174,19 @@ TEST_F(JsonObjectWriterTest, RenderPrimitives) {
       output_.substr(0, out_stream_->ByteCount()));
 }
 
+TEST_F(JsonObjectWriterTest, RenderInt64AsInteger) {
+  ow_ = new JsonObjectWriter("", out_stream_);
+  ow_->set_print_int64_as_integer(true);
+  ow_->StartObject("")
+      ->RenderInt64("long", std::numeric_limits<int64>::min())
+      ->RenderUint64("unsignedlong", std::numeric_limits<uint64>::max())
+      ->EndObject();
+  EXPECT_EQ(
+      "{\"long\":-9223372036854775808,"
+      "\"unsignedlong\":18446744073709551615}",
+      output_.substr(0, out_stream_->ByteCount()));
+}
+
 TEST_F(JsonObjectWriterTest, BytesEncodesAsNonWebSafeBase64) {
   string s;
   s.push_back('\377');

--- a/src/google/protobuf/util/json_format_proto3.proto
+++ b/src/google/protobuf/util/json_format_proto3.proto
@@ -91,6 +91,7 @@ message TestOneof {
     bytes oneof_bytes_value = 3;
     EnumType oneof_enum_value = 4;
     MessageType oneof_message_value = 5;
+    int64 oneof_int64_value = 6;
   }
 }
 
@@ -101,6 +102,7 @@ message TestMap {
   map<uint32, int32> uint32_map = 4;
   map<uint64, int32> uint64_map = 5;
   map<string, int32> string_map = 6;
+  map<string, int64> string_int64_map = 7;
 }
 
 message TestNestedMap {

--- a/src/google/protobuf/util/json_util.cc
+++ b/src/google/protobuf/util/json_util.cc
@@ -97,6 +97,7 @@ util::Status BinaryToJsonStream(TypeResolver* resolver,
   io::CodedOutputStream out_stream(json_output);
   converter::JsonObjectWriter json_writer(options.add_whitespace ? " " : "",
                                           &out_stream);
+  json_writer.set_print_int64_as_integer(options.always_print_int64s_as_ints);
   if (options.always_print_primitive_fields) {
     converter::DefaultValueObjectWriter default_value_writer(
         resolver, type, &json_writer);

--- a/src/google/protobuf/util/json_util.h
+++ b/src/google/protobuf/util/json_util.h
@@ -65,6 +65,10 @@ struct JsonPrintOptions {
   // Whether to always print enums as ints. By default they are rendered as
   // strings.
   bool always_print_enums_as_ints;
+  // Whether to always print 64-bit ints as ints. By default they are rendered
+  // as strings. Note that JavaScript parses numbers as 64-bit float thus int64
+  // and uint64 would lose precision if rendered as numbers.
+  bool always_print_int64s_as_ints;
   // Whether to preserve proto field names
   bool preserve_proto_field_names;
 
@@ -72,6 +76,7 @@ struct JsonPrintOptions {
       : add_whitespace(false),
         always_print_primitive_fields(false),
         always_print_enums_as_ints(false),
+        always_print_int64s_as_ints(false),
         preserve_proto_field_names(false) {}
 };
 


### PR DESCRIPTION
Though this won't work in javascript, keeping this option will be useful for other languages.
Related issue: https://github.com/google/protobuf/issues/2679