### PR TITLE
Document wrapper non-uses

### DIFF
--- a/src/google/protobuf/wrappers.proto
+++ b/src/google/protobuf/wrappers.proto
@@ -32,6 +32,11 @@
 // for embedding primitives in the `google.protobuf.Any` type and for places
 // where we need to distinguish between the absence of a primitive
 // typed field and its default value.
+//
+// These wrappers have no meaningful use within repeated fields as they lack
+// the ability to detect presence on individual elements.
+// These wrappers have no meaningful use within a map or a oneof since individual
+// entries of a map or fields of a oneof can already detect presence.
 
 syntax = "proto3";
 


### PR DESCRIPTION
Document the cases where the wrapper well-known types are not useful.