### PR TITLE
Change deprecated Bazel single file attr param

### DIFF
--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -178,7 +178,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(


### PR DESCRIPTION
This removes the need for --incompatible_disable_deprecated_attr_params when using Protobuf