### PR TITLE
Include version information in Windows binaries (backport #4579 for 3.6.x)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1036,6 +1036,7 @@ EXTRA_DIST = $(@DIST_LANG@_EXTRA_DIST)   \
   cmake/protobuf.pc.cmake                \
   cmake/protoc.cmake                     \
   cmake/tests.cmake                      \
+  cmake/version.rc.in                    \
   editors/README.txt                     \
   editors/proto.vim                      \
   editors/protobuf-mode.el               \

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -166,11 +166,22 @@ if (MSVC)
   add_definitions(/bigobj)
   string(REPLACE "/" "\\" PROTOBUF_SOURCE_WIN32_PATH ${protobuf_SOURCE_DIR})
   string(REPLACE "/" "\\" PROTOBUF_BINARY_WIN32_PATH ${protobuf_BINARY_DIR})
+  string(REPLACE "." ","  protobuf_RC_FILEVERSION "${protobuf_VERSION}")
   configure_file(extract_includes.bat.in extract_includes.bat)
 
   # Suppress linker warnings about files with no symbols defined.
   set(CMAKE_STATIC_LINKER_FLAGS /ignore:4221)
+
+  # Configure Resource Compiler
+  enable_language(RC)
+  # use English language (0x409) in resource compiler
+  set(rc_flags "/l0x409")
+  # fix rc.exe invocations because of usage of add_definitions()
+  set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_flags} <DEFINES> /fo<OBJECT> <SOURCE>")
+
+  configure_file(version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc @ONLY)
 endif (MSVC)
+
 
 get_filename_component(protobuf_source_dir ${protobuf_SOURCE_DIR} PATH)
 

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -48,8 +48,14 @@ set(libprotobuf_lite_includes
   ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.h
 )
 
+if (MSVC)
+set(libprotoc_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+endif()
+
 add_library(libprotobuf-lite ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_lite_includes})
+  ${libprotobuf_lite_files} ${libprotobuf_lite_includes} ${libprotobuf_lite_rc_files})
 target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -112,8 +112,14 @@ set(libprotobuf_includes
   ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.h
 )
 
+if (MSVC)
+set(libprotoc_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+endif()
+
 add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
-  ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes})
+  ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes} ${libprotobuf_rc_files})
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
 if(protobuf_WITH_ZLIB)
     target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -168,7 +168,7 @@ set(libprotoc_rc_files
 endif()
 
 add_library(libprotoc ${protobuf_SHARED_OR_STATIC}
-  ${libprotoc_files} ${libprotoc_headers})
+  ${libprotoc_files} ${libprotoc_headers} ${libprotoc_rc_files})
 target_link_libraries(libprotoc libprotobuf)
 if(MSVC AND protobuf_BUILD_SHARED_LIBS)
   target_compile_definitions(libprotoc

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -2,6 +2,13 @@ set(protoc_files
   ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc
 )
 
-add_executable(protoc ${protoc_files})
+set(protoc_rc_files
+  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+)
+
+add_executable(protoc ${protoc_files} ${protoc_rc_files})
 target_link_libraries(protoc libprotobuf libprotoc)
 add_executable(protobuf::protoc ALIAS protoc)
+
+set_target_properties(protoc PROPERTIES
+    VERSION ${protobuf_VERSION})

--- a/cmake/version.rc.in
+++ b/cmake/version.rc.in
@@ -1,0 +1,45 @@
+#define VS_FF_DEBUG 0x1L
+#define VS_VERSION_INFO 0x1L
+#define VS_FFI_FILEFLAGSMASK 0x17L
+#define VER_PRIVATEBUILD 0x0L
+#define VER_PRERELEASE 0x0L
+#define VOS__WINDOWS32 0x4L
+#define VFT_DLL 0x2L
+#define VFT2_UNKNOWN 0x0L
+
+#ifndef DEBUG
+#define VER_DEBUG 0
+#else
+#define VER_DEBUG VS_FF_DEBUG
+#endif
+
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    @protobuf_RC_FILEVERSION@,0
+  PRODUCTVERSION @protobuf_RC_FILEVERSION@,0
+  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+  FILEFLAGS      VER_DEBUG
+  FILEOS         VOS__WINDOWS32
+  FILETYPE       VFT_DLL
+BEGIN
+    BLOCK "VarFileInfo"
+    BEGIN 
+        // English language (0x409) and the Windows Unicode codepage (1200)
+        VALUE "Translation", 0x409, 1200
+    END
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "Compiled with @CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@\0"
+            VALUE "ProductVersion", "@protobuf_VERSION@\0"
+            VALUE "FileVersion", "@protobuf_VERSION@\0"
+            VALUE "InternalName", "protobuf\0"
+            VALUE "ProductName", "Protocol Buffers - Google's Data Interchange Format\0"
+            VALUE "CompanyName", "Google Inc.\0"
+            VALUE "LegalCopyright", "Copyright 2008 Google Inc.  All rights reserved.\0"
+            VALUE "Licence", "BSD\0"
+            VALUE "Info", "https://developers.google.com/protocol-buffers/\0"
+        END
+    END
+END


### PR DESCRIPTION
The 3.6.x branch contains part of the code from the #4579 (the `libprotoc_rc_files` in `make/libprotoc.cmake` file)

This backports the `version.rc` implementation to the 3.6.x branch.